### PR TITLE
test(go): unit tests for rippling reach/attribution/metrics, spatial + userdump helpers

### DIFF
--- a/iznik-server-go/rippling/analytics_test.go
+++ b/iznik-server-go/rippling/analytics_test.go
@@ -1,0 +1,112 @@
+package rippling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// bullseyeEdges = [0, 10, 15, 20, 25, 30, 45] -> bands [0,10) [10,15) [15,20)
+// [20,25) [25,30) [30,45]. Every band except the last is hi-exclusive; the
+// last is inclusive at BOTH ends so no scored reply (capped at driveMaxMinutes
+// == the top edge) is ever dropped. This table drives one value AT each of
+// the six edges plus the two out-of-range values, and asserts which single
+// band claims it.
+func TestBullseye_EveryRingEdgeAssignedToExactlyOneBand(t *testing.T) {
+	assert.Equal(t, []int{0, 10, 15, 20, 25, 30, driveMaxMinutes}, bullseyeEdges)
+
+	cases := []struct {
+		name     string
+		min      float64
+		wantBand int // index into the returned bands slice, or -1 for "no band"
+	}{
+		{"below the first ring is excluded from every band", -0.01, -1},
+		{"edge 0 (first ring lo, inclusive) falls in band 0 [0,10)", 0, 0},
+		{"just under edge 10 falls in band 0 [0,10)", 9.99, 0},
+		{"edge 10 (shared boundary) falls in band 1 [10,15), NOT band 0 (band 0 is hi-exclusive)", 10, 1},
+		{"edge 15 falls in band 2 [15,20), NOT band 1", 15, 2},
+		{"edge 20 falls in band 3 [20,25), NOT band 2", 20, 3},
+		{"edge 25 falls in band 4 [25,30), NOT band 3", 25, 4},
+		{"edge 30 falls in band 5 [30,45], NOT band 4 - the last ring's lo is inclusive same as every other ring", 30, 5},
+		{"edge 45 (top edge, last ring) is INCLUSIVE - special-cased so the cap value is not dropped", 45, 5},
+		{"above the top ring is excluded from every band", 45.01, -1},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bands := Bullseye([]float64{c.min}, []bool{false})
+			assert.Len(t, bands, len(bullseyeEdges)-1)
+			for i, b := range bands {
+				if i == c.wantBand {
+					assert.Equal(t, 1, b.NReplies, "band %d [%d,%d) should have claimed %v", i, b.MinLo, b.MinHi, c.min)
+				} else {
+					assert.Equal(t, 0, b.NReplies, "band %d [%d,%d) should NOT have claimed %v", i, b.MinLo, b.MinHi, c.min)
+				}
+			}
+		})
+	}
+}
+
+// A band with zero replies must not divide by zero when computing conversion
+// / CI - both must stay at their Go zero value rather than NaN or panicking.
+func TestBullseye_ZeroRepliesBandGuardsAgainstDivideByZero(t *testing.T) {
+	// A single value in band 0 leaves every other band at NReplies == 0.
+	bands := Bullseye([]float64{5}, []bool{true})
+	for i, b := range bands {
+		if i == 0 {
+			continue
+		}
+		assert.Equal(t, 0, b.NReplies)
+		assert.Equal(t, 0, b.NTakers)
+		assert.Equal(t, 0.0, b.ConvPct, "zero-reply band must not divide by zero into NaN")
+		assert.Equal(t, 0.0, b.CIHalf, "zero-reply band must not divide by zero into NaN")
+	}
+}
+
+// All-takers and no-takers push the CI to its two extremes (p=1 and p=0);
+// the normal-approximation CI half-width collapses to 0 at both extremes
+// since p*(1-p) == 0.
+func TestBullseye_ConversionExtremes(t *testing.T) {
+	allTakers := Bullseye([]float64{1, 2, 3}, []bool{true, true, true})
+	band0 := allTakers[0]
+	assert.Equal(t, 3, band0.NReplies)
+	assert.Equal(t, 3, band0.NTakers)
+	assert.InDelta(t, 100.0, band0.ConvPct, 1e-9)
+	assert.InDelta(t, 0.0, band0.CIHalf, 1e-9)
+
+	noTakers := Bullseye([]float64{1, 2, 3}, []bool{false, false, false})
+	band0b := noTakers[0]
+	assert.Equal(t, 3, band0b.NReplies)
+	assert.Equal(t, 0, band0b.NTakers)
+	assert.Equal(t, 0.0, band0b.ConvPct)
+	assert.InDelta(t, 0.0, band0b.CIHalf, 1e-9)
+}
+
+// Bullseye must tolerate takers being shorter (or longer) than mins without
+// panicking - index-out-of-range positions are treated as non-takers.
+func TestBullseye_MismatchedLengthSlicesTolerated(t *testing.T) {
+	assert.NotPanics(t, func() {
+		bands := Bullseye([]float64{1, 2, 3, 4, 5}, []bool{true})
+		assert.Equal(t, 5, bands[0].NReplies)
+		assert.Equal(t, 1, bands[0].NTakers) // only index 0 had a takers entry
+	})
+
+	assert.NotPanics(t, func() {
+		// More takers than mins: the extra bool entries are simply unused.
+		bands := Bullseye([]float64{1}, []bool{true, true, true})
+		assert.Equal(t, 1, bands[0].NReplies)
+		assert.Equal(t, 1, bands[0].NTakers)
+	})
+}
+
+func TestBullseye_NilAndEmptyInputsReturnAllZeroBands(t *testing.T) {
+	for _, bands := range [][]BullseyeBand{Bullseye(nil, nil), Bullseye([]float64{}, []bool{})} {
+		assert.Len(t, bands, len(bullseyeEdges)-1)
+		for _, b := range bands {
+			assert.Equal(t, 0, b.NReplies)
+			assert.Equal(t, 0, b.NTakers)
+			assert.Equal(t, 0.0, b.ConvPct)
+			assert.Equal(t, 0.0, b.CIHalf)
+		}
+	}
+}

