### PR TITLE
feat(modtools): Approved-list filter to exclude rippled-in posts (9808/638)

### DIFF
--- a/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
@@ -19,6 +19,9 @@
       />
       <span v-else class="mt-2"> Select a community to search messages. </span>
       <ModtoolsViewControl misckey="modtoolsMessagesApprovedSummary" />
+      <b-form-checkbox v-model="originOnly" class="mt-2">
+        Only this group's own posts (hide rippled-in)
+      </b-form-checkbox>
     </div>
     <div>
       <NoticeMessage v-if="loaded && !messages.length && !busy" class="mt-2">
@@ -90,6 +93,8 @@ const bump = ref(0)
 const urlOverride = ref(false)
 const loaded = ref(false)
 const highlightMsgId = ref(null)
+// 9808/638: when on, ask the API for this group's OWN posts only (exclude rippled-in).
+const originOnly = ref(false)
 
 // Computed properties
 const id = computed(() => {
@@ -142,6 +147,16 @@ watch(visibleMessages, (newVal) => {
       })
     }
   }
+})
+
+// 9808/638: re-run the listing from a clean slate when the rippled-in filter toggles.
+watch(originOnly, () => {
+  show.value = 0
+  context.value = null
+  modMessages.listingIds.value = new Set()
+  modMessages.listingIdOrder.value = []
+  messageStore.clear()
+  bump.value++
 })
 
 // Lifecycle
@@ -289,6 +304,11 @@ async function loadMore($state) {
         modtools: true,
         summary: false,
       }
+    }
+
+    // 9808/638: exclude posts that rippled in from other groups when the mod asks.
+    if (originOnly.value) {
+      params.originonly = true
     }
 
     params.context = context.value

--- a/iznik-server-go/message/message_list.go
+++ b/iznik-server-go/message/message_list.go
@@ -50,10 +50,9 @@ type ListMessageItem struct {
 }
 
 type ListMessagesResponse struct {
-	Messages []ListMessageItem `json:"messages"`
+	Messages []ListMessageItem  `json:"messages"`
 	Context  *PaginationContext `json:"context,omitempty"`
 }
