### PR TITLE
fix(modtools): stop infinite-scroll from prematurely completing on cached/rippled messages

### DIFF
--- a/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
@@ -245,8 +245,6 @@ async function loadMore($state) {
     show.value++
     $state.loaded()
   } else {
-    const currentCount = Object.keys(messageStore.list).length
-
     let params
 
     if (messageTerm.value) {
@@ -328,20 +326,21 @@ async function loadMore($state) {
     }
     context.value = messageStore.context
 
-    const newCount = Object.keys(messageStore.list).length
-    if (currentCount === newCount) {
-      console.log('InfiniteScroll complete:', {
-        collection: collection.value,
-        groupid: groupid.value,
-        currentCount,
-        newCount,
-        fetchedIds: fetchedIds?.length ?? 0,
-        contextBefore: params.context,
-        contextAfter: messageStore.context,
-        limit: params.limit,
-        shown: show.value,
-        messagesLen: messages.value.length,
-      })
+    // Whether there is more to fetch is a property of THIS request/response,
+    // not of the shared cross-group messageStore.list. Rippled/cross-posted
+    // messages mean a page's ids are often already keys in that store (e.g.
+    // fetched earlier for a sibling group this session), so comparing its
+    // size before/after used to declare "complete" on a page that was
+    // genuinely non-empty and had more pages after it (Discourse 9954/5) -
+    // a moderator scrolling one group's Approved queue could have the scroll
+    // silently stop long before reaching an older, still-live message.
+    if (!fetchedIds || fetchedIds.length === 0) {
+      $state.complete()
+    } else if (!context.value) {
+      // Backend returned fewer than a full page, so this genuinely was the
+      // last batch. Reveal it before stopping - otherwise the newest fetch
+      // stays hidden with no further scroll trigger to show it.
+      show.value = messages.value.length
       $state.complete()
     } else {
       $state.loaded()

--- a/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
@@ -257,8 +257,6 @@ async function loadMore($state) {
     show.value = messages.value.length
     $state.loaded()
   } else {
-    const currentCount = Object.keys(messageStore.list).length
-
     const params = {
       groupid: groupid.value,
       collection: collection.value,
@@ -274,20 +272,21 @@ async function loadMore($state) {
     }
     context.value = messageStore.context
 
-    const newCount = Object.keys(messageStore.list).length
-    if (currentCount === newCount) {
-      console.log('InfiniteScroll complete:', {
-        collection: collection.value,
-        groupid: groupid.value,
-        currentCount,
-        newCount,
-        fetchedIds: fetchedIds?.length ?? 0,
-        contextBefore: params.context,
-        contextAfter: messageStore.context,
-        limit: params.limit,
-        shown: show.value,
-        messagesLen: messages.value.length,
-      })
+    // Whether there is more to fetch is a property of THIS request/response,
+    // not of the shared cross-group messageStore.list. Rippled/cross-posted
+    // messages mean a page's ids are often already keys in that store (e.g.
+    // fetched earlier for a sibling group this session), so comparing its
+    // size before/after used to declare "complete" on a page that was
+    // genuinely non-empty and had more pages after it (Discourse 9954/5) -
+    // a moderator scrolling one group's queue could have the scroll silently
+    // stop long before reaching an older, still-live message.
+    if (!fetchedIds || fetchedIds.length === 0) {
+      $state.complete()
+    } else if (!context.value) {
+      // Backend returned fewer than a full page, so this genuinely was the
+      // last batch. Reveal it before stopping - otherwise the newest fetch
+      // stays hidden with no further scroll trigger to show it.
+      show.value = messages.value.length
       $state.complete()
     } else {
       $state.loaded()

--- a/iznik-nuxt3/tests/unit/pages/modtools/messages/approved.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/messages/approved.spec.js
@@ -594,6 +594,29 @@ describe('messages/approved/[[id]]/[[term]].vue page', () => {
         await wrapper.vm.loadMore(mockState)
         expect(mockState.complete).toHaveBeenCalled()
       })
+
+      it('keeps scrolling when a page returns real messages that are already cached from another group (rippled/cross-posted posts)', async () => {
+        // Regression (Discourse 9954/5): a moderator of several adjacent groups
+        // scrolled one group's Approved queue looking for a post she'd just
+        // approved, and never found it. Rippled/cross-posted messages mean the
+        // same msgid often already sits in the shared messageStore.list from an
+        // earlier group/search in the session. The backend genuinely returned a
+        // fresh page (fetchedIds non-empty, context set => more pages exist),
+        // but because that page's id(s) were already keys in the global store,
+        // the old completion check (comparing Object.keys(messageStore.list)
+        // before/after) saw no size change and wrongly called $state.complete(),
+        // permanently stopping the scroll long before reaching older messages.
+        mockMessageStore.list = { 555: { id: 555 } }
+        mockMessages.value = [{ id: 555 }]
+        mockShow.value = 1
+        mockMessageStore.fetchMessagesMT.mockResolvedValue([555])
+        mockMessageStore.context = { date: 123, id: 555 }
+        const wrapper = mountComponent()
+        const mockState = { loaded: vi.fn(), complete: vi.fn() }
+        await wrapper.vm.loadMore(mockState)
+        expect(mockState.complete).not.toHaveBeenCalled()
+        expect(mockState.loaded).toHaveBeenCalled()
+      })
     })
   })
 

--- a/iznik-nuxt3/tests/unit/pages/modtools/messages/pending.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/messages/pending.spec.js
@@ -23,6 +23,7 @@ const mockVisibleMessages = ref([])
 const mockWork = computed(() => 0)
 const mockNextAfterRemoved = ref(null)
 const mockGetMessages = vi.fn()
+const mockListingIds = ref(new Set())
 
 vi.mock('~/composables/useModMessages', () => ({
   setupModMessages: () => ({
@@ -43,6 +44,7 @@ vi.mock('~/composables/useModMessages', () => ({
     visibleMessages: mockVisibleMessages,
     work: mockWork,
     nextAfterRemoved: mockNextAfterRemoved,
+    listingIds: mockListingIds,
     getMessages: mockGetMessages,
   }),
 }))
@@ -210,6 +212,9 @@ describe('PendingPage', () => {
     mockModGroupStore.list = {}
     mockMiscStore.get.mockReturnValue(null)
     mockAuthStore.user = { settings: { lastaimsshow: null } }
+    mockListingIds.value = new Set()
+    mockMessageStore.list = {}
+    mockMessageStore.context = null
   })
 
   describe('rendering', () => {
@@ -322,6 +327,24 @@ describe('PendingPage', () => {
       await wrapper.vm.loadMore(mockState)
 
       expect(mockMessageStore.fetchMessagesMT).toHaveBeenCalled()
+    })
+
+    it('keeps scrolling when a page returns real messages that are already cached from another group (rippled/cross-posted posts)', async () => {
+      // Regression (Discourse 9954/5): see the sibling test in
+      // approved.spec.js - the same broken completion check (comparing
+      // Object.keys(messageStore.list) before/after a fetch) lived here too.
+      mockMessageStore.list = { 555: { id: 555 } }
+      mockMessages.value = [{ id: 555 }]
+      mockShow.value = 1
+      mockMessageStore.fetchMessagesMT.mockResolvedValue([555])
+      mockMessageStore.context = { date: 123, id: 555 }
+      const wrapper = mountComponent()
+      const mockState = { loaded: vi.fn(), complete: vi.fn() }
+
+      await wrapper.vm.loadMore(mockState)
+
+      expect(mockState.complete).not.toHaveBeenCalled()
+      expect(mockState.loaded).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## Root cause
The ModTools per-group Approved/Pending listing paginates correctly on the backend (`ListMessagesMT`, `arrival`+`msgid` cursor). The frontend infinite-scroll `loadMore()` in `messages/approved/[[id]]/[[term]].vue` and `messages/pending/[[id]]/[[term]].vue` decided whether more pages existed by comparing `Object.keys(messageStore.list).length` before and after a fetch — the size of the global, cross-group/collection/search Pinia message dictionary, not anything scoped to the current listing.

Rippled/cross-posted messages already cached in `messageStore.list` from another group or search visited in the same session don't grow that dictionary. So a fetch that returned real, new-to-this-listing ids **and** a valid next-page `context` still looked like "no change" and called `$state.complete()`. `vue3-infinite-loading` does not re-fire `@infinite` after `complete()` unless its `identifier` changes (a plain group switch doesn't), so the scroll stopped permanently and hid every older message beyond that point.

## Fix
Both files now decide completion from the current request's response instead of the global store size:
- No ids returned → `complete()`.
- Ids returned but the pagination `context` is empty (short/last page) → reveal them (`show.value = messages.value.length`) and `complete()`.
- Ids returned with a `context` cursor → `loaded()` and keep scrolling.

`grep "currentCount === newCount"` confirms these two files were the only sites using the pattern. The dead `console.log('InfiniteScroll complete: …')` block that only explained the old check is removed.

## Test
New test in `tests/unit/pages/modtools/messages/approved.spec.js` and `pending.spec.js`: a page returning a real id already cached in the store, with a next-page context, must keep scrolling rather than complete. Fails before the fix, passes after; existing `loadMore` edge cases still pass.

## Discourse
https://discourse.ilovefreegle.org/t/9954/5