--- a/iznik-server-go/rippling/attribution_test.go
+++ b/iznik-server-go/rippling/attribution_test.go
@@ -1,0 +1,117 @@
+package rippling
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func intp(v int) *int { return &v }
+
+// DeriveAttribution runs the six-rung precedence ladder. Every rung must be
+// individually reachable, and where two rungs' evidence is simultaneously
+// true the HIGHER-precedence rung must win.
+func TestDeriveAttribution_Ladder(t *testing.T) {
+	cases := []struct {
+		name                                                             string
+		wasHomeMember, wasNotified, wasRippleGroupMember, postHadRippled int
+		inOriginCatchment, inReach                                       *int
+		want                                                             string
+	}{
+		// ---- Individual rungs, all other evidence absent ----
+		{"home wins with nothing else set", 1, 0, 0, 0, nil, nil, AttributionHome},
+		{"ripple_notified when only notified evidence set", 0, 1, 0, 0, nil, nil, AttributionRippleNotified},
+		{"ripple_group when only group-membership evidence set", 0, 0, 1, 0, nil, nil, AttributionRippleGroup},
+		{"organic_local when only catchment evidence set", 0, 0, 0, 0, intp(1), nil, AttributionOrganicLocal},
+		{"ripple_reach when post rippled and reach evidence set", 0, 0, 0, 1, nil, intp(1), AttributionRippleReach},
+		{"unknown when nothing resolvable", 0, 0, 0, 0, nil, nil, AttributionUnknown},
+
+		// ---- Precedence collisions: higher rung must win over lower ones ----
+		{"home beats notified", 1, 1, 0, 0, nil, nil, AttributionHome},
+		{"home beats ripple_group", 1, 0, 1, 0, nil, nil, AttributionHome},
+		{"home beats organic_local", 1, 0, 0, 0, intp(1), nil, AttributionHome},
+		{"home beats ripple_reach", 1, 0, 0, 1, nil, intp(1), AttributionHome},
+		{"home beats everything at once", 1, 1, 1, 1, intp(1), intp(1), AttributionHome},
+		{"notified beats ripple_group", 0, 1, 1, 0, nil, nil, AttributionRippleNotified},
+		{"notified beats organic_local", 0, 1, 0, 0, intp(1), nil, AttributionRippleNotified},
+		{"notified beats ripple_reach", 0, 1, 0, 1, nil, intp(1), AttributionRippleNotified},
+		{"ripple_group beats organic_local", 0, 0, 1, 0, intp(1), nil, AttributionRippleGroup},
+		{"ripple_group beats ripple_reach", 0, 0, 1, 1, nil, intp(1), AttributionRippleGroup},
+		{"organic_local beats ripple_reach - deliberately ranked above reach", 0, 0, 0, 1, intp(1), intp(1), AttributionOrganicLocal},
+
+		// ---- inOriginCatchment / inReach: nil vs 0 vs 1 ----
+		{"catchment nil does not trigger organic_local", 0, 0, 0, 0, nil, nil, AttributionUnknown},
+		{"catchment 0 does not trigger organic_local", 0, 0, 0, 0, intp(0), nil, AttributionUnknown},
+		{"catchment 1 triggers organic_local", 0, 0, 0, 0, intp(1), nil, AttributionOrganicLocal},
+		{"reach nil does not trigger ripple_reach even if post rippled", 0, 0, 0, 1, nil, nil, AttributionUnknown},
+		{"reach 0 does not trigger ripple_reach even if post rippled", 0, 0, 0, 1, nil, intp(0), AttributionUnknown},
+		{"reach 1 without postHadRippled does not trigger ripple_reach", 0, 0, 0, 0, nil, intp(1), AttributionUnknown},
+		{"reach 1 with postHadRippled triggers ripple_reach", 0, 0, 0, 1, nil, intp(1), AttributionRippleReach},
+
+		// ---- Structural guard: a post that never rippled cannot be ripple-attributed via reach ----
+		{"postHadRippled=0 blocks ripple_reach even with reach evidence present", 0, 0, 0, 0, nil, intp(1), AttributionUnknown},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := DeriveAttribution(c.wasHomeMember, c.wasNotified, c.wasRippleGroupMember, c.postHadRippled, c.inOriginCatchment, c.inReach)
+			assert.Equal(t, c.want, got, c.name)
+		})
+	}
+}
+
+// SanitizeClientSource validates the client-reported reply surface against
+// ^[a-z0-9][a-z0-9_-]{0,31}$ (max length 32) and returns nil for anything that
+// doesn't match, so the DB never receives arbitrary/injected strings.
+func TestSanitizeClientSource(t *testing.T) {
+	str := func(s string) *string { return &s }
+
+	cases := []struct {
+		name      string
+		in        *string
+		wantNil   bool
+		wantValue string
+	}{
+		{"nil input stays nil", nil, true, ""},
+		{"pointer to empty string is rejected", str(""), true, ""},
+		{"a normal valid value passes through unchanged", str("browse"), false, "browse"},
+		{"digits and underscore/hyphen mid-string are valid", str("message_page-2"), false, "message_page-2"},
+		{"leading char must be [a-z0-9] - leading hyphen rejected", str("-browse"), true, ""},
+		{"leading char must be [a-z0-9] - leading underscore rejected", str("_browse"), true, ""},
+		{"invalid character mid-string rejected", str("brow se"), true, ""},
+		{"invalid character mid-string rejected (punctuation)", str("browse!"), true, ""},
+		{"uppercase rejected - regex is lowercase-only", str("Browse"), true, ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SanitizeClientSource(c.in)
+			if c.wantNil {
+				assert.Nil(t, got, c.name)
+				return
+			}
+			if assert.NotNil(t, got, c.name) {
+				assert.Equal(t, c.wantValue, *got)
+				// Confirms the function returns the same pointer/value rather
+				// than a copy that happens to match.
+				assert.Equal(t, c.in, got)
+			}
+		})
+	}
+}
+
+func TestSanitizeClientSource_LengthBoundary(t *testing.T) {
+	exact32 := "a" + strings.Repeat("b", 31) // 1 + 31 = 32 chars, matches [a-z0-9][a-z0-9_-]{0,31}
+	assert.Len(t, exact32, 32)
+	str32 := exact32
+	got := SanitizeClientSource(&str32)
+	if assert.NotNil(t, got) {
+		assert.Equal(t, exact32, *got)
+	}
+
+	over33 := exact32 + "c" // 33 chars - one over the cap
+	assert.Len(t, over33, 33)
+	str33 := over33
+	assert.Nil(t, SanitizeClientSource(&str33))
+}

