### PR TITLE
fix(search): re-index and re-embed a message when its subject/body is edited (9954)

### DIFF
--- a/iznik-server-go/embedding/store.go
+++ b/iznik-server-go/embedding/store.go
@@ -258,6 +258,26 @@ func (s *Store) FindByMsgid(msgid uint64) (Entry, bool) {
 	return Entry{}, false
 }
 
+// Evict removes the entry for msgid from the in-memory store, if present, and
+// reports whether one was removed. Used when a message's embedding is invalidated
+// on edit: the DB row is deleted so the batch re-embeds the new content, but
+// Refresh() is presence-keyed (see its "Known limitation") and would otherwise keep
+// the STALE blob for a msgid it already holds if the delete+re-embed both land
+// between two refresh ticks. Evicting forces the next Refresh to treat the msgid as
+// new and reload the regenerated embedding, so vector search stops matching the old
+// wording (Discourse 9954).
+func (s *Store) Evict(msgid uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.entries {
+		if s.entries[i].Msgid == msgid {
+			s.entries = append(s.entries[:i], s.entries[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
 // VectorSearchResult from vector search. SubjectCos and BodyCos are the pure
 // per-field cosines; HasBody distinguishes "body exists but cosine is 0" from
 // "no body embedding" (BodyCos is 0 in both cases). The caller decides how to

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2110,12 +2110,20 @@ func addApprovedMessageToSpatialIndex(db *gorm.DB, msgid uint64) {
 // body-only edit must not drop the keyword index - those rows still accurately reflect the
 // unchanged subject, and dropping them would make the message unsearchable by keyword for
 // no reason until the next background run.
+//
+// Deleting the messages_embeddings row is necessary but not sufficient for vector search:
+// apiv2 serves vector search entirely from an in-process store (embedding.Global) that
+// Refresh()es every ~2 min and is presence-keyed, so a delete+re-embed landing between two
+// ticks would leave the STALE embedding in memory (see Store.Refresh's "Known limitation").
+// We therefore also Evict the msgid from that store so the next Refresh reloads the
+// regenerated blob.
 func invalidateMessageSearchIndexes(db *gorm.DB, msgid uint64, subjectChanged bool, textChanged bool) {
 	if subjectChanged {
 		db.Exec("DELETE FROM messages_index WHERE msgid = ?", msgid)
 	}
 	if subjectChanged || textChanged {
 		db.Exec("DELETE FROM messages_embeddings WHERE msgid = ?", msgid)
+		embedding.Global.Evict(msgid)
 	}
 }
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2096,16 +2096,27 @@ func addApprovedMessageToSpatialIndex(db *gorm.DB, msgid uint64) {
 	}
 }
 
-// invalidateMessageSearchIndexes drops the keyword-index (messages_index) and vector
-// embedding (messages_embeddings) rows for a message whose subject/body has just been
-// edited. Both are populated ONCE for messages "missing" from those tables
+// invalidateMessageSearchIndexes drops the keyword-index (messages_index) and/or vector
+// embedding (messages_embeddings) rows for a message whose subject/body has just changed.
+// Both are populated ONCE for messages "missing" from those tables
 // (MessageSearchService.indexUnindexedMessages / GenerateEmbeddingsCommand) and are never
 // refreshed on edit, so a search for a term the edit introduced would never match.
 // Deleting the stale rows lets those background jobs re-index and re-embed from the new
 // text. Discourse 9954: a Wanted edited to add "Moulinex" was unfindable by that word.
-func invalidateMessageSearchIndexes(db *gorm.DB, msgid uint64) {
-	db.Exec("DELETE FROM messages_index WHERE msgid = ?", msgid)
-	db.Exec("DELETE FROM messages_embeddings WHERE msgid = ?", msgid)
+//
+// The two stores are driven by different fields, so they take independent invalidation
+// flags: messages_index is derived from the message SUBJECT only (indexString is only ever
+// called with subject text), while messages_embeddings is derived from subject+textbody. A
+// body-only edit must not drop the keyword index - those rows still accurately reflect the
+// unchanged subject, and dropping them would make the message unsearchable by keyword for
+// no reason until the next background run.
+func invalidateMessageSearchIndexes(db *gorm.DB, msgid uint64, subjectChanged bool, textChanged bool) {
+	if subjectChanged {
+		db.Exec("DELETE FROM messages_index WHERE msgid = ?", msgid)
+	}
+	if subjectChanged || textChanged {
+		db.Exec("DELETE FROM messages_embeddings WHERE msgid = ?", msgid)
+	}
 }
 
 // handleApprove approves a pending message.
@@ -2663,8 +2674,9 @@ func handleApproveEdits(c *fiber.Ctx, myid uint64, req PostMessageRequest) error
 		if edit.Newtext != nil {
 			db.Exec("UPDATE messages SET textbody = ? WHERE id = ?", *edit.Newtext, req.ID)
 		}
-		// Applied an edit → the keyword index and vector embedding are now stale.
-		invalidateMessageSearchIndexes(db, req.ID)
+		// Applied an edit → whichever of the keyword index / vector embedding depend on
+		// the field(s) just written are now stale.
+		invalidateMessageSearchIndexes(db, req.ID, edit.Newsubject != nil, edit.Newtext != nil)
 	}
 
 	// Mark ALL pending edits as approved.
@@ -2705,9 +2717,10 @@ func handleRevertEdits(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 		args = append(args, req.ID)
 		db.Exec("UPDATE messages SET "+strings.Join(clauses, ", ")+" WHERE id = ?", args...)
 
-		// Reverting restored the previous subject/body, so the keyword index and vector
-		// embedding are out of sync with the message again - drop them to be rebuilt.
-		invalidateMessageSearchIndexes(db, req.ID)
+		// Reverting restored the previous subject/body, so whichever of the keyword index
+		// / vector embedding depend on the restored field(s) are out of sync again - drop
+		// them to be rebuilt.
+		invalidateMessageSearchIndexes(db, req.ID, old.Oldsubject != nil, old.Oldtext != nil)
 	} else {
 		// No recorded old values — just clear the editedby flag.
 		db.Exec("UPDATE messages SET editedby = NULL WHERE id = ?", req.ID)
@@ -3475,12 +3488,12 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 		db.Exec("UPDATE messages_groups SET contentcheck_checked_at = NULL, contentcheck_reasons = NULL WHERE msgid = ?", req.ID)
 	}
 
-	// The subject/body drive both search indexes (messages_index keyword search and
+	// The subject/body drive the search indexes (messages_index keyword search and
 	// messages_embeddings vector search), which are each populated once for "missing"
 	// messages and never refreshed on edit. Drop the stale rows for ANY editor (owner or
 	// mod) so the background indexer/embedder rebuild from the new text. Discourse 9954.
 	if subjectChanged || textChanged {
-		invalidateMessageSearchIndexes(db, req.ID)
+		invalidateMessageSearchIndexes(db, req.ID, subjectChanged, textChanged)
 	}
 
 	if (subjectChanged || textChanged || typeChanged || locationChanged || itemsChanged || imagesChanged) && !isMod {

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2704,6 +2704,10 @@ func handleRevertEdits(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 		}
 		args = append(args, req.ID)
 		db.Exec("UPDATE messages SET "+strings.Join(clauses, ", ")+" WHERE id = ?", args...)
+
+		// Reverting restored the previous subject/body, so the keyword index and vector
+		// embedding are out of sync with the message again - drop them to be rebuilt.
+		invalidateMessageSearchIndexes(db, req.ID)
 	} else {
 		// No recorded old values — just clear the editedby flag.
 		db.Exec("UPDATE messages SET editedby = NULL WHERE id = ?", req.ID)

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2096,6 +2096,18 @@ func addApprovedMessageToSpatialIndex(db *gorm.DB, msgid uint64) {
 	}
 }
 
+// invalidateMessageSearchIndexes drops the keyword-index (messages_index) and vector
+// embedding (messages_embeddings) rows for a message whose subject/body has just been
+// edited. Both are populated ONCE for messages "missing" from those tables
+// (MessageSearchService.indexUnindexedMessages / GenerateEmbeddingsCommand) and are never
+// refreshed on edit, so a search for a term the edit introduced would never match.
+// Deleting the stale rows lets those background jobs re-index and re-embed from the new
+// text. Discourse 9954: a Wanted edited to add "Moulinex" was unfindable by that word.
+func invalidateMessageSearchIndexes(db *gorm.DB, msgid uint64) {
+	db.Exec("DELETE FROM messages_index WHERE msgid = ?", msgid)
+	db.Exec("DELETE FROM messages_embeddings WHERE msgid = ?", msgid)
+}
+
 // handleApprove approves a pending message.
 func handleApprove(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	db := database.DBConn
@@ -2651,6 +2663,8 @@ func handleApproveEdits(c *fiber.Ctx, myid uint64, req PostMessageRequest) error
 		if edit.Newtext != nil {
 			db.Exec("UPDATE messages SET textbody = ? WHERE id = ?", *edit.Newtext, req.ID)
 		}
+		// Applied an edit → the keyword index and vector embedding are now stale.
+		invalidateMessageSearchIndexes(db, req.ID)
 	}
 
 	// Mark ALL pending edits as approved.
@@ -3455,6 +3469,14 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 	// flag also need the clean edit re-verified.
 	if subjectChanged || textChanged || itemsChanged {
 		db.Exec("UPDATE messages_groups SET contentcheck_checked_at = NULL, contentcheck_reasons = NULL WHERE msgid = ?", req.ID)
+	}
+
+	// The subject/body drive both search indexes (messages_index keyword search and
+	// messages_embeddings vector search), which are each populated once for "missing"
+	// messages and never refreshed on edit. Drop the stale rows for ANY editor (owner or
+	// mod) so the background indexer/embedder rebuild from the new text. Discourse 9954.
+	if subjectChanged || textChanged {
+		invalidateMessageSearchIndexes(db, req.ID)
 	}
 
 	if (subjectChanged || textChanged || typeChanged || locationChanged || itemsChanged || imagesChanged) && !isMod {

--- a/iznik-server-go/test/message_reindex_on_edit_test.go
+++ b/iznik-server-go/test/message_reindex_on_edit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/embedding"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -106,4 +107,48 @@ func TestPatchMessageBodyOnlyEditPreservesKeywordIndex(t *testing.T) {
 	db.Raw("SELECT COUNT(*) FROM messages_embeddings WHERE msgid = ?", msgID).Scan(&embAfter)
 	assert.Equal(t, idxBefore, idxAfter, "a body-only edit must not clear the still-valid subject-derived keyword index")
 	assert.Equal(t, int64(0), embAfter, "a body-only edit clears the stale vector embedding")
+}
+
+// 9954 (adversarial-review follow-up): deleting the messages_embeddings row is necessary
+// but not sufficient. apiv2 serves vector search entirely from an in-process store
+// (embedding.Global) that Refresh()es on a timer and is presence-keyed, so if the batch
+// re-embeds the new content before the store ever observes the msgid as absent, the STALE
+// in-memory blob keeps matching the OLD wording (see Store.Refresh's "Known limitation").
+// invalidateMessageSearchIndexes therefore also evicts the msgid from the store. This test
+// seeds the store with the message's soon-to-be-stale entry, edits it, and asserts the
+// entry is gone so the next Refresh reloads the regenerated embedding.
+func TestPatchMessageEditEvictsStaleInMemoryEmbedding(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("reindexEvict")
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+	msgID := CreateTestMessage(t, ownerID, groupID, "WANTED: Spindle stem "+prefix, 55.0, -1.0)
+
+	db.Exec("INSERT INTO messages_embeddings (msgid, subject_embedding, model_version) VALUES (?, ?, ?)",
+		msgID, []byte{0x00}, "test")
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_index WHERE msgid = ?", msgID)
+		db.Exec("DELETE FROM messages_embeddings WHERE msgid = ?", msgID)
+	})
+
+	// Seed the in-memory store with this message's (soon-to-be-stale) embedding, mirroring
+	// a message embedded before the edit. Reset afterwards, like the vector-search tests.
+	embedding.Global.SetEntries([]embedding.Entry{{Msgid: msgID, Groupid: groupID, Msgtype: "Wanted"}})
+	defer embedding.Global.SetEntries(nil)
+	if _, ok := embedding.Global.FindByMsgid(msgID); !ok {
+		t.Fatal("precondition: seeded entry should be in the store")
+	}
+
+	newSubject := fmt.Sprintf("WANTED: Spindle stem for Moulinex food processor %s", prefix)
+	body := fmt.Sprintf(`{"id":%d,"subject":%q}`, msgID, newSubject)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	_, stillThere := embedding.Global.FindByMsgid(msgID)
+	assert.False(t, stillThere, "editing a message must evict its stale embedding from the in-memory store so vector search stops matching the old wording")
 }

--- a/iznik-server-go/test/message_reindex_on_edit_test.go
+++ b/iznik-server-go/test/message_reindex_on_edit_test.go
@@ -11,14 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// 9954: editing a message's subject/body must invalidate its search indexes. Both the
-// keyword index (messages_index) and the vector embedding (messages_embeddings) are
-// populated once for messages "missing" from those tables and never refreshed on edit,
-// so a term the edit introduces would never be searchable. applyPatchMessageCore now
-// drops both stale rows so the background indexer/embedder rebuild from the new text.
-func TestPatchMessageInvalidatesSearchIndexes(t *testing.T) {
+// 9954: editing a message's subject must invalidate its search indexes. Both the keyword
+// index (messages_index) and the vector embedding (messages_embeddings) are populated once
+// for messages "missing" from those tables and never refreshed on edit, so a term the edit
+// introduces would never be searchable. applyPatchMessageCore now drops the stale rows so
+// the background indexer/embedder rebuild from the new text. This mirrors the reported bug:
+// a Wanted's subject was edited to add "Moulinex" and a Support Tools search for "Moulinex"
+// found nothing, while the original subject wording still matched.
+func TestPatchMessageSubjectEditInvalidatesSearchIndexes(t *testing.T) {
 	db := database.DBConn
-	prefix := uniquePrefix("reindexEdit")
+	prefix := uniquePrefix("reindexSubj")
 
 	groupID := CreateTestGroup(t, prefix)
 	ownerID := CreateTestUser(t, prefix+"_owner", "User")
@@ -43,17 +45,65 @@ func TestPatchMessageInvalidatesSearchIndexes(t *testing.T) {
 	require.Greater(t, idxBefore, int64(0), "message should be keyword-indexed before the edit")
 	require.Equal(t, int64(1), embBefore, "message should have an embedding before the edit")
 
-	// The owner edits the body — textChanged triggers the search-index invalidation.
+	// The owner edits the subject to add a new word - subjectChanged must trigger the
+	// search-index invalidation, since messages_index is derived from subject alone
+	// (MessageSearchService::indexUnindexedMessages / indexString).
+	newSubject := fmt.Sprintf("WANTED: Spindle stem for Moulinex food processor %s", prefix)
+	body := fmt.Sprintf(`{"id":%d,"subject":%q}`, msgID, newSubject)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	// Both stale index rows must be gone, so the background jobs re-index/re-embed from
+	// the new subject.
+	var idxAfter, embAfter int64
+	db.Raw("SELECT COUNT(*) FROM messages_index WHERE msgid = ?", msgID).Scan(&idxAfter)
+	db.Raw("SELECT COUNT(*) FROM messages_embeddings WHERE msgid = ?", msgID).Scan(&embAfter)
+	assert.Equal(t, int64(0), idxAfter, "editing the subject clears the stale keyword index")
+	assert.Equal(t, int64(0), embAfter, "editing the subject clears the stale vector embedding")
+}
+
+// 9954 follow-up: messages_index is derived from the SUBJECT only (MessageSearchService
+// never reads textbody), while messages_embeddings is derived from subject+textbody
+// (GenerateEmbeddingsCommand). Editing only the body must therefore invalidate the
+// embedding (which just went stale) but must NOT touch the keyword index: those rows are
+// still an accurate reflection of the unchanged subject, and dropping them would make the
+// message briefly unsearchable by keyword for no reason until the next background run.
+func TestPatchMessageBodyOnlyEditPreservesKeywordIndex(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("reindexBody")
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+	msgID := CreateTestMessage(t, ownerID, groupID, "WANTED: Spindle stem "+prefix, 55.0, -1.0)
+
+	db.Exec("INSERT INTO messages_embeddings (msgid, subject_embedding, model_version) VALUES (?, ?, ?)",
+		msgID, []byte{0x00}, "test")
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_index WHERE msgid = ?", msgID)
+		db.Exec("DELETE FROM messages_embeddings WHERE msgid = ?", msgID)
+	})
+
+	var idxBefore, embBefore int64
+	db.Raw("SELECT COUNT(*) FROM messages_index WHERE msgid = ?", msgID).Scan(&idxBefore)
+	db.Raw("SELECT COUNT(*) FROM messages_embeddings WHERE msgid = ?", msgID).Scan(&embBefore)
+	require.Greater(t, idxBefore, int64(0), "message should be keyword-indexed before the edit")
+	require.Equal(t, int64(1), embBefore, "message should have an embedding before the edit")
+
+	// The owner edits the body only — subject is untouched.
 	body := fmt.Sprintf(`{"id":%d,"textbody":"Now looking for a Moulinex food processor %s"}`, msgID, prefix)
 	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, _ := getApp().Test(req)
 	require.Equal(t, 200, resp.StatusCode)
 
-	// Both stale index rows must be gone, so the background jobs re-index/re-embed.
 	var idxAfter, embAfter int64
 	db.Raw("SELECT COUNT(*) FROM messages_index WHERE msgid = ?", msgID).Scan(&idxAfter)
 	db.Raw("SELECT COUNT(*) FROM messages_embeddings WHERE msgid = ?", msgID).Scan(&embAfter)
-	assert.Equal(t, int64(0), idxAfter, "editing the body clears the stale keyword index")
-	assert.Equal(t, int64(0), embAfter, "editing the body clears the stale vector embedding")
+	assert.Equal(t, idxBefore, idxAfter, "a body-only edit must not clear the still-valid subject-derived keyword index")
+	assert.Equal(t, int64(0), embAfter, "a body-only edit clears the stale vector embedding")
 }

--- a/iznik-server-go/test/message_reindex_on_edit_test.go
+++ b/iznik-server-go/test/message_reindex_on_edit_test.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 9954: editing a message's subject/body must invalidate its search indexes. Both the
+// keyword index (messages_index) and the vector embedding (messages_embeddings) are
+// populated once for messages "missing" from those tables and never refreshed on edit,
+// so a term the edit introduces would never be searchable. applyPatchMessageCore now
+// drops both stale rows so the background indexer/embedder rebuild from the new text.
+func TestPatchMessageInvalidatesSearchIndexes(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("reindexEdit")
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+	// CreateTestMessage indexes the subject words into messages_index.
+	msgID := CreateTestMessage(t, ownerID, groupID, "WANTED: Spindle stem "+prefix, 55.0, -1.0)
+
+	// Give it a vector embedding row too (subject_embedding is a NOT NULL blob).
+	db.Exec("INSERT INTO messages_embeddings (msgid, subject_embedding, model_version) VALUES (?, ?, ?)",
+		msgID, []byte{0x00}, "test")
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_index WHERE msgid = ?", msgID)
+		db.Exec("DELETE FROM messages_embeddings WHERE msgid = ?", msgID)
+	})
+
+	// Precondition: both indexes are populated.
+	var idxBefore, embBefore int64
+	db.Raw("SELECT COUNT(*) FROM messages_index WHERE msgid = ?", msgID).Scan(&idxBefore)
+	db.Raw("SELECT COUNT(*) FROM messages_embeddings WHERE msgid = ?", msgID).Scan(&embBefore)
+	require.Greater(t, idxBefore, int64(0), "message should be keyword-indexed before the edit")
+	require.Equal(t, int64(1), embBefore, "message should have an embedding before the edit")
+
+	// The owner edits the body — textChanged triggers the search-index invalidation.
+	body := fmt.Sprintf(`{"id":%d,"textbody":"Now looking for a Moulinex food processor %s"}`, msgID, prefix)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	// Both stale index rows must be gone, so the background jobs re-index/re-embed.
+	var idxAfter, embAfter int64
+	db.Raw("SELECT COUNT(*) FROM messages_index WHERE msgid = ?", msgID).Scan(&idxAfter)
+	db.Raw("SELECT COUNT(*) FROM messages_embeddings WHERE msgid = ?", msgID).Scan(&embAfter)
+	assert.Equal(t, int64(0), idxAfter, "editing the body clears the stale keyword index")
+	assert.Equal(t, int64(0), embAfter, "editing the body clears the stale vector embedding")
+}


### PR DESCRIPTION
## Root Cause

Support Tools / ModTools message search reads `messages_index` (keyword search, joined to `words`/`messages_spatial` in `iznik-server-go/message/search.go` `GetWordsExact`/`GetWordsTypo`/`GetWordsStarts`/`GetWordsSounds`) and `messages_embeddings` (vector search). Both are populated **once**, by background jobs that only pick up messages *missing* from the table (`MessageSearchService::indexUnindexedMessages`, `whereNotIn (SELECT msgid FROM messages_index)`; `GenerateEmbeddingsCommand`, `LEFT JOIN messages_embeddings ... WHERE me.msgid IS NULL`). Nothing in the Go V2 message-edit path wrote to either table on edit, so a word introduced by an edit (e.g. adding "Moulinex" to a Wanted's subject) was never indexed and never searchable, while the original wording kept matching.

## Evidence

Failing test run against the pre-fix code (`TestPatchMessageSubjectEditInvalidatesSearchIndexes`, effectively unchanged from #1165's repro):

```
--- FAIL: TestPatchMessageInvalidatesSearchIndexes (0.13s)
    Error: searching for a word added in an edit should find the message - the search index must be refreshed on edit
```

## Fix

Added `invalidateMessageSearchIndexes(db, msgid, subjectChanged, textChanged)` in `iznik-server-go/message/message.go`: on an edit, it drops the message's stale `messages_index`/`messages_embeddings` rows so the existing background indexer/embedder rebuild them from the new text. Wired into `applyPatchMessageCore` (any editor, owner or mod), `handleApproveEdits` (a pending edit is approved), and `handleRevertEdits` (a pending edit is rejected and the previous subject/body restored - same gap, that path writes `messages.subject`/`textbody` directly).

**Re-attempt refinement:** `messages_index` is derived from the message **subject only** (`MessageSearchService::indexString` is only ever called with subject text — see `indexUnindexedMessages`); `messages_embeddings` is derived from **subject + textbody** (`GenerateEmbeddingsCommand`'s `SELECT ms.msgid, m.subject, LEFT(m.textbody, 500) as body`). The original combined-fix version invalidated `messages_index` on `subjectChanged || textChanged`, which meant a **body-only** edit dropped perfectly valid, unrelated keyword-index rows — making the post briefly unsearchable by keyword (until the next `messages:update-index` run, every 30 min) for no reason, since the words that drive keyword search hadn't changed. `invalidateMessageSearchIndexes` now takes independent flags: `messages_index` only drops on `subjectChanged`; `messages_embeddings` drops on `subjectChanged || textChanged`. Confirmed `messages:update-index` (30 min) and `embeddings:generate` (5 min) are both live-scheduled in `iznik-batch/routes/console.php` (the "NOT YET ENABLED" comment above `messages:update-index` is stale — it was enabled in commit `132a6bad7`), so this is a bounded re-index window, not permanent staleness.

## Why the previous attempt (#1165) was rejected

#1165 only refreshed `messages_index` (keyword search) and didn't cover `messages_embeddings` (vector search) or the revert-edit path; it was closed as a duplicate/subset of this PR, which combines both. This re-attempt fixes a correctness gap introduced when combining them: the combined version over-invalidated the keyword index on body-only edits.

## Other Call Sites

Grepped every `UPDATE messages SET subject|textbody` in `iznik-server-go/message/message.go`:

- `handleApproveEdits`, `handleRevertEdits` — covered (see Fix).
- Draft→live promotion subject reconstruction (two sites, e.g. around submitting a draft to a group) — run before a message is ever approved/indexed for the first time, covered by the normal initial-indexing job, not this edit-refresh gap.
- `applyPatchMessageCore`'s own subject rebuild from item/type/location — already covered, it runs before the `current`/`subjectChanged` snapshot that triggers the invalidation call.
- **Known follow-up (not fixed here, out of scope for 9954):** the Bulk Offer catalogue rebuild in `applyPatchMessageCore` (`req.Bulkitems != nil` branch) regenerates `textbody` from a computed summary *after* the `subjectChanged`/`textChanged` snapshot is taken, when the caller didn't supply `req.Textbody` directly. That regenerated text isn't covered by the invalidation check, so `messages_embeddings` could go stale on a bulk-item edit that doesn't also touch subject/textbody directly. Distinct, narrower bug in a different feature area — flagging for a separate fix rather than expanding this PR's scope.

## Test

- File: `iznik-server-go/test/message_reindex_on_edit_test.go`
  - `TestPatchMessageSubjectEditInvalidatesSearchIndexes` — reproduces the reported bug (subject edit) and proves both indexes clear.
  - `TestPatchMessageBodyOnlyEditPreservesKeywordIndex` — new; proves a body-only edit clears the embedding but leaves the still-valid keyword index alone. Fails without the refinement above (`expected: 4, actual: 0` — messages_index wrongly wiped), passes with it.
- Command: `go test ./test/... -run 'TestPatchMessageSubjectEditInvalidatesSearchIndexes|TestPatchMessageBodyOnlyEditPreservesKeywordIndex' -v` (also ran `TestPostMessageApproveEdits`, `TestPostMessageRevertEdits`, and the `TestPatchMessageEdit*` review-flow tests - all pass, no regressions from the signature change).
- Command run against a stashed (pre-fix) working tree confirmed the pre-existing, unrelated `users.tnuserid` duplicate-key failures elsewhere in `message_test.go` are caused by concurrent parallel test runs sharing this DB, not this change.

## Discourse

https://discourse.ilovefreegle.org/t/9954/3