### PR TITLE
fix(TrashNothing join request sync): don't swallow the membership INSERT error in the partner join path

### DIFF
--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -1215,20 +1215,36 @@ func putMembershipsPartner(c *fiber.Ctx, db *gorm.DB, partnerKey string) error {
 		return c.JSON(fiber.Map{"ret": 0, "status": "Success", "fduserid": userid, "addedto": utils.COLLECTION_APPROVED})
 	}
 
-	// Insert membership.
-	db.Exec("INSERT INTO memberships (userid, groupid, role, collection) VALUES (?, ?, ?, ?)",
-		userid, groupid, utils.ROLE_MEMBER, utils.COLLECTION_APPROVED)
+	// Insert membership. This must not be swallowed: if it fails, the partner
+	// (e.g. Trash Nothing) gets told the join succeeded while no membership
+	// row - and nothing else downstream - was ever created, so the request
+	// silently never reaches a moderator (Discourse #9961).
+	if err := InsertPartnerMembership(db, userid, groupid); err != nil {
+		stdlog.Printf("Failed to insert partner membership user %d group %d: %v", userid, groupid, err)
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to join group")
+	}
 
 	// Record in memberships_history with processingrequired=1 so the
 	// Laravel batch (memberships:process) sends the group welcome email,
 	// runs spam checks, and applies review flags. Without this row the
 	// cron has nothing to do and welcomes are silently dropped.
