### PR TITLE
fix(newsfeed): cap Nearby's radius on every GetNearbyDistance path

### DIFF
--- a/iznik-server-go/newsfeed/newsfeed.go
+++ b/iznik-server-go/newsfeed/newsfeed.go
@@ -115,6 +115,13 @@ func GetNearbyDistance(uid uint64) (float64, utils.LatLng, float64, float64, flo
 	// (a 169-mile-away post topping a "Nearby" feed because the radius
 	// silently became "no restriction").
 	const maxNearbyKm = 128.0
+	// minNearbyKm floors the same result from the other end. Both
+	// data-driven branches below can legitimately compute a distance of
+	// exactly 0 - a newsfeed post at the user's own coordinates (their own
+	// post, or someone else's right on top of them) has KNN distance 0 in
+	// decimal degrees - which hits the exact same "no restriction" path as
+	// an unbounded radius, per the comment above. That's #9937 again.
+	const minNearbyKm = 1.0
 
 	latlng := user.GetLatLng(uid)
 	if latlng.Lat == 0 && latlng.Lng == 0 {
@@ -125,8 +132,8 @@ func GetNearbyDistance(uid uint64) (float64, utils.LatLng, float64, float64, flo
 	}
 
 	// Default to the capped ceiling; every branch below either leaves this
-	// alone or overwrites it with a data-driven value that gets clamped to
-	// the same ceiling before we return.
+	// alone or overwrites it with a data-driven value that gets clamped
+	// between minNearbyKm and maxNearbyKm before we return.
 	distKm := maxNearbyKm
 
 	results, err := spatial.KNN("newsfeed", float64(latlng.Lng), float64(latlng.Lat), nearbyLimit*overFetch, "")
@@ -169,6 +176,8 @@ func GetNearbyDistance(uid uint64) (float64, utils.LatLng, float64, float64, flo
 
 	if distKm > maxNearbyKm {
 		distKm = maxNearbyKm
+	} else if distKm < minNearbyKm {
+		distKm = minNearbyKm
 	}
 
 	p := geo.NewPoint(float64(latlng.Lat), float64(latlng.Lng))

--- a/iznik-server-go/newsfeed/newsfeed.go
+++ b/iznik-server-go/newsfeed/newsfeed.go
@@ -107,46 +107,70 @@ func GetNearbyDistance(uid uint64) (float64, utils.LatLng, float64, float64, flo
 	// Over-fetch from the spatial index so that, after dropping alerts and posts
 	// older than the feed window, we still have at least nearbyLimit candidates.
 	const overFetch = 10
+	// maxNearbyKm bounds every radius computed below - the largest radius the
+	// pre-#459 doubling-box algorithm ever searched (1km doubling to 128km)
+	// before giving up. getFeed() treats a 0 return as "no geographic
+	// filtering at all", so every path here MUST end up at a positive,
+	// capped value rather than an unbounded or zero one - Discourse #9937
+	// (a 169-mile-away post topping a "Nearby" feed because the radius
+	// silently became "no restriction").
+	const maxNearbyKm = 128.0
 
 	latlng := user.GetLatLng(uid)
 	if latlng.Lat == 0 && latlng.Lng == 0 {
+		// We don't know where this user is at all, so there's no reference
+		// point to size a "nearby" radius from - the caller must fall back
+		// to an unfiltered feed.
 		return 0, latlng, 0, 0, 0, 0
 	}
+
+	// Default to the capped ceiling; every branch below either leaves this
+	// alone or overwrites it with a data-driven value that gets clamped to
+	// the same ceiling before we return.
+	distKm := maxNearbyKm
 
 	results, err := spatial.KNN("newsfeed", float64(latlng.Lng), float64(latlng.Lat), nearbyLimit*overFetch, "")
-	if err != nil || len(results) < nearbyLimit {
-		return 0, latlng, 0, 0, 0, 0
-	}
-
-	// The spatial "newsfeed" index has no type/timestamp columns, so it can't
-	// exclude alerts or stale posts — applying that here restores the
-	// pre-spatial query's behaviour (otherwise alerts/old posts shrink the
-	// computed radius).
-	ids := make([]int64, len(results))
-	for i, r := range results {
-		ids[i] = r.ID
-	}
-	allowed := RecentNonAlertNewsfeedIDs(ids)
-
-	// Walk the KNN results in distance order; the nearbyLimit-th allowed entry
-	// sets the radius (decimal degrees → km, 1 degree ≈ 111 km).
-	count := 0
-	distDeg := 0.0
-	for _, r := range results {
-		if _, ok := allowed[r.ID]; !ok {
-			continue
+	if err == nil && len(results) >= nearbyLimit {
+		// The spatial "newsfeed" index has no type/timestamp columns, so it can't
+		// exclude alerts or stale posts — applying that here restores the
+		// pre-spatial query's behaviour (otherwise alerts/old posts shrink the
+		// computed radius).
+		ids := make([]int64, len(results))
+		for i, r := range results {
+			ids[i] = r.ID
 		}
-		count++
+		allowed := RecentNonAlertNewsfeedIDs(ids)
+
+		// Walk the KNN results in distance order; the nearbyLimit-th allowed entry
+		// sets the radius (decimal degrees → km, 1 degree ≈ 111 km).
+		count := 0
+		distDeg := 0.0
+		for _, r := range results {
+			if _, ok := allowed[r.ID]; !ok {
+				continue
+			}
+			count++
+			if count == nearbyLimit {
+				distDeg = r.Distance
+				break
+			}
+		}
+
 		if count == nearbyLimit {
-			distDeg = r.Distance
-			break
+			// Enough recent, non-alert posts nearby - size the radius from their true density.
+			distKm = distDeg * 111.0
+		} else {
+			// Too few passed the recency/alert filter, but there's still enough
+			// raw local density data (>= nearbyLimit raw candidates) to size a
+			// radius from, rather than falling straight back to the flat ceiling.
+			distKm = results[nearbyLimit-1].Distance * 111.0
 		}
 	}
-	if count < nearbyLimit {
-		return 0, latlng, 0, 0, 0, 0
+
+	if distKm > maxNearbyKm {
+		distKm = maxNearbyKm
 	}
 
-	distKm := distDeg * 111.0
 	p := geo.NewPoint(float64(latlng.Lat), float64(latlng.Lng))
 	ne := p.PointAtDistanceAndBearing(distKm, 45)
 	sw := p.PointAtDistanceAndBearing(distKm, 225)

--- a/iznik-server-go/test/newsfeed_nearby_filter_test.go
+++ b/iznik-server-go/test/newsfeed_nearby_filter_test.go
@@ -1,0 +1,67 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/newsfeed"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression test for Discourse #9937 post 1: selecting "Nearby" in the
+// ChitChat distance filter showed the same unfiltered feed as "Anywhere",
+// with a post 169 miles away appearing at the top.
+//
+// Root cause: GetNearbyDistance returned 0 ("give up") whenever the spatial
+// "newsfeed" KNN index couldn't supply nearbyLimit (10) candidates, and
+// getFeed() treats a 0 return as "apply no geographic filtering at all" -
+// exactly the same code path used for "Anywhere". The test spatial mock
+// (ensureSpatialMock in main_test.go) only serves the "postcodes" dataset
+// and returns an empty result for every other dataset including "newsfeed",
+// so this exercises exactly that fallback.
+func TestFeedNearbyDistanceExcludesFarAwayPost(t *testing.T) {
+	prefix := uniquePrefix("nearbyfilter")
+	userID, token := CreateFullTestUser(t, prefix)
+
+	// A post right where the user is (Edinburgh, set by CreateTestUser).
+	localMessage := "Local test post " + prefix
+	CreateTestNewsfeed(t, userID, 55.9533, -3.1883, localMessage)
+
+	// A post in London - about 534km / 332 miles from Edinburgh, far beyond
+	// any reasonable "Nearby" radius.
+	farMessage := "Far away test post " + prefix
+	CreateTestNewsfeed(t, userID, 51.5074, -0.1278, farMessage)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed?distance=nearby&jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var feed []newsfeed.NewsfeedSummary
+	json.Unmarshal(rsp(resp), &feed)
+
+	ids := make(map[uint64]bool)
+	for _, entry := range feed {
+		ids[entry.ID] = true
+	}
+
+	localID := findNewsfeedIDByMessage(t, localMessage)
+	farID := findNewsfeedIDByMessage(t, farMessage)
+
+	assert.True(t, ids[localID], "the local post should be in the Nearby feed")
+
+	// The far-away post must NOT leak into "Nearby". Before the fix,
+	// GetNearbyDistance fell back to an unfiltered (zero/disabled) radius
+	// whenever it couldn't establish a data-driven one, so this assertion
+	// fails on the bug and passes once Nearby is bounded.
+	assert.False(t, ids[farID], "far-away post should NOT appear under Nearby")
+}
+
+func findNewsfeedIDByMessage(t *testing.T, message string) uint64 {
+	var id uint64
+	database.DBConn.Raw("SELECT id FROM newsfeed WHERE message = ? ORDER BY id DESC LIMIT 1", message).Scan(&id)
+	if id == 0 {
+		t.Fatalf("could not find newsfeed entry for message %q", message)
+	}
+	return id
+}

--- a/iznik-server-go/test/newsfeed_nearby_test.go
+++ b/iznik-server-go/test/newsfeed_nearby_test.go
@@ -18,6 +18,9 @@ import (
 // documented contract instead of just re-reading whatever the constant says.
 const maxNearbyKmForTest = 128.0
 
+// minNearbyKmForTest mirrors newsfeed.go's minNearbyKm floor - see below.
+const minNearbyKmForTest = 1.0
+
 // Regression test for the PR #459 review: the spatial "newsfeed" index dropped
 // the type!=ALERT and 31-day recency filters that the old GetNearbyDistance
 // query applied. RecentNonAlertNewsfeedIDs restores them so alerts and stale
@@ -155,4 +158,74 @@ func TestGetNearbyDistanceCapsHappyPathRadius(t *testing.T) {
 
 	assert.Greater(t, dist, 0.0)
 	assert.LessOrEqual(t, dist, maxNearbyKmForTest, "even the happy-path (enough recent, non-alert posts) radius must be capped so a sparse/spread-out area can't produce an unbounded 'Nearby' radius")
+}
+
+// Regression test from the adversarial review of the #9937 fix: capping the
+// radius from above isn't enough, because both data-driven branches can
+// compute a distance of exactly 0, not just an unbounded one. A newsfeed
+// post at the user's own coordinates - their own post, or someone else's
+// right on top of them - has KNN distance 0 in decimal degrees, and 0 hits
+// getFeed()'s "no restriction at all" path exactly like an unbounded radius
+// does. This exercises the "happy path" branch (>= nearbyLimit recent,
+// non-alert posts, all co-located with the user).
+func TestGetNearbyDistanceFloorsHappyPathZeroRadius(t *testing.T) {
+	uid := CreateTestUser(t, "nearbyfloorhappy", "User")
+	lat, lng := 55.9533, -3.1883
+
+	var ids []int64
+	var dists []float64
+
+	addPoint := func(degrees float64) {
+		id := CreateTestNewsfeedWithType(t, uid, lat, lng, fmt.Sprintf("floorhappy post %d", len(ids)), "Message", 24)
+		ids = append(ids, int64(id))
+		dists = append(dists, degrees)
+	}
+
+	// 10 recent, non-alert posts, all at the user's exact coordinates - the
+	// 10th-nearest (index 9) is 0 degrees away.
+	for i := 0; i < 10; i++ {
+		addPoint(0.0)
+	}
+
+	restore := mockNewsfeedKNN(t, ids, dists)
+	defer restore()
+
+	dist, _, _, _, _, _ := newsfeed.GetNearbyDistance(uid)
+
+	assert.GreaterOrEqual(t, dist, minNearbyKmForTest, "a 0-degree happy-path radius must be floored to a positive value, not left at 0 (which getFeed() treats as 'no restriction', reintroducing #9937)")
+}
+
+// Same review finding, but for the raw-KNN fallback branch: too few recent,
+// non-alert posts to reach nearbyLimit, and the raw nearbyLimit-th KNN
+// candidate is also co-located with the user (distance 0).
+func TestGetNearbyDistanceFloorsRawKNNFallbackZeroRadius(t *testing.T) {
+	uid := CreateTestUser(t, "nearbyfloorfallback", "User")
+	lat, lng := 55.9533, -3.1883
+
+	var ids []int64
+	var dists []float64
+
+	addPoint := func(hoursAgo int, degrees float64) {
+		id := CreateTestNewsfeedWithType(t, uid, lat, lng, fmt.Sprintf("floorfallback post %d", len(ids)), "Message", hoursAgo)
+		ids = append(ids, int64(id))
+		dists = append(dists, degrees)
+	}
+
+	// Only 2 recent, non-alert posts - fewer than nearbyLimit (10), so
+	// GetNearbyDistance must fall back to raw KNN density.
+	for i := 0; i < 2; i++ {
+		addPoint(24, 0.0)
+	}
+	// 13 more raw KNN candidates (stale, >31 days), all co-located with the
+	// user - the 10th-nearest overall (index 9) is 0 degrees away.
+	for i := 0; i < 13; i++ {
+		addPoint(24*40, 0.0)
+	}
+
+	restore := mockNewsfeedKNN(t, ids, dists)
+	defer restore()
+
+	dist, _, _, _, _, _ := newsfeed.GetNearbyDistance(uid)
+
+	assert.GreaterOrEqual(t, dist, minNearbyKmForTest, "a 0-degree raw-KNN fallback radius must be floored to a positive value, not left at 0 (which getFeed() treats as 'no restriction', reintroducing #9937)")
 }

--- a/iznik-server-go/test/newsfeed_nearby_test.go
+++ b/iznik-server-go/test/newsfeed_nearby_test.go
@@ -1,12 +1,22 @@
 package test
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/freegle/iznik-server-go/newsfeed"
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/stretchr/testify/assert"
 )
+
+// maxNearbyKmForTest mirrors newsfeed.go's maxNearbyKm ceiling. Kept here
+// rather than exported from the package so the test independently pins the
+// documented contract instead of just re-reading whatever the constant says.
+const maxNearbyKmForTest = 128.0
 
 // Regression test for the PR #459 review: the spatial "newsfeed" index dropped
 // the type!=ALERT and 31-day recency filters that the old GetNearbyDistance
@@ -29,4 +39,120 @@ func TestRecentNonAlertNewsfeedIDs(t *testing.T) {
 	assert.True(t, hasRecent, "recent non-alert post should count towards the nearby radius")
 	assert.False(t, hasOld, "post older than 31 days should be excluded")
 	assert.False(t, hasAlert, "alert post should be excluded")
+}
+
+// mockNewsfeedKNN points the spatial client at an in-process server that
+// answers /v1/newsfeed/knn with the given ids/distances (already in the
+// order GetNearbyDistance expects: nearest first) and returns an empty
+// result for every other path. Returns a restore func that must be
+// deferred to put SPATIAL_KNN_URL back so later tests are unaffected.
+func mockNewsfeedKNN(t *testing.T, ids []int64, dists []float64) func() {
+	t.Helper()
+	original := os.Getenv("SPATIAL_KNN_URL")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !strings.Contains(r.URL.Path, "/newsfeed/knn") {
+			fmt.Fprint(w, `{"results":[]}`)
+			return
+		}
+		var b strings.Builder
+		b.WriteString(`{"results":[`)
+		for i, id := range ids {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, `{"id":%d,"distance":%g}`, id, dists[i])
+		}
+		b.WriteString(`]}`)
+		fmt.Fprint(w, b.String())
+	}))
+
+	os.Setenv("SPATIAL_KNN_URL", srv.URL)
+
+	return func() {
+		srv.Close()
+		os.Setenv("SPATIAL_KNN_URL", original)
+	}
+}
+
+// Regression test for Discourse #9937: when the spatial KNN index has enough
+// raw candidates (any age/type) but too few pass the recent/non-alert filter
+// to reach nearbyLimit, GetNearbyDistance must still size a radius from the
+// raw KNN density rather than giving up (which callers treat as "no
+// restriction at all", making "Nearby" behave exactly like "Anywhere").
+//
+// Two earlier attempts at this fix (PRs #1114, #1115) both introduced a
+// "maxNearbyKm" constant but only used it as an initial default - the raw
+// KNN 10th-nearest distance was still written into distKm unconditionally
+// afterwards, so a sparse/spread-out area could still produce an unbounded
+// radius. This test uses raw candidates ~370-400km away specifically so
+// that an uncapped implementation would return a radius far past
+// maxNearbyKmForTest, and only a genuine unconditional clamp passes it.
+func TestGetNearbyDistanceCapsRawKNNFallbackRadius(t *testing.T) {
+	uid := CreateTestUser(t, "nearbycapfallback", "User")
+	lat, lng := 55.9533, -3.1883
+
+	var ids []int64
+	var dists []float64
+
+	addPoint := func(hoursAgo int, degrees float64) {
+		id := CreateTestNewsfeedWithType(t, uid, lat, lng, fmt.Sprintf("fallback post %d", len(ids)), "Message", hoursAgo)
+		ids = append(ids, int64(id))
+		dists = append(dists, degrees)
+	}
+
+	// Only 2 recent, non-alert posts - fewer than nearbyLimit (10), so
+	// GetNearbyDistance must fall back to raw KNN density.
+	for i := 0; i < 2; i++ {
+		addPoint(24, 0.01*float64(i+1)) // ~1-2km away, 1 day ago
+	}
+	// 13 more raw KNN candidates (stale, >31 days) spread far out, ascending
+	// distance - the 10th-nearest overall (index 9) is ~3.7 degrees
+	// (~410km) away.
+	for i := 0; i < 13; i++ {
+		addPoint(24*40, 3.0+0.1*float64(i)) // 40 days ago
+	}
+
+	restore := mockNewsfeedKNN(t, ids, dists)
+	defer restore()
+
+	dist, _, _, _, _, _ := newsfeed.GetNearbyDistance(uid)
+
+	assert.Greater(t, dist, 0.0, "Nearby should still apply a geographic radius when there aren't enough recent posts to size one from alone, rather than silently becoming Anywhere")
+	assert.LessOrEqual(t, dist, maxNearbyKmForTest, "the raw-KNN fallback radius must be capped rather than left at the 10th raw candidate's ~410km distance")
+}
+
+// Regression test for the same PR #1114/#1115 review finding, but for the
+// "happy path": even when there ARE enough recent, non-alert posts to avoid
+// the raw-KNN fallback entirely, a sparse/spread-out area could still size
+// an unbounded radius directly from their distance. That path must be
+// capped too.
+func TestGetNearbyDistanceCapsHappyPathRadius(t *testing.T) {
+	uid := CreateTestUser(t, "nearbycaphappy", "User")
+	lat, lng := 55.9533, -3.1883
+
+	var ids []int64
+	var dists []float64
+
+	addPoint := func(degrees float64) {
+		id := CreateTestNewsfeedWithType(t, uid, lat, lng, fmt.Sprintf("happy post %d", len(ids)), "Message", 24)
+		ids = append(ids, int64(id))
+		dists = append(dists, degrees)
+	}
+
+	// 10 recent, non-alert posts (enough to avoid the fallback branch), but
+	// spread very far apart - the 10th-nearest (index 9) is ~4.1 degrees
+	// (~455km) away.
+	for i := 0; i < 10; i++ {
+		addPoint(0.5 + 0.4*float64(i))
+	}
+
+	restore := mockNewsfeedKNN(t, ids, dists)
+	defer restore()
+
+	dist, _, _, _, _, _ := newsfeed.GetNearbyDistance(uid)
+
+	assert.Greater(t, dist, 0.0)
+	assert.LessOrEqual(t, dist, maxNearbyKmForTest, "even the happy-path (enough recent, non-alert posts) radius must be capped so a sparse/spread-out area can't produce an unbounded 'Nearby' radius")
 }


### PR DESCRIPTION
## Root Cause
`newsfeed.GetNearbyDistance` (`iznik-server-go/newsfeed/newsfeed.go`) sizes the geographic radius for the ChitChat "Nearby" feed filter. It fetches up to 100 nearest posts from the spatial KNN index, then narrows to the 10th-nearest post that is both non-alert and posted in the last 31 days. Whenever it couldn't find 10 such posts — spatial call error, too few raw KNN candidates, or too few of those candidates passing the recency/alert filter — it returned distance `0`. `getFeed()` treats `0` identically to "no location available": it applies **no geographic restriction at all**, producing exactly the same feed as "Anywhere". This is common outside busy areas, not just an edge case.

Traced end-to-end: the Nuxt frontend (`pages/chitchat/[[id]].vue` → `stores/newsfeed.js` → `api/NewsAPI.js`) correctly sends `?distance=nearby`, and the Go handler (`newsfeed.Feed`) correctly parses it as "auto-calculate" (`gotDistance=false`) — both working as designed. The bug is entirely inside the radius calculation.

Confirmed as a regression, not working-as-designed: the pre-#459 (`242d8a15c`) implementation always bounded its fallback to a maximum search radius (doubling 1km→128km before giving up), so it never returned "no restriction". The #459 spatial-server rewrite dropped that ceiling and returns 0 outright — Discourse #9937's exact symptom (a 169-mile-away post topping "Nearby").

This branch previously had two rejected attempts (PRs #1114, #1115, both auto-closed by review): both introduced a `maxNearbyKm` constant but only used it as an initial *default* for the all-data-missing case — the raw-KNN-fallback and "enough recent posts" happy-path branches still wrote their computed `distKm` unconditionally afterwards, so a sparse/spread-out area could still produce an unbounded radius. This version fixes that gap directly (see Fix below).

## Evidence
Failing test output (before fix, buggy `master` code):
```
=== RUN   TestFeedNearbyDistanceExcludesFarAwayPost
    newsfeed_nearby_filter_test.go:57:
        Error:      Should be false
        Messages:   far-away post should NOT appear under Nearby
--- FAIL: TestFeedNearbyDistanceExcludesFarAwayPost (0.28s)

=== RUN   TestGetNearbyDistanceCapsRawKNNFallbackRadius
    newsfeed_nearby_test.go:122:
        Error:      "0" is not greater than "0"
        Messages:   Nearby should still apply a geographic radius when there aren't enough recent posts to size one from alone, rather than silently becoming Anywhere
--- FAIL: TestGetNearbyDistanceCapsRawKNNFallbackRadius (0.29s)

=== RUN   TestGetNearbyDistanceCapsHappyPathRadius
    newsfeed_nearby_test.go:157:
        Error:      "455.09999999999997" is not less than or equal to "128"
        Messages:   even the happy-path (enough recent, non-alert posts) radius must be capped so a sparse/spread-out area can't produce an unbounded 'Nearby' radius
--- FAIL: TestGetNearbyDistanceCapsHappyPathRadius (0.23s)
FAIL
```
All three pass after the fix (see Test below); confirmed by stashing the fix out and re-running against unmodified code, reproducing the identical failures above.

## Fix
`GetNearbyDistance` now:
1. Initialises `distKm` to a `maxNearbyKm = 128.0` ceiling (the largest radius the pre-#459 doubling-box algorithm ever searched before giving up) as soon as the user has a known location.
2. Overwrites `distKm` with a data-driven value on either the "enough recent, non-alert posts" happy path, or (new) a raw-KNN-fallback path using the 10th-nearest raw candidate's distance when too few pass the recency/alert filter but there's still enough raw local density data.
3. Applies a single, unconditional `if distKm > maxNearbyKm { distKm = maxNearbyKm }` clamp *after* both branches, so every path - happy path, raw-KNN fallback, and the KNN-error/too-few-raw-candidates default - is bounded the same way. This is the piece both prior attempts missed.

The only path left returning `0` is when the user has no known location at all (`latlng.Lat == 0 && latlng.Lng == 0`) - there is no reference point to size *any* radius from in that case, so falling back to unfiltered is the only sensible behaviour, and is unchanged from before.

## Other Call Sites
```
$ grep -rn "spatial.KNN" --include=*.go . | grep -v _test.go
./location/location.go:60:  spatial.KNN("postcodes", ...)   # ClosestPostcode - single lookup, not a distance filter
./job/job.go:56:            spatial.KNN("jobs", ...)         # GetJobs - fails CLOSED (empty list) on error/empty, not open
./newsfeed/newsfeed.go:132: spatial.KNN("newsfeed", ...)     # fixed here
```
Neither other call site has the "silently fall back to fully unrestricted" pattern that was unique to `GetNearbyDistance`'s overloaded 0-means-both-"no filter" reading - no changes needed there.

## Test
- Files: `iznik-server-go/test/newsfeed_nearby_test.go` (`TestGetNearbyDistanceCapsRawKNNFallbackRadius`, `TestGetNearbyDistanceCapsHappyPathRadius` - both use deliberately far-apart mocked KNN distances, ~410km and ~455km respectively, specifically so an uncapped implementation fails and only a genuine unconditional clamp passes) and `iznik-server-go/test/newsfeed_nearby_filter_test.go` (`TestFeedNearbyDistanceExcludesFarAwayPost`, HTTP-level regression matching the reported symptom)
- Command: `go test ./test/... -run 'TestGetNearbyDistanceCapsRawKNNFallbackRadius|TestGetNearbyDistanceCapsHappyPathRadius|TestFeedNearbyDistanceExcludesFarAwayPost|TestRecentNonAlertNewsfeedIDs' -v`
- Proves fail-before/pass-after: all three new/updated tests fail on unmodified master (see Evidence) and pass after the fix. Also ran the full `newsfeed`/`Feed`-related test file set (36 tests, `TestNewsfeed*|TestFeed*|TestGetNearbyDistance*|TestRecentNonAlert*`) - all pass, no regressions. `go build ./...` and `go vet ./...` clean.

## Discourse
https://discourse.ilovefreegle.org/t/9937/1