### PR TITLE
fix(browse): index cross-posted/rippled posts per group in messages_spatial (9954)

### DIFF
--- a/iznik-batch/database/migrations/2026_07_23_000001_messages_spatial_per_group_unique_key.php
+++ b/iznik-batch/database/migrations/2026_07_23_000001_messages_spatial_per_group_unique_key.php
@@ -1,0 +1,102 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * messages_spatial backs the public browse/map, with one row PER GROUP a message
+     * is approved on - a cross-posted or rippled-out post must appear in browse on
+     * each of its groups. The Go inserter (addApprovedMessageToSpatialIndex) and the
+     * every-5-minute reconciler both do `INSERT ... ON DUPLICATE KEY UPDATE` assuming
+     * the unique key is (msgid, groupid), and deliberately never update groupid on
+     * conflict.
+     *
+     * But the table was created with a single-column `UNIQUE (msgid)`. So the second
+     * and subsequent groups for a message collapsed onto the first-inserted row: a
+     * rippled post ended up indexed on only ONE (non-deterministic) group and was
+     * invisible in browse on all the others - including its origin group. Reported on
+     * Discourse 9954 ("Post disappeared after I approved it"): an approved Wanted that
+     * could not be found because its single spatial row landed on a rippled-into group,
+     * not the poster's / moderator's own group.
+     *
+     * Fix: make the unique key (msgid, groupid). The composite still serves the
+     * WHERE msgid = ? lookups (msgid leads). Then backfill the missing per-group rows
+     * for messages that are currently indexed, so the browse gap clears without waiting
+     * for each post to be re-touched by the reconciler.
+     */
+    private function indexExists(string $table, string $index): bool
+    {
+        if (!Schema::hasTable($table)) {
+            return false;
+        }
+
+        return DB::table('information_schema.statistics')
+            ->where('table_schema', DB::raw('DATABASE()'))
+            ->where('table_name', $table)
+            ->where('index_name', $index)
+            ->exists();
+    }
+
+    public function up(): void
+    {
+        if (!Schema::hasTable('messages_spatial')) {
+            return;
+        }
+
+        // 1) Add the correct composite unique. Safe: with UNIQUE(msgid) there is at
+        //    most one row per msgid today, so every (msgid, groupid) pair is unique.
+        if (!$this->indexExists('messages_spatial', 'msgid_groupid')) {
+            DB::statement('ALTER TABLE `messages_spatial` ADD UNIQUE `msgid_groupid` (`msgid`, `groupid`)');
+        }
+
+        // 2) Drop the single-column unique that collapsed the per-group rows. The
+        //    composite above keeps msgid as a leading indexed column for lookups.
+        if ($this->indexExists('messages_spatial', 'msgid')) {
+            DB::statement('ALTER TABLE `messages_spatial` DROP INDEX `msgid`');
+        }
+
+        // 3) Backfill the per-group rows that were previously lost, but only for
+        //    messages already present in the index (bounded to the active browse
+        //    window). INSERT IGNORE relies on the new (msgid, groupid) unique to skip
+        //    the rows that already exist. Mirrors addApprovedMessageToSpatialIndex:
+        //    Approved, not deleted, has a location, no outcome.
+        DB::statement(
+            'INSERT IGNORE INTO messages_spatial (msgid, point, groupid, msgtype, arrival) '.
+            'SELECT m.id, '.
+            "       ST_GeomFromText(CONCAT('POINT(', m.lng, ' ', m.lat, ')'), 3857), ".
+            '       mg.groupid, m.type, '.
+            "       DATE_FORMAT(mg.arrival, '%Y-%m-%d %H:%i:%s') ".
+            'FROM (SELECT DISTINCT msgid FROM messages_spatial) s '.
+            'INNER JOIN messages_groups mg ON mg.msgid = s.msgid '.
+            "    AND mg.collection = 'Approved' AND mg.deleted = 0 ".
+            'INNER JOIN messages m ON m.id = s.msgid '.
+            '    AND m.deleted IS NULL AND m.lat IS NOT NULL AND m.lng IS NOT NULL '.
+            'LEFT JOIN messages_outcomes mo ON mo.msgid = s.msgid '.
+            'WHERE mo.id IS NULL'
+        );
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('messages_spatial')) {
+            return;
+        }
+
+        // Restoring the single-column unique requires one row per msgid again, so
+        // collapse duplicates (keep the lowest id) before re-adding it.
+        if (!$this->indexExists('messages_spatial', 'msgid')) {
+            DB::statement(
+                'DELETE s1 FROM messages_spatial s1 '.
+                'INNER JOIN messages_spatial s2 ON s1.msgid = s2.msgid AND s1.id > s2.id'
+            );
+            DB::statement('ALTER TABLE `messages_spatial` ADD UNIQUE `msgid` (`msgid`)');
+        }
+
+        if ($this->indexExists('messages_spatial', 'msgid_groupid')) {
+            DB::statement('ALTER TABLE `messages_spatial` DROP INDEX `msgid_groupid`');
+        }
+    }
+};

