### PR TITLE
fix(monitor-fsm): don't classify the monitor's own Discourse posts as bugs

### DIFF
--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -1345,6 +1345,13 @@ for i, tid in enumerate(sorted(topic_ids)):
         pn = post.get('post_number', 0)
         if pn <= effective_cursor:
             continue
+        # Skip the monitor's OWN account (AI_Edward). Its posts are our diagnostic /
+        # "possible fix, please retest" replies, not member bug reports; classifying them
+        # re-opens bugs we just fixed and dispatches duplicate fix delegates (the feedback
+        # loop that produced duplicate PRs #1165/#1166 for topic 9954). The cursor still
+        # advances past them (latestPostNumber above), so they are marked seen.
+        if post.get('username', '') == 'AI_Edward':
+            continue
         cooked = post.get('cooked', '')
         text = re.sub(r'<[^>]+>', '', cooked)
         text = html.unescape(text)


### PR DESCRIPTION
## Problem
`fetch_discourse` returns every new post in a tracked topic and hands them to triage. That includes posts made by the monitor's own account (`AI_Edward`) — its diagnostic replies and "possible fix applied, please retest" messages. Triage classified those as if they were member bug reports, which re-opened bugs the FSM had just fixed and dispatched duplicate fix delegates. That is the loop that produced duplicate PRs #1165/#1166 for topic 9954 (and re-dispatched an already-fixed bug on 9954 post 3/5).

## Fix
Skip posts authored by `AI_Edward` in the collection loop. The topic cursor still advances past them (it is derived from the highest post number seen), so they are marked seen and never re-pulled. The human operator's account (`Edward_Hibbert`) is deliberately NOT skipped — those posts are real direction/confirmations and must still be classified.

## Discourse
https://discourse.ilovefreegle.org/t/9954