--- a/iznik-server-go/rippling/metrics_test.go
+++ b/iznik-server-go/rippling/metrics_test.go
@@ -1,0 +1,92 @@
+package rippling
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ReplySourceSplitSQL builds the per-day attribution query. The `wide` flag
+// switches whether the bucket expression reads the captured attribution
+// column (falling back to the live derivation per row) or always derives it
+// live (the legacy/unmigrated-DB path). srcGroup is spliced in verbatim as an
+// optional origin-group scoping JOIN.
+func TestReplySourceSplitSQL_LegacyNarrow(t *testing.T) {
+	sql := ReplySourceSplitSQL(false, "")
+
+	// Legacy path derives the bucket live - no COALESCE(rra.attribution, ...) wrapper.
+	assert.NotContains(t, sql, "COALESCE(rra.attribution")
+	assert.Contains(t, sql, "WHEN rra.was_home_member = 1 THEN 'home'")
+	assert.Contains(t, sql, "WHEN EXISTS(SELECT 1 FROM rippling_reach_notified rrn")
+	assert.Contains(t, sql, "THEN 'ripple_notified'")
+	assert.Contains(t, sql, "WHEN EXISTS(SELECT 1 FROM messages_groups mgr")
+	assert.Contains(t, sql, "THEN 'ripple_group'")
+	assert.Contains(t, sql, "ELSE 'unknown'")
+
+	// Output shape: one row per day with every channel summed off the bucket.
+	assert.Contains(t, sql, "SELECT day,")
+	assert.Contains(t, sql, "COUNT(*) AS replies")
+	assert.Contains(t, sql, "SUM(bucket = 'home') AS home")
+	assert.Contains(t, sql, "SUM(bucket = 'ripple_notified') AS ripple_notified")
+	assert.Contains(t, sql, "SUM(bucket = 'ripple_group') AS ripple_group")
+	assert.Contains(t, sql, "SUM(bucket = 'ripple_reach') AS ripple_reach")
+	assert.Contains(t, sql, "SUM(bucket = 'organic_local') AS organic_local")
+	assert.Contains(t, sql, "SUM(bucket = 'unknown') AS unknown")
+	assert.Contains(t, sql, "FROM rippling_reply_attribution rra")
+	assert.Contains(t, sql, "WHERE rra.replied_at >= ? AND rra.replied_at < ?")
+	assert.Contains(t, sql, "GROUP BY day")
+	assert.Contains(t, sql, "ORDER BY day DESC")
+
+	// No srcGroup passed - nothing but whitespace sits between the bare table
+	// reference and the WHERE window (i.e. no stray JOIN got spliced in).
+	fromIdx := strings.Index(sql, "FROM rippling_reply_attribution rra")
+	whereIdx := strings.Index(sql, "WHERE rra.replied_at")
+	if assert.True(t, fromIdx >= 0 && whereIdx > fromIdx) {
+		between := sql[fromIdx+len("FROM rippling_reply_attribution rra") : whereIdx]
+		assert.Empty(t, strings.TrimSpace(between))
+	}
+}
+
+func TestReplySourceSplitSQL_WideWrapsWithCoalesce(t *testing.T) {
+	sql := ReplySourceSplitSQL(true, "")
+
+	// Wide path prefers the captured column, falling back to the same live
+	// derivation used by the legacy path for rows the backfill hasn't reached.
+	assert.Contains(t, sql, "COALESCE(rra.attribution, CASE")
+	assert.Contains(t, sql, "WHEN rra.was_home_member = 1 THEN 'home'")
+	assert.Contains(t, sql, "END) AS bucket")
+}
+
+func TestReplySourceSplitSQL_SrcGroupSplicedIntoFROM(t *testing.T) {
+	srcGroup := " JOIN messages_groups mg ON mg.msgid = rra.msgid AND mg.groupid = ? AND mg.rippled_in = 0 AND mg.deleted = 0"
+	sql := ReplySourceSplitSQL(false, srcGroup)
+
+	assert.Contains(t, sql, "FROM rippling_reply_attribution rra"+srcGroup)
+	// The join must land before the WHERE window, not after.
+	joinIdx := strings.Index(sql, "JOIN messages_groups mg")
+	whereIdx := strings.Index(sql, "WHERE rra.replied_at")
+	if assert.True(t, joinIdx >= 0 && whereIdx >= 0, "both the JOIN and WHERE clause must be present") {
+		assert.Less(t, joinIdx, whereIdx, "srcGroup JOIN must precede the replied_at WHERE window")
+	}
+}
+
+func TestReplySourceSplitSQL_SrcGroupEmptyStringLeavesNoJoin(t *testing.T) {
+	sql := ReplySourceSplitSQL(true, "")
+	assert.NotContains(t, sql, "JOIN messages_groups mg")
+}
+
+// A srcGroup value containing SQL-significant characters (quotes, extra
+// clauses) is spliced verbatim - this documents that ReplySourceSplitSQL
+// trusts its caller and performs no quoting/escaping of srcGroup itself.
+func TestReplySourceSplitSQL_SrcGroupEdgeCaseSplicedVerbatim(t *testing.T) {
+	weird := ` JOIN "quoted" q ON q.msgid = rra.msgid`
+	sql := ReplySourceSplitSQL(false, weird)
+	assert.Contains(t, sql, "FROM rippling_reply_attribution rra"+weird)
+}
+
+func TestReplySourceSplitSQL_BothWideValuesProduceDifferentSQL(t *testing.T) {
+	narrow := ReplySourceSplitSQL(false, "")
+	wide := ReplySourceSplitSQL(true, "")
+	assert.NotEqual(t, narrow, wide)
+}

