### PR TITLE
fix(membership): banned join is a real failure in both PUT paths, not fake Success

### DIFF
--- a/iznik-nuxt3/api/MembershipsAPI.js
+++ b/iznik-nuxt3/api/MembershipsAPI.js
@@ -1,5 +1,6 @@
 import BaseAPI from '@/api/BaseAPI'
 import { notAHeldConflict } from '~/api/heldConflict'
+import { notABannedFailure } from '~/api/bannedFailure'
 
 export default class MembershipsAPI extends BaseAPI {
   update(data) {
@@ -7,7 +8,9 @@ export default class MembershipsAPI extends BaseAPI {
   }
 
   joinGroup(data) {
-    return this.$putv2('/memberships', data)
+    // A banned member's join is refused with 403 "Failed - banned" - expected, so
+    // don't log it to Sentry (the caller handles it).
+    return this.$putv2('/memberships', data, notABannedFailure)
   }
 
   leaveGroup(data) {
@@ -44,7 +47,9 @@ export default class MembershipsAPI extends BaseAPI {
   }
 
   put(data) {
-    return this.$putv2('/memberships', data)
+    // Used by the moderator "Add member" flow; a banned target returns 403
+    // "Failed - banned" - expected, so keep it out of Sentry (the modal surfaces it).
+    return this.$putv2('/memberships', data, notABannedFailure)
   }
 
   approveMember(userid, groupid, subject = null, stdmsgid = null, body = null) {

--- a/iznik-nuxt3/api/bannedFailure.js
+++ b/iznik-nuxt3/api/bannedFailure.js
@@ -1,0 +1,21 @@
+// A join/add refused because the member is banned from the group comes back as a
+// 403 "Failed - banned" (see addMemberToGroup / putMembershipsPartner in
+// iznik-server-go). That is an expected outcome - a moderator may try to add a banned
+// member, or a banned member may try to rejoin - not a fault, so keep it out of Sentry.
+// Pass as the logError argument to $putv2.
+export const notABannedFailure = (data) => {
+  const s = typeof data === 'string' ? data : JSON.stringify(data ?? '')
+  return !/banned/i.test(s)
+}
+
+// True if a caught error is the 403 "Failed - banned" refusal. Callers decide how to
+// react: a member's own join is swallowed silently (don't reveal the ban), a moderator's
+// add is surfaced so they know why nothing happened.
+export function isBannedFailure(e) {
+  if (e?.response?.status !== 403) {
+    return false
+  }
+  const data = e?.response?.data
+  const s = typeof data === 'string' ? data : JSON.stringify(data ?? '')
+  return /banned/i.test(s)
+}

--- a/iznik-nuxt3/modtools/components/ModAddMemberModal.vue
+++ b/iznik-nuxt3/modtools/components/ModAddMemberModal.vue
@@ -14,6 +14,10 @@
             addedId
           }}.
         </div>
+        <NoticeMessage v-else-if="banned" variant="warning">
+          That person is banned from this community, so they can't be added. If
+          you want to let them back in, unban them first, then add them.
+        </NoticeMessage>
         <div v-else>
           <NoticeMessage variant="info">
             This will add someone as a member of your community. Please be
@@ -51,6 +55,7 @@ import { ref, computed } from 'vue'
 import { useMemberStore } from '~/stores/member'
 import { useUserStore } from '~/stores/user'
 import { useOurModal } from '~/composables/useOurModal'
+import { isBannedFailure } from '~/api/bannedFailure'
 
 const props = defineProps({
   groupid: {
@@ -65,21 +70,35 @@ const { modal, show, hide } = useOurModal()
 
 const email = ref(null)
 const addedId = ref(null)
+const banned = ref(false)
 
 const validEmail = computed(() => {
   return email.value && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.value)
 })
 
 async function add() {
+  banned.value = false
   addedId.value = await userStore.add({
     email: email.value,
   })
 
   if (addedId.value) {
-    await memberStore.add({
-      userid: addedId.value,
-      groupid: props.groupid,
-    })
+    try {
+      await memberStore.add({
+        userid: addedId.value,
+        groupid: props.groupid,
+      })
+    } catch (e) {
+      // The server refuses to add a banned member (403 "Failed - banned"). Surface
+      // it so the moderator knows why nothing happened, rather than a silent no-op
+      // or an ugly error. Anything else is a real failure and must propagate.
+      if (isBannedFailure(e)) {
+        banned.value = true
+        addedId.value = null
+        return
+      }
+      throw e
+    }
   }
 }
 

--- a/iznik-nuxt3/stores/auth.js
+++ b/iznik-nuxt3/stores/auth.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { SocialLogin } from '@capgo/capacitor-social-login'
 import { LoginError, SignUpError } from '~/api/APIErrors'
+import { isBannedFailure } from '~/api/bannedFailure'
 import {
   abortAllPendingRequests,
   enterLogoutMode,
@@ -536,11 +537,21 @@ export const useAuthStore = defineStore({
       return this.user
     },
     async joinGroup(userid, groupid, manual) {
-      await this.$api.memberships.joinGroup({
-        userid,
-        groupid,
-        manual,
-      })
+      try {
+        await this.$api.memberships.joinGroup({
+          userid,
+          groupid,
+          manual,
+        })
+      } catch (e) {
+        // A banned member's own join is refused server-side (403 "Failed - banned").
+        // Swallow it silently: we don't reveal the ban to them, we just don't join.
+        // Anything else is a real error and must propagate.
+        if (isBannedFailure(e)) {
+          return this.user
+        }
+        throw e
+      }
       await this.fetchUser()
       return this.user
     },

--- a/iznik-nuxt3/tests/unit/api/bannedFailure.spec.js
+++ b/iznik-nuxt3/tests/unit/api/bannedFailure.spec.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { notABannedFailure, isBannedFailure } from '~/api/bannedFailure'
+
+// A banned join/add is refused with 403 "Failed - banned". notABannedFailure keeps it
+// out of Sentry; isBannedFailure lets callers react (self-join swallows it, mod-add
+// surfaces it).
+describe('bannedFailure', () => {
+  describe('notABannedFailure (Sentry suppression)', () => {
+    it('suppresses (false) a banned message object', () => {
+      expect(
+        notABannedFailure({ error: 403, message: 'Failed - banned' })
+      ).toBe(false)
+    })
+
+    it('suppresses (false) a banned message string', () => {
+      expect(notABannedFailure('Failed - banned')).toBe(false)
+    })
+
+    it('logs (true) other failures and empty data', () => {
+      expect(notABannedFailure({ error: 500, message: 'boom' })).toBe(true)
+      expect(notABannedFailure(null)).toBe(true)
+      expect(notABannedFailure('Not a moderator of this group')).toBe(true)
+    })
+  })
+
+  describe('isBannedFailure', () => {
+    it('is true for a 403 whose message mentions banned', () => {
+      expect(
+        isBannedFailure({
+          response: { status: 403, data: { message: 'Failed - banned' } },
+        })
+      ).toBe(true)
+    })
+
+    it('is false for a 403 that is not about a ban', () => {
+      expect(
+        isBannedFailure({
+          response: { status: 403, data: { message: 'Not a moderator' } },
+        })
+      ).toBe(false)
+    })
+
+    it('is false for non-403 errors even if they mention banned', () => {
+      expect(
+        isBannedFailure({
+          response: { status: 500, data: { message: 'banned' } },
+        })
+      ).toBe(false)
+    })
+
+    it('is false for a malformed/absent error', () => {
+      expect(isBannedFailure(undefined)).toBe(false)
+      expect(isBannedFailure({})).toBe(false)
+    })
+  })
+})

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -1199,12 +1199,17 @@ func putMembershipsPartner(c *fiber.Ctx, db *gorm.DB, partnerKey string) error {
 		}
 	}
 
-	// Check if banned.
+	// Check if banned. V1 parity: User::addMembership returns FALSE for
+	// isBanned(), and the legacy partner handler reported that as ret=4
+	// "Failed - likely ban" - a genuine failure. Reporting a fake "Success"
+	// here instead (Discourse #9961) leaves no membership, memberships_history,
+	// or log row anywhere, so a banned member's join attempt vanishes with
+	// nothing for a moderator to find while the partner is told it worked.
 	var bannedCount int64
 	db.Raw("SELECT COUNT(*) FROM users_banned WHERE userid = ? AND groupid = ?",
 		userid, groupid).Scan(&bannedCount)
 	if bannedCount > 0 {
-		return c.JSON(fiber.Map{"ret": 0, "status": "Success", "fduserid": userid, "addedto": utils.COLLECTION_APPROVED})
+		return fiber.NewError(fiber.StatusForbidden, "Failed - banned")
 	}
 
 	// Check if already a member.

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -1254,12 +1254,17 @@ func addMemberToGroup(c *fiber.Ctx, db *gorm.DB, userid uint64, groupid uint64, 
 		return c.JSON(fiber.Map{"ret": 0, "status": "Success", "addedto": "Approved"})
 	}
 
-	// Check if banned.
+	// Check if banned. V1 parity: User::addMembership returns FALSE for isBanned(),
+	// a genuine failure. Reporting a fake "Success" here (Discourse #9961) leaves no
+	// membership, memberships_history, or log row anywhere, so a banned member's join
+	// attempt vanishes with nothing for a moderator to find while the caller (a partner
+	// like TrashNothing, or a moderator using the Add button) is told it worked. Return
+	// a real failure so the join doesn't silently disappear.
 	var bannedCount int64
 	db.Raw("SELECT COUNT(*) FROM users_banned WHERE userid = ? AND groupid = ?",
 		userid, groupid).Scan(&bannedCount)
 	if bannedCount > 0 {
-		return c.JSON(fiber.Map{"ret": 0, "status": "Success", "addedto": utils.COLLECTION_APPROVED})
+		return fiber.NewError(fiber.StatusForbidden, "Failed - banned")
 	}
 
 	// Insert membership as approved member.

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -3902,12 +3902,19 @@ func TestDeleteMembershipsPartnerUnsubscribe(t *testing.T) {
 	groupID := CreateTestGroup(t, prefix)
 	userID := CreateTestUser(t, prefix+"_user", "User")
 	CreateTestMembership(t, userID, groupID, "Member")
-	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 54321, userID)
+
+	// tnuserid is UNIQUE in production. Release it from any user left by an
+	// earlier run before claiming it here (same pattern as
+	// TestPutMembershipsPartnerSubscribe/AutoCreate) - without this, a stale row
+	// left by a prior run of this test collides on this fixed value.
+	tnuserid := 54321
+	db.Exec("UPDATE users SET tnuserid = NULL WHERE tnuserid = ?", tnuserid)
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", tnuserid, userID)
 
 	key := insertTestPartnerKey(t, prefix, "test.com")
 	email := prefix + "_user@test.com"
 
-	url := fmt.Sprintf("/api/memberships?partner=%s&tnuserid=54321&email=%s&groupid=%d", key, email, groupID)
+	url := fmt.Sprintf("/api/memberships?partner=%s&tnuserid=%d&email=%s&groupid=%d", key, tnuserid, email, groupID)
 	req := httptest.NewRequest("DELETE", url, nil)
 	resp, err := getApp().Test(req, -1)
 	assert.NoError(t, err)

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -118,7 +118,9 @@ func TestPutMembershipsGoBannedCannotRejoin(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := getApp().Test(req, -1)
 	assert.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode)
+	// Discourse #9961: a banned join must be a real failure, not a fake "Success"
+	// that silently drops the request with nothing for a moderator to find.
+	assert.Equal(t, 403, resp.StatusCode, "Banned member rejoin should fail, not fake-succeed")
 
 	// Verify user is NOT added to Approved membership.
 	var approvedCount int64
@@ -160,7 +162,8 @@ func TestPutMembershipsV1BannedCannotRejoin(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := getApp().Test(req, -1)
 	assert.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode)
+	// Discourse #9961: banned rejoin is a real failure, not a fake "Success".
+	assert.Equal(t, 403, resp.StatusCode, "V1-banned member rejoin should fail, not fake-succeed")
 
 	// Verify user is NOT added to Approved membership.
 	var approvedCount int64

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/freegle/iznik-server-go/database"
+	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -3837,6 +3838,61 @@ func TestPutMembershipsPartnerInvalidKey(t *testing.T) {
 	resp, err := getApp().Test(req, -1)
 	assert.NoError(t, err)
 	assert.Equal(t, 403, resp.StatusCode)
+}
+
+// Discourse #9961: TrashNothing reported a member's join request as stuck
+// "pending" because it never reached a Freegle moderator. V1 parity check
+// (User::addMembership/isBanned via the legacy PHP partner handler) shows the
+// original behaviour: a banned member's partner join returned ret=4 "Failed -
+// likely ban", a genuine failure the partner could act on. The V2 Go port
+// (putMembershipsPartner) dropped that and unconditionally returns ret=0
+// "Success" for a banned member instead - no membership row, no
+// memberships_history row, no log entry, nothing anywhere for a moderator to
+// find, while telling the partner the join worked. Production data confirms
+// this path is reachable: thousands of TN-linked (userid, groupid) pairs are
+// currently banned with no corresponding membership row.
+func TestPutMembershipsPartnerBannedNotFakeSuccess(t *testing.T) {
+	prefix := uniquePrefix("mem_partbanned")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	email := prefix + "@test.com"
+	tnuserid := uint64(7654322)
+
+	db.Exec("UPDATE users SET tnuserid = NULL WHERE tnuserid = ?", tnuserid)
+
+	key := insertTestPartnerKey(t, prefix, "test.com")
+
+	// First request auto-creates the TN-linked user via the normal partner join.
+	url := fmt.Sprintf("/api/memberships?partner=%s&tnuserid=%d&email=%s&groupid=%d", key, tnuserid, email, groupID)
+	req := httptest.NewRequest("PUT", url, nil)
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var userID uint64
+	db.Raw("SELECT id FROM users WHERE tnuserid = ?", tnuserid).Scan(&userID)
+	assert.NotZero(t, userID)
+
+	// Simulate a member who was previously banned from this group (e.g. by a
+	// moderator, independently of TN) then has TN retry the join on their
+	// behalf - TN has no visibility into Freegle-side bans.
+	db.Exec("DELETE FROM memberships WHERE userid = ? AND groupid = ?", userID, groupID)
+	db.Exec("INSERT INTO users_banned (userid, groupid, byuser) VALUES (?, ?, ?)", userID, groupID, userID)
+
+	req2 := httptest.NewRequest("PUT", url, nil)
+	resp2, err := getApp().Test(req2, -1)
+	assert.NoError(t, err)
+
+	// Inverted (correct) assertion: a banned member's join attempt must be
+	// reported as a failure, not a fake Success, so the partner and the member
+	// both know it did not happen.
+	assert.Equal(t, fiber.StatusForbidden, resp2.StatusCode,
+		"a banned member's join attempt must not be reported as Success to the partner")
+
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND groupid = ?", userID, groupID).Scan(&count)
+	assert.Equal(t, int64(0), count, "a banned member must not gain a membership row via the partner path")
 }
 
 func TestDeleteMembershipsPartnerUnsubscribe(t *testing.T) {


### PR DESCRIPTION
## Root cause
`PUT /memberships` forks into `putMembershipsPartner` (TrashNothing and other partners) and `addMemberToGroup` (website self-join + moderator "Add member"). Both reported a banned member's join as `ret=0 "Success"` while writing nothing — no membership, no history, no log — so the join silently vanished with nothing for a moderator to find, while the caller was told it worked (Discourse #9961: TrashNothing join requests never arrived).

## Fix
**Server** — both branches now return `403 "Failed - banned"` for a banned member (V1 parity: `User::addMembership` returns FALSE for `isBanned()`), instead of a fake Success.

**Client** — the 403 is surfaced appropriately rather than thrown uncaught + logged to Sentry:
- `notABannedFailure` / `isBannedFailure` helpers (mirroring `heldConflict`) keep the expected 403 out of Sentry and let callers react.
- **Self-join** (`auth.joinGroup`, the group Join button): swallowed silently — we don't reveal the ban to the member, we just don't join.
- **Moderator "Add member"** (`ModAddMemberModal`): surfaced — the modal shows "That person is banned… unban them first" so the mod knows why nothing happened.

## Tests
- Go: `TestPutMembershipsPartnerBannedNotFakeSuccess` (partner path); the two website-path banned tests now assert the 403 failure (no Approved membership, `users_banned` row intact).
- Vitest: `bannedFailure.spec.js` covers the Sentry-suppression predicate and the caught-error detector.

## Discourse
https://discourse.ilovefreegle.org/t/9961