-	db.Exec("INSERT INTO memberships_history (userid, groupid, collection, processingrequired) VALUES (?, ?, ?, 1)",
-		userid, groupid, utils.COLLECTION_APPROVED)
+	if result := db.Exec("INSERT INTO memberships_history (userid, groupid, collection, processingrequired) VALUES (?, ?, ?, 1)",
+		userid, groupid, utils.COLLECTION_APPROVED); result.Error != nil {
+		stdlog.Printf("Failed to insert partner memberships_history user %d group %d: %v", userid, groupid, result.Error)
+	}
 
 	logMembershipAction(log.LOG_TYPE_GROUP, log.LOG_SUBTYPE_JOINED, groupid, userid, userid, "via partner")
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "fduserid": userid, "addedto": utils.COLLECTION_APPROVED})
+}
+
+// InsertPartnerMembership inserts the memberships row for a partner
+// (Trash Nothing) join. It is a package-level var - rather than a plain
+// function - purely so tests can substitute a stub that simulates a DB
+// failure without needing to physically break the connection.
+var InsertPartnerMembership = func(db *gorm.DB, userid uint64, groupid uint64) error {
+	return db.Exec("INSERT INTO memberships (userid, groupid, role, collection) VALUES (?, ?, ?, ?)",
+		userid, groupid, utils.ROLE_MEMBER, utils.COLLECTION_APPROVED).Error
 }
 
 // addMemberToGroup is the shared logic for adding a user to a group (JWT auth paths).

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -3,13 +3,16 @@ package test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/membership"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 )
 
 func TestPutMembershipsNotLoggedIn(t *testing.T) {
@@ -3837,6 +3840,54 @@ func TestPutMembershipsPartnerInvalidKey(t *testing.T) {
 	resp, err := getApp().Test(req, -1)
 	assert.NoError(t, err)
 	assert.Equal(t, 403, resp.StatusCode)
+}
+
+// Discourse #9961: TrashNothing reported join requests "showing as pending" on
+// their side because they never reached a Freegle moderator. Production data
+// confirmed accounts created via the partner path (tnuserid set) with zero
+// memberships ever recorded. Root cause: putMembershipsPartner discarded the
+// error from the memberships INSERT and always reported "Success" to the
+// partner, so a failed insert vanished silently - no membership row, nothing
+// for a moderator to see, and no signal to the partner that anything was
+// wrong. This uses the InsertPartnerMembership seam to simulate that INSERT
+// failing without needing to break the real DB connection.
+func TestPutMembershipsPartnerInsertFailureNotSwallowed(t *testing.T) {
+	prefix := uniquePrefix("mem_partinsertfail")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	email := prefix + "@test.com"
+	tnuserid := uint64(7654321)
+
+	db.Exec("UPDATE users SET tnuserid = NULL WHERE tnuserid = ?", tnuserid)
+
+	key := insertTestPartnerKey(t, prefix, "test.com")
+
+	original := membership.InsertPartnerMembership
+	membership.InsertPartnerMembership = func(_ *gorm.DB, _ uint64, _ uint64) error {
+		return errors.New("simulated DB failure")
+	}
+	defer func() { membership.InsertPartnerMembership = original }()
+
+	url := fmt.Sprintf("/api/memberships?partner=%s&tnuserid=%d&email=%s&groupid=%d", key, tnuserid, email, groupID)
+	req := httptest.NewRequest("PUT", url, nil)
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+
+	// Inverted (correct) assertion: a failed insert must not be reported as a
+	// success to the partner.
+	assert.NotEqual(t, 200, resp.StatusCode,
+		"a failed membership insert must not be reported as Success to the partner")
+
+	// And the user that was auto-created for this join must not be left with
+	// a membership row it doesn't actually have.
+	var userID uint64
+	db.Raw("SELECT id FROM users WHERE tnuserid = ?", tnuserid).Scan(&userID)
+	if userID > 0 {
+		var count int64
+		db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND groupid = ?", userID, groupID).Scan(&count)
+		assert.Equal(t, int64(0), count)
+	}
 }
 
 func TestDeleteMembershipsPartnerUnsubscribe(t *testing.T) {


### PR DESCRIPTION
## Root Cause
`putMembershipsPartner` (`iznik-server-go/membership/membership.go`), the handler behind `PUT /apiv2/memberships?partner=...` used by the TrashNothing (TN) integration, discarded the error from the `INSERT INTO memberships` call and unconditionally returned `{"ret":0,"status":"Success"}` to the partner. If that INSERT failed for any reason, no membership row was created, so the join never appeared in any moderator-facing queue and TN was told it had succeeded regardless - the request vanished with no trace and no way for either side to know something went wrong.

Production data confirms this actually happens: several TN-created accounts (`tnuserid` set, only ever set by this same handler's `CreatePartnerUser`) have **zero** rows in `memberships` despite repeated join attempts recorded in `memberships_history` for multiple groups each. This matches the report exactly - the requester's join request never reached a moderator.

## Evidence
Test run against the **unfixed** handler (kept the new `InsertPartnerMembership` seam but restored the original "ignore the error" behaviour) - `go test ./test/... -run TestPutMembershipsPartnerInsertFailureNotSwallowed -v`:
```
=== RUN   TestPutMembershipsPartnerInsertFailureNotSwallowed
    membership_test.go:3879:
        Error Trace: /app/test/membership_test.go:3879
        Error:       Should not be: 200
        Test:        TestPutMembershipsPartnerInsertFailureNotSwallowed
        Messages:    a failed membership insert must not be reported as Success to the partner
--- FAIL: TestPutMembershipsPartnerInsertFailureNotSwallowed (0.48s)
FAIL
```

## Fix
- Extracted the `memberships` INSERT into an exported package-level var `InsertPartnerMembership` (a seam so it can be stubbed in tests without breaking a real DB connection).
- `putMembershipsPartner` now checks its error and returns HTTP 500 (instead of a false "Success") when the insert fails, so the partner can see the failure and retry rather than the request disappearing silently.
- Also checks (and logs) the error on the companion `memberships_history` insert, matching the error-handling style already used elsewhere in this file (e.g. the `Hold`/`Approve`/`Reject` actions a few lines up).

## Other Call Sites
Same "insert result is captured/ignored but the handler still unconditionally returns Success" pattern exists at two other spots in the same file - left alone here to keep this fix scoped to the reported partner-join bug:
- `addMemberToGroup` (JWT self-join path, `membership.go`): checks `result.RowsAffected` to decide whether to write history/log, but returns `"Success"` regardless of whether the initial INSERT itself errored.
- `deleteMembershipsPartner` (partner leave path, `membership.go`): same shape on the `DELETE FROM memberships` call - lower impact since it only affects leaving a group, not the reported joining bug.

## Test
- File: `iznik-server-go/test/membership_test.go`, `TestPutMembershipsPartnerInsertFailureNotSwallowed`.
- Command: `go test ./test/... -run TestPutMembershipsPartnerInsertFailureNotSwallowed -v`.
- Proves fail-before (buggy code returns 200 "Success" even though the insert failed) / pass-after (fixed code returns a non-200 error and leaves no membership row) using the new `InsertPartnerMembership` seam to simulate the DB failure.
- Also re-ran the full `TestPutMembershipsPartner*`/`TestDeleteMembershipsPartner*` set to check for regressions in the surrounding code; all pass except a pre-existing, unrelated flake (`TestDeleteMembershipsPartnerUnsubscribe`, a hardcoded-`tnuserid` collision in the shared test DB) reproduced in complete isolation on unmodified `master` - unrelated to this change.

## Discourse
https://discourse.ilovefreegle.org/t/9961