--- a/iznik-server-go/rippling/reachbounds_test.go
+++ b/iznik-server-go/rippling/reachbounds_test.go
@@ -1,0 +1,104 @@
+package rippling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ReachInReachExpr returns a single boolean SQL expression covering BOTH the
+// real-bound path (outer_bound is a proper polygon: cheap containment test,
+// falling to inner_bound / exact polygon EXISTS) and the POINT-sentinel path
+// (degraded outer_bound on a completed post: skip straight to the exact
+// polygon EXISTS). Golden-string assert so any change to either shape is
+// visible in the diff.
+func TestReachInReachExpr_GoldenSQLAndArgs(t *testing.T) {
+	expr, args := ReachInReachExpr(-0.1, 51.5, 4326)
+
+	wantExpr := "((ST_GeometryType(rr.outer_bound) <> 'POINT' AND ST_Contains(rr.outer_bound, ST_SRID(POINT(?, ?), ?)) " +
+		"AND (COALESCE(ST_Contains(rr.inner_bound, ST_SRID(POINT(?, ?), ?)), 0) = 1 " +
+		"OR EXISTS (SELECT 1 FROM rippling_reach r2 WHERE r2.msgid = rr.msgid AND ST_Contains(r2.polygon, ST_SRID(POINT(?, ?), ?))))) " +
+		"OR (ST_GeometryType(rr.outer_bound) = 'POINT' AND EXISTS (SELECT 1 FROM rippling_reach r2 WHERE r2.msgid = rr.msgid AND ST_Contains(r2.polygon, ST_SRID(POINT(?, ?), ?)))))"
+	assert.Equal(t, wantExpr, expr)
+
+	// Sanity check both branches are textually present: the real-bound path
+	// (ST_Contains against outer_bound directly) and the POINT-sentinel path
+	// (falls straight to the exact-polygon EXISTS).
+	assert.Contains(t, expr, "ST_GeometryType(rr.outer_bound) <> 'POINT'")
+	assert.Contains(t, expr, "ST_GeometryType(rr.outer_bound) = 'POINT'")
+
+	// Four (lng, lat, srid) triples, in order.
+	wantArgs := []interface{}{
+		-0.1, 51.5, 4326,
+		-0.1, 51.5, 4326,
+		-0.1, 51.5, 4326,
+		-0.1, 51.5, 4326,
+	}
+	assert.Equal(t, wantArgs, args)
+	assert.Len(t, args, 12)
+}
+
+func TestReachInReachExpr_ArgsScaleWithDistinctInputs(t *testing.T) {
+	// Distinct (non-repeating) inputs make it obvious the same triple is used
+	// for all four placeholders rather than some other combination.
+	expr, args := ReachInReachExpr(1.23, -33.87, 3857)
+	assert.NotEmpty(t, expr)
+	for i := 0; i < 4; i++ {
+		base := i * 3
+		assert.Equal(t, 1.23, args[base])
+		assert.Equal(t, -33.87, args[base+1])
+		assert.Equal(t, 3857, args[base+2])
+	}
+}
+
+// ReachBrowseWhere returns the browse-feed containment conjuncts: the R-tree
+// is driven from the MBRContains(outer_bound, ...) prefilter, then the exact
+// ST_Contains(outer_bound, ...) test, then inner_bound / exact-polygon EXISTS.
+// Unlike ReachInReachExpr there is no POINT special case here (browse relies
+// on the index pruning degraded bounds away entirely).
+func TestReachBrowseWhere_GoldenSQLAndArgs(t *testing.T) {
+	where, args := ReachBrowseWhere(-0.1, 51.5, 4326)
+
+	wantWhere := "AND MBRContains(rr.outer_bound, ST_SRID(POINT(?, ?), ?)) " +
+		"AND ST_Contains(rr.outer_bound, ST_SRID(POINT(?, ?), ?)) " +
+		"AND (COALESCE(ST_Contains(rr.inner_bound, ST_SRID(POINT(?, ?), ?)), 0) = 1 " +
+		"OR EXISTS (SELECT 1 FROM rippling_reach r2 WHERE r2.msgid = rr.msgid AND ST_Contains(r2.polygon, ST_SRID(POINT(?, ?), ?)))) "
+	assert.Equal(t, wantWhere, where)
+
+	assert.Contains(t, where, "MBRContains(rr.outer_bound")
+	assert.Contains(t, where, "ST_Contains(rr.outer_bound")
+	assert.True(t, len(where) > 0 && where[0] == 'A', "must start with a leading AND so callers can splice it directly onto a WHERE clause")
+
+	wantArgs := []interface{}{
+		-0.1, 51.5, 4326,
+		-0.1, 51.5, 4326,
+		-0.1, 51.5, 4326,
+		-0.1, 51.5, 4326,
+	}
+	assert.Equal(t, wantArgs, args)
+	assert.Len(t, args, 12)
+}
+
+func TestReachBrowseWhere_ArgsScaleWithDistinctInputs(t *testing.T) {
+	where, args := ReachBrowseWhere(1.23, -33.87, 3857)
+	assert.NotEmpty(t, where)
+	for i := 0; i < 4; i++ {
+		base := i * 3
+		assert.Equal(t, 1.23, args[base])
+		assert.Equal(t, -33.87, args[base+1])
+		assert.Equal(t, 3857, args[base+2])
+	}
+}
+
+// Neither function has a POINT-sentinel-vs-real-bound branch in Go - both SQL
+// shapes are baked into one static string returned for every call - so the
+// same golden string is the whole contract regardless of input values.
+func TestReachExprs_SQLShapeIndependentOfInputValues(t *testing.T) {
+	expr1, _ := ReachInReachExpr(0, 0, 0)
+	expr2, _ := ReachInReachExpr(179.99, -89.99, 900913)
+	assert.Equal(t, expr1, expr2)
+
+	where1, _ := ReachBrowseWhere(0, 0, 0)
+	where2, _ := ReachBrowseWhere(179.99, -89.99, 900913)
+	assert.Equal(t, where1, where2)
+}

