### PR TITLE
fix(modtools): allow Hold on charity-request pending posts instead of forcing Reject

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessageButton.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButton.vue
@@ -380,6 +380,8 @@ async function click(callback) {
       stdmsgAction.value = 'Reject'
     } else if (props.leave) {
       stdmsgAction.value = 'Leave'
+    } else if (props.holdMessage) {
+      stdmsgAction.value = 'Hold Message'
     } else if (props.stdmsgid) {
       // We have a standard message.  Fetch it into the store.
       await stdmsgStore.fetch(props.stdmsgid)

--- a/iznik-nuxt3/modtools/components/ModMessageButtons.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButtons.vue
@@ -64,6 +64,15 @@
         label="Hold"
       />
       <ModMessageButton
+        v-if="!message.heldby"
+        :messageid="message.id"
+        :groupid="groupid"
+        variant="warning"
+        icon="comment"
+        hold-message
+        label="Hold & Message"
+      />
+      <ModMessageButton
         v-else
         :messageid="message.id"
         :groupid="groupid"

--- a/iznik-nuxt3/tests/e2e/test-modtools-hold-release.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-modtools-hold-release.spec.js
@@ -92,12 +92,17 @@ test.describe('ModTools hold and release message', () => {
       await firstCard.locator('button:has-text("Release")').first().click()
       // Wait for Hold button to reappear after release
       await firstCard
-        .locator('button:has-text("Hold")')
+        .getByRole('button', { name: 'Hold', exact: true })
         .waitFor({ state: 'visible', timeout: timeouts.ui.appearance })
     }
 
-    // Find and click the Hold button within the first card
-    const holdButton = firstCard.locator('button:has-text("Hold")')
+    // Find and click the Hold button within the first card.
+    // Use exact match: a "Hold & Message" button also exists in the same
+    // card, and button:has-text("Hold") would match both.
+    const holdButton = firstCard.getByRole('button', {
+      name: 'Hold',
+      exact: true,
+    })
     await expect(holdButton).toBeVisible({
       timeout: timeouts.ui.appearance,
     })

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
@@ -367,6 +367,24 @@ describe('ModMessageButton', () => {
     })
   })
 
