### PR TITLE
feat(compose): show local community as a card with profile picture and tagline

### DIFF
--- a/iznik-nuxt3/components/ComposeGroup.vue
+++ b/iznik-nuxt3/components/ComposeGroup.vue
@@ -20,7 +20,7 @@
   </div>
 </template>
 <script setup>
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import GroupProfileImage from '~/components/GroupProfileImage.vue'
 import { useComposeStore } from '~/stores/compose'
 import { useGroupStore } from '~/stores/group'
@@ -64,28 +64,34 @@ const groupName = computed(() => {
 })
 
 // The postcode's groupsnear entries are deliberately trimmed (id/name only) to keep the
-// compose store small, so the profile picture and tagline come from the full group record,
-// which we fetch below. Name shows immediately; profile/tagline fill in once it loads.
-const fullGroup = computed(() => {
-  const id = selectedGroupId.value
-  return id ? groupStore.get(id) : null
-})
+// compose store small, so the profile picture and tagline come from the full group record.
+// We hold the FETCHED group in a local ref and drive the card from it, rather than reading
+// groupStore.get(id) reactively: get() returns a cross-store getter result whose dependency
+// on list[id] didn't reliably re-render the card once the fetch resolved, so the profile
+// image could stay on the /icon.png fallback (logged-in EH4 1HY showed the default instead
+// of the Edinburgh logo). Awaiting fetch() and assigning the result is deterministic. Name
+// shows immediately; profile/tagline fill in when the fetch resolves.
+const fullGroup = ref(null)
 
