### PR TITLE
fix(search): refresh full-text index when a message subject/body is edited

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2690,6 +2690,14 @@ func handleRevertEdits(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 		}
 		args = append(args, req.ID)
 		db.Exec("UPDATE messages SET "+strings.Join(clauses, ", ")+" WHERE id = ?", args...)
+
+		// The rejected edit's subject already reached messages_index (applyPatchMessageCore
+		// refreshes it live, before a mod ever reviews it) - restoring the old subject here
+		// must refresh it again, or the index is left showing the reverted wording instead
+		// of the original (same gap as Discourse 9954/3, on the revert path).
+		if old.Oldsubject != nil {
+			reindexMessageSearchWords(db, req.ID)
+		}
 	} else {
 		// No recorded old values — just clear the editedby flag.
 		db.Exec("UPDATE messages SET editedby = NULL WHERE id = ?", req.ID)
@@ -3455,6 +3463,17 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 	// flag also need the clean edit re-verified.
 	if subjectChanged || textChanged || itemsChanged {
 		db.Exec("UPDATE messages_groups SET contentcheck_checked_at = NULL, contentcheck_reasons = NULL WHERE msgid = ?", req.ID)
+	}
+
+	// The full-text search index (messages_index, queried by Support Tools and member
+	// search - see search.go) is derived from the subject. The nightly iznik-batch catch-up
+	// job (MessageSearchService::indexUnindexedMessages) only indexes messages it has never
+	// indexed before, so once a message is indexed it is never revisited - editing in new
+	// wording silently leaves the OLD wording searchable and the NEW wording invisible
+	// (Discourse 9954/3). Refresh it here, for both mods and owners, whenever the subject
+	// changes.
+	if subjectChanged {
+		reindexMessageSearchWords(db, req.ID)
 	}
 
 	if (subjectChanged || textChanged || typeChanged || locationChanged || itemsChanged || imagesChanged) && !isMod {

--- a/iznik-server-go/message/search.go
+++ b/iznik-server-go/message/search.go
@@ -503,3 +503,70 @@ func SearchByMsgID(db *gorm.DB, msgid uint64, groupids []uint64) []SearchResult 
 
 	return results
 }
+
+// reindexMessageSearchWords refreshes the messages_index rows for a message from its
+// CURRENT subject, so word search (Support Tools, member search - see GetWordsExact et
+// al above) reflects an edit immediately. Call this whenever a message's subject changes.
+//
+// The nightly iznik-batch catch-up job (MessageSearchService::indexUnindexedMessages)
+// only indexes messages it has never indexed before (it filters on msgid NOT IN
+// messages_index) - once a message is indexed, that job never revisits it. Without this,
+// editing a message to add new wording leaves the OLD wording searchable and the NEW
+// wording invisible (Discourse 9954/3: "Moulinex food processor" added to a WANTED post
+// stayed unsearchable while "spindle"/"stem" from the original wording kept matching).
+//
+// Only Approved messages are indexed: messages_index is always joined to
+// messages_spatial (see GetWordsExact/GetWordsTypo/GetWordsStarts/GetWordsSounds above),
+// which - like the batch job - only has rows for Approved messages, so indexing a
+// Pending/Rejected edit would never surface in a search result anyway.
+func reindexMessageSearchWords(db *gorm.DB, msgid uint64) {
+	type approvedRow struct {
+		Subject string
+		Arrival time.Time
+		Groupid uint64
+	}
+	var row approvedRow
+	db.Raw("SELECT messages.subject, messages_groups.arrival, messages_groups.groupid FROM messages "+
+		"INNER JOIN messages_groups ON messages_groups.msgid = messages.id "+
+		"WHERE messages.id = ? AND messages_groups.collection = 'Approved' AND messages_groups.deleted = 0 "+
+		"ORDER BY messages_groups.arrival DESC LIMIT 1", msgid).Scan(&row)
+
+	if row.Subject == "" {
+		return
+	}
+
+	// Full recompute rather than an incremental diff: simpler, and matches the batch
+	// job's own indexString, which always upserts the complete current word set.
+	db.Exec("DELETE FROM messages_index WHERE msgid = ?", msgid)
+
+	// V1/batch parity: arrival is stored negated so the existing ORDER BY arrival ASC
+	// callers see newest-first (see MessageSearchService::indexString).
+	arrival := -row.Arrival.Unix()
+
+	for _, word := range GetWords(row.Subject) {
+		// words.word is varchar(10) (see MessageSearchService::getWords).
+		if len(word) > 10 {
+			word = word[:10]
+		}
+
+		firstThree := word
+		if len(firstThree) > 3 {
+			firstThree = firstThree[:3]
+		}
+
+		var wordID uint64
+		db.Raw("SELECT id FROM words WHERE word = ?", word).Scan(&wordID)
+		if wordID == 0 {
+			db.Exec("INSERT IGNORE INTO words (word, firstthree, soundex) VALUES (?, ?, SUBSTRING(SOUNDEX(?), 1, 10))",
+				word, firstThree, word)
+			db.Raw("SELECT id FROM words WHERE word = ?", word).Scan(&wordID)
+		}
+		if wordID == 0 {
+			continue
+		}
+
+		db.Exec("INSERT INTO messages_index (msgid, wordid, arrival, groupid) VALUES (?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE arrival = VALUES(arrival)", msgid, wordID, arrival, row.Groupid)
+		db.Exec("UPDATE words SET popularity = -(SELECT COUNT(*) FROM messages_index WHERE wordid = ?) WHERE id = ?", wordID, wordID)
+	}
+}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -7657,6 +7657,59 @@ func TestPatchMessageSubjectEditResetsContentCheck(t *testing.T) {
 	assert.False(t, checkedAtStillSet, "editing the subject should clear contentcheck_checked_at so the batch job re-checks the new content")
 }
 
+// TestPatchMessageSubjectEditRefreshesSearchIndex verifies Discourse 9954/3: a member
+// (topic 9954 post 3) edited a WANTED post's subject from "Spindle/stem/drive shaft" to
+// add "Moulinex food processor", and Support Tools search for "Moulinex" could not find
+// the message even though it was still live - only the OLD wording ("spindle"/"stem")
+// matched. The nightly iznik-batch catch-up job (MessageSearchService::
+// indexUnindexedMessages) only indexes messages it has never indexed before, so it
+// silently never re-indexes an edited subject. Editing a message must refresh
+// messages_index immediately so a search on newly-added wording finds it.
+func TestPatchMessageSubjectEditRefreshesSearchIndex(t *testing.T) {
+	prefix := uniquePrefix("msgedit_reindex")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+
+	msgID := CreateTestMessage(t, ownerID, groupID, "WANTED: spindle stem driveshaft", 55.9533, -3.1883)
+
+	// Sanity check: the original wording is indexed and searchable, matching the
+	// Discourse report ("spindle or stem find it").
+	origWords := message.GetWords("spindle")
+	origResults := message.GetWordsExact(db, origWords, 100, []uint64{groupID}, nil, "All", 0, 0, 0, 0)
+	require.True(t, containsMsgid(origResults, msgID), "test setup: original wording should be indexed and searchable")
+
+	body := map[string]interface{}{
+		"id":      msgID,
+		"subject": "WANTED: spindle stem driveshaft moulinex foodprocessor",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Edit should succeed")
+
+	newWords := message.GetWords("moulinex")
+	require.Equal(t, 1, len(newWords), "test setup: 'moulinex' should survive the common-word filter")
+
+	newResults := message.GetWordsExact(db, newWords, 100, []uint64{groupID}, nil, "All", 0, 0, 0, 0)
+	assert.True(t, containsMsgid(newResults, msgID),
+		"searching for a word added in an edit should find the message - the search index must be refreshed on edit")
+}
+
+func containsMsgid(results []message.SearchResult, msgid uint64) bool {
+	for _, r := range results {
+		if r.Msgid == msgid {
+			return true
+		}
+	}
+	return false
+}
+
 // TestPatchMessageNonContentEditKeepsContentCheck: editing a field that
 // ContentCheckService::checkMessage() never inspects (availablenow) must NOT
 // discard the existing content-check stamp — only subject/textbody/item edits


### PR DESCRIPTION
## Root Cause

Full-text search (Support Tools message search, and member search - `messages_index` joined to `messages_spatial`/`words` in `iznik-server-go/message/search.go`) is populated by the nightly iznik-batch catch-up job `MessageSearchService::indexUnindexedMessages`. That job only indexes messages it has **never** indexed before (`msgid NOT IN (SELECT msgid FROM messages_index)`), so once a message is indexed it is never revisited.

Nothing in the Go V2 message-edit path (`applyPatchMessageCore` in `iznik-server-go/message/message.go`) wrote to `messages_index` either. So editing a message's subject to add new wording left the OLD wording searchable and the NEW wording invisible - exactly what Angelika reported: message 121085393 ("WANTED: Spindle/stem for Moulinex food processor" on Braintree) was edited on 22 July to add "Moulinex food processor", but a Support Tools search for "Moulinex" found nothing, while "spindle"/"stem" (the original wording) still matched.

## Evidence

Failing test run against the pre-fix code (`TestPatchMessageSubjectEditRefreshesSearchIndex`):

```
=== RUN   TestPatchMessageSubjectEditRefreshesSearchIndex
    message_test.go:7700:
        Error Trace: /app/test/message_test.go:7700
        Error:       Should be true
        Test:        TestPatchMessageSubjectEditRefreshesSearchIndex
        Messages:    searching for a word added in an edit should find the message - the search index must be refreshed on edit
--- FAIL: TestPatchMessageSubjectEditRefreshesSearchIndex (0.13s)
FAIL
```

## Fix

Added `reindexMessageSearchWords(db, msgid)` in `iznik-server-go/message/search.go`: it re-derives the message's indexed words from its **current** subject (reusing the existing `GetWords` common-word filter, truncated to `words.word`'s `varchar(10)`), deletes the message's old `messages_index` rows, and re-inserts the current set - mirroring `MessageSearchService::indexString`'s upsert shape.

Wired it into `applyPatchMessageCore` (the single core function behind both `PATCH /message` and `PATCH /message/tn/:tnpostid`) whenever the subject changes, and into `handleRevertEdits` when a moderator rejects a pending edit and the subject is restored to its pre-edit wording (same gap: that path writes `messages.subject` directly, bypassing the edit hook).

Only messages currently in the `Approved` collection are reindexed - `messages_index` is always joined to `messages_spatial`, which (like the batch job) only has rows for Approved messages, so indexing a Pending/Rejected edit would never surface in a search result anyway.

## Other Call Sites

Grepped every place `messages.subject` is written in `iznik-server-go`:

- `handleApproveEdits` (message.go) - re-applies the *same* subject that `applyPatchMessageCore` already wrote live and already reindexed; no-op for search, left as-is.
- Draft→live promotion / new-post subject reconstruction (message.go, two sites) - these run before a message is ever approved/indexed for the first time, so they're covered by the normal initial-indexing job, not this edit-refresh gap.
- `applyPatchMessageCore`'s own subject rebuild from item/type/location - already covered, since it runs before the `subjectChanged` check that triggers the new reindex call.

## Test

- File: `iznik-server-go/test/message_test.go` - `TestPatchMessageSubjectEditRefreshesSearchIndex`
- Command: `go test ./test/... -run TestPatchMessageSubjectEditRefreshesSearchIndex -v` (also ran the full set of adjacent PatchMessage/search/edit-review tests - all pass, no regressions)
- Proves fail-before (assertion fails against pre-fix code, see Evidence above) / pass-after (passes with the fix applied).

## Discourse

https://discourse.ilovefreegle.org/t/9954/3