+  describe('holdMessage action (standard message modal)', () => {
+    // Discourse 9808: a mod reviewing a charity-request post wanted to hold it
+    // and ask for a charity number, but ModTools only offered a one-click
+    // compose-and-send for Reject/Leave - Hold had no equivalent, so the raw
+    // Hold button just silently held with no way to explain why.
+    it('sets stdmsgAction to Hold Message when holdMessage prop is true', async () => {
+      const wrapper = mountComponent({ holdMessage: true })
+      await wrapper.vm.click()
+      expect(wrapper.vm.stdmsgAction).toBe('Hold Message')
+    })
+
+    it('shows stdmsg modal when holdMessage prop is true', async () => {
+      const wrapper = mountComponent({ holdMessage: true })
+      await wrapper.vm.click()
+      expect(wrapper.vm.showStdMsgModal).toBe(true)
+    })
+  })
+
   describe('stdmsgid action (fetch standard message)', () => {
     it('fetches standard message when stdmsgid prop is set', async () => {
       const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: true })

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
@@ -103,6 +103,7 @@ describe('ModMessageButtons', () => {
           reject: reject === '' || reject === true,
           delete: $props.delete === '' || $props.delete === true,
           hold: hold === '' || hold === true,
+          holdMessage: holdMessage === '' || holdMessage === true,
           release: release === '' || release === true,
           spam: spam === '' || spam === true,
           approveedits: approveedits === '' || approveedits === true,
@@ -120,6 +121,7 @@ describe('ModMessageButtons', () => {
         'reject',
         'delete',
         'hold',
+        'holdMessage',
         'release',
         'spam',
         'approveedits',
@@ -242,6 +244,35 @@ describe('ModMessageButtons', () => {
         }
       )
       expect(wrapper.find('.mod-message-button.hold').exists()).toBe(false)
+    })
+
+    // Discourse 9808: mods need to hold a post AND ask a question (e.g. for a
+    // charity request, "please provide your charity number") in one click,
+    // the same way Reject already lets them compose a custom message.
+    it('shows a hold-and-message button for pending messages without heldby', () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          groups: [{ groupid: 456, collection: 'Pending' }],
+          heldby: null,
+        }
+      )
+      expect(wrapper.find('.mod-message-button.holdMessage').exists()).toBe(
+        true
+      )
+    })
+
+    it('hides hold-and-message button when message is held', () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          groups: [{ groupid: 456, collection: 'Pending' }],
+          heldby: { id: 1 },
+        }
+      )
+      expect(wrapper.find('.mod-message-button.holdMessage').exists()).toBe(
+        false
+      )
     })
 
     it('shows spam button for pending messages', () => {


### PR DESCRIPTION
## Root Cause
ModTools' pending-message action bar (`ModMessageButtons.vue` / `ModMessageButton.vue`) offers a one-click "compose a custom message + change moderation state" flow for **Reject** and **Leave**, but not for **Hold**. The raw Hold button just silently holds the post with no way to attach a note explaining why (e.g. "please provide your charity registration number").

The `holdMessage` boolean prop on `ModMessageButton.vue` already existed (declared in `defineProps`) and `ModStdMessageModal.vue` already fully supports a `'Hold Message'` action (hold + send reply) - but nothing ever set `stdmsgAction` to `'Hold Message'` for a bare click, and no button passed the prop. It was dead code: the feature was half-wired. A mod who wanted to hold-and-ask therefore had no one-click path unless their group happened to have a pre-configured "Hold Message" standard message for that exact scenario - so composing a custom Reject message (which *is* one click away) was the only way to ask a question, which reads as "forced to reject" even though rejecting isn't what the mod wanted.

Confirmed this is not "working as designed": `ModMessageButtons.spec.js` already tests Hold-for-Pending, Hold-for-Spam and Hold-hidden-when-held as deliberate, so the gap is specifically the missing compose option, not the plain Hold button itself.

## Evidence
Before the fix, with the `holdMessage` prop set:
```
 FAIL  tests/unit/components/modtools/ModMessageButton.spec.js > ModMessageButton > holdMessage action (standard message modal) > sets stdmsgAction to Hold Message when holdMessage prop is true
AssertionError: expected null to be 'Hold Message'
 ❯ tests/unit/components/modtools/ModMessageButton.spec.js:378:39
    376|       const wrapper = mountComponent({ holdMessage: true })
    377|       await wrapper.vm.click()
    378|       expect(wrapper.vm.stdmsgAction).toBe('Hold Message')
       |                                       ^
```

## Fix
- `ModMessageButton.vue`: `click()` now sets `stdmsgAction.value = 'Hold Message'` when `props.holdMessage` is set, opening the same compose modal Reject/Leave already use (no new modal code - `ModStdMessageModal.vue`'s existing `'Hold Message'` case already holds + sends the reply).
- `ModMessageButtons.vue`: added a "Hold & Message" button next to the existing "Hold" button in the Pending/Spam action set (same `v-if="!message.heldby"` scoping), using the now-wired `hold-message` prop.

## Other Call Sites
Grepped for other `ModMessageButton` usages in `modtools/components` - only one other call site (`ModMessage.vue`'s "Release" button on an already-held message), which is unrelated to this action set and untouched.

## Test
- `iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js` - new `describe('holdMessage action (standard message modal)')`: proved fail-before (assertion above) by temporarily stashing the production fix, then pass-after with the fix restored.
- `iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js` - new tests asserting the "Hold & Message" button renders for pending messages without `heldby`, and is hidden once held.
- Ran both full spec files plus the pre-existing (separate-path) `tests/unit/components/ModMessageButton.spec.js` - all pass, no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9808