### PR TITLE
fix(modtools): refresh pending-count badges after Hold/Release via a coalesced fetch

### DIFF
--- a/iznik-nuxt3/composables/useMe.js
+++ b/iznik-nuxt3/composables/useMe.js
@@ -5,8 +5,12 @@ import { useGroupStore } from '~/stores/group'
 import { useTeamStore } from '~/stores/team'
 
 let fetchingPromise = null
+// A single coalesced "trailing" fetch for forceServer callers that arrive while a fetch is
+// already in flight (see the forceServer branch below). Shared so N such callers trigger ONE
+// extra fetch, not one each.
+let trailingRefetch = null
 
-export async function fetchMe(hitServer) {
+export async function fetchMe(hitServer, forceServer = false) {
   const authStore = useAuthStore()
 
   // We can be called in several ways.
@@ -14,6 +18,12 @@ export async function fetchMe(hitServer) {
   // - hitServer = true.  We must query the server, and wait for the response before returning.  This is used
   //   mostly when we really care about the data being tightly in sync, and occasionally when we want to
   //   ensure that the server call has completed (e.g. in timers).  You would always call this with await.
+  //   - forceServer = true additionally means "the result must reflect state as of NOW".  If a fetch is
+  //     already in flight it may have STARTED before the caller's action (e.g. a moderator holds then
+  //     releases a message, and Release's checkWork() fires while the periodic refresh is mid-flight), so
+  //     piggybacking on it returns stale counts (Discourse #9951).  We therefore do a fresh fetch AFTER the
+  //     in-flight one - but coalesced, so a burst of actions triggers a single trailing refetch, not a
+  //     flood of /session calls (the dedup added in 53d04927d exists precisely to avoid that flood).
   //
   // - hitServer = false
   //   - with await.  We must have the user info, but it's ok for them to be a little out of
@@ -38,15 +48,36 @@ export async function fetchMe(hitServer) {
 
     // We always need to fetch to do the background update.
     needToFetch = true
-  } else {
-    // We have been asked to hit the server.
-    // eslint-disable-next-line no-lonely-if
-    if (fetchingPromise) {
-      // We are in the process of fetching the user, so we need to wait until that completes.
-      await fetchingPromise
-    } else {
-      needToFetch = true
+  } else if (fetchingPromise && forceServer) {
+    // A fetch is in flight but we need data as of now. Coalesce every forceServer caller that
+    // arrives during it onto ONE trailing fetch that starts once the in-flight one completes.
+    if (!trailingRefetch) {
+      const inFlight = fetchingPromise
+      trailingRefetch = (async () => {
+        try {
+          await inFlight
+        } catch {
+          // The in-flight fetch's own caller handles its rejection; we just need to fetch after it.
+        }
+        const p = authStore.fetchUser()
+        fetchingPromise = p
+        trailingRefetch = null
+        try {
+          await p
+        } finally {
+          if (fetchingPromise === p) {
+            fetchingPromise = null
+          }
+        }
+      })()
     }
+    await trailingRefetch
+  } else if (fetchingPromise) {
+    // A fetch is in flight and stale-by-a-moment is fine (boot, timers) - piggyback on it so
+    // concurrent callers share a single /session request.
+    await fetchingPromise
+  } else {
+    needToFetch = true
   }
 
   if (needToFetch) {

--- a/iznik-nuxt3/modtools/composables/useModMe.js
+++ b/iznik-nuxt3/modtools/composables/useModMe.js
@@ -101,8 +101,14 @@ export function useModMe() {
       let currentTotal = 0
       if (authStore.work) currentTotal += authStore.work.total
       if (chatStore) currentTotal += Math.min(99, chatStore.unreadCount)
-      const { fetchMe } = useMe()
-      await fetchMe(true)
+      // Call authStore.fetchUser() directly rather than the shared fetchMe(true)
+      // helper. fetchMe() dedups concurrent hitServer=true calls onto a single
+      // in-flight promise - fine for e.g. two layouts booting at once, but wrong
+      // here: a mod action (Hold, then Release moments later) needs THIS call to
+      // reflect state as of now, not piggyback on an earlier still-in-flight
+      // fetch and pick up stale counts, which left the pending-message badges
+      // showing the pre-action state until a manual page refresh (Discourse #9951).
+      await authStore.fetchUser()
       await modGroupStore.getModGroups()
 
       const chatcount = chatStore ? Math.min(99, chatStore.unreadCount) : 0

--- a/iznik-nuxt3/modtools/composables/useModMe.js
+++ b/iznik-nuxt3/modtools/composables/useModMe.js
@@ -24,7 +24,7 @@ async function makebeep() {
 
 export function useModMe() {
   function hasPermission(perm) {
-    const { me } = useMe()
+    const { me, fetchMe } = useMe()
     const perms = me.value ? me.value.permissions : null
     return perms && perms.includes(perm)
   }
@@ -101,14 +101,13 @@ export function useModMe() {
       let currentTotal = 0
       if (authStore.work) currentTotal += authStore.work.total
       if (chatStore) currentTotal += Math.min(99, chatStore.unreadCount)
-      // Call authStore.fetchUser() directly rather than the shared fetchMe(true)
-      // helper. fetchMe() dedups concurrent hitServer=true calls onto a single
-      // in-flight promise - fine for e.g. two layouts booting at once, but wrong
-      // here: a mod action (Hold, then Release moments later) needs THIS call to
-      // reflect state as of now, not piggyback on an earlier still-in-flight
-      // fetch and pick up stale counts, which left the pending-message badges
-      // showing the pre-action state until a manual page refresh (Discourse #9951).
-      await authStore.fetchUser()
+      // Refresh the work counts (the source of the blue/red pending-message badges).
+      // Use forceServer so the result reflects state as of NOW: a mod action (Hold, then
+      // Release moments later) must not piggyback on an earlier still-in-flight fetchMe()
+      // and pick up stale counts, which left the badges showing the pre-action state until
+      // a manual page refresh (Discourse #9951). fetchMe coalesces these forceServer calls
+      // onto a single trailing refetch, so rapid actions don't flood /session.
+      await fetchMe(true, true)
       await modGroupStore.getModGroups()
 
       const chatcount = chatStore ? Math.min(99, chatStore.unreadCount) : 0

--- a/iznik-nuxt3/modtools/composables/useModMe.js
+++ b/iznik-nuxt3/modtools/composables/useModMe.js
@@ -24,7 +24,7 @@ async function makebeep() {
 
 export function useModMe() {
   function hasPermission(perm) {
-    const { me, fetchMe } = useMe()
+    const { me } = useMe()
     const perms = me.value ? me.value.permissions : null
     return perms && perms.includes(perm)
   }
@@ -77,6 +77,7 @@ export function useModMe() {
     const authStore = useAuthStore()
     const chatStore = useChatStore()
     const miscStore = useMiscStore()
+    const { fetchMe } = useMe()
     if (miscStore.workTimer) {
       clearTimeout(miscStore.workTimer)
     }

--- a/iznik-nuxt3/tests/unit/composables/useMe.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMe.spec.js
@@ -642,6 +642,42 @@ describe('fetchMe', () => {
     expect(mockFetchUser).toHaveBeenCalledTimes(1)
   })
 
+  it('forceServer during an in-flight fetch does ONE trailing refetch (not stale piggyback) - Discourse 9951', async () => {
+    // A plain hitServer=true piggybacks on the in-flight fetch (test above) and so can
+    // return counts captured before a mod's Hold/Release. forceServer must instead fetch
+    // AGAIN once the in-flight one completes, so the result reflects state as of now.
+    let resolveFirst
+    const firstFetch = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+    mockFetchUser.mockReturnValueOnce(firstFetch).mockResolvedValue({ id: 2 })
+    const p1 = fetchMe(true) // starts the in-flight fetch
+    const p2 = fetchMe(true, true) // arrives mid-flight, needs fresh -> trailing refetch
+    resolveFirst({ id: 1 })
+    await Promise.all([p1, p2])
+    // Once for the in-flight fetch, once for the trailing forceServer refetch.
+    expect(mockFetchUser).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces several concurrent forceServer calls onto a SINGLE trailing refetch (no flood)', async () => {
+    // The dedup added in 53d04927d exists to avoid a flood of /session calls. A burst of
+    // mod actions must not each trigger their own refetch: they share one trailing fetch.
+    let resolveFirst
+    const firstFetch = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+    mockFetchUser.mockReturnValueOnce(firstFetch).mockResolvedValue({ id: 2 })
+    const p1 = fetchMe(true)
+    const p2 = fetchMe(true, true)
+    const p3 = fetchMe(true, true)
+    const p4 = fetchMe(true, true)
+    resolveFirst({ id: 1 })
+    await Promise.all([p1, p2, p3, p4])
+    // In-flight fetch + exactly ONE coalesced trailing refetch, regardless of how many
+    // forceServer callers arrived during it.
+    expect(mockFetchUser).toHaveBeenCalledTimes(2)
+  })
+
   it('returns immediately when hitServer=false and user already loaded', async () => {
     // Simulate user already present from a previous fetch
     mockAuthState.user = makeUser()

--- a/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
@@ -58,17 +58,14 @@ beforeEach(() => {
     body: { style: { overflow: '' } },
     title: '',
   }
-  // Reset store state via globalThis pattern used by pre-aliased mocks.
-  // fetchUser defaults to mockFetchMe so existing tests that configure
-  // mockFetchMe's implementation (to set globalThis.__mockAuthStore.work)
-  // keep working now that checkWork() calls authStore.fetchUser() directly
-  // instead of the shared, deduped fetchMe() helper.
+  // Reset store state via globalThis pattern used by pre-aliased mocks. checkWork()
+  // refreshes the counts via the mocked fetchMe() (mockFetchMe), which existing tests
+  // configure to populate globalThis.__mockAuthStore.work.
   globalThis.__mockAuthStore = {
     work: null,
     user: { settings: {} },
     member: vi.fn(() => null),
     groups: [],
-    fetchUser: mockFetchMe,
   }
   globalThis.__mockChatStore = {
     unreadCount: 0,
@@ -266,27 +263,16 @@ describe('useModMe document.title refresh after mod action', () => {
 })
 
 describe('useModMe checkWork badge freshness after rapid mod actions (Discourse 9951)', () => {
-  it('refreshes work counts via a direct, un-deduped fetch rather than the shared fetchMe() promise', async () => {
-    // useMe.js's exported fetchMe() dedups concurrent hitServer=true calls onto
-    // a single in-flight authStore.fetchUser() promise. When a mod holds a
-    // pending message and releases it moments later, the Release action's
-    // checkWorkDeferGetMessages() -> checkWork() can fire while the Hold
-    // action's own checkWork() is still awaiting fetchMe(true) - so it
-    // piggybacks on that in-flight promise and resolves with counts captured
-    // BEFORE the release happened, leaving the blue/red badges stuck showing
-    // the held state until a manual page refresh.
-    //
-    // Simulate that here: fetchMe() (the deduped path) resolves with stale
-    // counts, while a direct authStore.fetchUser() call (which never dedups)
-    // resolves with the true, current counts.
+  it('refreshes work counts via fetchMe with forceServer so it cannot piggyback stale in-flight counts', async () => {
+    // A mod holds a pending message and releases it moments later. Release's
+    // checkWorkDeferGetMessages() -> checkWork() can fire while an earlier
+    // fetchMe(true) is still in flight; a plain fetchMe(true) would piggyback on
+    // that in-flight promise and resolve with counts captured BEFORE the release,
+    // leaving the blue/red badges stuck until a manual refresh. checkWork() must
+    // pass forceServer so fetchMe does a fresh (coalesced) fetch reflecting NOW.
+    // The coalescing itself is covered in useMe.spec.js; here we assert checkWork
+    // asks for it.
     mockFetchMe.mockImplementation(async () => {
-      globalThis.__mockAuthStore.work = {
-        total: 1,
-        pending: 1,
-        pendingother: 0,
-      }
-    })
-    globalThis.__mockAuthStore.fetchUser = vi.fn(async () => {
       globalThis.__mockAuthStore.work = {
         total: 0,
         pending: 0,
@@ -298,10 +284,7 @@ describe('useModMe checkWork badge freshness after rapid mod actions (Discourse 
     const { checkWork } = useModMe()
     await checkWork(true)
 
-    // FAILS on buggy code: checkWork() calls the deduped fetchMe(true), which
-    // never touches authStore.fetchUser() in this test, so work stays at the
-    // stale snapshot (pending: 1) instead of the fresh one (pending: 0).
-    expect(globalThis.__mockAuthStore.fetchUser).toHaveBeenCalled()
+    expect(mockFetchMe).toHaveBeenCalledWith(true, true)
     expect(globalThis.__mockAuthStore.work.pending).toBe(0)
   })
 })

--- a/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
@@ -58,12 +58,17 @@ beforeEach(() => {
     body: { style: { overflow: '' } },
     title: '',
   }
-  // Reset store state via globalThis pattern used by pre-aliased mocks
+  // Reset store state via globalThis pattern used by pre-aliased mocks.
+  // fetchUser defaults to mockFetchMe so existing tests that configure
+  // mockFetchMe's implementation (to set globalThis.__mockAuthStore.work)
+  // keep working now that checkWork() calls authStore.fetchUser() directly
+  // instead of the shared, deduped fetchMe() helper.
   globalThis.__mockAuthStore = {
     work: null,
     user: { settings: {} },
     member: vi.fn(() => null),
     groups: [],
+    fetchUser: mockFetchMe,
   }
   globalThis.__mockChatStore = {
     unreadCount: 0,
@@ -257,5 +262,46 @@ describe('useModMe document.title refresh after mod action', () => {
     // FAILS on buggy code: guard blocks title refresh when body overflow is 'hidden'
     // and force is not passed, leaving stale '(2) ModTools' as the tab title.
     expect(global.document.title).toBe('ModTools')
+  })
+})
+
+describe('useModMe checkWork badge freshness after rapid mod actions (Discourse 9951)', () => {
+  it('refreshes work counts via a direct, un-deduped fetch rather than the shared fetchMe() promise', async () => {
+    // useMe.js's exported fetchMe() dedups concurrent hitServer=true calls onto
+    // a single in-flight authStore.fetchUser() promise. When a mod holds a
+    // pending message and releases it moments later, the Release action's
+    // checkWorkDeferGetMessages() -> checkWork() can fire while the Hold
+    // action's own checkWork() is still awaiting fetchMe(true) - so it
+    // piggybacks on that in-flight promise and resolves with counts captured
+    // BEFORE the release happened, leaving the blue/red badges stuck showing
+    // the held state until a manual page refresh.
+    //
+    // Simulate that here: fetchMe() (the deduped path) resolves with stale
+    // counts, while a direct authStore.fetchUser() call (which never dedups)
+    // resolves with the true, current counts.
+    mockFetchMe.mockImplementation(async () => {
+      globalThis.__mockAuthStore.work = {
+        total: 1,
+        pending: 1,
+        pendingother: 0,
+      }
+    })
+    globalThis.__mockAuthStore.fetchUser = vi.fn(async () => {
+      globalThis.__mockAuthStore.work = {
+        total: 0,
+        pending: 0,
+        pendingother: 0,
+      }
+    })
+
+    const { useModMe } = await import('~/modtools/composables/useModMe')
+    const { checkWork } = useModMe()
+    await checkWork(true)
+
+    // FAILS on buggy code: checkWork() calls the deduped fetchMe(true), which
+    // never touches authStore.fetchUser() in this test, so work stays at the
+    // stale snapshot (pending: 1) instead of the fresh one (pending: 0).
+    expect(globalThis.__mockAuthStore.fetchUser).toHaveBeenCalled()
+    expect(globalThis.__mockAuthStore.work.pending).toBe(0)
   })
 })


### PR DESCRIPTION
## Root cause
The blue/red pending-message badges in `ModMenuItemLeft.vue` are driven by the moderator work counts refreshed in `checkWork()` (`useModMe.js`) via `fetchMe(true)`. `fetchMe()` dedups concurrent `hitServer=true` calls onto a single in-flight `authStore.fetchUser()` promise (added in `53d04927d` to avoid duplicate `GET /session` at boot). So when a mod holds a pending message then releases it moments later, Release's `checkWork()` can fire while an earlier fetch is still in flight — it piggybacks and resolves with counts captured **before** the release, leaving the badges stuck on the pre-action state until a manual refresh (Discourse #9951).

## Fix
`fetchMe(hitServer, forceServer)` gains a `forceServer` mode. When a fetch is already in flight but the caller needs state as of *now*, it does **one fresh fetch after the in-flight one completes** — and **coalesces** every `forceServer` caller that arrives during the in-flight fetch onto that single trailing refetch. So:
- the badges reflect post-action counts (#9951 fixed), and
- a burst of rapid mod actions triggers **one** trailing `/session` fetch, not one per action — the boot-time dedup is preserved (plain `hitServer=true` callers still piggyback).

`checkWork()` calls `fetchMe(true, true)`.

## Tests
- `tests/unit/composables/useMe.spec.js` — a `forceServer` call during an in-flight fetch does exactly one trailing refetch; several concurrent `forceServer` calls coalesce onto a single trailing refetch (no flood).
- `tests/unit/composables/useModMe.spec.js` — `checkWork()` requests `fetchMe(true, true)`.

## Discourse
https://discourse.ilovefreegle.org/t/9951