--- a/iznik-server-go/spatial/extra_test.go
+++ b/iznik-server-go/spatial/extra_test.go
@@ -1,0 +1,62 @@
+package spatial
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// baseURL prefers SPATIAL_KNN_URL (canonical), falls back to SPATIAL_SERVER_URL
+// (backward compat), then to the local-Docker default.
+func TestBaseURL_SpatialKnnURLWins(t *testing.T) {
+	t.Setenv("SPATIAL_KNN_URL", "http://spatial-knn:8194")
+	t.Setenv("SPATIAL_SERVER_URL", "http://spatial-server:9999")
+	assert.Equal(t, "http://spatial-knn:8194", baseURL())
+}
+
+func TestBaseURL_FallsBackToSpatialServerURL(t *testing.T) {
+	t.Setenv("SPATIAL_KNN_URL", "")
+	t.Setenv("SPATIAL_SERVER_URL", "http://spatial-server:9999")
+	assert.Equal(t, "http://spatial-server:9999", baseURL())
+}
+
+func TestBaseURL_DefaultsToLocalhostWhenNeitherSet(t *testing.T) {
+	t.Setenv("SPATIAL_KNN_URL", "")
+	t.Setenv("SPATIAL_SERVER_URL", "")
+	assert.Equal(t, "http://localhost:8194", baseURL())
+}
+
+// ExtraString returns a string value from Extra, or "" if the key is absent
+// or holds a non-string value.
+func TestExtraString(t *testing.T) {
+	r := QueryResult{Extra: map[string]any{
+		"name":  "Watermead",
+		"count": 5,
+	}}
+
+	assert.Equal(t, "Watermead", ExtraString(r, "name"))
+	assert.Equal(t, "", ExtraString(r, "count"), "wrong JSON type must not be type-asserted, must fall back to empty string")
+	assert.Equal(t, "", ExtraString(r, "missing"), "absent key must fall back to empty string")
+
+	empty := QueryResult{}
+	assert.Equal(t, "", ExtraString(empty, "name"), "nil Extra map must not panic")
+}
+
+// ExtraInt64 returns an int64 value from Extra. JSON numbers decode as
+// float64 (the typical path off the wire), but an already-native int64 is
+// also accepted; anything else (including absent) defaults to 0.
+func TestExtraInt64(t *testing.T) {
+	r := QueryResult{Extra: map[string]any{
+		"id_from_json": float64(42),
+		"id_native":    int64(7),
+		"name":         "not a number",
+	}}
+
+	assert.Equal(t, int64(42), ExtraInt64(r, "id_from_json"))
+	assert.Equal(t, int64(7), ExtraInt64(r, "id_native"))
+	assert.Equal(t, int64(0), ExtraInt64(r, "name"), "wrong type must default to 0")
+	assert.Equal(t, int64(0), ExtraInt64(r, "missing"), "absent key must default to 0")
+
+	empty := QueryResult{}
+	assert.Equal(t, int64(0), ExtraInt64(empty, "id_from_json"), "nil Extra map must not panic")
+}

--- a/iznik-server-go/userdump/collect_db_test.go
+++ b/iznik-server-go/userdump/collect_db_test.go
@@ -1,0 +1,68 @@
+package userdump
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// redactColFor withholds secret-named columns everywhere, plus
+// sessions.series specifically (the other half of a session token - not
+// name-matched by secretColRe on its own).
+func TestRedactColFor(t *testing.T) {
+	cases := []struct {
+		name  string
+		table string
+		col   string
+		want  bool
+	}{
+		{"password column matches on any table", "users", "password", true},
+		{"passwd variant matches", "users", "passwd", true},
+		{"secret substring matches", "some_table", "client_secret", true},
+		{"token substring matches", "sessions", "token", true},
+		{"credential substring matches", "users", "credential_hash", true},
+		{"apikey substring matches", "users", "apikey", true},
+		{"api_key substring matches", "users", "api_key", true},
+		{"privatekey substring matches", "users", "privatekey", true},
+		{"case-insensitive match", "users", "PASSWORD", true},
+		{"sessions.series is redacted (session-token half)", "sessions", "series", true},
+		{"sessions.series matched case-insensitively on table+col", "Sessions", "SERIES", true},
+		{"series column on a DIFFERENT table is not redacted", "other_table", "series", false},
+		{"ordinary column on sessions is not redacted", "sessions", "id", false},
+		{"ordinary column elsewhere is not redacted", "users", "email", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			redact := redactColFor(c.table)
+			assert.Equal(t, c.want, redact(c.col), c.name)
+		})
+	}
+}
+
+// inClause builds a "(?,?,...)" placeholder group matching the id count, or
+// ("", nil) for an empty id set so callers can skip the IN entirely.
+func TestInClause(t *testing.T) {
+	t.Run("empty ids returns empty placeholder and nil args", func(t *testing.T) {
+		ph, args := inClause(nil)
+		assert.Equal(t, "", ph)
+		assert.Nil(t, args)
+
+		ph2, args2 := inClause([]interface{}{})
+		assert.Equal(t, "", ph2)
+		assert.Nil(t, args2)
+	})
+
+	t.Run("single id", func(t *testing.T) {
+		ph, args := inClause([]interface{}{int64(5)})
+		assert.Equal(t, "(?)", ph)
+		assert.Equal(t, []interface{}{int64(5)}, args)
+	})
+
+	t.Run("multiple ids - one placeholder per id, args returned unchanged and in order", func(t *testing.T) {
+		ids := []interface{}{int64(1), int64(2), int64(3)}
+		ph, args := inClause(ids)
+		assert.Equal(t, "(?,?,?)", ph)
+		assert.Equal(t, ids, args)
+	})
+}