--- a/iznik-batch/tests/Unit/Services/MessageSpatialServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageSpatialServiceTest.php
@@ -52,6 +52,45 @@ class MessageSpatialServiceTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $result);
     }
 
+    public function test_indexes_cross_posted_message_once_per_group(): void
+    {
+        // A message approved on more than one group must get a messages_spatial row PER
+        // GROUP, so it shows in browse on each. Regression for the single-column
+        // UNIQUE(msgid) that collapsed every group onto one row, leaving a cross-posted /
+        // rippled post visible on only one (non-deterministic) group (Discourse 9954).
+        $user = $this->createTestUser();
+        $groupA = $this->createTestGroup();
+        $groupB = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: cross-posted item (London)',
+            'textbody' => 'Cross-posted.',
+            'source' => 'Platform',
+            'date' => now()->subDays(3),
+            'arrival' => now()->subDays(3),
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+        foreach ([$groupA->id, $groupB->id] as $gid) {
+            MessageGroup::create([
+                'msgid' => $message->id,
+                'groupid' => $gid,
+                'collection' => MessageGroup::COLLECTION_APPROVED,
+                'arrival' => now()->subDays(3),
+            ]);
+        }
+
+        $this->service->updateSpatialIndex();
+
+        $groupids = DB::table('messages_spatial')->where('msgid', $message->id)->pluck('groupid')->all();
+        sort($groupids);
+        $expected = [$groupA->id, $groupB->id];
+        sort($expected);
+        $this->assertEquals($expected, $groupids, 'a cross-posted message is indexed once per group');
+    }
+
     public function test_removes_withdrawn_message_from_spatial_index(): void
     {
         $user = $this->createTestUser();


### PR DESCRIPTION
## The bug (Discourse 9954, "Post disappeared after I approved it")
A moderator approved a Wanted, then couldn't find it **"with my member hat on"** (i.e. browse). The post was Approved and fully intact — not withdrawn, not deleted. It was **invisible in browse on her own group** because its `messages_spatial` row was on a *different* group.

## Root cause
`messages_spatial` backs the public browse/map and needs **one row per group** a message is approved on (a cross-posted or rippled-out post shows in browse on each of its groups). Both writers — the Go inserter `addApprovedMessageToSpatialIndex` and the every-5-minute `MessageSpatialService` reconciler — do `INSERT ... ON DUPLICATE KEY UPDATE` **assuming the unique key is `(msgid, groupid)`**.

But the table was created with a **single-column `UNIQUE (msgid)`** (`2025_12_10_..._create_messages_spatial_table`, `->unique('msgid')`). So the second and later groups collapsed onto the first-inserted row:

- a rippled/cross-posted post ends up indexed on **only one, non-deterministic group** → invisible in browse on all the others, including its origin group;
- the reconciler's `ON DUPLICATE KEY UPDATE` also updates `groupid`, so under `UNIQUE(msgid)` it kept **flipping the single row between groups** every 5 minutes (observed live: the one row's groupid changed between two queries), never settling.

A scope check found **thousands** of approved posts in the last 2 days missing their group's spatial row.

## Fix
- **Migration** `2026_07_23_000001_messages_spatial_per_group_unique_key`: swap the unique key `msgid` → `(msgid, groupid)`. The composite still serves `WHERE msgid = ?` (msgid leads); the writers' inserts now create one row per group instead of overwriting, and the churn stops. Idempotent, defensive (checks `information_schema`), with a reversible `down()`.
- **Backfill** in the same migration (bounded to messages already in the index, `INSERT IGNORE`) so the browse gap clears immediately instead of waiting for each post to be re-touched.
- **Regression** in `MessageSpatialServiceTest`: a two-group message must be indexed once per group.

## Validation
Migration PHP syntax-checked (`php -l`) via the batch container. Migration + Laravel suite run in CI (the local WSL toolchain is gated). Note: after deploy, consider a wider one-time backfill for older un-touched posts (the reconciler self-heals recent ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjavhAHn6siYfunR5bacK6
