### PR TITLE
feat(post): warn to check contact lens solution is sealed and in date

### DIFF
--- a/iznik-batch/tests/Unit/Services/EeeSqliteServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/EeeSqliteServiceTest.php
@@ -1,0 +1,950 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\EeeSqliteService;
+use PDO;
+use Tests\TestCase;
+
+/**
+ * Unit tests for EeeSqliteService.
+ *
+ * The service owns its own SQLite file (separate from the MySQL `iznik` DB used
+ * elsewhere in the app), so every test points `freegle.eee.sqlite_path` at a
+ * fresh temp file and constructs a brand-new service instance — no shared
+ * state, no MySQL fixtures required.
+ */
+class EeeSqliteServiceTest extends TestCase
+{
+    /** @var string[] */
+    private array $tempPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempPaths as $path) {
+            foreach ([$path, $path . '-wal', $path . '-shm', $path . '-journal'] as $file) {
+                if (is_file($file)) {
+                    @unlink($file);
+                }
+            }
+            $dir = dirname($path);
+            if (is_dir($dir) && str_contains($dir, 'eee_sqlite_test_')) {
+                @rmdir($dir);
+                $parent = dirname($dir);
+                if (is_dir($parent) && str_contains($parent, 'eee_sqlite_test_')) {
+                    @rmdir($parent);
+                }
+            }
+        }
+        $this->tempPaths = [];
+
+        parent::tearDown();
+    }
+
+    private function newService(?string $path = null): EeeSqliteService
+    {
+        $path ??= sys_get_temp_dir() . '/eee_sqlite_test_' . uniqid() . '.sqlite';
+        $this->tempPaths[] = $path;
+        config(['freegle.eee.sqlite_path' => $path]);
+        return new EeeSqliteService();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // getPdo() / migrate() bootstrap
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_get_pdo_creates_missing_nested_directory_and_file(): void
+    {
+        $path = sys_get_temp_dir() . '/eee_sqlite_test_' . uniqid() . '/nested/classifications.sqlite';
+        $this->tempPaths[] = $path;
+        config(['freegle.eee.sqlite_path' => $path]);
+        $service = new EeeSqliteService();
+
+        $this->assertFileDoesNotExist($path);
+
+        $pdo = $service->getPdo();
+
+        $this->assertInstanceOf(PDO::class, $pdo);
+        $this->assertFileExists($path);
+    }
+
+    public function test_get_pdo_returns_same_instance_on_repeat_calls(): void
+    {
+        $service = $this->newService();
+
+        $this->assertSame($service->getPdo(), $service->getPdo());
+    }
+
+    public function test_migrate_creates_all_expected_tables(): void
+    {
+        $service = $this->newService();
+        $pdo     = $service->getPdo();
+
+        $tables = $pdo->query("SELECT name FROM sqlite_master WHERE type='table'")->fetchAll(PDO::FETCH_COLUMN);
+
+        foreach ([
+            'eee_item_types',
+            'eee_classifications',
+            'eee_item_type_samples',
+            'eee_runs',
+            'eee_observations',
+            'eee_component_types',
+        ] as $expected) {
+            $this->assertContains($expected, $tables, "Missing table: {$expected}");
+        }
+    }
+
+    public function test_migrate_upgrades_legacy_schema_missing_classification_mode_column(): void
+    {
+        $path = sys_get_temp_dir() . '/eee_sqlite_test_' . uniqid() . '.sqlite';
+        $this->tempPaths[] = $path;
+
+        // Simulate a pre-existing v1 database: the full column set the upgrade
+        // code expects, but no classification_mode column at all.
+        $legacy = new PDO('sqlite:' . $path);
+        $legacy->exec("
+            CREATE TABLE eee_item_types (
+                item_name                TEXT,
+                item_id                  INTEGER,
+                popularity               INTEGER,
+                sample_size              INTEGER DEFAULT 0,
+                images_analysed          INTEGER DEFAULT 0,
+                eee_sample_count         INTEGER DEFAULT 0,
+                is_eee                   INTEGER,
+                is_eee_confidence        REAL,
+                is_eee_agree_rate        REAL,
+                weee_category            INTEGER,
+                weee_category_name       TEXT,
+                weee_category_confidence REAL,
+                needs_image_analysis     INTEGER DEFAULT 0,
+                model                    TEXT,
+                prompt_version           TEXT,
+                classified_at            DATETIME,
+                PRIMARY KEY (item_name, model, prompt_version)
+            )
+        ");
+        $legacy->exec("
+            INSERT INTO eee_item_types
+                (item_name, item_id, popularity, sample_size, is_eee, model, prompt_version, classified_at)
+            VALUES ('Toaster', 1, 5, 3, 1, 'gemini', '1.0.0', '2026-01-01 00:00:00')
+        ");
+        $legacy = null;
+
+        config(['freegle.eee.sqlite_path' => $path]);
+        $service = new EeeSqliteService();
+
+        $row = $service->getItemType('Toaster', 'gemini', '1.0.0', 'combined');
+
+        $this->assertNotNull($row);
+        $this->assertSame('combined', $row['classification_mode']);
+        $this->assertSame(5, (int) $row['popularity']);
+    }
+
+    public function test_migrate_upgrades_schema_with_mode_column_but_short_primary_key(): void
+    {
+        // TODO: latent bug — migrate()'s "add contains_eee_components /
+        // electrical_components_description if missing" block runs BEFORE the
+        // hasMode=true/pkCols<4 upgrade block, widening the source table to 19
+        // columns. The upgrade then does `INSERT INTO eee_item_types_new (17 cols)
+        // SELECT * FROM eee_item_types (19 cols)`, which SQLite rejects with
+        // "table eee_item_types_new has 17 columns but 19 values were supplied".
+        // Any real v2-schema DB (classification_mode present, PK still 3 columns)
+        // would crash on migrate(). Not fixed here per task instructions (test
+        // files only, no production code changes).
+        $this->markTestSkipped('Latent bug in EeeSqliteService::migrate(): v2-schema (hasMode=true, pkCols<4) upgrade crashes with a column-count mismatch because ADD COLUMN runs before the upgrade SELECT *.');
+
+        $path = sys_get_temp_dir() . '/eee_sqlite_test_' . uniqid() . '.sqlite';
+        $this->tempPaths[] = $path;
+
+        // v2: classification_mode column already exists, but the PK is still
+        // only 3 columns (not the 4-column composite the current schema needs).
+        $legacy = new PDO('sqlite:' . $path);
+        $legacy->exec("
+            CREATE TABLE eee_item_types (
+                item_name                TEXT,
+                item_id                  INTEGER,
+                popularity               INTEGER,
+                sample_size              INTEGER DEFAULT 0,
+                images_analysed          INTEGER DEFAULT 0,
+                eee_sample_count         INTEGER DEFAULT 0,
+                is_eee                   INTEGER,
+                is_eee_confidence        REAL,
+                is_eee_agree_rate        REAL,
+                weee_category            INTEGER,
+                weee_category_name       TEXT,
+                weee_category_confidence REAL,
+                needs_image_analysis     INTEGER DEFAULT 0,
+                model                    TEXT,
+                prompt_version           TEXT,
+                classification_mode      TEXT NOT NULL DEFAULT 'combined',
+                classified_at            DATETIME,
+                PRIMARY KEY (item_name, model, prompt_version)
+            )
+        ");
+        $legacy->exec("
+            INSERT INTO eee_item_types
+                (item_name, item_id, popularity, is_eee, model, prompt_version, classification_mode, classified_at)
+            VALUES ('Kettle', 2, 9, 1, 'gemini', '1.0.0', 'per_image', '2026-01-02 00:00:00')
+        ");
+        $legacy = null;
+
+        config(['freegle.eee.sqlite_path' => $path]);
+        $service = new EeeSqliteService();
+
+        $row = $service->getItemType('Kettle', 'gemini', '1.0.0', 'per_image');
+
+        $this->assertNotNull($row);
+        $this->assertSame('per_image', $row['classification_mode']);
+        $this->assertSame(9, (int) $row['popularity']);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // upsertItemType() / getItemType()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_get_item_type_returns_null_when_not_found(): void
+    {
+        $service = $this->newService();
+
+        $this->assertNull($service->getItemType('Nonexistent', 'gemini', '1.0.0'));
+    }
+
+    public function test_upsert_item_type_inserts_new_row(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertItemType([
+            'item_name'            => 'Blender',
+            'item_id'              => 10,
+            'popularity'           => 4,
+            'is_eee'               => 1,
+            'model'                => 'gemini',
+            'prompt_version'       => '1.1.0',
+            'classification_mode'  => 'combined',
+        ]);
+
+        $row = $service->getItemType('Blender', 'gemini', '1.1.0');
+
+        $this->assertNotNull($row);
+        $this->assertSame(4, (int) $row['popularity']);
+        $this->assertSame(1, (int) $row['is_eee']);
+    }
+
+    public function test_upsert_item_type_updates_existing_row_on_conflict(): void
+    {
+        $service = $this->newService();
+
+        $base = [
+            'item_name'           => 'Fan',
+            'model'               => 'gemini',
+            'prompt_version'      => '1.1.0',
+            'classification_mode' => 'combined',
+            'popularity'          => 1,
+        ];
+        $service->upsertItemType($base);
+        $service->upsertItemType([...$base, 'popularity' => 99]);
+
+        $row = $service->getItemType('Fan', 'gemini', '1.1.0');
+
+        $this->assertSame(99, (int) $row['popularity']);
+    }
+
+    public function test_upsert_item_type_with_only_key_columns(): void
+    {
+        // TODO: latent bug — upsertItemType() builds `$updates` by filtering OUT
+        // the 4 key columns from array_keys($data). When $data contains ONLY the
+        // key columns (a legitimate call — e.g. "register that this item type
+        // exists, nothing else known yet"), $updates is an empty string, producing
+        // `... ON CONFLICT(...) DO UPDATE SET ` with nothing after SET, which
+        // SQLite rejects with "incomplete input". Not fixed here per task
+        // instructions (test files only, no production code changes).
+        $this->markTestSkipped('Latent bug in EeeSqliteService::upsertItemType(): calling it with only the 4 primary-key columns produces an empty "DO UPDATE SET" clause and throws a PDOException.');
+
+        $service = $this->newService();
+
+        $service->upsertItemType([
+            'item_name'           => 'Toaster',
+            'model'               => 'gemini',
+            'prompt_version'      => '1.0.0',
+            'classification_mode' => 'combined',
+        ]);
+
+        $this->assertNotNull($service->getItemType('Toaster', 'gemini', '1.0.0'));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // getUnclassifiedItemTypeNames()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_get_unclassified_item_type_names_returns_empty_for_empty_input(): void
+    {
+        $service = $this->newService();
+
+        $this->assertSame([], $service->getUnclassifiedItemTypeNames([]));
+    }
+
+    public function test_get_unclassified_item_type_names_excludes_already_classified(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertItemType([
+            'item_name'           => 'Toaster',
+            'model'               => 'gemini',
+            'prompt_version'      => '1.0.0',
+            'classification_mode' => 'combined',
+            'is_eee'              => 1,
+        ]);
+
+        $result = $service->getUnclassifiedItemTypeNames(
+            ['Toaster', 'Kettle', 'Fan'],
+            'gemini',
+            '1.0.0',
+            'combined'
+        );
+
+        $this->assertSame(['Kettle', 'Fan'], array_values($result));
+    }
+
+    public function test_get_unclassified_item_type_names_is_scoped_by_mode(): void
+    {
+        $service = $this->newService();
+
+        // Classified under 'combined' only — should still be "unclassified" for 'per_image'.
+        $service->upsertItemType([
+            'item_name'           => 'Toaster',
+            'model'               => 'gemini',
+            'prompt_version'      => '1.0.0',
+            'classification_mode' => 'combined',
+            'is_eee'              => 1,
+        ]);
+
+        $result = $service->getUnclassifiedItemTypeNames(['Toaster'], 'gemini', '1.0.0', 'per_image');
+
+        $this->assertSame(['Toaster'], array_values($result));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // insertClassification() / hasClassification() / getClassificationsForMessage()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function classificationRow(array $overrides = []): array
+    {
+        return array_merge([
+            'messageid'      => 100,
+            'model'          => 'gemini',
+            'prompt_version' => '1.0.0',
+            'run_at'         => '2026-01-01 00:00:00',
+            'data_sources'   => 'text,image',
+            'is_eee'         => 1,
+        ], $overrides);
+    }
+
+    public function test_insert_classification_returns_last_insert_id(): void
+    {
+        $service = $this->newService();
+
+        $id1 = $service->insertClassification($this->classificationRow());
+        $id2 = $service->insertClassification($this->classificationRow(['messageid' => 101]));
+
+        $this->assertSame($id1 + 1, $id2);
+        $this->assertGreaterThan(0, $id1);
+    }
+
+    /**
+     * @dataProvider provideHasClassificationCases
+     */
+    public function test_has_classification(array $inserted, int $messageid, string $model, ?string $promptVersion, bool $expected): void
+    {
+        $service = $this->newService();
+        $service->insertClassification($this->classificationRow($inserted));
+
+        $this->assertSame($expected, $service->hasClassification($messageid, $model, $promptVersion));
+    }
+
+    public static function provideHasClassificationCases(): array
+    {
+        return [
+            'matches messageid+model, no prompt version filter' => [
+                ['messageid' => 5, 'model' => 'gemini'], 5, 'gemini', null, true,
+            ],
+            'wrong model, no prompt version filter' => [
+                ['messageid' => 5, 'model' => 'gemini'], 5, 'openai', null, false,
+            ],
+            'wrong messageid, no prompt version filter' => [
+                ['messageid' => 5, 'model' => 'gemini'], 6, 'gemini', null, false,
+            ],
+            'matches messageid+model+prompt version' => [
+                ['messageid' => 7, 'model' => 'gemini', 'prompt_version' => '2.0.0'], 7, 'gemini', '2.0.0', true,
+            ],
+            'wrong prompt version' => [
+                ['messageid' => 7, 'model' => 'gemini', 'prompt_version' => '2.0.0'], 7, 'gemini', '1.0.0', false,
+            ],
+        ];
+    }
+
+    public function test_get_classifications_for_message_returns_empty_array_when_none(): void
+    {
+        $service = $this->newService();
+
+        $this->assertSame([], $service->getClassificationsForMessage(999));
+    }
+
+    public function test_get_classifications_for_message_keyed_by_model(): void
+    {
+        $service = $this->newService();
+
+        $service->insertClassification($this->classificationRow(['messageid' => 42, 'model' => 'gemini']));
+        $service->insertClassification($this->classificationRow(['messageid' => 42, 'model' => 'openai']));
+        $service->insertClassification($this->classificationRow(['messageid' => 43, 'model' => 'gemini']));
+
+        $result = $service->getClassificationsForMessage(42);
+
+        $this->assertSame(['gemini', 'openai'], array_keys($result));
+        $this->assertSame(42, (int) $result['gemini']['messageid']);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // startRun() / finishRun()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_start_run_and_finish_run_updates_stats(): void
+    {
+        $service = $this->newService();
+
+        $runId = $service->startRun('gemini', '1.0.0', 'all', 'test note');
+        $this->assertGreaterThan(0, $runId);
+
+        $service->finishRun($runId, 50, 12, 2, 1.2345);
+
+        $pdo = $service->getPdo();
+        $row = $pdo->prepare('SELECT * FROM eee_runs WHERE id = ?');
+        $row->execute([$runId]);
+        $run = $row->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame('gemini', $run['model']);
+        $this->assertSame('test note', $run['notes']);
+        $this->assertSame(50, (int) $run['processed']);
+        $this->assertSame(12, (int) $run['eee_found']);
+        $this->assertSame(2, (int) $run['errors']);
+        $this->assertEqualsWithDelta(1.2345, (float) $run['cost_usd_total'], 0.0001);
+        $this->assertNotNull($run['completed_at']);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // getStats()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_get_stats_on_empty_database(): void
+    {
+        $service = $this->newService();
+
+        $stats = $service->getStats();
+
+        $this->assertSame(0, $stats['total']);
+        $this->assertSame(0, $stats['eeeCount']);
+        $this->assertSame(0, $stats['unusual']);
+        $this->assertSame(0, $stats['typesCount']);
+        $this->assertSame([], $stats['byCategory']);
+        $this->assertSame([], $stats['byCondition']);
+        $this->assertSame([], $stats['topBrands']);
+        $this->assertSame([], $stats['monthlyTrend']);
+        $this->assertNull($stats['weightTotal']);
+    }
+
+    public function test_get_stats_aggregates_across_classifications(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertItemType(['item_name' => 'Toaster', 'model' => 'gemini', 'prompt_version' => '1.0.0', 'classification_mode' => 'combined', 'is_eee' => 1]);
+        $service->upsertItemType(['item_name' => 'Chair', 'model' => 'gemini', 'prompt_version' => '1.0.0', 'classification_mode' => 'combined', 'is_eee' => 0]);
+
+        $service->insertClassification($this->classificationRow([
+            'messageid' => 1, 'is_eee' => 1, 'is_unusual_eee' => 1,
+            'weee_category' => 4, 'weee_category_name' => 'Large household appliances',
+            'condition' => 'Working', 'brand' => 'Acme',
+            'weight_kg_min' => 2.0, 'weight_kg_max' => 4.0,
+            'run_at' => '2026-01-15 10:00:00',
+        ]));
+        $service->insertClassification($this->classificationRow([
+            'messageid' => 2, 'is_eee' => 1, 'is_unusual_eee' => 0,
+            'weee_category' => 4, 'weee_category_name' => 'Large household appliances',
+            'condition' => 'Working', 'brand' => 'Acme',
+            'weight_kg_min' => 1.0, 'weight_kg_max' => 3.0,
+            'run_at' => '2026-01-20 10:00:00',
+        ]));
+        $service->insertClassification($this->classificationRow([
+            'messageid' => 3, 'is_eee' => 0, 'is_unusual_eee' => 0,
+            'run_at' => '2026-01-20 10:00:00',
+        ]));
+
+        $stats = $service->getStats();
+
+        $this->assertSame(3, $stats['total']);
+        $this->assertSame(2, $stats['eeeCount']);
+        $this->assertSame(1, $stats['unusual']);
+        $this->assertSame(2, $stats['typesCount']);
+
+        $this->assertCount(1, $stats['byCategory']);
+        $this->assertSame(2, $stats['byCategory'][0]['cnt']);
+
+        $this->assertCount(1, $stats['byCondition']);
+        $this->assertSame('Working', $stats['byCondition'][0]['condition']);
+        $this->assertSame(2, $stats['byCondition'][0]['cnt']);
+
+        $this->assertCount(1, $stats['topBrands']);
+        $this->assertSame('Acme', $stats['topBrands'][0]['brand']);
+
+        $this->assertCount(1, $stats['monthlyTrend']);
+        $this->assertSame('2026-01', $stats['monthlyTrend'][0]['month']);
+        $this->assertSame(3, (int) $stats['monthlyTrend'][0]['total']);
+        $this->assertSame(2, (int) $stats['monthlyTrend'][0]['eee_count']);
+
+        // (2+4)/2 + (1+3)/2 = 3 + 2 = 5
+        $this->assertEqualsWithDelta(5.0, (float) $stats['weightTotal'], 0.0001);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Item type samples
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function sampleAttachment(array $overrides = []): object
+    {
+        return (object) array_merge([
+            'messageid'   => 1,
+            'attid'       => 1,
+            'externaluid' => 'uid-1',
+            'subject'     => 'OFFER: Toaster',
+            'textbody'    => 'Free toaster',
+        ], $overrides);
+    }
+
+    public function test_has_sample_for_item_type_false_when_none_recorded(): void
+    {
+        $service = $this->newService();
+
+        $this->assertFalse($service->hasSampleForItemType('Toaster'));
+        $this->assertSame([], $service->getSampleForItemType('Toaster'));
+    }
+
+    public function test_record_and_retrieve_item_type_sample(): void
+    {
+        $service = $this->newService();
+
+        $service->recordItemTypeSample('Toaster', [
+            $this->sampleAttachment(['messageid' => 2, 'attid' => 20, 'externaluid' => 'uid-2']),
+            $this->sampleAttachment(['messageid' => 1, 'attid' => 10, 'externaluid' => 'uid-1']),
+        ]);
+
+        $this->assertTrue($service->hasSampleForItemType('Toaster'));
+
+        $samples = $service->getSampleForItemType('Toaster');
+
+        $this->assertCount(2, $samples);
+        // Ordered by messageid ascending.
+        $this->assertSame(1, $samples[0]->messageid);
+        $this->assertSame(2, $samples[1]->messageid);
+    }
+
+    public function test_record_item_type_sample_ignores_duplicates(): void
+    {
+        $service = $this->newService();
+
+        $att = $this->sampleAttachment();
+        $service->recordItemTypeSample('Toaster', [$att]);
+        $service->recordItemTypeSample('Toaster', [$att]);
+
+        $this->assertCount(1, $service->getSampleForItemType('Toaster'));
+    }
+
+    public function test_get_sample_message_ids_returns_distinct_ids_within_limit(): void
+    {
+        $service = $this->newService();
+
+        $service->recordItemTypeSample('Toaster', [
+            $this->sampleAttachment(['messageid' => 1, 'attid' => 1, 'externaluid' => 'a']),
+        ]);
+        $service->recordItemTypeSample('Kettle', [
+            $this->sampleAttachment(['messageid' => 1, 'attid' => 2, 'externaluid' => 'b']),
+            $this->sampleAttachment(['messageid' => 2, 'attid' => 3, 'externaluid' => 'c']),
+        ]);
+
+        $ids = $service->getSampleMessageIds();
+        sort($ids);
+        $this->assertSame([1, 2], $ids);
+
+        $limited = $service->getSampleMessageIds(1);
+        $this->assertCount(1, $limited);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // getMessageidsForModel()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_get_messageids_for_model_orders_desc_and_respects_limit(): void
+    {
+        $service = $this->newService();
+
+        foreach ([10, 20, 30] as $mid) {
+            $service->insertClassification($this->classificationRow(['messageid' => $mid, 'model' => 'gemini']));
+        }
+        $service->insertClassification($this->classificationRow(['messageid' => 40, 'model' => 'openai']));
+
+        $ids = $service->getMessageidsForModel('gemini', 2);
+
+        $this->assertSame([30, 20], $ids);
+    }
+
+    public function test_get_messageids_for_model_returns_empty_for_unknown_model(): void
+    {
+        $service = $this->newService();
+
+        $this->assertSame([], $service->getMessageidsForModel('unknown-model', 10));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Research journal: recordObservation() / getObservations()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_record_observation_defaults_to_preliminary_confidence(): void
+    {
+        $service = $this->newService();
+
+        $id = $service->recordObservation('classify_item_types', 'overall', 'Test finding.');
+
+        $this->assertGreaterThan(0, $id);
+
+        $observations = $service->getObservations();
+        $this->assertCount(1, $observations);
+        $this->assertSame('preliminary', $observations[0]['confidence']);
+        $this->assertSame('Test finding.', $observations[0]['finding']);
+    }
+
+    public function test_record_observation_stores_evidence_as_json(): void
+    {
+        $service = $this->newService();
+
+        $service->recordObservation('scope', 'x', 'finding', 'emerging', ['count' => 5]);
+
+        $observations = $service->getObservations();
+        $this->assertSame(['count' => 5], json_decode($observations[0]['evidence'], true));
+    }
+
+    /**
+     * @dataProvider provideConfidenceFilterCases
+     */
+    public function test_get_observations_filters_by_min_confidence(string $minConfidence, array $expectedFindings): void
+    {
+        $service = $this->newService();
+
+        $service->recordObservation('s', 'a', 'preliminary finding', 'preliminary');
+        $service->recordObservation('s', 'b', 'emerging finding', 'emerging');
+        $service->recordObservation('s', 'c', 'consistent finding', 'consistent');
+        $service->recordObservation('s', 'd', 'verified finding', 'verified');
+
+        $results = array_column($service->getObservations($minConfidence), 'finding');
+        sort($results);
+        $expected = $expectedFindings;
+        sort($expected);
+
+        $this->assertSame($expected, $results);
+    }
+
+    public static function provideConfidenceFilterCases(): array
+    {
+        return [
+            'preliminary returns all' => ['preliminary', ['preliminary finding', 'emerging finding', 'consistent finding', 'verified finding']],
+            'emerging excludes preliminary' => ['emerging', ['emerging finding', 'consistent finding', 'verified finding']],
+            'consistent only consistent and verified' => ['consistent', ['consistent finding', 'verified finding']],
+            'verified only verified' => ['verified', ['verified finding']],
+            'unknown level treated as preliminary (0)' => ['bogus', ['preliminary finding', 'emerging finding', 'consistent finding', 'verified finding']],
+        ];
+    }
+
+    public function test_get_observations_excludes_superseded_entries(): void
+    {
+        // TODO: latent bug — getObservations() filters `WHERE o.supersedes_id IS
+        // NULL`, which keeps the OLD/original row (supersedes_id never set on it)
+        // and HIDES the newer row that supersedes it (that row is the one with
+        // supersedes_id populated). This is inverted: per the class docblock,
+        // observations "can be promoted" as findings recur, and callers should see
+        // the latest/promoted finding, not the one it replaced. Not fixed here per
+        // task instructions (test files only, no production code changes).
+        $this->markTestSkipped('Latent bug in EeeSqliteService::getObservations(): the supersedes_id IS NULL filter keeps the original (superseded) row and hides the newer row that supersedes it — the opposite of "show the latest finding".');
+
+        $service = $this->newService();
+
+        $originalId = $service->recordObservation('s', 'a', 'original finding', 'preliminary');
+        $service->recordObservation('s', 'a', 'updated finding', 'consistent', null, null, $originalId);
+
+        $findings = array_column($service->getObservations(), 'finding');
+
+        $this->assertNotContains('original finding', $findings);
+        $this->assertContains('updated finding', $findings);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // journalItemTypeRun()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_journal_item_type_run_records_only_overall_when_nothing_mixed_or_ambiguous(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertItemType([
+            'item_name' => 'Toaster', 'model' => 'gemini', 'prompt_version' => '1.0.0',
+            'classification_mode' => 'combined', 'is_eee' => 1,
+        ]);
+
+        $runId = $service->startRun('gemini', '1.0.0', 'all');
+        $service->journalItemTypeRun($runId, '1.0.0');
+
+        $scopes = array_column($service->getObservations(), 'scope');
+
+        $this->assertContains('overall', $scopes);
+        $this->assertNotContains('mixed_types', $scopes);
+        $this->assertNotContains('ambiguous_types', $scopes);
+        $this->assertNotContains('photo_quality', $scopes);
+    }
+
+    public function test_journal_item_type_run_records_mixed_types_observation(): void
+    {
+        $service = $this->newService();
+
+        // Nominally non-EEE, but has EEE samples in the mix.
+        $service->upsertItemType([
+            'item_name' => 'Chair', 'model' => 'gemini', 'prompt_version' => '1.0.0',
+            'classification_mode' => 'combined', 'is_eee' => 0, 'eee_sample_count' => 2,
+        ]);
+
+        $runId = $service->startRun('gemini', '1.0.0', 'all');
+        $service->journalItemTypeRun($runId, '1.0.0');
+
+        $scopes = array_column($service->getObservations(), 'scope');
+        $this->assertContains('mixed_types', $scopes);
+    }
+
+    public function test_journal_item_type_run_records_ambiguous_types_observation(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertItemType([
+            'item_name' => 'Lamp', 'model' => 'gemini', 'prompt_version' => '1.0.0',
+            'classification_mode' => 'combined', 'needs_image_analysis' => 1,
+            'is_eee_agree_rate' => 0.4, 'is_eee_confidence' => 0.5,
+        ]);
+
+        $runId = $service->startRun('gemini', '1.0.0', 'all');
+        $service->journalItemTypeRun($runId, '1.0.0');
+
+        $scopes = array_column($service->getObservations(), 'scope');
+        $this->assertContains('ambiguous_types', $scopes);
+    }
+
+    public function test_journal_item_type_run_records_photo_quality_when_present(): void
+    {
+        $service = $this->newService();
+
+        $service->insertClassification($this->classificationRow(['photo_quality' => 4]));
+        $service->insertClassification($this->classificationRow(['messageid' => 2, 'photo_quality' => 2]));
+
+        $runId = $service->startRun('gemini', '1.0.0', 'all');
+        $service->journalItemTypeRun($runId, '1.0.0');
+
+        $photoQualityObs = array_values(array_filter(
+            $service->getObservations(),
+            fn ($o) => $o['scope'] === 'photo_quality'
+        ));
+
+        $this->assertCount(1, $photoQualityObs);
+        $this->assertStringContainsString('3', $photoQualityObs[0]['finding']); // avg of 4 and 2
+    }
+
+    public function test_journal_item_type_run_skips_photo_quality_when_none_recorded(): void
+    {
+        $service = $this->newService();
+
+        $runId = $service->startRun('gemini', '1.0.0', 'all');
+        $service->journalItemTypeRun($runId, '1.0.0');
+
+        $scopes = array_column($service->getObservations(), 'scope');
+        $this->assertNotContains('photo_quality', $scopes);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Component knowledge base
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_get_component_type_by_name_returns_null_when_not_found(): void
+    {
+        $service = $this->newService();
+
+        $this->assertNull($service->getComponentTypeByName('motor'));
+    }
+
+    public function test_upsert_component_type_inserts_with_embedding_blob(): void
+    {
+        $service = $this->newService();
+
+        $embedding = pack('f*', 0.1, 0.2, 0.3);
+        $service->upsertComponentType([
+            'canonical_name' => 'motor',
+            'category'       => 'primary_eee',
+            'embedding'      => $embedding,
+            'raw_strings'    => 'motor,drum motor',
+        ]);
+
+        $row = $service->getComponentTypeByName('motor');
+
+        $this->assertSame('primary_eee', $row['category']);
+        $this->assertSame($embedding, $row['embedding']);
+    }
+
+    public function test_upsert_component_type_inserts_with_null_embedding_and_default_category(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertComponentType(['canonical_name' => 'gasket']);
+
+        $row = $service->getComponentTypeByName('gasket');
+
+        $this->assertSame('unknown', $row['category']);
+        $this->assertNull($row['embedding']);
+    }
+
+    public function test_upsert_component_type_on_conflict_preserves_embedding_when_new_value_is_null(): void
+    {
+        $service = $this->newService();
+
+        $embedding = pack('f*', 0.5, 0.6);
+        $service->upsertComponentType(['canonical_name' => 'motor', 'category' => 'primary_eee', 'embedding' => $embedding]);
+
+        // Re-upsert with a category change but no embedding — COALESCE must keep the old one.
+        $service->upsertComponentType(['canonical_name' => 'motor', 'category' => 'supplementary_eee']);
+
+        $row = $service->getComponentTypeByName('motor');
+
+        $this->assertSame('supplementary_eee', $row['category']);
+        $this->assertSame($embedding, $row['embedding']);
+    }
+
+    public function test_get_component_type_by_name_is_case_insensitive(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertComponentType(['canonical_name' => 'Motor']);
+
+        $this->assertNotNull($service->getComponentTypeByName('MOTOR'));
+        $this->assertNotNull($service->getComponentTypeByName('motor'));
+    }
+
+    public function test_get_component_types_filtered_by_category(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertComponentType(['canonical_name' => 'motor', 'category' => 'primary_eee']);
+        $service->upsertComponentType(['canonical_name' => 'gasket', 'category' => 'non_electrical']);
+
+        $primary = $service->getComponentTypes('primary_eee');
+
+        $this->assertCount(1, $primary);
+        $this->assertSame('motor', $primary[0]['canonical_name']);
+    }
+
+    public function test_get_component_types_without_filter_returns_all(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertComponentType(['canonical_name' => 'motor', 'category' => 'primary_eee']);
+        $service->upsertComponentType(['canonical_name' => 'gasket', 'category' => 'non_electrical']);
+
+        $this->assertCount(2, $service->getComponentTypes());
+    }
+
+    public function test_count_component_types_groups_by_category(): void
+    {
+        $service = $this->newService();
+
+        $service->upsertComponentType(['canonical_name' => 'motor', 'category' => 'primary_eee']);
+        $service->upsertComponentType(['canonical_name' => 'fan motor', 'category' => 'primary_eee']);
+        $service->upsertComponentType(['canonical_name' => 'gasket', 'category' => 'non_electrical']);
+
+        $counts = $service->countComponentTypes();
+
+        $this->assertSame(2, $counts['primary_eee']);
+        $this->assertSame(1, $counts['non_electrical']);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // journalCompareRun()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * @dataProvider provideJournalCompareRunCases
+     */
+    public function test_journal_compare_run_confidence_tiers(array $agreementStats, bool $expectObservation, ?string $expectedConfidence = null): void
+    {
+        $service = $this->newService();
+
+        $runId = $service->startRun('gemini', '1.0.0', 'compare');
+        $service->journalCompareRun($runId, $agreementStats);
+
+        $observations = $service->getObservations();
+
+        if (!$expectObservation) {
+            $this->assertSame([], $observations);
+            return;
+        }
+
+        $this->assertCount(1, $observations);
+        $this->assertSame($expectedConfidence, $observations[0]['confidence']);
+    }
+
+    public static function provideJournalCompareRunCases(): array
+    {
+        return [
+            'missing seen/agree keys is skipped' => [
+                ['gemini' => ['brand' => ['other_key' => 1]]], false,
+            ],
+            'below minimum sample size (seen < 10) is skipped' => [
+                ['gemini' => ['brand' => ['seen' => 9, 'agree' => 9]]], false,
+            ],
+            'consistent tier: seen >= 100 and rate >= 85%' => [
+                ['gemini' => ['brand' => ['seen' => 100, 'agree' => 90]]], true, 'consistent',
+            ],
+            'emerging tier: seen >= 50 but rate below 85%' => [
+                ['gemini' => ['brand' => ['seen' => 60, 'agree' => 30]]], true, 'emerging',
+            ],
+            'emerging tier: seen >= 100 but rate below 85%' => [
+                ['gemini' => ['brand' => ['seen' => 100, 'agree' => 50]]], true, 'emerging',
+            ],
+            'preliminary tier: seen between 10 and 49' => [
+                ['gemini' => ['brand' => ['seen' => 10, 'agree' => 10]]], true, 'preliminary',
+            ],
+        ];
+    }
+
+    public function test_journal_compare_run_records_observation_per_attribute_per_model(): void
+    {
+        $service = $this->newService();
+
+        $runId = $service->startRun('gemini', '1.0.0', 'compare');
+        $service->journalCompareRun($runId, [
+            'gemini' => [
+                'brand'     => ['seen' => 20, 'agree' => 18],
+                'condition' => ['seen' => 20, 'agree' => 10],
+            ],
+            'openai' => [
+                'brand' => ['seen' => 20, 'agree' => 15],
+            ],
+        ]);
+
+        $scopes = array_column($service->getObservations(), 'scope');
+        sort($scopes);
+
+        $this->assertSame([
+            'model:gemini:attr:brand',
+            'model:gemini:attr:condition',
+            'model:openai:attr:brand',
+        ], $scopes);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MicrovolunteeringNotifyServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MicrovolunteeringNotifyServiceTest.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\MicrovolunteeringNotifyService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Unit tests for MicrovolunteeringNotifyService, exercised directly rather
+ * than through the `microvolunteering:notify` artisan command.
+ *
+ * Tests\Feature\AI\MicrovolunteeringNotifyCommandTest already covers the
+ * command's happy-path DB effects (who gets notified for Pending vs Approved
+ * messages, the microactions review exclusion, etc). This class targets what
+ * that Feature test does not:
+ *   - the returned $stats array itself (the command never inspects it)
+ *   - the CANDIDATES_PER_MESSAGE (10) cap via array_rand
+ *   - the alreadyNotifiedToday cross-message exclusion (distinct from the
+ *     per-message MAX_PER_USER existing-count check)
+ *   - the dry-run branch of markStaleReviewedNotificationsSeen (SELECT COUNT
+ *     rather than UPDATE)
+ *   - the users_skipped++ stat for the existing-count-at-cap path specifically
+ */
+class MicrovolunteeringNotifyServiceTest extends TestCase
+{
+    private function createGroup(bool $microvolunteering = true): int
+    {
+        return DB::table('groups')->insertGetId([
+            'nameshort'         => 'TestGroup' . uniqid(),
+            'namefull'          => 'Test Group',
+            'type'              => 'Freegle',
+            'publish'           => 1,
+            'onhere'            => 1,
+            'microvolunteering' => $microvolunteering ? 1 : 0,
+            'polyindex'         => DB::raw("ST_GeomFromText('POINT(-0.1 51.5)', 3857)"),
+        ]);
+    }
+
+    private function createUser(string $trustlevel = 'Basic'): int
+    {
+        $userId = DB::table('users')->insertGetId([
+            'fullname'   => 'Test User ' . uniqid(),
+            'trustlevel' => $trustlevel,
+            'lastaccess' => now(),
+            'added'      => now(),
+        ]);
+
+        $email = 'test-' . uniqid() . '@example.com';
+        DB::table('users_emails')->insert([
+            'userid'    => $userId,
+            'email'     => $email,
+            'backwards' => strrev($email),
+            'preferred' => 1,
+            'added'     => now(),
+        ]);
+
+        return $userId;
+    }
+
+    private function addMembership(int $userId, int $groupId, string $role = 'Member'): void
+    {
+        DB::table('memberships')->insert([
+            'userid'     => $userId,
+            'groupid'    => $groupId,
+            'role'       => $role,
+            'collection' => 'Approved',
+            'added'      => now(),
+        ]);
+    }
+
+    private function createMessage(int $groupId, int $fromuser, string $collection = 'Approved'): int
+    {
+        $msgId = DB::table('messages')->insertGetId([
+            'subject'  => 'OFFER: Test item (Test Area)',
+            'message'  => 'Test item description.',
+            'type'     => 'Offer',
+            'fromuser' => $fromuser,
+            'deleted'  => null,
+            'heldby'   => null,
+        ]);
+
+        DB::table('messages_groups')->insert([
+            'msgid'      => $msgId,
+            'groupid'    => $groupId,
+            'collection' => $collection,
+            'arrival'    => now(),
+        ]);
+
+        return $msgId;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Returned stats array
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_stats_are_all_zero_when_no_messages(): void
+    {
+        $service = new MicrovolunteeringNotifyService();
+
+        $stats = $service->notifyForMessages();
+
+        $this->assertSame([
+            'messages_considered'         => 0,
+            'users_notified'              => 0,
+            'users_skipped'               => 0,
+            'stale_notifications_cleared' => 0,
+        ], $stats);
+    }
+
+    public function test_stats_reflect_a_single_notification(): void
+    {
+        $groupId  = $this->createGroup();
+        $fromUser = $this->createUser('Basic');
+        $reviewer = $this->createUser('Moderate');
+
+        $this->addMembership($fromUser, $groupId);
+        $this->addMembership($reviewer, $groupId);
+
+        $this->createMessage($groupId, $fromUser, 'Pending');
+
+        $service = new MicrovolunteeringNotifyService();
+        $stats   = $service->notifyForMessages();
+
+        $this->assertSame(1, $stats['messages_considered']);
+        $this->assertSame(1, $stats['users_notified']);
+        $this->assertSame(0, $stats['users_skipped']);
+        $this->assertSame(0, $stats['stale_notifications_cleared']);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // CANDIDATES_PER_MESSAGE cap (array_rand branch)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_candidates_are_capped_at_ten_per_message(): void
+    {
+        $groupId  = $this->createGroup();
+        $fromUser = $this->createUser('Basic');
+        $this->addMembership($fromUser, $groupId);
+
+        for ($i = 0; $i < 15; $i++) {
+            $reviewer = $this->createUser('Moderate');
+            $this->addMembership($reviewer, $groupId);
+        }
+
+        $msgId = $this->createMessage($groupId, $fromUser, 'Pending');
+
+        $service = new MicrovolunteeringNotifyService();
+        $stats   = $service->notifyForMessages();
+
+        $this->assertSame(10, $stats['users_notified']);
+
+        $inserted = DB::table('users_notifications')
+            ->where('type', 'Exhort')
+            ->where('url', '/microvolunteering/message/' . $msgId)
+            ->count();
+        $this->assertSame(10, $inserted);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // alreadyNotifiedToday — cross-message exclusion
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_user_notified_about_another_message_today_is_excluded_from_new_message(): void
+    {
+        $groupId  = $this->createGroup();
+        $fromUser = $this->createUser('Basic');
+        $reviewer = $this->createUser('Moderate');
+
+        $this->addMembership($fromUser, $groupId);
+        $this->addMembership($reviewer, $groupId);
+
+        // Reviewer already got an Exhort notification today about a different message.
+        DB::table('users_notifications')->insert([
+            'touser'    => $reviewer,
+            'type'      => 'Exhort',
+            'url'       => '/microvolunteering/message/999999',
+            'timestamp' => now(),
+        ]);
+
+        $msgId = $this->createMessage($groupId, $fromUser, 'Pending');
+
+        $service = new MicrovolunteeringNotifyService();
+        $stats   = $service->notifyForMessages();
+
+        $this->assertSame(1, $stats['messages_considered']);
+        $this->assertSame(0, $stats['users_notified']);
+        $this->assertSame(0, $stats['users_skipped']);
+
+        $this->assertDatabaseMissing('users_notifications', [
+            'touser' => $reviewer,
+            'url'    => '/microvolunteering/message/' . $msgId,
+        ]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // users_skipped++ for the per-message MAX_PER_USER existing-count check
+    // (distinct from the alreadyNotifiedToday pool-filter path: the existing
+    // rows here are deliberately outside the 24h window so the reviewer stays
+    // eligible in the pool and is only rejected by the per-candidate count).
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_users_skipped_increments_when_existing_notifications_for_this_message_hit_cap(): void
+    {
+        $groupId  = $this->createGroup();
+        $fromUser = $this->createUser('Basic');
+        $reviewer = $this->createUser('Moderate');
+
+        $this->addMembership($fromUser, $groupId);
+        $this->addMembership($reviewer, $groupId);
+
+        $msgId = $this->createMessage($groupId, $fromUser, 'Pending');
+        $url   = '/microvolunteering/message/' . $msgId;
+
+        for ($i = 0; $i < 3; $i++) {
+            DB::table('users_notifications')->insert([
+                'touser'    => $reviewer,
+                'type'      => 'Exhort',
+                'url'       => $url,
+                'timestamp' => now()->subDays(2),
+            ]);
+        }
+
+        $service = new MicrovolunteeringNotifyService();
+        $stats   = $service->notifyForMessages();
+
+        $this->assertSame(0, $stats['users_notified']);
+        $this->assertSame(1, $stats['users_skipped']);
+
+        $this->assertSame(3, DB::table('users_notifications')
+            ->where('touser', $reviewer)->where('url', $url)->count());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Dry-run branch of markStaleReviewedNotificationsSeen (SELECT COUNT, no UPDATE)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function test_dry_run_counts_stale_notifications_without_clearing_them(): void
+    {
+        $groupId  = $this->createGroup();
+        $fromUser = $this->createUser('Basic');
+        $reviewer = $this->createUser('Moderate');
+
+        $this->addMembership($fromUser, $groupId);
+        $this->addMembership($reviewer, $groupId);
+
+        $msgId = $this->createMessage($groupId, $fromUser, 'Pending');
+
+        DB::table('microactions')->insert([
+            'actiontype'     => 'CheckMessage',
+            'userid'         => $reviewer,
+            'msgid'          => $msgId,
+            'result'         => 'Approve',
+            'score_negative' => 0,
+        ]);
+
+        $notifId = DB::table('users_notifications')->insertGetId([
+            'touser' => $reviewer,
+            'type'   => 'Exhort',
+            'url'    => '/microvolunteering/message/' . $msgId,
+        ]);
+
+        $service = new MicrovolunteeringNotifyService();
+        $stats   = $service->notifyForMessages(dryRun: true);
+
+        $this->assertSame(1, $stats['stale_notifications_cleared']);
+
+        $this->assertDatabaseHas('users_notifications', [
+            'id'   => $notifId,
+            'seen' => 0,
+        ]);
+    }
+
+    public function test_non_dry_run_actually_clears_stale_notifications_and_matches_stat(): void
+    {
+        $groupId  = $this->createGroup();
+        $fromUser = $this->createUser('Basic');
+        $reviewer = $this->createUser('Moderate');
+
+        $this->addMembership($fromUser, $groupId);
+        $this->addMembership($reviewer, $groupId);
+
+        $msgId = $this->createMessage($groupId, $fromUser, 'Pending');
+
+        DB::table('microactions')->insert([
+            'actiontype'     => 'CheckMessage',
+            'userid'         => $reviewer,
+            'msgid'          => $msgId,
+            'result'         => 'Approve',
+            'score_negative' => 0,
+        ]);
+
+        $notifId = DB::table('users_notifications')->insertGetId([
+            'touser' => $reviewer,
+            'type'   => 'Exhort',
+            'url'    => '/microvolunteering/message/' . $msgId,
+        ]);
+
+        $service = new MicrovolunteeringNotifyService();
+        $stats   = $service->notifyForMessages();
+
+        $this->assertSame(1, $stats['stale_notifications_cleared']);
+
+        $this->assertDatabaseHas('users_notifications', [
+            'id'   => $notifId,
+            'seen' => 1,
+        ]);
+    }
+}

--- a/iznik-nuxt3/components/PostItem.vue
+++ b/iznik-nuxt3/components/PostItem.vue
@@ -163,15 +163,23 @@ const warnings = [
     keywords: ['knife', 'knives', 'sword', 'swords'],
   },
   {
-    type: 'Contact lens solution',
-    message:
-      'Please make sure contact lens solution is sealed and in date - it goes in the eyes, so it needs to be sterile and safe to use.',
+    type: 'Sealed and in date',
+    message: 'Please make sure this is sealed and in date.',
     keywords: [
       'contact lens solution',
       'contact lens fluid',
       'contact lens cleaner',
       'lens solution',
       'lens fluid',
+      'cosmetics',
+      'make up',
+      'makeup',
+      'mascara',
+      'sunscreen',
+      'sun cream',
+      'suncream',
+      'sun lotion',
+      'aftersun',
     ],
   },
   {

--- a/iznik-nuxt3/components/PostItem.vue
+++ b/iznik-nuxt3/components/PostItem.vue
@@ -163,6 +163,18 @@ const warnings = [
     keywords: ['knife', 'knives', 'sword', 'swords'],
   },
   {
+    type: 'Contact lens solution',
+    message:
+      'Please make sure contact lens solution is sealed and in date - it goes in the eyes, so it needs to be sterile and safe to use.',
+    keywords: [
+      'contact lens solution',
+      'contact lens fluid',
+      'contact lens cleaner',
+      'lens solution',
+      'lens fluid',
+    ],
+  },
+  {
     type: 'Free',
     message:
       "Everything on Freegle is given away freely.  You don't need to say that - and it keeps things simpler if you remove it.",

--- a/iznik-nuxt3/components/ProxyImage.vue
+++ b/iznik-nuxt3/components/ProxyImage.vue
@@ -103,6 +103,14 @@ const imgAttrsComputed = computed(() => {
   return undefined
 })
 
+// Whether this fires depends on incidental test data (some rendered image's
+// src happening to contain "gimg_0.jpg"), so it flips covered/uncovered
+// between Playwright runs and repeatedly trips Coveralls' "coverage
+// decreased" check on unrelated PRs - the same disease previously fixed for
+// SpinButton.vue/LoginModal.vue (PR #910/#1007). Excluded from V8/Playwright
+// coverage only; vitest (istanbul, which ignores v8 comments) still counts
+// it, and ProxyImage.spec.js covers it deterministically.
+/* v8 ignore next 5 */
 if (process.client && props.src.includes('gimg_0.jpg')) {
   import('@sentry/browser').then((Sentry) => {
     Sentry.captureMessage('Broken image: ' + props.src)

--- a/iznik-nuxt3/composables/useCompose.js
+++ b/iznik-nuxt3/composables/useCompose.js
@@ -128,10 +128,10 @@ export function setup(type) {
 
   const myid = authStore.user?.id
 
-  if (myid) {
-    // Get our own posts so that we can spot duplicates.
-    messageStore.fetchByUser(myid, false)
-  }
+  // Load our own active posts so PostItem's duplicate check can spot a repost of
+  // something still open (see loadOwnActivePosts). Fire-and-forget: the check is
+  // reactive and lights up as the messages arrive.
+  loadOwnActivePosts(messageStore, myid)
 
   // Update all the refs with initial values
   loggedIn.value = !!myid
@@ -225,6 +225,22 @@ export function setup(type) {
     postcodeValid,
     emailIsntOurs,
   }
+}
+
+// loadOwnActivePosts loads the member's own active posts as FULL messages into the
+// message store's `list`, so PostItem's duplicate check - which reads
+// messageStore.all and compares on item.name - can spot a repost of something still
+// open. fetchByUser only fills byUserList with lean summaries that omit item.name (a
+// slot the check never reads), so pull each active post's full record into `list`
+// (mirrors pages/myposts.vue). No-op when logged out.
+export function loadOwnActivePosts(messageStore, myid) {
+  if (!myid) {
+    return Promise.resolve()
+  }
+
+  return messageStore.fetchByUser(myid, true).then((active) => {
+    ;(active || []).forEach((p) => messageStore.fetch(p.id))
+  })
 }
 
 // makeCanSubmit returns a computed that gates the submit button on message validity.

--- a/iznik-nuxt3/tests/e2e/fixtures.js
+++ b/iznik-nuxt3/tests/e2e/fixtures.js
@@ -335,6 +335,7 @@ const test = base.test.extend({
       /Failed to fetch dynamically imported module.*\.localhost/, // Transient network error loading JS chunks from local dev server under parallel test load — not a production code bug
       /net::ERR_SOCKET_NOT_CONNECTED.*delivery\.ilovefreegle\.org/, // External CDN not accessible in local/Docker test environments
       /Failed to load resource.*delivery\.ilovefreegle\.org/, // External CDN not accessible in local/Docker test environments
+      /Failed to load resource.*yesterday\.ilovefreegle\.org/, // ModYesterday.vue polls the live Yesterday backup host directly (real prod system, not part of the CI Docker stack) — its response code depends on that system's own restore/refresh cycle, outside test control
       /Your focus-trap must have at least one container/, // Bootstrap Vue focus-trap error during modal transitions (transient, non-critical)
       /Failed to load resource.*adtrafficquality\.google.*sodar/, // Google CSE script internally calls sodar (ad traffic quality) — external service, not our code
     ]

--- a/iznik-nuxt3/tests/e2e/test-compare-pages.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-compare-pages.spec.js
@@ -1,0 +1,101 @@
+/**
+ * Tests for the /compare/* pages (pages/compare/index.vue and
+ * pages/compare/[competitor].vue). These are static, unauthenticated
+ * informational pages with no prior e2e coverage: a listing page that links
+ * to one entry per competitor, and a dynamic per-competitor page that either
+ * renders the comparison content or 404s for an unknown slug.
+ */
+
+const { test, expect } = require('./fixtures')
+const { timeouts } = require('./config')
+
+// Kept in sync with constants/comparisons.js — one row per competitor entry.
+const COMPARISONS = [
+  { slug: 'trash-nothing', title: 'Freegle vs Trash Nothing' },
+  { slug: 'olio', title: 'Freegle vs Olio' },
+  { slug: 'freecycle', title: 'Freegle vs Freecycle' },
+  { slug: 'lovejunk', title: 'Freegle vs LoveJunk' },
+  { slug: 'facebook-marketplace', title: 'Freegle vs Facebook Marketplace' },
+  { slug: 'gumtree', title: 'Freegle vs Gumtree' },
+  { slug: 'nextdoor', title: 'Freegle vs Nextdoor' },
+]
+
+test.describe('Compare pages', () => {
+  test('/compare index lists every comparison with a working link', async ({
+    page,
+    waitForNuxtPageLoad,
+  }) => {
+    await page.gotoAndVerify('/compare')
+    await waitForNuxtPageLoad({ timeout: timeouts.navigation.default })
+
+    await expect(page.locator('.compare__title')).toHaveText(
+      'Freegle and the alternatives',
+      { timeout: timeouts.ui.appearance }
+    )
+
+    for (const { slug } of COMPARISONS) {
+      await expect(
+        page.locator(`a.compare__list-link[href="/compare/${slug}"]`)
+      ).toBeVisible()
+    }
+
+    // Link back to help section is present (the mobile nav also has one,
+    // hidden at this desktop viewport, so filter to the visible match).
+    await expect(
+      page.locator('a[href="/help"]').filter({ visible: true }).first()
+    ).toBeVisible()
+  })
+
+  for (const { slug, title } of COMPARISONS) {
+    test(`/compare/${slug} renders the comparison content`, async ({
+      page,
+      waitForNuxtPageLoad,
+    }) => {
+      await page.gotoAndVerify(`/compare/${slug}`)
+      await waitForNuxtPageLoad({ timeout: timeouts.navigation.default })
+
+      await expect(page.locator('.compare__title')).toHaveText(title, {
+        timeout: timeouts.ui.appearance,
+      })
+
+      // At-a-glance table, FAQ section and both CTAs should all render —
+      // these are the branches that are only reachable when `entry` resolves.
+      await expect(page.locator('.compare__table')).toBeVisible()
+      await expect(page.locator('.compare__faq-q').first()).toBeVisible()
+      await expect(page.locator('a.compare__cta-btn[href="/"]')).toBeVisible()
+      await expect(
+        page.locator('a.compare__cta-link[href="/compare"]')
+      ).toBeVisible()
+    })
+  }
+
+  test('/compare/<unknown slug> shows the 404 page', async ({ page }) => {
+    // gotoAndVerify treats any 404 render as a hard failure (it exists to
+    // catch *accidental* 404s on pages that should have loaded) so it can't
+    // be used here — this test is deliberately exercising the 404 branch
+    // that pages/compare/[competitor].vue throws via createError() when the
+    // slug isn't in constants/comparisons.js.
+    //
+    // A real HTTP 404 response for the navigation itself logs a browser
+    // console error, and Sentry captures the resulting "Page not found"
+    // exception — both expected here, so allow them for this deliberate
+    // negative-path test rather than letting the global console-error
+    // listener fail the test.
+    page.addAllowedErrorPattern(
+      /Failed to load resource: the server responded with a status of 404.*compare\/not-a-real-competitor/
+    )
+    page.addAllowedErrorPattern(
+      /\[Exc?eption for Sentry\]:.*Error: Page not found/
+    )
+
+    await page.goto('/compare/not-a-real-competitor', {
+      waitUntil: 'domcontentloaded',
+      timeout: timeouts.navigation.default,
+    })
+
+    await expect(page.locator('body')).toContainText(
+      "Oh no! That page doesn't seem to exist",
+      { timeout: timeouts.ui.appearance }
+    )
+  })
+})

--- a/iznik-nuxt3/tests/e2e/test-informational-pages.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-informational-pages.spec.js
@@ -1,0 +1,191 @@
+/**
+ * e2e coverage for a handful of static, unauthenticated informational pages
+ * that had no Playwright coverage at all: /together, /maintenance, /charity
+ * (including its signup form's conditional branches, without ever actually
+ * submitting it — that hits a real API and would create data), and the
+ * generic 404 error page (error.vue) reached via an unknown route.
+ */
+
+const { test, expect } = require('./fixtures')
+const { timeouts } = require('./config')
+
+test.describe('Together (charity/community landing) page', () => {
+  test('loads with hero, all five feature cards and the video/testimonial sections', async ({
+    page,
+    waitForNuxtPageLoad,
+  }) => {
+    await page.gotoAndVerify('/together')
+    await waitForNuxtPageLoad({ timeout: timeouts.navigation.default })
+
+    await expect(page.locator('.together__hero h1')).toContainText(
+      'Freegle supports charities',
+      { timeout: timeouts.ui.appearance }
+    )
+
+    // Hero action links — the mobile nav also has /find and /give links,
+    // hidden at this desktop viewport, so filter to the visible match.
+    await expect(
+      page.locator('a[href="/charity"]').filter({ visible: true }).first()
+    ).toBeVisible()
+    await expect(
+      page.locator('a[href="/find"]').filter({ visible: true }).first()
+    ).toBeVisible()
+    await expect(
+      page.locator('a[href="/give"]').filter({ visible: true }).first()
+    ).toBeVisible()
+
+    // All five "what Freegle can do" cards render (v-for over `cards`),
+    // plus the static "Coming soon" card which shares the same class.
+    await expect(page.locator('.together__card')).toHaveCount(6)
+    await expect(
+      page.locator('.together__card--charity[href="/charity"]')
+    ).toBeVisible()
+    await expect(
+      page.locator('.together__card--volunteer[href="/volunteerings"]')
+    ).toBeVisible()
+
+    // Video placeholder section (showVideo branch) with its chapter list.
+    await expect(page.locator('.together__video')).toBeVisible()
+    await expect(page.locator('.together__chapter')).toHaveCount(4)
+
+    // Testimonial + logos section (showTestimonial branch).
+    await expect(page.locator('.together__quote')).toBeVisible()
+    await expect(page.locator('.together__logo')).toHaveCount(5)
+
+    // "Coming soon" card and contact mailto link.
+    await expect(page.locator('.together__card--soon')).toBeVisible()
+    await expect(
+      page.locator('a[href^="mailto:partnerships@ilovefreegle.org"]')
+    ).toHaveCount(2)
+  })
+})
+
+test.describe('Maintenance page', () => {
+  test('loads with the maintenance message and a link back home', async ({
+    page,
+    waitForNuxtPageLoad,
+  }) => {
+    await page.gotoAndVerify('/maintenance')
+    await waitForNuxtPageLoad({ timeout: timeouts.navigation.default })
+
+    await expect(page.locator('.maintenance__container h1')).toContainText(
+      "Sorry - we're doing some maintenance",
+      { timeout: timeouts.ui.appearance }
+    )
+    await expect(
+      page.locator('.maintenance__container a[href="/"]')
+    ).toBeVisible()
+    await expect(
+      page.locator('a[href*="paypal.com/gb/fundraiser/charity"]')
+    ).toBeVisible()
+  })
+})
+
+test.describe('Charity partner signup page', () => {
+  test('loads with hero and preview content, and scrolling to the form works', async ({
+    page,
+    waitForNuxtPageLoad,
+  }) => {
+    await page.gotoAndVerify('/charity')
+    await waitForNuxtPageLoad({ timeout: timeouts.navigation.default })
+
+    await expect(page.locator('.hero-title')).toHaveText(
+      'Partner with Freegle',
+      { timeout: timeouts.ui.appearance }
+    )
+
+    // Post preview mockup (always rendered — no conditional here, but it
+    // pulls in CharityBadge, which otherwise has no e2e coverage).
+    await expect(page.locator('.phone-mockup')).toBeVisible()
+    await expect(page.locator('.browse-card--charity').first()).toBeVisible()
+
+    // Clicking the hero CTA scrolls the signup form into view.
+    await page.locator('.hero-cta-btn').click()
+    await expect(page.locator('#signup')).toBeInViewport({
+      timeout: timeouts.ui.appearance,
+    })
+  })
+
+  test('submit is disabled until required fields are filled, and org type toggles the right conditional field', async ({
+    page,
+    waitForNuxtPageLoad,
+  }) => {
+    await page.gotoAndVerify('/charity')
+    await waitForNuxtPageLoad({ timeout: timeouts.navigation.default })
+
+    const submitBtn = page.locator('.submit-btn')
+    await expect(submitBtn).toBeVisible({ timeout: timeouts.ui.appearance })
+
+    // Nothing filled in yet — submit must be disabled (canSubmit === false).
+    await expect(submitBtn).toBeDisabled()
+
+    // Neither conditional field is shown until an org type is picked.
+    await expect(page.locator('#charity-number')).toHaveCount(0)
+    await expect(page.locator('#org-details')).toHaveCount(0)
+
+    await page.locator('#org-name').fill('Wandsworth Community Aid')
+    await page.locator('#contact-email').fill('info@example-charity.org.uk')
+
+    // Still disabled — no org type selected yet.
+    await expect(submitBtn).toBeDisabled()
+
+    // Picking "Registered charity" reveals the charity-number field only.
+    await page.getByLabel('Registered charity').check()
+    await expect(page.locator('#charity-number')).toBeVisible()
+    await expect(page.locator('#org-details')).toHaveCount(0)
+    await expect(submitBtn).toBeEnabled()
+
+    // Switching to "Other community organisation" swaps which field shows.
+    await page
+      .getByLabel('Other community organisation (CIC, trust, etc.)')
+      .check()
+    await expect(page.locator('#org-details')).toBeVisible()
+    await expect(page.locator('#charity-number')).toHaveCount(0)
+    await expect(submitBtn).toBeEnabled()
+  })
+
+  test('has a link to sign up as an individual instead', async ({
+    page,
+    waitForNuxtPageLoad,
+  }) => {
+    await page.gotoAndVerify('/charity')
+    await waitForNuxtPageLoad({ timeout: timeouts.navigation.default })
+
+    await expect(page.locator('a[href="/explore"]')).toBeVisible({
+      timeout: timeouts.ui.appearance,
+    })
+  })
+})
+
+test.describe('404 page', () => {
+  test('an unknown route shows the "page not found" message', async ({
+    page,
+  }) => {
+    // gotoAndVerify treats any 404 render as a hard failure (it exists to
+    // catch *accidental* 404s on pages that should have loaded), so it can't
+    // be used to test the 404 page itself — use page.goto() directly.
+    //
+    // A real HTTP 404 response for the navigation itself logs a browser
+    // console error, and Sentry captures the resulting "Page not found"
+    // exception — both expected here, so allow them for this deliberate
+    // negative-path test rather than letting the global console-error
+    // listener fail the test.
+    page.addAllowedErrorPattern(
+      /Failed to load resource: the server responded with a status of 404.*this-route-does-not-exist-e2e-check/
+    )
+    page.addAllowedErrorPattern(
+      /\[Exc?eption for Sentry\]:.*Error: Page not found/
+    )
+
+    await page.goto('/this-route-does-not-exist-e2e-check', {
+      waitUntil: 'domcontentloaded',
+      timeout: timeouts.navigation.default,
+    })
+
+    await expect(page.locator('body')).toContainText(
+      "Oh no! That page doesn't seem to exist",
+      { timeout: timeouts.ui.appearance }
+    )
+    await expect(page.locator('a[href="/"]')).toBeVisible()
+  })
+})

--- a/iznik-nuxt3/tests/e2e/test-modtools-move-message.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-modtools-move-message.spec.js
@@ -47,9 +47,15 @@ test.describe('ModTools move message', () => {
         .catch(() => {})
     }
 
-    // Step 3: Try both groups — the message may be on either one from a previous run.
-    // Navigate to the group that has the approved message.
+    // Step 3: Try both groups — the message may be on either one from a
+    // previous run, since this very test moves it from whichever group it
+    // starts on to the other and never moves it back. Check for THIS
+    // specific message's card, not just any card on the page - a previous
+    // run can easily leave an unrelated approved message (e.g. the WANTED
+    // fixture message) on the first group we check, which would otherwise
+    // make the loop stop one group too early.
     let foundGroup = null
+    const messageCard = page.locator(`#msg-${msgId}`)
 
     for (const gid of [group1Id, group2Id]) {
       await page.goto(`${MODTOOLS_URL}/messages/approved/${gid}`, {
@@ -61,32 +67,27 @@ test.describe('ModTools move message', () => {
         timeout: timeouts.navigation.slowPage,
       })
 
-      // Check if messages are visible (short timeout)
+      // Check if this specific message is visible (short timeout)
       try {
-        await expect(page.locator('.card').first()).toBeVisible({
+        await expect(messageCard).toBeVisible({
           timeout: 15000,
         })
         foundGroup = gid
-        console.log(`Found approved messages on group ${gid}`)
+        console.log(`Found message ${msgId} on group ${gid}`)
         break
       } catch {
-        console.log(`No approved messages on group ${gid}, trying next...`)
+        console.log(`Message ${msgId} not on group ${gid}, trying next...`)
       }
     }
 
     expect(foundGroup).toBeTruthy()
 
-    // Step 4: Locate this specific message's card. Cards render fully expanded
-    // by default (ModMessage's `summary` prop defaults to false), so there is
-    // nothing to click to "expand" it — a blind click on the whole card is
-    // unsafe, since depending on the card's content height it can land on any
-    // of the card's own interactive elements (e.g. the "View rippling reach"
-    // button), opening an unrelated fullscreen modal that then blocks every
-    // other click on the page.
-    const messageCard = page.locator(`#msg-${msgId}`)
-    await expect(messageCard).toBeVisible({
-      timeout: timeouts.ui.appearance,
-    })
+    // Step 4: Cards render fully expanded by default (ModMessage's `summary`
+    // prop defaults to false), so there is nothing to click to "expand" it -
+    // a blind click on the whole card is unsafe, since depending on the
+    // card's content height it can land on any of the card's own interactive
+    // elements (e.g. the "View rippling reach" button), opening an unrelated
+    // fullscreen modal that then blocks every other click on the page.
 
     // Step 5: Click the Edit button, scoped to this message's card so it
     // can't resolve to a different (already-visible) message in the queue.

--- a/iznik-nuxt3/tests/e2e/test-post-item-warnings.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-post-item-warnings.spec.js
@@ -1,0 +1,362 @@
+/**
+ * Tests for the item-name warning banners shown while composing a post
+ * (components/PostItem.vue).
+ *
+ * Covers the "Sealed and in date" warning added for contact lens solution
+ * and similar regulated items, plus the neighbouring validation branches in
+ * the same component that had no e2e coverage at all: the other
+ * keyword-triggered safety warnings, the hard-blocked unpostable-item
+ * messages, the soft "too vague" nudge, and the duplicate-open-post check.
+ */
+
+const { test, expect } = require('./fixtures')
+const { timeouts } = require('./config')
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 }
+
+// Locates the item-name input within the compose form, regardless of
+// whether we're on /give (Offer) or /find (Wanted).
+function itemInputLocator(page) {
+  return page
+    .locator('.post-item-container')
+    .locator('input[placeholder*="single word"], input[id^="what"]')
+    .first()
+}
+
+// The keyword-triggered warning renders as an <h1> with the warning's
+// "type" as its text (see PostItem.vue). Scoped to the compose form so it
+// can't collide with unrelated h1.header--size3 elements elsewhere on the
+// page (e.g. ExploreNearby, MicroVolunteering).
+function warningHeadingLocator(page) {
+  return page.locator('.post-item-container h1.header--size3')
+}
+
+test.describe('PostItem compose warnings (desktop)', () => {
+  test.use({ viewport: DESKTOP_VIEWPORT })
+
+  test('Shows the correct regulated-item warning (or none) across a range of items - OFFER', async ({
+    page,
+  }) => {
+    await page.gotoAndVerify('/give', {
+      timeout: timeouts.navigation.default,
+    })
+
+    const itemInput = itemInputLocator(page)
+    await itemInput.waitFor({
+      state: 'visible',
+      timeout: timeouts.ui.appearance,
+    })
+
+    // [item text, expected warning heading (or null for no warning)]
+    const cases = [
+      ['contact lens solution', 'Sealed and in date'],
+      ['sunscreen', 'Sealed and in date'],
+      ['wooden bookshelf', null],
+      ['knife', 'Knives'],
+      ['car seat', 'Car seats'],
+      ['motorcycle helmet', 'Motorcycle and cycle helmets'],
+      ['cot mattress', 'Cot Mattress'],
+      ['leather sofa', 'Upholstered household items and furniture'],
+      ['lamp - free to a good home', 'Free'],
+      ['giant hogweed', 'Banned Plants'],
+      ['bicycle', null],
+    ]
+
+    for (const [itemText, expectedType] of cases) {
+      await itemInput.fill(itemText)
+
+      if (expectedType) {
+        const heading = warningHeadingLocator(page)
+        await expect(heading).toBeVisible({
+          timeout: timeouts.assertion.slow,
+        })
+        await expect(heading).toContainText(expectedType)
+        console.log(`"${itemText}" correctly showed "${expectedType}" warning`)
+      } else {
+        await expect(warningHeadingLocator(page)).toHaveCount(0)
+        console.log(`"${itemText}" correctly showed no keyword warning`)
+      }
+    }
+
+    // The PR's actual new copy - verify the message text, not just the heading.
+    await itemInput.fill('contact lens fluid')
+    await expect(
+      page
+        .locator('.post-item-container')
+        .getByText('Please make sure this is sealed and in date.')
+    ).toBeVisible({ timeout: timeouts.assertion.slow })
+  })
+
+  test('Shows the sealed-and-in-date warning on the WANTED flow too, and not for unrelated items', async ({
+    page,
+  }) => {
+    await page.gotoAndVerify('/find', {
+      timeout: timeouts.navigation.default,
+    })
+
+    const itemInput = itemInputLocator(page)
+    await itemInput.waitFor({
+      state: 'visible',
+      timeout: timeouts.ui.appearance,
+    })
+
+    await itemInput.fill('contact lens cleaner')
+    const heading = warningHeadingLocator(page)
+    await expect(heading).toBeVisible({ timeout: timeouts.assertion.slow })
+    await expect(heading).toContainText('Sealed and in date')
+    console.log('WANTED flow correctly showed the sealed-and-in-date warning')
+
+    // Unrelated item on the WANTED flow shows no warning.
+    await itemInput.fill('office chair')
+    await expect(warningHeadingLocator(page)).toHaveCount(0)
+    console.log('WANTED flow correctly showed no warning for an unrelated item')
+  })
+
+  test('Blocks unpostable items and nudges on overly-vague ones - OFFER', async ({
+    page,
+  }) => {
+    await page.gotoAndVerify('/give', {
+      timeout: timeouts.navigation.default,
+    })
+
+    const itemInput = itemInputLocator(page)
+    await itemInput.waitFor({
+      state: 'visible',
+      timeout: timeouts.ui.appearance,
+    })
+    const form = page.locator('.post-item-container')
+
+    // Hard block: numeric-only item.
+    await itemInput.fill('123')
+    await expect(form.getByText(/not a valid item/i)).toBeVisible({
+      timeout: timeouts.assertion.slow,
+    })
+    console.log('Numeric-only item correctly hard-blocked')
+
+    // Hard block: content-free catch-all item.
+    await itemInput.fill('anything')
+    await expect(
+      form.getByText(/isn.t enough for people to know what you mean/i)
+    ).toBeVisible({ timeout: timeouts.assertion.slow })
+    console.log('Catch-all "anything" item correctly hard-blocked')
+
+    // Soft nudge: overly general but postable term - not a hard block.
+    await itemInput.fill('furniture')
+    await expect(form.getByText(/avoid very general terms/i)).toBeVisible({
+      timeout: timeouts.assertion.slow,
+    })
+    await expect(form.getByText(/not a valid item/i)).toHaveCount(0)
+    await expect(
+      form.getByText(/isn.t enough for people to know what you mean/i)
+    ).toHaveCount(0)
+    console.log('Overly-general "furniture" item correctly soft-nudged only')
+
+    // A specific, valid item shows none of the above.
+    await itemInput.fill('quality garden tools')
+    await expect(form.getByText(/not a valid item/i)).toHaveCount(0)
+    await expect(
+      form.getByText(/isn.t enough for people to know what you mean/i)
+    ).toHaveCount(0)
+    await expect(form.getByText(/avoid very general terms/i)).toHaveCount(0)
+    console.log('Specific valid item correctly showed no validation warnings')
+  })
+
+  test('Contact-lens-solution item can still be posted end to end (OFFER)', async ({
+    page,
+    testEmail,
+    postMessage,
+    withdrawPost,
+  }) => {
+    const uniqueItem = `contact lens solution ${Date.now()}${Math.floor(
+      Math.random() * 100
+    )}`
+
+    const result = await postMessage({
+      type: 'OFFER',
+      item: uniqueItem,
+      description:
+        'Unopened contact lens solution, still sealed and in date. Created by automated test.',
+      email: testEmail,
+    })
+
+    expect(result.id).toBeTruthy()
+    console.log(
+      `Contact-lens-solution OFFER posted successfully with ID: ${result.id}`
+    )
+
+    await withdrawPost({ item: result.item })
+  })
+
+  test('Contact-lens-solution item can still be posted end to end (WANTED)', async ({
+    page,
+    testEmail,
+    postMessage,
+    withdrawPost,
+  }) => {
+    const uniqueItem = `contact lens solution wanted ${Date.now()}${Math.floor(
+      Math.random() * 100
+    )}`
+
+    const result = await postMessage({
+      type: 'WANTED',
+      item: uniqueItem,
+      description:
+        'Looking for contact lens solution. Created by automated test.',
+      email: testEmail,
+    })
+
+    expect(result.id).toBeTruthy()
+    console.log(
+      `Contact-lens-solution WANTED posted successfully with ID: ${result.id}`
+    )
+
+    await withdrawPost({ item: result.item })
+  })
+
+  test('Detects a duplicate open post with the same item name', async ({
+    page,
+    testEmail,
+    postMessage,
+    withdrawPost,
+  }) => {
+    const uniqueItem = `test duplicate item ${Date.now()}${Math.floor(
+      Math.random() * 100
+    )}`
+
+    const first = await postMessage({
+      type: 'OFFER',
+      item: uniqueItem,
+      description:
+        'First post, left open on purpose to test duplicate detection.',
+      email: testEmail,
+    })
+    expect(first.id).toBeTruthy()
+
+    try {
+      // postMessage() lands on /myposts, whose mount awaits
+      // messageStore.fetch(id) for every active post before it stops showing
+      // its loading state (see the `myid` watcher in pages/myposts.vue) -
+      // populating messageStore.list, which is what PostItem's duplicate
+      // check actually reads (via messageStore.all). That population lives
+      // only in this tab's Pinia store: a hard reload (page.goto/
+      // page.reload) wipes it, and /give's own mount never repopulates
+      // messageStore.list.
+      //
+      // TODO: latent bug - duplicate-open-post detection in PostItem.vue
+      // only works if messageStore.list already happens to hold the user's
+      // other posts from earlier in the same session (e.g. a /myposts
+      // visit); loading /give or /find directly never shows the warning.
+      // useCompose.js:133 fires a messageStore.fetchByUser() call that looks
+      // like it should cover this gap, but it's fire-and-forget (not
+      // awaited by setup()) AND it writes into messageStore.byUserList, a
+      // different key that the duplicate check does not read - so it can
+      // never populate messageStore.list no matter how long you wait.
+      // This test therefore navigates the way a real user does right after
+      // posting - via the in-app nav link (a client-side transition that
+      // preserves the Pinia store) - rather than a reload.
+      await expect(page).toHaveURL(/\/myposts/, {
+        timeout: timeouts.navigation.default,
+      })
+
+      const messageCard = page
+        .locator(`.message-card:has-text("${uniqueItem}")`)
+        .first()
+      await expect(messageCard).toBeVisible({
+        timeout: timeouts.ui.appearance,
+      })
+
+      await page.locator('#menu-option-give').click()
+      await expect(page).toHaveURL(/\/give/, {
+        timeout: timeouts.navigation.default,
+      })
+
+      const itemInput = itemInputLocator(page)
+      await itemInput.waitFor({
+        state: 'visible',
+        timeout: timeouts.ui.appearance,
+      })
+      await itemInput.fill(uniqueItem)
+
+      const duplicateWarning = page
+        .locator('.post-item-container')
+        .getByText(/already have an open post/i)
+      await expect(duplicateWarning).toBeVisible({
+        timeout: timeouts.assertion.slow,
+      })
+      console.log('Duplicate-open-post warning correctly shown')
+    } finally {
+      await withdrawPost({ item: first.item })
+    }
+  })
+
+  test('Shows a keyword warning inside the Edit-post modal (edititem prop branch)', async ({
+    page,
+    testEmail,
+    postMessage,
+    withdrawPost,
+  }) => {
+    // MessageEditModal renders PostItem with edit/edititem props instead of
+    // the compose store the /give and /find flows use above - a separate
+    // code path through the same component (see the `item` computed's
+    // props.edit branch in PostItem.vue) that had no e2e coverage at all.
+    const uniqueItem = `plain bookshelf ${Date.now()}${Math.floor(
+      Math.random() * 100
+    )}`
+
+    const result = await postMessage({
+      type: 'OFFER',
+      item: uniqueItem,
+      description:
+        'A plain item with no warnings, to be edited. Created by automated test.',
+      email: testEmail,
+    })
+    expect(result.id).toBeTruthy()
+
+    try {
+      await expect(page).toHaveURL(/\/myposts/, {
+        timeout: timeouts.navigation.default,
+      })
+
+      const messageCard = page
+        .locator(`.message-card:has-text("${uniqueItem}")`)
+        .first()
+      await expect(messageCard).toBeVisible({
+        timeout: timeouts.ui.appearance,
+      })
+      await messageCard.locator('button:has-text("Edit")').first().click()
+
+      const editModal = page.locator('.modal.show')
+      await expect(editModal).toBeVisible({ timeout: timeouts.ui.appearance })
+
+      const editItemInput = editModal
+        .locator('input[placeholder*="single word"], input[id^="what"]')
+        .first()
+      await expect(editItemInput).toHaveValue(uniqueItem, {
+        timeout: timeouts.ui.appearance,
+      })
+
+      // No warning yet for the plain item name.
+      await expect(editModal.locator('h1.header--size3')).toHaveCount(0)
+
+      await editItemInput.fill('contact lens solution')
+
+      const editWarningHeading = editModal.locator('h1.header--size3')
+      await expect(editWarningHeading).toBeVisible({
+        timeout: timeouts.assertion.slow,
+      })
+      await expect(editWarningHeading).toContainText('Sealed and in date')
+      console.log(
+        'Edit modal correctly showed the sealed-and-in-date warning via the edititem branch'
+      )
+
+      // Cancel without saving - the original item name stands, so cleanup
+      // below can still find it by its original text.
+      await editModal.locator('button:has-text("Cancel")').first().click()
+      await expect(editModal).not.toBeVisible({
+        timeout: timeouts.ui.appearance,
+      })
+    } finally {
+      await withdrawPost({ item: result.item })
+    }
+  })
+})

--- a/iznik-nuxt3/tests/e2e/test-post-item-warnings.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-post-item-warnings.spec.js
@@ -233,39 +233,16 @@ test.describe('PostItem compose warnings (desktop)', () => {
     expect(first.id).toBeTruthy()
 
     try {
-      // postMessage() lands on /myposts, whose mount awaits
-      // messageStore.fetch(id) for every active post before it stops showing
-      // its loading state (see the `myid` watcher in pages/myposts.vue) -
-      // populating messageStore.list, which is what PostItem's duplicate
-      // check actually reads (via messageStore.all). That population lives
-      // only in this tab's Pinia store: a hard reload (page.goto/
-      // page.reload) wipes it, and /give's own mount never repopulates
-      // messageStore.list.
-      //
-      // TODO: latent bug - duplicate-open-post detection in PostItem.vue
-      // only works if messageStore.list already happens to hold the user's
-      // other posts from earlier in the same session (e.g. a /myposts
-      // visit); loading /give or /find directly never shows the warning.
-      // useCompose.js:133 fires a messageStore.fetchByUser() call that looks
-      // like it should cover this gap, but it's fire-and-forget (not
-      // awaited by setup()) AND it writes into messageStore.byUserList, a
-      // different key that the duplicate check does not read - so it can
-      // never populate messageStore.list no matter how long you wait.
-      // This test therefore navigates the way a real user does right after
-      // posting - via the in-app nav link (a client-side transition that
-      // preserves the Pinia store) - rather than a reload.
+      // Load /give with a fresh full page load (page.goto wipes the Pinia store),
+      // the way a member arriving directly to post does - not a client-side nav that
+      // would carry over a prior /myposts fetch. useCompose loads the member's active
+      // posts as full messages into messageStore.list on mount, so the duplicate
+      // check finds the still-open first post even on a cold /give visit.
       await expect(page).toHaveURL(/\/myposts/, {
         timeout: timeouts.navigation.default,
       })
 
-      const messageCard = page
-        .locator(`.message-card:has-text("${uniqueItem}")`)
-        .first()
-      await expect(messageCard).toBeVisible({
-        timeout: timeouts.ui.appearance,
-      })
-
-      await page.locator('#menu-option-give').click()
+      await page.goto('/give')
       await expect(page).toHaveURL(/\/give/, {
         timeout: timeouts.navigation.default,
       })

--- a/iznik-nuxt3/tests/e2e/test-proxy-image-branches.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-proxy-image-branches.spec.js
@@ -1,0 +1,108 @@
+/**
+ * Deterministic coverage for two small, stable, always-on-master components
+ * whose Playwright coverage flips run-to-run because nothing explicitly
+ * waits for them to finish rendering (the same "timing-dependent line"
+ * disease previously found in SpinButton.vue / LoginModal.vue):
+ *
+ *  - components/ProxyImage.vue: the preloadValue/imgAttrsComputed branches
+ *    (preload+fetchpriority vs neither) only both execute if a page renders
+ *    both variants and something actually waits for them; the fullSrc
+ *    branches (prepend USER_SITE, encode a '?' query string) only execute
+ *    for a src that needs both transforms.
+ *  - components/SupportLink.vue: wrapped in <client-only>, so it mounts on
+ *    a post-hydration tick; the href computed also branches on logged-in
+ *    vs logged-out.
+ *
+ * FreeglerPhotoGrid.vue (rendered on the logged-out homepage) passes image
+ * 1 preload+fetchpriority="high" and image 3 neither, exercising both
+ * ProxyImage branches in one render. NationalReuseDay.vue's banner
+ * (src="/NRD/Banner.png?a=1", non-http, contains '?') exercises the
+ * fullSrc branches, and its SupportLink exercises both auth branches.
+ */
+const { test, expect } = require('./fixtures')
+const { timeouts } = require('./config')
+const { loginViaHomepage } = require('./utils/user')
+
+test.describe('ProxyImage and SupportLink branch coverage', () => {
+  test('logged-out homepage photo grid: first image gets preload+fetchpriority, a later one gets neither', async ({
+    page,
+    waitForNuxtPageLoad,
+  }) => {
+    await page.gotoAndVerify('/')
+    await waitForNuxtPageLoad({ timeout: timeouts.ui.appearance })
+
+    const grid = page.locator('.photo-grid')
+    await expect(grid).toBeVisible({ timeout: timeouts.ui.appearance })
+
+    const firstImg = grid.locator('.photo-cell:nth-child(1) img')
+    await expect(firstImg).toBeVisible({ timeout: timeouts.ui.appearance })
+    await expect(firstImg).toHaveAttribute('fetchpriority', 'high')
+
+    const thirdImg = grid.locator('.photo-cell:nth-child(3) img')
+    await expect(thirdImg).toBeVisible({ timeout: timeouts.ui.appearance })
+    expect(await thirdImg.getAttribute('fetchpriority')).toBeNull()
+
+    // Both resolve through ProxyImage's fullSrc computed, which prepends
+    // USER_SITE to the non-http /landingpage/... src before handing it to
+    // the weserv provider as the proxied url= param.
+    const firstSrc = await firstImg.getAttribute('src')
+    expect(firstSrc).toContain('/landingpage/Freegler')
+  })
+
+  test('National Reuse Day: banner image resolves the non-http + query-string branches, and the logged-out support link renders', async ({
+    page,
+    waitForNuxtPageLoad,
+  }) => {
+    await page.gotoAndVerify('/NationalReuseDay')
+    await waitForNuxtPageLoad({ timeout: timeouts.ui.appearance })
+
+    const banner = page.locator('img[alt="National Reuse Day banner"]')
+    await expect(banner).toBeVisible({ timeout: timeouts.ui.appearance })
+
+    // fullSrc must have prepended the site origin (didn't start with http)
+    // and correctly re-encoded the '?a=1' query string (encodeURIComponent
+    // turns 'a=1' into 'a%3D1') before handing it to the weserv provider.
+    const bannerSrc = await banner.getAttribute('src')
+    expect(bannerSrc).toContain('/NRD/Banner.png?a%3D1')
+
+    // SupportLink is <client-only>; wait for its mailto link explicitly
+    // rather than relying on the page title, so hydration has actually
+    // finished before the test (and coverage collection) ends.
+    const supportLink = page.locator(
+      'a[href^="mailto:partnerships@ilovefreegle.org"]'
+    )
+    await expect(supportLink).toBeVisible({ timeout: timeouts.ui.appearance })
+    const loggedOutHref = await supportLink.getAttribute('href')
+    expect(loggedOutHref).toContain('not logged in when contacting Support')
+  })
+
+  test('National Reuse Day: logged-in support link href includes the user id note', async ({
+    page,
+    testEnv,
+  }) => {
+    // TODO: latent bug - SupportLink.vue's `const myid = authStore.user?.id`
+    // (line 29) is a plain, non-reactive const captured once when the
+    // <client-only>-wrapped component's <script setup> runs. Confirmed via
+    // this exact session (login + /qr showing genuine mod-only content,
+    // proving the user really is authenticated): the mailto href still says
+    // "not logged in when contacting Support", because SupportLink's own
+    // setup ran before the auth store finished restoring from localStorage,
+    // and nothing re-evaluates myid afterwards. Not fixed here (production
+    // code is out of scope for this PR) - see PR comment.
+    test.skip(
+      true,
+      'latent bug: SupportLink.vue myid is captured non-reactively and never reflects a login that completes after its own client-only mount'
+    )
+
+    await loginViaHomepage(page, testEnv.user.email, 'freegle')
+
+    await page.gotoAndVerify('/NationalReuseDay')
+
+    const supportLink = page.locator(
+      'a[href^="mailto:partnerships@ilovefreegle.org"]'
+    )
+    await expect(supportLink).toBeVisible({ timeout: timeouts.ui.appearance })
+    const loggedInHref = await supportLink.getAttribute('href')
+    expect(loggedInHref).toContain('logged in as user id')
+  })
+})

--- a/iznik-nuxt3/tests/e2e/test-proxy-image-branches.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-proxy-image-branches.spec.js
@@ -17,7 +17,12 @@
  * 1 preload+fetchpriority="high" and image 3 neither, exercising both
  * ProxyImage branches in one render. NationalReuseDay.vue's banner
  * (src="/NRD/Banner.png?a=1", non-http, contains '?') exercises the
- * fullSrc branches, and its SupportLink exercises both auth branches.
+ * fullSrc branches, and its (logged-out) SupportLink covers that branch.
+ * The logged-in SupportLink branch is exercised on /mobile instead:
+ * NationalReuseDay uses the 'no-navbar' layout, which never calls
+ * useBootSession()/fetchMe(), so authStore.user is never populated there
+ * regardless of login - see the comment on that test below. /mobile uses
+ * the default layout (which does boot the session).
  */
 const { test, expect } = require('./fixtures')
 const { timeouts } = require('./config')
@@ -76,33 +81,31 @@ test.describe('ProxyImage and SupportLink branch coverage', () => {
     expect(loggedOutHref).toContain('not logged in when contacting Support')
   })
 
-  test('National Reuse Day: logged-in support link href includes the user id note', async ({
+  test('Mobile app page: logged-in support link href includes the user id note', async ({
     page,
     testEnv,
   }) => {
-    // TODO: latent bug - SupportLink.vue's `const myid = authStore.user?.id`
-    // (line 29) is a plain, non-reactive const captured once when the
-    // <client-only>-wrapped component's <script setup> runs. Confirmed via
-    // this exact session (login + /qr showing genuine mod-only content,
-    // proving the user really is authenticated): the mailto href still says
-    // "not logged in when contacting Support", because SupportLink's own
-    // setup ran before the auth store finished restoring from localStorage,
-    // and nothing re-evaluates myid afterwards. Not fixed here (production
-    // code is out of scope for this PR) - see PR comment.
-    test.skip(
-      true,
-      'latent bug: SupportLink.vue myid is captured non-reactively and never reflects a login that completes after its own client-only mount'
-    )
-
+    // NationalReuseDay uses the 'no-navbar' layout, which never calls
+    // useBootSession()/fetchMe() - so authStore.user is never populated
+    // there regardless of login, and SupportLink's logged-in branch can't be
+    // observed on that page. /mobile uses the default layout (which does
+    // boot the session) and also renders a plain, unconditional
+    // <SupportLink /> - see components/ProxyImage.vue coverage tests above
+    // for why NationalReuseDay is still the right page for the other
+    // branches.
     await loginViaHomepage(page, testEnv.user.email, 'freegle')
 
-    await page.gotoAndVerify('/NationalReuseDay')
+    await page.gotoAndVerify('/mobile')
 
     const supportLink = page.locator(
-      'a[href^="mailto:partnerships@ilovefreegle.org"]'
+      'a[href^="mailto:support@ilovefreegle.org"]'
     )
-    await expect(supportLink).toBeVisible({ timeout: timeouts.ui.appearance })
-    const loggedInHref = await supportLink.getAttribute('href')
-    expect(loggedInHref).toContain('logged in as user id')
+    // Poll the attribute itself (rather than a single getAttribute snapshot
+    // right after visibility) since the default layout's session boot and
+    // this <client-only> component's own mount both happen asynchronously,
+    // in no guaranteed order.
+    await expect(supportLink).toHaveAttribute('href', /logged in as user id/, {
+      timeout: timeouts.ui.appearance,
+    })
   })
 })

--- a/iznik-nuxt3/tests/e2e/test-qr-page.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-qr-page.spec.js
@@ -1,0 +1,109 @@
+/**
+ * Tests for the QR code generator page (pages/qr.vue), which had no e2e
+ * coverage at all. The page has three mutually-exclusive branches gated on
+ * auth/mod state:
+ *   - not logged in: a "log in to continue" prompt
+ *   - logged in, not a mod: a "volunteers only" warning
+ *   - logged in as a mod: the actual QR generator (qr-code-styling), which
+ *     reacts to URL input changes and supports a PNG download
+ * All three are exercised here, plus the generator's empty-URL and
+ * URL-change branches.
+ */
+
+const { test, expect } = require('./fixtures')
+const { timeouts } = require('./config')
+const { loginViaHomepage } = require('./utils/user')
+
+test.describe('QR code generator page (/qr)', () => {
+  test('not logged in: shows a login prompt, and clicking it opens the login modal', async ({
+    page,
+  }) => {
+    await page.gotoAndVerify('/qr')
+
+    const page_ = page.locator('.qr-page')
+    await expect(
+      page_.getByText(
+        'This page is only available to Freegle volunteers. Please log in to continue.'
+      )
+    ).toBeVisible({ timeout: timeouts.ui.appearance })
+
+    // Neither of the other two branches' content is present.
+    await expect(page_.locator('#qr-url')).toHaveCount(0)
+    await expect(
+      page_.getByText('Sorry, this page is only available to Freegle volunteers.')
+    ).toHaveCount(0)
+
+    await page_.locator('button:has-text("Log in to continue")').click()
+
+    await expect(page.locator('#loginModal')).toBeVisible({
+      timeout: timeouts.ui.appearance,
+    })
+    console.log('Logged-out /qr correctly prompted login and opened the modal')
+  })
+
+  test('logged in as a regular (non-mod) user: shows the volunteers-only message, not the generator', async ({
+    page,
+    testEnv,
+  }) => {
+    await loginViaHomepage(page, testEnv.user.email, 'freegle')
+
+    await page.gotoAndVerify('/qr')
+
+    const page_ = page.locator('.qr-page')
+    await expect(
+      page_.getByText('Sorry, this page is only available to Freegle volunteers.')
+    ).toBeVisible({ timeout: timeouts.ui.appearance })
+
+    // Neither the generator nor the logged-out prompt is present.
+    await expect(page_.locator('#qr-url')).toHaveCount(0)
+    await expect(
+      page_.locator('button:has-text("Log in to continue")')
+    ).toHaveCount(0)
+    console.log('Logged-in non-mod /qr correctly showed the volunteers-only message')
+  })
+
+  test('logged in as a mod: generates a QR code, reacts to URL changes, and supports download', async ({
+    page,
+    testEnv,
+  }) => {
+    await loginViaHomepage(page, testEnv.mod.email, 'freegle')
+
+    await page.gotoAndVerify('/qr')
+
+    const urlInput = page.locator('#qr-url')
+    await expect(urlInput).toBeVisible({ timeout: timeouts.ui.appearance })
+    await expect(urlInput).toHaveValue('https://www.ilovefreegle.org')
+
+    // The default URL renders a code on mount (hasCode branch).
+    const qrCanvas = page.locator('.qr-target canvas')
+    await expect(qrCanvas).toBeVisible({ timeout: timeouts.assertion.slow })
+
+    const downloadBtn = page.locator('button:has-text("Download PNG")')
+    await expect(downloadBtn).toBeEnabled()
+    console.log('Mod /qr correctly generated a code for the default URL')
+
+    // Clearing the URL removes the code and shows the empty-state prompt
+    // (the !url / hasCode=false branches).
+    await urlInput.fill('')
+    await expect(
+      page.getByText('Enter a link above to see your QR code.')
+    ).toBeVisible({ timeout: timeouts.ui.appearance })
+    await expect(downloadBtn).toBeDisabled()
+    console.log('Clearing the URL correctly hid the code and disabled download')
+
+    // Entering a new URL re-renders the code (the url watcher branch).
+    await urlInput.fill('https://www.ilovefreegle.org/give')
+    await expect(qrCanvas).toBeVisible({ timeout: timeouts.assertion.slow })
+    await expect(downloadBtn).toBeEnabled()
+    console.log('Changing the URL correctly re-rendered the code')
+
+    // Download produces a PNG (the download() branch).
+    const downloadPromise = page.waitForEvent('download')
+    await downloadBtn.click()
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toContain('freegle-qr')
+    console.log(
+      `Download button correctly produced a file: ${download.suggestedFilename()}`
+    )
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/PostItem.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostItem.spec.js
@@ -169,6 +169,8 @@ describe('PostItem', () => {
       ['helmet', 'Motorcycle and cycle helmets'],
       ['car seat', 'Car seats'],
       ['knife', 'Knives'],
+      ['contact lens solution', 'Contact lens solution'],
+      ['all in one contact lens fluid', 'Contact lens solution'],
     ])('shows warning for "%s"', (item, expectedType) => {
       mockMessage.mockReturnValue({ item })
       const wrapper = createWrapper()

--- a/iznik-nuxt3/tests/unit/components/PostItem.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostItem.spec.js
@@ -169,8 +169,11 @@ describe('PostItem', () => {
       ['helmet', 'Motorcycle and cycle helmets'],
       ['car seat', 'Car seats'],
       ['knife', 'Knives'],
-      ['contact lens solution', 'Contact lens solution'],
-      ['all in one contact lens fluid', 'Contact lens solution'],
+      ['contact lens solution', 'Sealed and in date'],
+      ['all in one contact lens fluid', 'Sealed and in date'],
+      ['sunscreen', 'Sealed and in date'],
+      ['eye makeup', 'Sealed and in date'],
+      ['mascara', 'Sealed and in date'],
     ])('shows warning for "%s"', (item, expectedType) => {
       mockMessage.mockReturnValue({ item })
       const wrapper = createWrapper()

--- a/iznik-nuxt3/tests/unit/components/ProxyImage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ProxyImage.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import ProxyImage from '~/components/ProxyImage.vue'
 
@@ -89,6 +89,58 @@ describe('ProxyImage', () => {
       const wrapper = createWrapper()
       await wrapper.find('img').trigger('error')
       expect(wrapper.emitted('error')).toBeTruthy()
+    })
+  })
+
+  describe('generic broken-image placeholder (gimg_0.jpg)', () => {
+    // This branch only runs client-side and only for the specific
+    // gimg_0.jpg placeholder src, so nothing exercises it unless a test
+    // deliberately sets both up - which meant its Playwright/e2e coverage
+    // depended on incidental test data (some rendered image's src happening
+    // to contain "gimg_0.jpg") and flipped covered/uncovered run to run,
+    // repeatedly tripping Coveralls' "coverage decreased" check on unrelated
+    // PRs. Covering it deterministically here (see the matching v8-ignore in
+    // ProxyImage.vue) removes that source of jitter.
+    const originalClient = process.client
+
+    afterEach(() => {
+      process.client = originalClient
+    })
+
+    it('reports to Sentry when src is the generic broken-image placeholder', async () => {
+      process.client = true
+      const Sentry = await import('@sentry/browser')
+      Sentry.captureMessage.mockClear()
+
+      createWrapper({ src: '/uploads/gimg_0.jpg' })
+
+      await vi.waitFor(() =>
+        expect(Sentry.captureMessage).toHaveBeenCalledWith(
+          'Broken image: /uploads/gimg_0.jpg'
+        )
+      )
+    })
+
+    it('does not report to Sentry for a normal image src', async () => {
+      process.client = true
+      const Sentry = await import('@sentry/browser')
+      Sentry.captureMessage.mockClear()
+
+      createWrapper({ src: '/uploads/photo.jpg' })
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(Sentry.captureMessage).not.toHaveBeenCalled()
+    })
+
+    it('does not report to Sentry server-side, even for the placeholder src', async () => {
+      process.client = false
+      const Sentry = await import('@sentry/browser')
+      Sentry.captureMessage.mockClear()
+
+      createWrapper({ src: '/uploads/gimg_0.jpg' })
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(Sentry.captureMessage).not.toHaveBeenCalled()
     })
   })
 

--- a/iznik-nuxt3/tests/unit/composables/useCompose.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useCompose.spec.js
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
-import { postcodeSelect, makeCanSubmit } from '~/composables/useCompose.js'
+import {
+  postcodeSelect,
+  makeCanSubmit,
+  loadOwnActivePosts,
+} from '~/composables/useCompose.js'
 
 let mockGroup = null
 let mockPostcode = null
@@ -230,5 +234,36 @@ describe('makeCanSubmit', () => {
     expect(canSubmit.value).toBe(false)
     messageValid.value = true
     expect(canSubmit.value).toBe(true)
+  })
+})
+
+describe('loadOwnActivePosts', () => {
+  it('pulls each active post into list as a full message so duplicate detection has item names', async () => {
+    const messageStore = {
+      fetchByUser: vi.fn().mockResolvedValue([{ id: 10 }, { id: 11 }]),
+      fetch: vi.fn(),
+    }
+    await loadOwnActivePosts(messageStore, 123)
+    // active=true so the query returns the member's still-open posts...
+    expect(messageStore.fetchByUser).toHaveBeenCalledWith(123, true)
+    // ...and each is fetched in full (the summary lacks item.name, list has it).
+    expect(messageStore.fetch).toHaveBeenCalledWith(10)
+    expect(messageStore.fetch).toHaveBeenCalledWith(11)
+  })
+
+  it('does nothing when logged out', async () => {
+    const messageStore = { fetchByUser: vi.fn(), fetch: vi.fn() }
+    await loadOwnActivePosts(messageStore, undefined)
+    expect(messageStore.fetchByUser).not.toHaveBeenCalled()
+    expect(messageStore.fetch).not.toHaveBeenCalled()
+  })
+
+  it('tolerates a null result from fetchByUser', async () => {
+    const messageStore = {
+      fetchByUser: vi.fn().mockResolvedValue(null),
+      fetch: vi.fn(),
+    }
+    await loadOwnActivePosts(messageStore, 123)
+    expect(messageStore.fetch).not.toHaveBeenCalled()
   })
 })

--- a/iznik-server-go/rippling/analytics_extra_test.go
+++ b/iznik-server-go/rippling/analytics_extra_test.go
@@ -1,0 +1,378 @@
+package rippling
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// envInt reads a positive int env var, falling back to def for unset, empty,
+// non-numeric, zero and negative values.
+func TestEnvInt(t *testing.T) {
+	cases := []struct {
+		name string
+		set  bool
+		val  string
+		def  int
+		want int
+	}{
+		{"unset falls back to default", false, "", 42, 42},
+		{"valid positive int wins", true, "7", 42, 7},
+		{"non-numeric falls back to default", true, "notanumber", 42, 42},
+		{"zero falls back to default", true, "0", 42, 42},
+		{"negative falls back to default", true, "-5", 42, 42},
+		{"empty string falls back to default", true, "", 42, 42},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.set {
+				t.Setenv("TEST_ENV_INT_KEY", c.val)
+			} else {
+				t.Setenv("TEST_ENV_INT_KEY", "")
+				// Ensure truly unset, not just empty - os.Getenv treats both the
+				// same way here since envInt checks v != "".
+			}
+			got := envInt("TEST_ENV_INT_KEY", c.def)
+			assert.Equal(t, c.want, got, c.name)
+		})
+	}
+}
+
+// driveSampleSize / driveConcurrency default to their documented constants and
+// are overridable via their respective env vars.
+func TestDriveSampleSize(t *testing.T) {
+	t.Setenv("RIPPLE_ANALYTICS_SAMPLE", "")
+	assert.Equal(t, 250, driveSampleSize())
+
+	t.Setenv("RIPPLE_ANALYTICS_SAMPLE", "500")
+	assert.Equal(t, 500, driveSampleSize())
+}
+
+func TestDriveConcurrency(t *testing.T) {
+	t.Setenv("RIPPLE_ANALYTICS_CONCURRENCY", "")
+	assert.Equal(t, 16, driveConcurrency())
+
+	t.Setenv("RIPPLE_ANALYTICS_CONCURRENCY", "4")
+	assert.Equal(t, 4, driveConcurrency())
+}
+
+// StratumFilter renders the SQL predicate for each density stratum, and imposes
+// no extra bound for "all" or any unrecognised value.
+func TestStratumFilter(t *testing.T) {
+	cases := []struct {
+		stratum string
+		want    string
+	}{
+		{"rural", " AND rr.total_freeglers < 1700"},
+		{"suburban", " AND rr.total_freeglers >= 1700 AND rr.total_freeglers < 3800"},
+		{"dense", " AND rr.total_freeglers >= 3800"},
+		{"all", ""},
+		{"", ""},
+		{"unknown-stratum", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.stratum, func(t *testing.T) {
+			assert.Equal(t, c.want, StratumFilter(c.stratum))
+		})
+	}
+}
+
+func fptr(v float64) *float64 { return &v }
+
+// scoreOnePost posts to the routing server's /v1/ripple-eval and turns the
+// response into driveObs, tagging each with its rippled/day/taker flag by
+// index. It is best-effort: any transport, HTTP-status or shape mismatch
+// yields no observations rather than an error.
+func TestScoreOnePost_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rippleEvalReq
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "drive", req.Mode)
+		assert.Equal(t, float64(driveMaxMinutes), req.MaxMinutes)
+		assert.Len(t, req.Points, 2)
+
+		resp := rippleEvalResp{Results: []struct {
+			DriveMin *float64 `json:"drive_min"`
+		}{
+			{DriveMin: fptr(12.5)},
+			{DriveMin: fptr(30)},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer srv.Close()
+	t.Setenv("ROUTING_EVAL_URL", srv.URL)
+
+	p := samplePost{
+		lat: 51.5, lng: -0.1,
+		points:  [][2]float64{{-0.2, 51.4}, {-0.3, 51.3}},
+		rippled: []bool{true, false},
+		days:    []string{"2026-07-01", "2026-07-02"},
+		takers:  []bool{false, true},
+	}
+	obs := scoreOnePost(p)
+	assert.Len(t, obs, 2)
+	assert.Equal(t, 12.5, obs[0].min)
+	assert.True(t, obs[0].rippled)
+	assert.Equal(t, "2026-07-01", obs[0].day)
+	assert.False(t, obs[0].taker)
+	assert.Equal(t, 30.0, obs[1].min)
+	assert.False(t, obs[1].rippled)
+	assert.Equal(t, "2026-07-02", obs[1].day)
+	assert.True(t, obs[1].taker)
+}
+
+func TestScoreOnePost_NilDriveMinSkipped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := rippleEvalResp{Results: []struct {
+			DriveMin *float64 `json:"drive_min"`
+		}{
+			{DriveMin: nil},
+			{DriveMin: fptr(5)},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+	t.Setenv("ROUTING_EVAL_URL", srv.URL)
+
+	p := samplePost{points: [][2]float64{{0, 0}, {1, 1}}, rippled: []bool{true, true}, days: []string{"d1", "d2"}, takers: []bool{true, true}}
+	obs := scoreOnePost(p)
+	assert.Len(t, obs, 1)
+	assert.Equal(t, 5.0, obs[0].min)
+}
+
+func TestScoreOnePost_IndexOutOfRangeUsesZeroValue(t *testing.T) {
+	// rippled/days/takers shorter than points: the extra results still score,
+	// just without the per-point tag.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := rippleEvalResp{Results: []struct {
+			DriveMin *float64 `json:"drive_min"`
+		}{
+			{DriveMin: fptr(1)},
+			{DriveMin: fptr(2)},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+	t.Setenv("ROUTING_EVAL_URL", srv.URL)
+
+	p := samplePost{points: [][2]float64{{0, 0}, {1, 1}}} // rippled/days/takers all nil
+	obs := scoreOnePost(p)
+	assert.Len(t, obs, 2)
+	assert.False(t, obs[1].rippled)
+	assert.Equal(t, "", obs[1].day)
+	assert.False(t, obs[1].taker)
+}
+
+func TestScoreOnePost_NetworkErrorReturnsNil(t *testing.T) {
+	// A closed listener refuses the connection immediately (deterministic and
+	// fast, unlike routing to an arbitrary unused port).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+	t.Setenv("ROUTING_EVAL_URL", srv.URL)
+
+	p := samplePost{points: [][2]float64{{0, 0}}}
+	assert.Nil(t, scoreOnePost(p))
+}
+
+func TestScoreOnePost_NonOKStatusReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("ROUTING_EVAL_URL", srv.URL)
+
+	p := samplePost{points: [][2]float64{{0, 0}}}
+	assert.Nil(t, scoreOnePost(p))
+}
+
+func TestScoreOnePost_BadJSONReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+	t.Setenv("ROUTING_EVAL_URL", srv.URL)
+
+	p := samplePost{points: [][2]float64{{0, 0}}}
+	assert.Nil(t, scoreOnePost(p))
+}
+
+func TestScoreOnePost_MismatchedResultCountReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := rippleEvalResp{Results: []struct {
+			DriveMin *float64 `json:"drive_min"`
+		}{
+			{DriveMin: fptr(1)},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+	t.Setenv("ROUTING_EVAL_URL", srv.URL)
+
+	// Two points requested but only one result returned.
+	p := samplePost{points: [][2]float64{{0, 0}, {1, 1}}}
+	assert.Nil(t, scoreOnePost(p))
+}
+
+// statFromObs computes the mean drive-time (+95% CI) over the observations,
+// optionally restricted to rippled-out replies.
+func TestStatFromObs_Empty(t *testing.T) {
+	stat := statFromObs(nil, false)
+	assert.Equal(t, 0, stat.NReplies)
+	assert.False(t, stat.Available)
+	assert.Equal(t, 0.0, stat.MeanMin)
+	assert.Equal(t, 0.0, stat.CIHalf)
+}
+
+func TestStatFromObs_SingleValueNoCIHalf(t *testing.T) {
+	obs := []driveObs{{min: 10}}
+	stat := statFromObs(obs, false)
+	assert.True(t, stat.Available)
+	assert.Equal(t, 1, stat.NReplies)
+	assert.Equal(t, 10.0, stat.MeanMin)
+	// A single sample has no variance -> CI half stays the zero value.
+	assert.Equal(t, 0.0, stat.CIHalf)
+}
+
+func TestStatFromObs_MultipleValuesComputesMeanAndCI(t *testing.T) {
+	obs := []driveObs{{min: 10}, {min: 20}, {min: 30}}
+	stat := statFromObs(obs, false)
+	assert.True(t, stat.Available)
+	assert.Equal(t, 3, stat.NReplies)
+	assert.InDelta(t, 20.0, stat.MeanMin, 1e-9)
+	assert.True(t, stat.CIHalf > 0)
+}
+
+func TestStatFromObs_RippledOnlyFiltersNonRippled(t *testing.T) {
+	obs := []driveObs{{min: 10, rippled: true}, {min: 100, rippled: false}}
+	stat := statFromObs(obs, true)
+	assert.Equal(t, 1, stat.NReplies)
+	assert.Equal(t, 10.0, stat.MeanMin)
+}
+
+func TestStatFromObs_RippledOnlyNoMatchesIsUnavailable(t *testing.T) {
+	obs := []driveObs{{min: 10, rippled: false}}
+	stat := statFromObs(obs, true)
+	assert.False(t, stat.Available)
+	assert.Equal(t, 0, stat.NReplies)
+}
+
+// driveTrendFromObs buckets the sampled drive-times by reply day (ascending),
+// dropping observations with no day tag.
+func TestDriveTrendFromObs_Empty(t *testing.T) {
+	assert.Empty(t, driveTrendFromObs(nil))
+}
+
+func TestDriveTrendFromObs_SkipsEmptyDay(t *testing.T) {
+	obs := []driveObs{{min: 5, day: ""}}
+	assert.Empty(t, driveTrendFromObs(obs))
+}
+
+func TestDriveTrendFromObs_GroupsAndSortsByDay(t *testing.T) {
+	obs := []driveObs{
+		{min: 20, day: "2026-07-02"},
+		{min: 10, day: "2026-07-01"},
+		{min: 30, day: "2026-07-02"},
+	}
+	trend := driveTrendFromObs(obs)
+	assert.Len(t, trend, 2)
+	// Ascending day order.
+	assert.Equal(t, "2026-07-01", trend[0].Day)
+	assert.Equal(t, 10.0, trend[0].MeanMin)
+	assert.Equal(t, 1, trend[0].N)
+	assert.Equal(t, "2026-07-02", trend[1].Day)
+	assert.Equal(t, 25.0, trend[1].MeanMin) // (20+30)/2
+	assert.Equal(t, 2, trend[1].N)
+}
+
+// Bullseye buckets parallel (drive-time, taker?) observations into the fixed
+// drive-time rings and computes reply->take conversion per ring.
+func TestBullseye_EmptyInput(t *testing.T) {
+	bands := Bullseye(nil, nil)
+	assert.Len(t, bands, len(bullseyeEdges)-1)
+	for _, b := range bands {
+		assert.Equal(t, 0, b.NReplies)
+		assert.Equal(t, 0.0, b.ConvPct)
+	}
+}
+
+func TestBullseye_BandsAssignedCorrectly(t *testing.T) {
+	// 0-10 band (first, exclusive of hi=10), 10-15 band, and the last band
+	// (30-45) which is inclusive at both ends.
+	mins := []float64{5, 10, 45}
+	takers := []bool{true, false, true}
+	bands := Bullseye(mins, takers)
+
+	band0 := bands[0] // [0,10)
+	assert.Equal(t, 1, band0.NReplies)
+	assert.Equal(t, 1, band0.NTakers)
+	assert.InDelta(t, 100.0, band0.ConvPct, 1e-9)
+
+	band1 := bands[1] // [10,15)
+	assert.Equal(t, 1, band1.NReplies)
+	assert.Equal(t, 0, band1.NTakers)
+	assert.Equal(t, 0.0, band1.ConvPct)
+
+	last := bands[len(bands)-1] // [30,45] inclusive
+	assert.Equal(t, 1, last.NReplies)
+	assert.Equal(t, 1, last.NTakers)
+}
+
+func TestBullseye_ValueBelowZeroExcludedFromEveryBand(t *testing.T) {
+	bands := Bullseye([]float64{-1}, []bool{true})
+	for _, b := range bands {
+		assert.Equal(t, 0, b.NReplies)
+	}
+}
+
+func TestBullseye_ValueAboveMaxExcludedFromEveryBand(t *testing.T) {
+	bands := Bullseye([]float64{1000}, []bool{true})
+	for _, b := range bands {
+		assert.Equal(t, 0, b.NReplies)
+	}
+}
+
+func TestBullseye_TakerIndexOutOfRangeTreatedAsFalse(t *testing.T) {
+	// More mins than takers: the extra mins must not panic and count as
+	// non-takers.
+	bands := Bullseye([]float64{5}, nil)
+	assert.Equal(t, 1, bands[0].NReplies)
+	assert.Equal(t, 0, bands[0].NTakers)
+}
+
+func TestBullseye_ConversionAndCIHalfComputed(t *testing.T) {
+	// Band [0,10): 4 replies, 2 takers -> 50% conversion with a non-zero CI.
+	mins := []float64{1, 2, 3, 4}
+	takers := []bool{true, true, false, false}
+	bands := Bullseye(mins, takers)
+	band0 := bands[0]
+	assert.Equal(t, 4, band0.NReplies)
+	assert.Equal(t, 2, band0.NTakers)
+	assert.InDelta(t, 50.0, band0.ConvPct, 1e-9)
+	assert.True(t, band0.CIHalf > 0)
+}
+
+// bullseyeFromObs pulls the drive-time + taker flag off the sampled
+// observations and bands them, matching Bullseye run directly on the same
+// mins/takers.
+func TestBullseyeFromObs_MatchesDirectBullseyeCall(t *testing.T) {
+	obs := []driveObs{
+		{min: 5, taker: true},
+		{min: 12, taker: false},
+	}
+	got := bullseyeFromObs(obs)
+	want := Bullseye([]float64{5, 12}, []bool{true, false})
+	assert.Equal(t, want, got)
+}
+
+func TestBullseyeFromObs_Empty(t *testing.T) {
+	bands := bullseyeFromObs(nil)
+	assert.Len(t, bands, len(bullseyeEdges)-1)
+}

--- a/iznik-server-go/town/select_near_extra_test.go
+++ b/iznik-server-go/town/select_near_extra_test.go
@@ -1,0 +1,75 @@
+package town
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func dm(v float64) *float64 { return &v }
+
+// SelectNear picks the furthest reachable towns within maxMinutes, capped at
+// limit, then re-orders the result by population (ascending id) for display.
+func TestSelectNear_FiltersUnreachable(t *testing.T) {
+	cands := []TownCand{
+		{ID: 1, Name: "Reachable", DriveMin: dm(10)},
+		{ID: 2, Name: "TooFar", DriveMin: dm(50)},
+		{ID: 3, Name: "Unreachable", DriveMin: nil},
+	}
+	got := SelectNear(cands, 20, 5)
+	assert.Equal(t, []string{"Reachable"}, got)
+}
+
+func TestSelectNear_FurthestFirstThenLimited(t *testing.T) {
+	cands := []TownCand{
+		{ID: 1, Name: "Near", DriveMin: dm(5)},
+		{ID: 2, Name: "Mid", DriveMin: dm(15)},
+		{ID: 3, Name: "Far", DriveMin: dm(25)},
+	}
+	// Limit to 2: keeps the two FURTHEST (Far, Mid), then displays by id asc.
+	got := SelectNear(cands, 30, 2)
+	assert.Equal(t, []string{"Mid", "Far"}, got)
+}
+
+func TestSelectNear_TieBreakByPopulationSmallerIDWins(t *testing.T) {
+	cands := []TownCand{
+		{ID: 10, Name: "SmallerPopBigID", DriveMin: dm(20)},
+		{ID: 2, Name: "BiggerPopSmallID", DriveMin: dm(20)},
+	}
+	// Both equally far; limit 1 keeps the tie-break winner (smaller id = bigger
+	// population).
+	got := SelectNear(cands, 30, 1)
+	assert.Equal(t, []string{"BiggerPopSmallID"}, got)
+}
+
+func TestSelectNear_DisplayOrderIsPopulationDescending(t *testing.T) {
+	cands := []TownCand{
+		{ID: 5, Name: "Fifth", DriveMin: dm(5)},
+		{ID: 1, Name: "First", DriveMin: dm(15)},
+		{ID: 3, Name: "Third", DriveMin: dm(10)},
+	}
+	got := SelectNear(cands, 30, 5)
+	// All reachable; displayed by ascending id regardless of drive-time order.
+	assert.Equal(t, []string{"First", "Third", "Fifth"}, got)
+}
+
+func TestSelectNear_EmptyCandidates(t *testing.T) {
+	assert.Empty(t, SelectNear(nil, 30, 5))
+}
+
+func TestSelectNear_NoneReachable(t *testing.T) {
+	cands := []TownCand{{ID: 1, Name: "Far", DriveMin: dm(999)}}
+	assert.Empty(t, SelectNear(cands, 10, 5))
+}
+
+func TestSelectNear_ExactlyAtMaxMinutesIsReachable(t *testing.T) {
+	cands := []TownCand{{ID: 1, Name: "Edge", DriveMin: dm(30)}}
+	got := SelectNear(cands, 30, 5)
+	assert.Equal(t, []string{"Edge"}, got)
+}
+
+func TestSelectNear_LimitLargerThanCandidates(t *testing.T) {
+	cands := []TownCand{{ID: 1, Name: "Only", DriveMin: dm(5)}}
+	got := SelectNear(cands, 30, 100)
+	assert.Equal(t, []string{"Only"}, got)
+}


### PR DESCRIPTION
## Sealed-and-in-date posting warning
Discourse [8643/18](https://discourse.ilovefreegle.org/t/all-in-one-contact-lens-solution/8643/18): a compose-time advisory (like the existing fire-label / car-seat / knife guidance) for items that need to be sterile and in date. Advisory only, not a block.

`components/PostItem.vue` — new `warnings` entry: type "Sealed and in date", message "Please make sure this is sealed and in date.", keywords covering contact lens solution/fluid/cleaner, cosmetics, make-up, mascara, and sunscreen/sun cream/sun lotion/aftersun.

## Duplicate-detection fix
`PostItem`'s `duplicate` computed reads `messageStore.all` (the `list` dict) and matches on `item.name`, but nothing loaded the member's own posts there on a cold `/give`/`/find` visit. `useCompose` fired `fetchByUser(myid, false)`, which only fills `byUserList` with lean summaries that omit `item.name` — a store slot the check never reads — so the "you already have an open post … use Repost" warning never appeared unless the member had already visited `/myposts` that session. `useCompose` now fetches the member's active posts and pulls each full record into `list` (mirrors `pages/myposts.vue`), so the check works on a direct load.

## Tests
- `tests/unit/components/PostItem.spec.js` — keyword coverage for the new warning; existing duplicate-detection unit tests.
- `tests/e2e/test-post-item-warnings.spec.js` — warning renders, item still posts (OFFER/WANTED), the edit-modal path, and a duplicate-detection test that now loads `/give` with a fresh page (`page.goto`) so it exercises the compose-time load rather than the previous client-side-nav workaround.
- Coverage for previously-untested code: `iznik-server-go/rippling/analytics_extra_test.go`, `iznik-server-go/town/select_near_extra_test.go`, `iznik-batch/tests/Unit/Services/{EeeSqliteService,MicrovolunteeringNotifyService}Test.php`, and e2e coverage for several 0%-covered informational pages.
- Fixes a pre-existing flaky assertion in `test-modtools-move-message.spec.js`: its group-detection loop matched the first group with any visible `.card` instead of the target message's `#msg-<id>`.

## Discourse
https://discourse.ilovefreegle.org/t/all-in-one-contact-lens-solution/8643/18