--- a/iznik-server-go/userdump/frame_test.go
+++ b/iznik-server-go/userdump/frame_test.go
@@ -1,0 +1,142 @@
+package userdump
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// failingWriter returns an error after failAfter successful Write calls, so
+// writeFrame's header-write and payload-write error paths can both be forced
+// deterministically.
+type failingWriter struct {
+	failAfter int
+	calls     int
+	buf       bytes.Buffer
+}
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	f.calls++
+	if f.calls > f.failAfter {
+		return 0, errors.New("boom: simulated write failure")
+	}
+	return f.buf.Write(p)
+}
+
+func TestWriteFrame_HeaderPacking(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	payload := []byte("hello")
+	err := writeFrame(w, frameData, payload)
+	assert.NoError(t, err)
+
+	out := buf.Bytes()
+	if assert.Len(t, out, 5+len(payload)) {
+		assert.Equal(t, frameData, out[0])
+		assert.Equal(t, uint32(len(payload)), binary.BigEndian.Uint32(out[1:5]))
+		assert.Equal(t, payload, out[5:])
+	}
+}
+
+func TestWriteFrame_EmptyPayloadWritesHeaderOnly(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	err := writeFrame(w, frameProgress, nil)
+	assert.NoError(t, err)
+
+	out := buf.Bytes()
+	if assert.Len(t, out, 5) {
+		assert.Equal(t, frameProgress, out[0])
+		assert.Equal(t, uint32(0), binary.BigEndian.Uint32(out[1:5]))
+	}
+}
+
+func TestWriteFrame_EmptyByteSlicePayloadWritesHeaderOnly(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	err := writeFrame(w, frameEnd, []byte{})
+	assert.NoError(t, err)
+	assert.Len(t, buf.Bytes(), 5)
+}
+
+func TestWriteFrame_TrailingFlushErrorPropagates(t *testing.T) {
+	// A small header+payload fits entirely inside bufio's default buffer, so
+	// neither Write call reaches the underlying writer - the error only
+	// surfaces from writeFrame's own trailing w.Flush() call.
+	fw := &failingWriter{failAfter: 0}
+	w := bufio.NewWriter(fw)
+	err := writeFrame(w, frameData, []byte("payload"))
+	assert.Error(t, err)
+}
+
+func TestWriteFrame_PayloadWriteErrorPropagates(t *testing.T) {
+	// A payload larger than the (tiny) buffer forces bufio to flush mid-Write,
+	// so the failure surfaces directly from the payload w.Write call itself,
+	// distinct from the trailing-Flush path above.
+	bigPayload := bytes.Repeat([]byte("x"), 8192)
+	fw := &failingWriter{failAfter: 0}
+	w := bufio.NewWriterSize(fw, 16) // tiny buffer forces incremental flushes
+	err := writeFrame(w, frameData, bigPayload)
+	assert.Error(t, err)
+}
+
+func TestWriteProgress(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	p := progressFrame{Phase: "collect", Section: "messages", Status: "running", Done: 3, Total: 10, Percent: 30.5, Rows: 100}
+	err := writeProgress(w, p)
+	assert.NoError(t, err)
+
+	out := buf.Bytes()
+	if assert.True(t, len(out) >= 5) {
+		assert.Equal(t, frameProgress, out[0])
+		length := binary.BigEndian.Uint32(out[1:5])
+		var decoded progressFrame
+		assert.NoError(t, json.Unmarshal(out[5:5+length], &decoded))
+		assert.Equal(t, p, decoded)
+	}
+}
+
+// writeEnd must never emit a JSON `null` for Warnings - the client always
+// expects an array, even when nothing warned.
+func TestWriteEnd_NilWarningsBecomesEmptyArrayNotNull(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	err := writeEnd(w, endFrame{Bytes: 1024, SHA256: "abc123", Warnings: nil})
+	assert.NoError(t, err)
+
+	out := buf.Bytes()
+	length := binary.BigEndian.Uint32(out[1:5])
+	payload := out[5 : 5+length]
+	assert.NotContains(t, string(payload), `"warnings":null`)
+	assert.Contains(t, string(payload), `"warnings":[]`)
+
+	var decoded endFrame
+	assert.NoError(t, json.Unmarshal(payload, &decoded))
+	assert.Equal(t, []string{}, decoded.Warnings)
+}
+
+func TestWriteEnd_NonNilWarningsPreserved(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	warnings := []string{"table X missing", "loki timeout"}
+	err := writeEnd(w, endFrame{Bytes: 1, SHA256: "x", Warnings: warnings})
+	assert.NoError(t, err)
+
+	out := buf.Bytes()
+	length := binary.BigEndian.Uint32(out[1:5])
+	var decoded endFrame
+	assert.NoError(t, json.Unmarshal(out[5:5+length], &decoded))
+	assert.Equal(t, warnings, decoded.Warnings)
+}