-
 
 // ListMessages handles GET /messages - list messages with moderation queue support.
 func ListMessages(c *fiber.Ctx) error {
@@ -462,6 +461,16 @@ func ListMessagesMT(c *fiber.Ctx) error {
 		contentcheckFilter = " AND (mg.collection != 'Pending' OR mg.contentcheck_checked_at IS NOT NULL OR mg.arrival < NOW() - INTERVAL 30 MINUTE)"
 	}
 
+	// 9808/638: when a mod asks for their OWN-group posts only (?originonly=true), exclude
+	// posts that rippled INTO the group (rippled_in = 1) - they otherwise dominate the
+	// Approved list and make finding a group's own members' posts hard. Folded into the
+	// per-branch filter that every query variant below already appends, using the same
+	// messages_groups.rippled_in marker the Edit branch above hardcodes (9808/633). Constant
+	// clause, so no bound parameter is added.
+	if c.Query("originonly") == "true" {
+		contentcheckFilter += " AND mg.rippled_in = 0"
+	}
+
 	if collection == "Edit" {
 		// Edit review uses messages_edits table, not messages_groups collection.
 		// Restrict to ORIGIN messages_groups rows (rippled_in = 0). A post rippled INTO a
@@ -630,4 +639,3 @@ func GetMessagesWithHistory(c *fiber.Ctx) error {
 
 	return c.JSON(messages)
 }
-

--- a/iznik-server-go/test/modtools_approved_originonly_test.go
+++ b/iznik-server-go/test/modtools_approved_originonly_test.go
@@ -51,10 +51,8 @@ func TestListMessagesMTApprovedOriginOnly(t *testing.T) {
 		require.NoError(t, json2.NewDecoder(resp.Body).Decode(&result))
 		msgs, _ := result["messages"].([]interface{})
 		for _, m := range msgs {
-			if mm, ok := m.(map[string]interface{}); ok {
-				if id, ok := mm["id"].(float64); ok && uint64(id) == msgID {
-					return true
-				}
+			if id, ok := m.(float64); ok && uint64(id) == msgID {
+				return true
 			}
 		}
 		return false

--- a/iznik-server-go/test/modtools_approved_originonly_test.go
+++ b/iznik-server-go/test/modtools_approved_originonly_test.go
@@ -1,0 +1,72 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 9808/638: the ModTools Approved-messages list is dominated by posts that rippled INTO a
+// group, which makes post-moderating a group's OWN members hard. ListMessagesMT with
+// ?collection=Approved&originonly=true adds a rippled_in=0 filter so only posts that
+// originated on the group are returned. Same messages_groups.rippled_in marker the Edit
+// queue already uses (9808/633 / PR #1144); see modtools_edits_rippled_in_test.go.
+func TestListMessagesMTApprovedOriginOnly(t *testing.T) {
+	prefix := uniquePrefix("mtApprovedRipple")
+	db := database.DBConn
+
+	originGroup := CreateTestGroup(t, prefix+"_orig")
+	rippledGroup := CreateTestGroup(t, prefix+"_rip")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, originGroup, "Member")
+	CreateTestMembership(t, modID, originGroup, "Moderator")
+	CreateTestMembership(t, modID, rippledGroup, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Approved on its origin group (rippled_in=0 from CreateTestMessage), then rippled
+	// (rippled_in=1) into the other group.
+	msgID := CreateTestMessage(t, posterID, originGroup, prefix+" OFFER: MT Ripple Item", 51.5, -0.1)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) "+
+		"VALUES (?, ?, NOW(), 'Approved', 0, 1)", msgID, rippledGroup)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, rippledGroup)
+	})
+
+	listHasMsg := func(groupid uint64, originOnly bool) bool {
+		url := fmt.Sprintf("/api/modtools/messages?collection=Approved&groupid=%d&jwt=%s", groupid, modToken)
+		if originOnly {
+			url += "&originonly=true"
+		}
+		resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		var result map[string]interface{}
+		require.NoError(t, json2.NewDecoder(resp.Body).Decode(&result))
+		msgs, _ := result["messages"].([]interface{})
+		for _, m := range msgs {
+			if mm, ok := m.(map[string]interface{}); ok {
+				if id, ok := mm["id"].(float64); ok && uint64(id) == msgID {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Default: the rippled-in copy appears in the receiving group's Approved list.
+	assert.True(t, listHasMsg(rippledGroup, false),
+		"without originonly, a rippled-in post appears in the receiving group's Approved list")
+	// originonly=true: excluded from the receiving group.
+	assert.False(t, listHasMsg(rippledGroup, true),
+		"with originonly, a rippled-in post is excluded from the receiving group's Approved list")
+	// originonly=true on the ORIGIN group: still present (rippled_in=0 there).
+	assert.True(t, listHasMsg(originGroup, true),
+		"with originonly, the post still appears in its origin group's Approved list")
+}


### PR DESCRIPTION
## Why
On Discourse — [Rippling Out, 9808/638](https://discourse.ilovefreegle.org/t/rippling-out/9808/639) — Neville_Reid asked (seconded by Jos) for a filter on the ModTools **Approved messages** page to show only posts approved on their *own* groups, excluding posts that rippled in — because the list is otherwise dominated by rippled-in copies, making post-moderation of a group's own members hard.

Same "rippled-in pollutes a ModTools view" pattern already fixed for the Edit queue (9808/633 → PR #1144).

## What
**Backend** — `ListMessagesMT` (`GET /modtools/messages`, the endpoint the ModTools list actually uses) now accepts **`?originonly=true`**, folding `AND mg.rippled_in = 0` into the per-branch filter that every query variant already appends. Uses the same `messages_groups.rippled_in` marker the `Edit` branch in the same handler already hardcodes; it's a constant clause, so it adds no bound parameter. Applies to the Approved list and its member/message searches; the Edit branch is untouched (already `rippled_in = 0`).

**Frontend** — a **"Only this group's own posts (hide rippled-in)"** toggle on `pages/messages/approved/…` sets `originonly=true` on the fetch params and refetches from a clean slate (mirrors the existing search-reset pattern).

**Test** — `modtools_approved_originonly_test.go`: a rippled-in post is excluded from the receiving group's Approved list with the flag, and the origin post still appears in its own group's list.

## Correction
The **first version of this PR filtered the wrong endpoint** — `GetGroupMessages` (the member *browse* feed) rather than `ListMessagesMT` (the ModTools list). This force-push moves it to the right handler and adds the UI toggle + a matching test. Go/vitest run in CI (WSL toolchain gated); Go files gofmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjavhAHn6siYfunR5bacK6
