### PR TITLE
fix(modtools): re-index message when subject is edited

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3457,6 +3457,18 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 		db.Exec("UPDATE messages_groups SET contentcheck_checked_at = NULL, contentcheck_reasons = NULL WHERE msgid = ?", req.ID)
 	}
 
+	// The keyword search index (messages_index) is built once from the message's
+	// subject by the batch reindexer (MessageSearchService::indexUnindexedMessages(),
+	// iznik-batch), which skips a msgid entirely once it has ANY messages_index rows
+	// - so a subject edit otherwise leaves the OLD subject's words searchable forever
+	// while a term only present in the NEW subject (e.g. a brand name added after the
+	// original post) can never be found by search (Discourse 9954/5). Deleting the
+	// stale rows here makes the message look "unindexed" again so the next batch run
+	// rebuilds it from the current subject.
+	if subjectChanged {
+		db.Exec("DELETE FROM messages_index WHERE msgid = ?", req.ID)
+	}
+
 	if (subjectChanged || textChanged || typeChanged || locationChanged || itemsChanged || imagesChanged) && !isMod {
 		// Store oldtype/newtype only when type actually changed.
 		var oldType, newType interface{}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -7689,6 +7689,55 @@ func TestPatchMessageNonContentEditKeepsContentCheck(t *testing.T) {
 	assert.True(t, checkedAtStillSet, "a non-content edit should not discard the existing content-check stamp")
 }
 
+// TestPatchMessageSubjectEditInvalidatesSearchIndex (Discourse 9954/5): the keyword
+// search index (messages_index) is built once from the message's subject by the
+// batch reindexer (MessageSearchService::indexUnindexedMessages(), iznik-batch),
+// which skips a msgid entirely once it has ANY messages_index rows at all. If a
+// subject edit leaves those stale rows in place, a term only present in the new
+// subject (e.g. a brand name added after the initial post) can never be found by
+// search, while an old, now-removed term stays searchable forever. Editing the
+// subject must clear the stale rows so the message looks "unindexed" again and
+// the batch job rebuilds it from the current subject.
+func TestPatchMessageSubjectEditInvalidatesSearchIndex(t *testing.T) {
+	prefix := uniquePrefix("msgedit_reindex")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+
+	msgID := createPendingMessage(t, ownerID, groupID, prefix)
+	db.Exec("UPDATE messages_groups SET collection = 'Approved' WHERE msgid = ? AND groupid = ?", msgID, groupID)
+
+	// Simulate the batch reindexer having already indexed the message under its
+	// original subject (as it would have, shortly after approval).
+	var wordID uint64
+	db.Exec("INSERT IGNORE INTO words (word, firstthree, soundex, popularity) VALUES ('drive', 'dri', SOUNDEX('drive'), 1)")
+	db.Raw("SELECT id FROM words WHERE word = 'drive'").Scan(&wordID)
+	require.NotZero(t, wordID, "test setup: word row should exist")
+	db.Exec("INSERT INTO messages_index (msgid, wordid, arrival, groupid) VALUES (?, ?, UNIX_TIMESTAMP(), ?)", msgID, wordID, groupID)
+
+	var indexRowsBefore int64
+	db.Raw("SELECT COUNT(*) FROM messages_index WHERE msgid = ?", msgID).Scan(&indexRowsBefore)
+	require.EqualValues(t, 1, indexRowsBefore, "test setup: message should start with a stale index row")
+
+	body := map[string]interface{}{
+		"id":      msgID,
+		"subject": prefix + " edited subject with a new brand name",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Edit should succeed")
+
+	var indexRowsAfter int64
+	db.Raw("SELECT COUNT(*) FROM messages_index WHERE msgid = ?", msgID).Scan(&indexRowsAfter)
+	assert.EqualValues(t, 0, indexRowsAfter, "editing the subject should clear the stale search index rows so the batch job rebuilds them from the new subject")
+}
+
 // --- tnpostid and expiresat tests ---
 
 func TestGetMessageTnpostid(t *testing.T) {


### PR DESCRIPTION
## Root Cause
`MessageSearchService::indexUnindexedMessages()` (iznik-batch) only indexes a message's subject **once**: it selects recently-approved messages `whereNotIn` `messages_index` msgid, indexes them, and never revisits a msgid that already has any `messages_index` row. When a message's subject is later edited, `iznik-server-go`'s `applyPatchMessageCore` commits the new subject to `messages.subject` immediately but never touches `messages_index` — so the stale, pre-edit words stay searchable forever and any term only present in the new subject can never be found by ModTools keyword search.

Confirmed against the reported message (id 121085393, live/Approved on Braintree and rippled into 6 other groups): `messages_edits` shows its subject was edited from `"WANTED: Spindle/stem/drive shaft (Bocking CM7)"` to `"WANTED: Spindle/stem for Moulinex food processor (Bocking CM7)"`. `messages_index` still only contains the words from the **original** subject (`drive`, `stem`, `spindle`, `shaft`) — `moulinex`, `food` and `processor` were never indexed, so searching "Moulinex" in ModTools finds nothing, even though the message is live and approved.

## Evidence
Failing test output (before fix):
```
=== RUN   TestPatchMessageSubjectEditInvalidatesSearchIndex
    message_test.go:7738:
        Error Trace: /src/test/message_test.go:7738
        Error:       Not equal:
                     expected: int(0)
                     actual  : int64(1)
        Test:        TestPatchMessageSubjectEditInvalidatesSearchIndex
        Messages:    editing the subject should clear the stale search index rows so the batch job rebuilds them from the new subject
--- FAIL: TestPatchMessageSubjectEditInvalidatesSearchIndex (0.17s)
FAIL
```

## Fix
In `applyPatchMessageCore` (`iznik-server-go/message/message.go`), when `subjectChanged` is true, delete the message's existing `messages_index` rows. This makes the message look "unindexed" again from `indexUnindexedMessages()`'s point of view, so the next batch run rebuilds the index from the current subject. Placed alongside the existing `contentcheck_checked_at` reset for the same `subjectChanged` condition (same pattern, same call site), so it fires for both self-edits and moderator edits, review-required or not.

## Other Call Sites
`grep -n "UPDATE messages SET subject" iznik-server-go` finds 3 other sites, all already covered:
- Two in `applyPatchMessageCore` itself (subject reconstructed from type/item/location) — these run *before* the `subjectChanged` diff, so they're already caught.
- `handleApproveEdits` — re-applies a subject that was already committed (and already invalidated) at edit-submission time; no separate change needed.
- One in the draft-creation path (`newMsgID`) — a brand new message has no existing index to invalidate.

## Test
- File: `iznik-server-go/test/message_test.go`, `TestPatchMessageSubjectEditInvalidatesSearchIndex`
- Command: `go test ./test/... -run TestPatchMessageSubjectEditInvalidatesSearchIndex -v`
- Proves fail-before (stale index row survives a subject-changing PATCH) / pass-after (row is cleared) the fix in `message.go`. Also re-ran 24 adjacent PATCH/edit tests (content-check reset, edit review flow, edit records) — all pass.

## Discourse
https://discourse.ilovefreegle.org/t/9954/5