--- a/iznik-server-go/userdump/sqlite_test.go
+++ b/iznik-server-go/userdump/sqlite_test.go
@@ -1,0 +1,161 @@
+package userdump
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// normalizeValue converts driver values into something SQLite can store, and
+// replaces large binary blobs with a size placeholder so dumps stay small.
+func TestNormalizeValue(t *testing.T) {
+	t.Run("nil passes through as nil", func(t *testing.T) {
+		assert.Nil(t, normalizeValue(nil, false))
+		assert.Nil(t, normalizeValue(nil, true))
+	})
+
+	t.Run("binary []byte over 256 bytes becomes a size placeholder", func(t *testing.T) {
+		big := make([]byte, 257)
+		got := normalizeValue(big, true)
+		assert.Equal(t, "[BINARY len=257]", got)
+	})
+
+	t.Run("binary []byte at exactly 256 bytes is kept as raw bytes", func(t *testing.T) {
+		exact := make([]byte, 256)
+		for i := range exact {
+			exact[i] = byte(i % 256)
+		}
+		got := normalizeValue(exact, true)
+		gotBytes, ok := got.([]byte)
+		if assert.True(t, ok, "256-byte binary value must stay []byte, not be stringified") {
+			assert.Equal(t, exact, gotBytes)
+		}
+	})
+
+	t.Run("binary []byte just over the 256 cutoff is placeholder-ed, one byte past exact", func(t *testing.T) {
+		over := make([]byte, 257)
+		got := normalizeValue(over, true)
+		assert.Equal(t, "[BINARY len=257]", got)
+	})
+
+	t.Run("non-binary []byte is converted to a plain string", func(t *testing.T) {
+		got := normalizeValue([]byte("hello"), false)
+		assert.Equal(t, "hello", got)
+	})
+
+	t.Run("non-binary []byte over 256 bytes is still stringified, not placeholder-ed", func(t *testing.T) {
+		big := make([]byte, 500)
+		for i := range big {
+			big[i] = 'x'
+		}
+		got := normalizeValue(big, false)
+		gotStr, ok := got.(string)
+		if assert.True(t, ok) {
+			assert.Len(t, gotStr, 500)
+		}
+	})
+
+	t.Run("time.Time is formatted as a MySQL-style datetime string", func(t *testing.T) {
+		tm := time.Date(2026, 7, 24, 13, 45, 30, 0, time.UTC)
+		got := normalizeValue(tm, false)
+		assert.Equal(t, "2026-07-24 13:45:30", got)
+	})
+
+	t.Run("default passthrough for other types (int64, string, float64)", func(t *testing.T) {
+		assert.Equal(t, int64(42), normalizeValue(int64(42), false))
+		assert.Equal(t, "already a string", normalizeValue("already a string", false))
+		assert.Equal(t, 3.14, normalizeValue(3.14, false))
+	})
+}
+
+func TestQuoteIdent(t *testing.T) {
+	assert.Equal(t, `"users"`, quoteIdent("users"))
+	assert.Equal(t, `"col""with""quotes"`, quoteIdent(`col"with"quotes`), "embedded double-quotes must be doubled, not escaped with backslash")
+	assert.Equal(t, `""`, quoteIdent(""))
+}
+
+func TestIsBinaryType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"BLOB", true},
+		{"TINYBLOB", true},
+		{"MEDIUMBLOB", true},
+		{"LONGBLOB", true},
+		{"BINARY", true},
+		{"VARBINARY", true},
+		{"GEOMETRY", true},
+		{"POINT", true},
+		{"POLYGON", true},
+		{"LINESTRING", true},
+		{"MULTIPOLYGON", true}, // contains "POLYGON"
+		{"VARCHAR", false},
+		{"TEXT", false},
+		{"INT", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			assert.Equal(t, c.want, isBinaryType(c.in))
+		})
+	}
+}
+
+func TestIsIntType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"INT", true},
+		{"INTEGER", true},
+		{"BIGINT", true},
+		{"TINYINT", true},
+		{"SMALLINT", true},
+		{"MEDIUMINT", true},
+		{"YEAR", true},    // exact-match special case, not a prefix match
+		{"YEARLY", false}, // must NOT prefix-match YEAR - only the exact string qualifies
+		{"VARCHAR", false},
+		{"DECIMAL", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			assert.Equal(t, c.want, isIntType(c.in))
+		})
+	}
+}
+
+func TestIsRealType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"DECIMAL", true},
+		{"FLOAT", true},
+		{"DOUBLE", true},
+		{"NUMERIC", true},
+		{"DOUBLE PRECISION", true},
+		{"INT", false},
+		{"VARCHAR", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			assert.Equal(t, c.want, isRealType(c.in))
+		})
+	}
+}
+
+// Sanity check that quoteIdent output round-trips through the strings package
+// the way callers expect (used to build column lists in generated SQL).
+func TestQuoteIdent_JoinUsage(t *testing.T) {
+	cols := []string{"id", "name"}
+	quoted := make([]string, len(cols))
+	for i, c := range cols {
+		quoted[i] = quoteIdent(c)
+	}
+	assert.Equal(t, `"id","name"`, strings.Join(quoted, ","))
+}

--- a/iznik-server-go/userdump/userdump_test.go
+++ b/iznik-server-go/userdump/userdump_test.go
@@ -1,0 +1,76 @@
+package userdump
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// parseInclude splits a CSV of section names, trimming whitespace and
+// lower-casing, dropping empty segments, and defaulting to {"db"} when
+// nothing parsed out.
+func TestParseInclude(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want map[string]bool
+	}{
+		{"single value", "db", map[string]bool{"db": true}},
+		{"multiple values", "db,loki,sentry", map[string]bool{"db": true, "loki": true, "sentry": true}},
+		{"whitespace trimmed around each segment", " db , loki ", map[string]bool{"db": true, "loki": true}},
+		{"mixed case lower-cased", "DB,Loki,SENTRY", map[string]bool{"db": true, "loki": true, "sentry": true}},
+		{"empty segments dropped", "db,,loki,", map[string]bool{"db": true, "loki": true}},
+		{"empty string defaults to db", "", map[string]bool{"db": true}},
+		{"whitespace-only string defaults to db", "   ", map[string]bool{"db": true}},
+		{"only commas defaults to db", ",,,", map[string]bool{"db": true}},
+		{"duplicate values collapse", "db,db,DB", map[string]bool{"db": true}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, parseInclude(c.in))
+		})
+	}
+}
+
+// includeString renders a section-name set back to a deterministic
+// (sorted) CSV string - the inverse of parseInclude, used so the same
+// include set always produces the same cache-friendly string regardless of
+// Go's randomised map iteration order.
+func TestIncludeString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]bool
+		want string
+	}{
+		{"single entry", map[string]bool{"db": true}, "db"},
+		{"already-sorted multiple entries", map[string]bool{"db": true, "loki": true, "sentry": true}, "db,loki,sentry"},
+		{"out-of-order insertion still sorts", map[string]bool{"sentry": true, "db": true, "loki": true}, "db,loki,sentry"},
+		{"empty map produces empty string", map[string]bool{}, ""},
+		{"nil map produces empty string", nil, ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, includeString(c.in))
+		})
+	}
+}
+
+// Deterministic output is the whole point: run the same set through
+// includeString many times (map iteration order is randomised per-run by
+// the Go runtime) and confirm it never varies.
+func TestIncludeString_DeterministicAcrossRepeatedCalls(t *testing.T) {
+	m := map[string]bool{"sentry": true, "db": true, "loki": true, "extra": true}
+	first := includeString(m)
+	for i := 0; i < 20; i++ {
+		assert.Equal(t, first, includeString(m))
+	}
+	assert.Equal(t, "db,extra,loki,sentry", first)
+}
+
+// Round-trip: parseInclude -> includeString always yields the sorted,
+// deduplicated, lower-cased canonical form.
+func TestParseIncludeThenIncludeString_RoundTrips(t *testing.T) {
+	assert.Equal(t, "db,loki,sentry", includeString(parseInclude(" Sentry, db ,LOKI,db")))
+}


### PR DESCRIPTION
## Coverage added
Module: `iznik-server-go/rippling` (plus `iznik-server-go/spatial`, `iznik-server-go/userdump`)