-const profile = computed(() => fullGroup.value?.profile || '/icon.png')
-
-const tagline = computed(() => fullGroup.value?.tagline || null)
-
-// Fetch the full group whenever the derived origin changes, so the card can show its
-// profile picture and tagline.
 watch(
   selectedGroupId,
-  (id) => {
-    if (id) {
-      groupStore.fetch(id)
+  async (id) => {
+    fullGroup.value = null
+    if (!id) {
+      return
+    }
+    const g = await groupStore.fetch(id)
+    // Guard against a stale resolution if the origin group changed while awaiting.
+    if (id === selectedGroupId.value) {
+      fullGroup.value = g
     }
   },
   { immediate: true }
 )
+
+const profile = computed(() => fullGroup.value?.profile || '/icon.png')
+
+const tagline = computed(() => fullGroup.value?.tagline || null)
 
 onMounted(async () => {
   // Refetch the postcode so its group list is fresh (groups can merge), then lock the origin

--- a/iznik-nuxt3/components/ComposeGroup.vue
+++ b/iznik-nuxt3/components/ComposeGroup.vue
@@ -1,13 +1,26 @@
 <template>
   <div class="compose-group" data-test="compose-group">
-    <span v-if="groupName" class="compose-group__name">{{ groupName }}</span>
+    <div v-if="groupName" class="compose-group__card">
+      <b-img
+        rounded
+        alt="Community profile picture"
+        :src="profile"
+        class="compose-group__logo"
+      />
+      <div class="compose-group__info">
+        <span class="compose-group__name">{{ groupName }}</span>
+        <p v-if="tagline" class="compose-group__tagline">
+          {{ tagline }}
+        </p>
+      </div>
+    </div>
     <span v-else class="compose-group__finding text-muted">
       Finding your local community…
     </span>
   </div>
 </template>
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 import { useComposeStore } from '~/stores/compose'
 import { useGroupStore } from '~/stores/group'
 import api from '~/api'
@@ -49,6 +62,30 @@ const groupName = computed(() => {
   )
 })
 
+// The postcode's groupsnear entries are deliberately trimmed (id/name only) to keep the
+// compose store small, so the profile picture and tagline come from the full group record,
+// which we fetch below. Name shows immediately; profile/tagline fill in once it loads.
+const fullGroup = computed(() => {
+  const id = selectedGroupId.value
+  return id ? groupStore.get(id) : null
+})
+
+const profile = computed(() => fullGroup.value?.profile || '/icon.png')
+
+const tagline = computed(() => fullGroup.value?.tagline || null)
+
+// Fetch the full group whenever the derived origin changes, so the card can show its
+// profile picture and tagline.
+watch(
+  selectedGroupId,
+  (id) => {
+    if (id) {
+      groupStore.fetch(id)
+    }
+  },
+  { immediate: true }
+)
+
 onMounted(async () => {
   // Refetch the postcode so its group list is fresh (groups can merge), then lock the origin
   // group to the containing-or-closest community, overriding any pre-set group.
@@ -70,8 +107,44 @@ onMounted(async () => {
   }
 })
 </script>
-<style scoped>
+<style scoped lang="scss">
+@import 'assets/css/_color-vars.scss';
+
+.compose-group__card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid $color-gray--light;
+  border-radius: 8px;
+  background: $color-white;
+}
+
+.compose-group__logo {
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+  object-fit: cover;
+  border: 2px solid $color-gray--light;
+}
+
+.compose-group__info {
+  flex: 1;
+  min-width: 0;
+}
+
 .compose-group__name {
-  font-weight: 600;
+  display: block;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: $color-header;
+  line-height: 1.2;
+}
+
+.compose-group__tagline {
+  margin: 0.15rem 0 0;
+  font-size: 0.85rem;
+  color: $color-gray--darker;
+  line-height: 1.3;
 }
 </style>

--- a/iznik-nuxt3/components/ComposeGroup.vue
+++ b/iznik-nuxt3/components/ComposeGroup.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="compose-group" data-test="compose-group">
     <div v-if="groupName" class="compose-group__card">
-      <b-img
-        rounded
-        alt="Community profile picture"
-        :src="profile"
+      <GroupProfileImage
+        :image="profile"
+        size="sm"
+        alt-text="Community profile picture"
         class="compose-group__logo"
       />
       <div class="compose-group__info">
@@ -21,6 +21,7 @@
 </template>
 <script setup>
 import { computed, onMounted, watch } from 'vue'
+import GroupProfileImage from '~/components/GroupProfileImage.vue'
 import { useComposeStore } from '~/stores/compose'
 import { useGroupStore } from '~/stores/group'
 import api from '~/api'
@@ -121,11 +122,9 @@ onMounted(async () => {
 }
 
 .compose-group__logo {
-  width: 56px;
-  height: 56px;
+  /* GroupProfileImage sizes itself (60px via size="sm") and draws its own
+     thumbnail border; just stop it being squashed in the flex row. */
   flex-shrink: 0;
-  object-fit: cover;
-  border: 2px solid $color-gray--light;
 }
 
 .compose-group__info {

--- a/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
@@ -71,9 +71,11 @@ describe('ComposeGroup', () => {
       props,
       global: {
         stubs: {
-          'b-img': {
-            template: '<img :src="src" :alt="alt" />',
-            props: ['src', 'alt', 'rounded'],
+          // GroupProfileImage renders the group's profile with an @error fallback to
+          // /icon.png; stub it to a plain img so we can assert the src it receives.
+          GroupProfileImage: {
+            template: '<img :src="image" :alt="altText" />',
+            props: ['image', 'size', 'altText'],
           },
         },
       },

--- a/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
@@ -29,7 +29,8 @@ const mockApi = {
 
 const mockGroupStore = {
   get: vi.fn().mockReturnValue(null),
-  fetch: vi.fn(),
+  // The card awaits fetch(id) and drives the profile/tagline off its resolved value.
+  fetch: vi.fn().mockResolvedValue(null),
 }
 
 vi.mock('~/stores/compose', () => ({
@@ -63,7 +64,7 @@ describe('ComposeGroup', () => {
     mockComposeStore.group = null
     mockComposeStore.setPostcode = vi.fn()
     mockGroupStore.get.mockReturnValue(null)
-    mockGroupStore.fetch = vi.fn()
+    mockGroupStore.fetch = vi.fn().mockResolvedValue(null)
   })
 
   function createWrapper(props = {}) {
@@ -162,10 +163,12 @@ describe('ComposeGroup', () => {
     expect(mockApi.location.typeahead).not.toHaveBeenCalled()
   })
 
-  it('fetches the full group and shows its profile picture and tagline', async () => {
-    // groupsnear entries are trimmed to name-only, so the card fetches the full group
-    // record for its profile image and tagline (like GroupHeader).
-    mockGroupStore.get.mockReturnValue({
+  it('shows the profile picture and tagline from the awaited fetch result', async () => {
+    // groupsnear entries are trimmed to name-only, so the card awaits the full group
+    // record (fetch) and drives the card off its result - NOT groupStore.get(), whose
+    // reactive dependency left the profile stuck on /icon.png for a logged-in member
+    // (Discourse #1170 follow-up: EH4 1HY showed the default instead of the group logo).
+    mockGroupStore.fetch.mockResolvedValue({
       id: 1,
       namedisplay: 'London Central',
       profile: 'https://example.com/logo.png',
@@ -181,8 +184,12 @@ describe('ComposeGroup', () => {
     )
   })
 
-  it('uses the default icon and omits the tagline when the group has neither', async () => {
-    // get() returns null (full group not loaded), so profile falls back and no tagline shows.
+  it('uses the default icon and omits the tagline when the fetch has no profile/tagline', async () => {
+    // fetch resolves a group without profile/tagline → falls back to /icon.png, no tagline.
+    mockGroupStore.fetch.mockResolvedValue({
+      id: 1,
+      namedisplay: 'London Central',
+    })
     const wrapper = createWrapper()
     await flushPromises()
     expect(wrapper.find('.compose-group__logo').attributes('src')).toBe(

--- a/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
@@ -29,6 +29,7 @@ const mockApi = {
 
 const mockGroupStore = {
   get: vi.fn().mockReturnValue(null),
+  fetch: vi.fn(),
 }
 
 vi.mock('~/stores/compose', () => ({
@@ -62,10 +63,21 @@ describe('ComposeGroup', () => {
     mockComposeStore.group = null
     mockComposeStore.setPostcode = vi.fn()
     mockGroupStore.get.mockReturnValue(null)
+    mockGroupStore.fetch = vi.fn()
   })
 
   function createWrapper(props = {}) {
-    return mount(ComposeGroup, { props })
+    return mount(ComposeGroup, {
+      props,
+      global: {
+        stubs: {
+          'b-img': {
+            template: '<img :src="src" :alt="alt" />',
+            props: ['src', 'alt', 'rounded'],
+          },
+        },
+      },
+    })
   }
 
   it('shows the derived origin community read-only, with no picker', async () => {
@@ -146,5 +158,34 @@ describe('ComposeGroup', () => {
     await flushPromises()
     expect(wrapper.text()).toContain('Finding your local community')
     expect(mockApi.location.typeahead).not.toHaveBeenCalled()
+  })
+
+  it('fetches the full group and shows its profile picture and tagline', async () => {
+    // groupsnear entries are trimmed to name-only, so the card fetches the full group
+    // record for its profile image and tagline (like GroupHeader).
+    mockGroupStore.get.mockReturnValue({
+      id: 1,
+      namedisplay: 'London Central',
+      profile: 'https://example.com/logo.png',
+      tagline: 'Reuse in central London',
+    })
+    const wrapper = createWrapper()
+    await flushPromises()
+    expect(mockGroupStore.fetch).toHaveBeenCalledWith(1)
+    const img = wrapper.find('.compose-group__logo')
+    expect(img.attributes('src')).toBe('https://example.com/logo.png')
+    expect(wrapper.find('.compose-group__tagline').text()).toBe(
+      'Reuse in central London'
+    )
+  })
+
+  it('uses the default icon and omits the tagline when the group has neither', async () => {
+    // get() returns null (full group not loaded), so profile falls back and no tagline shows.
+    const wrapper = createWrapper()
+    await flushPromises()
+    expect(wrapper.find('.compose-group__logo').attributes('src')).toBe(
+      '/icon.png'
+    )
+    expect(wrapper.find('.compose-group__tagline').exists()).toBe(false)
   })
 })


### PR DESCRIPTION
## Why
The "Your local community" step in the compose flow showed only the group's name as bare text. This turns it into a recognisable card with the community's profile picture and tagline, like `GroupHeader`.

## Before
![before](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/compose-community-card/before.png)

## After
![after](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/compose-community-card/after.png)

## What
`ComposeGroup` renders the derived origin community as a compact card: profile picture, community name, and tagline when present. The picture is rendered via the shared `GroupProfileImage` component (as `MapGroup` / `GroupMarkerRich` do), so a group whose profile image is missing or fails to load falls back to `/icon.png` instead of showing a broken-image glyph.

The postcode's `groupsnear` entries are trimmed to name-only to keep the compose store small, so the card fetches the full group record (`groupStore.fetch`) for the profile image and tagline. The name shows immediately; the picture and tagline fill in when the fetch resolves. Applies wherever `ComposeGroup` is used (give/find, mobile and desktop).

## Tests
`tests/unit/components/ComposeGroup.spec.js` — asserts the card fetches the full group and renders its profile image + tagline via `GroupProfileImage`, and falls back to `/icon.png` with no tagline when the group has neither. Existing origin-derivation tests are unchanged.

The `pr-assets/compose-community-card` branch is a throwaway image host, deletable after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjavhAHn6siYfunR5bacK6