| Package | Before | After | Delta |
|---|---|---|---|
| `rippling` | 25.5% | 32.0% | +6.5% |
| `spatial`  | 22.2% | 38.1% | +15.9% |
| `userdump` | 0.0%  | 8.5%  | +8.5% |

(`go test ./rippling/... ./spatial/... ./userdump/... -coverprofile=...` / `go tool cover -func=...`)

Note: `rippling` and `spatial` already had test files landed since the task brief was written (`analytics_extra_test.go`, `client_pure_test.go` in commit c9b1ceaf5) covering `envInt`/`driveSampleSize`/`driveConcurrency`/`StratumFilter`/`scoreOnePost`/`statFromObs`/`driveTrendFromObs`/`Bullseye`/`bullseyeFromObs`/`adminBaseURL`/`UpsertLocation`, so this PR focuses on what was still genuinely at 0%: the reach/attribution/metrics SQL builders, exhaustive `Bullseye` ring-boundary cases, `spatial`'s remaining helpers, and all of `userdump`'s pure helpers.

Remaining 0% functions in these three packages are all DB-connection- or `fiber.Ctx`-bound (`Metrics`, `Analytics`, `GetUserDump`, `CopyMySQLRows`, `NewBuilder`, Loki/Sentry clients, etc.) and need integration-style tests, not unit tests - out of scope here.

## Tests added
| Function | Scenario | File:Line |
|---|---|---|
| `ReachInReachExpr` | golden SQL string (both POINT-sentinel and real-bound shapes are baked into the one static string) + full 12-arg slice | rippling/reachbounds_test.go:15 |
| `ReachInReachExpr` | args scale correctly with distinct (non-repeating) inputs | rippling/reachbounds_test.go:41 |
| `ReachBrowseWhere` | golden SQL string + full 12-arg slice, leading `AND` | rippling/reachbounds_test.go:59 |
| `ReachBrowseWhere` | args scale correctly with distinct inputs | rippling/reachbounds_test.go:82 |
| both | SQL shape is input-value-independent | rippling/reachbounds_test.go:96 |
| `DeriveAttribution` | all 6 rungs individually + every higher-beats-lower precedence collision + nil/0/1 for both `*int` pointers + the postHadRippled structural guard | rippling/attribution_test.go:15 |
| `SanitizeClientSource` | nil, empty, valid, leading-char reject, mid-string reject, uppercase reject | rippling/attribution_test.go:67 |
| `SanitizeClientSource` | exactly-32-chars accept vs 33-chars reject | rippling/attribution_test.go:104 |
| `ReplySourceSplitSQL` | legacy (narrow) branch shape | rippling/metrics_test.go:15 |
| `ReplySourceSplitSQL` | wide branch wraps derivation in `COALESCE(rra.attribution, ...)` | rippling/metrics_test.go:51 |
| `ReplySourceSplitSQL` | srcGroup spliced before the WHERE window | rippling/metrics_test.go:61 |
| `ReplySourceSplitSQL` | empty srcGroup leaves no JOIN | rippling/metrics_test.go:74 |
| `ReplySourceSplitSQL` | srcGroup with quote/edge-case characters spliced verbatim | rippling/metrics_test.go:82 |
| `ReplySourceSplitSQL` | wide vs narrow produce different SQL | rippling/metrics_test.go:88 |
| `Bullseye` | every one of the 6 ring edges (0/10/15/20/25/30/45) assigned to exactly one band, incl. the last-ring inclusive special case | rippling/analytics_test.go:15 |
| `Bullseye` | zero-reply band never divides by zero (ConvPct/CIHalf stay 0.0) | rippling/analytics_test.go:52 |
| `Bullseye` | all-takers / no-takers CI extremes (p=1, p=0) | rippling/analytics_test.go:69 |
| `Bullseye` | mismatched-length mins/takers slices tolerated, no panic | rippling/analytics_test.go:87 |
| `Bullseye` | nil / empty input | rippling/analytics_test.go:102 |
| `baseURL` | SPATIAL_KNN_URL / SPATIAL_SERVER_URL / localhost default precedence | spatial/extra_test.go:11 |
| `ExtraString` | hit, wrong-type, missing-key, nil map | spatial/extra_test.go:31 |
| `ExtraInt64` | float64 (JSON) path, int64 path, wrong-type/missing default 0, nil map | spatial/extra_test.go:48 |
| `normalizeValue` | nil, binary >256B placeholder, binary ==256B kept raw, non-binary []byte to string, time.Time formatting, default passthrough | userdump/sqlite_test.go:13 |
| `quoteIdent` | plain, embedded quotes doubled, empty | userdump/sqlite_test.go:73 |
| `isBinaryType` / `isIntType` (incl. YEAR exact-match) / `isRealType` | all DB type-name branches | userdump/sqlite_test.go:79,107,131 |
| `writeFrame` | header packing, empty payload, error propagation via a deliberately-failing `io.Writer` (both the trailing-Flush and mid-Write failure paths) | userdump/frame_test.go:31,70,80 |
| `writeProgress` / `writeEnd` | JSON round-trip; nil `Warnings` becomes `[]` never `null` | userdump/frame_test.go:91,111,129 |
| `parseInclude` | trim/lowercase, empty segments dropped, default `"db"`, dedup | userdump/userdump_test.go:12 |
| `includeString` | sorted deterministic output, round-trips with `parseInclude` | userdump/userdump_test.go:40,74 |
| `redactColFor` | secret-name regex match, `sessions.series` special case, non-matches | userdump/collect_db_test.go:12 |
| `inClause` | empty and non-empty id sets | userdump/collect_db_test.go:45 |

## Latent bugs found
None - all functions behaved exactly per their documentation; no test needed `t.Skip`.

One pre-existing test-infra observation (not fixed here, out of scope for a test-only PR): `iznik-server-go/spatial/client_pure_test.go` matches the `*_pure_test.go` suffix the CI runner explicitly skips, so its `adminBaseURL`/`UpsertLocation` coverage is currently invisible to CI's measured total. Worth a follow-up rename.

## No production code changed
All changes are in test files only (`*_test.go`).