### PR TITLE
SEO: make posts and their photos findable

### DIFF
--- a/delivery-imagesweserv.conf
+++ b/delivery-imagesweserv.conf
@@ -81,6 +81,25 @@ server {
     include weserv-headers.conf;
     add_header X-Cache-Status $upstream_cache_status;
 
+    # Serve our own robots.txt rather than the one shipped in the upstream
+    # images.weserv public/ directory. Theirs ends with:
+    #
+    #   User-agent: *
+    #   Disallow: /*?*
+    #   Allow: /$
+    #
+    # which upstream use to keep their free public proxy from being crawled.
+    # Every Freegle item photo is a query-string URL
+    # (/?filename=...&url=https://uploads.ilovefreegle.org/...), so under
+    # longest-match-wins that rule blocked Googlebot-Image from every photo on
+    # the site. This is our own domain serving our own members' photos, and we
+    # want them in image search.
+    location = /robots.txt {
+        default_type text/plain;
+        add_header Cache-Control 'public, max-age=3600';
+        return 200 'User-agent: *\nAllow: /\n';
+    }
+
     location / {
         expires 1y; # Far-future expiration for static files
         try_files $uri $uri.html$is_args @proxy;

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -39,6 +39,7 @@ Read these directly; the pages above link into them rather than copy them:
 | Browser testing with Chrome DevTools | [./reference/browser-testing.md](./reference/browser-testing.md) |
 | Worktrees / parallel instances | [./reference/worktrees.md](./reference/worktrees.md) |
 | TrashNothing / LoveJunk integration | [./reference/trashnothing.md](./reference/trashnothing.md) |
+| SEO: how posts get found | [./reference/seo.md](./reference/seo.md) |
 | ModTools AI Support Helper | [./reference/ai-support-helper.md](./reference/ai-support-helper.md) |
 
 Each component also has its own README (`iznik-nuxt3/README.md`, `iznik-server-go/README.md`,

--- a/docs/developers/reference/seo.md
+++ b/docs/developers/reference/seo.md
@@ -1,0 +1,227 @@
+---
+last_reviewed: 2026-07-27
+owner: Freegle dev team
+covers:
+  - iznik-nuxt3/server/utils/sitemap.ts
+  - iznik-nuxt3/server/routes/sitemap.xml.ts
+  - iznik-nuxt3/server/routes/sitemap-pages.xml.ts
+  - iznik-nuxt3/composables/useBuildHead.js
+  - iznik-nuxt3/composables/useMessageJsonLd.js
+  - iznik-nuxt3/pages/message/[id].vue
+  - iznik-nuxt3/public/robots.txt
+  - iznik-server-go/message/sitemap.go
+  - iznik-server-go/group/groupMessages.go
+  - delivery-imagesweserv.conf
+---
+
+# SEO: how posts get found
+
+How a Freegle post becomes something Google can find, and the decisions behind
+each piece. Written up after a member searched for one of our own posts and got
+the Trash Nothing copy of it instead.
+
+## The three things a crawler needs
+
+1. **To learn the URL exists.** From the sitemap, or from a link on a page it
+   already crawls.
+2. **To fetch something worth indexing.** Real content in the server-rendered
+   HTML, a description that isn't identical on every page, a heading.
+3. **Not to be told to go away.** No `robots.txt` rule blocking it, no
+   `noindex`, no 404.
+
+We used to fail all three for individual posts, and the third one for every
+photo on the site.
+
+## Sitemaps
+
+`robots.txt` advertises `/sitemap.xml`, which is a **sitemap index**, not a list
+of URLs:
+
+| Route | Contents | ISR |
+|-------|----------|-----|
+| `/sitemap.xml` | index listing the children below | 600s |
+| `/sitemap-pages.xml` | landing/policy pages, `/compare/*`, one per community | 3600s |
+| `/sitemap-posts/<n>` | up to 20,000 live posts each, with `lastmod` | 600s |
+
+Building blocks live in `server/utils/sitemap.ts` (pure functions, unit tested in
+`tests/unit/server/sitemap.spec.js`); the routes are thin wrappers that fetch and
+render.
+
+**`/sitemap.xml` must not be prerendered.** It was, once, which meant a copy was
+baked at deploy time. That is harmless for a list of static pages and useless for
+a list of posts, which turn over hourly: within minutes it would be advertising
+posts that had already been taken. It is served on demand with a short ISR window
+instead (`nuxt.config.ts` `routeRules`).
+
+The post sitemap routes have no `.xml` extension because a Nitro route parameter
+has to be a whole path segment. `/sitemap-posts-:chunk.xml` does not match
+anything in radix3. What a crawler cares about is the content type, which the
+route sets.
+
+### Where the post list comes from
+
+`GET /message/sitemap` in the Go API (`message/sitemap.go`) reads
+**`messages_spatial`**, not `messages`/`messages_groups`/`messages_outcomes`.
+That table:
+
+- is already exactly the set the site treats as currently visible, because the
+  daily batch prunes expired posts out of it;
+- holds one row per message (`msgid` is `UNIQUE`), so no dedup is needed;
+- is ~51,000 rows, against 8.3m in `messages`.
+
+Joining the message tables to work out the same set is a far heavier query to run
+every time the sitemap regenerates.
+
+Excluded from the sitemap: `successful` posts (they answer 410, see below), and
+anything that isn't an `Offer` or a `Wanted`.
+
+## Finished posts answer 410
+
+A post that has been taken, received, withdrawn, deleted, or rejected everywhere
+is **gone**. `pages/message/[id].vue` computes this once (`gone`) and:
+
+- calls `setResponseStatus(410)` (a no-op on the client);
+- adds `noindex, follow`;
+- still renders the friendly "This post isn't available" page for humans.
+
+410 rather than 404 because these are posts that genuinely existed and are
+deliberately, permanently finished.
+
+Why this matters: there are roughly **8.3 million** such URLs against **~42,000**
+live ones. They used to answer HTTP 200 with the item's subject as the `<title>`
+and an identical body, which reads to a crawler as millions of near-identical
+thin pages, and gets the whole `/message/*` path discounted and crawled less.
+
+`?showtaken=1` deliberately overrides this, for links that are meant to show a
+finished post.
+
+## Community pages are a crawl path
+
+`/explore/<group>` renders its interactive content inside `<client-only>`, so the
+HTML a crawler receives contained **no links to posts at all**. Google can run our
+JavaScript, but on a delayed second pass and not for every page every time, so
+which communities surfaced a given post was effectively arbitrary.
+
+The page now also renders a plain, server-rendered list of post links, hidden from
+sighted users with `visually-hidden` but present in the served HTML with real
+`<a href="/message/...">` and the post subject as link text. It is fed by
+`GET /group/:id/message/summary` (`group/groupMessages.go`), which returns id +
+subject for up to 200 recent live posts.
+
+That endpoint is deliberately **anonymous** — unlike `GET /group/:id/message` it
+never folds in the caller's own pending posts, because its output is rendered into
+a page that gets cached and served to everyone.
+
+`/explore/**` is on a 600s ISR window, down from 3600s: a community page is the
+crawl path into that community's new posts, so an hour of cache meant a new post
+could sit invisible for an hour after it landed.
+
+## Meta tags
+
+Everything goes through `buildHead` (`composables/useBuildHead.js`), which now
+also emits:
+
+- **`rel=canonical`**, agreeing with `og:url`. Both are the clean path with query
+  strings stripped, so `?src=` tracking on inbound links doesn't fragment the
+  signal. Pass `options.canonical` to override, which the post page does
+  (`/message/<id>`) and the community page does (`/explore/<group>`, so that
+  `/explore/<group>/<msgid>` folds into it).
+- **`options.noindex`**, which adds `robots: noindex, follow` while leaving the
+  rest of the tags in place. Call sites used to do this by assigning `head.meta`,
+  which replaced the array and silently threw away the description and every
+  `og:`/`twitter:` tag.
+- **cleaned descriptions**, via `seoDescription()`: strips HTML (group
+  descriptions are WYSIWYG and arrived as raw `<p><strong>...` in the meta tag),
+  decodes entities, collapses whitespace, truncates at a word boundary.
+
+`seoDescription` strips only an **allowlist** of real HTML tags rather than
+anything shaped like `<word>`, so an item described as fitting "`<angle>`
+brackets" survives.
+
+### Post descriptions
+
+The post page used to emit `content="Click for more details"` on **every post on
+the site**, because it read `message.snippet` and the API has no such field. It
+now derives the description from `textbody`.
+
+## Structured data
+
+`composables/useMessageJsonLd.js` emits a JSON-LD `Product` block on post pages.
+
+It replaces microdata in `OurMessage.vue` which never did anything: it declared
+`schema.org/Product` but carried only `price`, `priceCurrency` and
+`availability`, with no `name`, `image` or `description`, so Google discarded it.
+`availability` was the string `"Instock"`, which is not a schema.org value, and
+the whole block sat inside a `d-none` element, which Google's guidelines do not
+allow for microdata.
+
+Deliberately emits **nothing** for:
+
+- **Wanted** posts. A `Product`/`Offer` describes something available; a Wanted is
+  a request. Marking one up as a product on offer would be false.
+- **gone** posts, which are 410 and noindex anyway.
+
+## Images
+
+Every item photo is served from `delivery.ilovefreegle.org` as a query-string URL:
+
+```
+https://delivery.ilovefreegle.org/?filename=<hash>&w=640&url=https://uploads.ilovefreegle.org/<hash>
+```
+
+We self-host images.weserv (`delivery-imagesweserv.conf`, rooted at
+`/var/www/imagesweserv/public`), and that directory ships **upstream's**
+`robots.txt`, which ends:
+
+```
+User-agent: *
+Disallow: /*?*
+Allow: /$
+```
+
+Upstream use that to keep their free public proxy from being crawled. On our
+domain, serving our own members' photos, it meant `Disallow: /*?*` matched every
+photo URL on the site under longest-match-wins, so **Googlebot-Image was blocked
+from all ~40,000 live post photos**.
+
+The vhost now serves its own `robots.txt` from a `location = /robots.txt` block
+that wins over the file on disk. If image indexing ever silently stops, check that
+first:
+
+```bash
+curl -s --compressed https://delivery.ilovefreegle.org/robots.txt
+```
+
+It is Cloudflare-cached, so purge after changing it.
+
+Alt text is the item subject rather than the literal `"Item Photo"` that used to
+be on every image (`MessageExpanded.vue`, `MessageSummary.vue`). Alt text is a
+primary ranking input for image search.
+
+`buildHead` also strips the internal `:8080` port from image URLs; crawlers and
+social preview fetchers are wary of images on non-standard ports, and the same
+file serves fine on 443.
+
+## Checking it
+
+```bash
+# What a crawler actually receives
+curl -s -A "Googlebot" https://www.ilovefreegle.org/message/<id> | grep -o '<title>[^<]*</title>'
+curl -s -A "Googlebot" https://www.ilovefreegle.org/message/<id> | grep -o '<meta name="description"[^>]*>'
+
+# A finished post should be 410
+curl -s -o /dev/null -w '%{http_code}\n' https://www.ilovefreegle.org/message/<taken-id>
+
+# Community page should contain post links in the raw HTML
+curl -s https://www.ilovefreegle.org/explore/<group> | grep -c 'href="/message/'
+
+# Photos must not be disallowed
+curl -s --compressed https://delivery.ilovefreegle.org/robots.txt | tail -5
+
+# Sitemap chain
+curl -s https://www.ilovefreegle.org/sitemap.xml
+curl -s https://www.ilovefreegle.org/sitemap-posts/0 | grep -c '<loc>'
+```
+
+Worth watching in Search Console after any change here: indexed count for
+`/message/*`, the "Discovered but not indexed" bucket, and image impressions.

--- a/iznik-nuxt3/components/MessageAttachments.vue
+++ b/iznik-nuxt3/components/MessageAttachments.vue
@@ -45,7 +45,7 @@
         v-else-if="attachments[0].ouruid"
         :src="attachments[0].ouruid"
         :modifiers="attachments[0].externalmods"
-        alt="Item Photo"
+        :alt="photoAlt"
         :width="width"
         :height="height"
         :sizes="thumbnail ? '200px' : '320px md:768px'"
@@ -59,7 +59,7 @@
         provider="uploadcare"
         :src="attachments[0].externaluid"
         :modifiers="attachments[0].externalmods"
-        alt="Item Photo"
+        :alt="photoAlt"
         :width="width"
         :height="height"
         :sizes="thumbnail ? '200px' : '320px md:768px'"
@@ -70,8 +70,8 @@
       <ProxyImage
         v-else
         class-name="p-0 rounded"
-        alt="Item picture"
-        title="Item picture"
+        :alt="photoAlt"
+        :title="photoAlt"
         :src="attachments[0].path"
         :sizes="thumbnail ? '200px' : '320px md:768px'"
         :width="width"
@@ -121,7 +121,16 @@ const props = defineProps({
     required: false,
     default: null,
   },
+  /* What the photo is of, for the alt text. Optional so callers that don't have the
+  subject to hand still work; we fall back to a generic description. */
+  subject: {
+    type: String,
+    required: false,
+    default: null,
+  },
 })
+
+const photoAlt = computed(() => props.subject || 'Item photo')
 
 const defaultAttachments = ref(false)
 const imagewrapper = ref(null)

--- a/iznik-nuxt3/components/MessageExpanded.vue
+++ b/iznik-nuxt3/components/MessageExpanded.vue
@@ -67,7 +67,7 @@
                 v-if="attachment.ouruid"
                 :src="attachment.ouruid"
                 :modifiers="attachment.externalmods"
-                alt="Thumbnail"
+                :alt="thumbnailAlt(index)"
                 class="thumbnail-image"
                 :width="80"
                 :height="80"
@@ -78,7 +78,7 @@
                 provider="uploadcare"
                 :src="attachment.externaluid"
                 :modifiers="attachment.externalmods"
-                alt="Thumbnail"
+                :alt="thumbnailAlt(index)"
                 class="thumbnail-image"
                 :width="80"
                 :height="80"
@@ -86,7 +86,7 @@
               <ProxyImage
                 v-else-if="attachment.path"
                 class-name="thumbnail-image"
-                alt="Thumbnail"
+                :alt="thumbnailAlt(index)"
                 :src="attachment.path"
                 :width="80"
                 :height="80"
@@ -105,7 +105,7 @@
               v-if="currentAttachment?.ouruid"
               :src="currentAttachment.ouruid"
               :modifiers="currentAttachment.externalmods"
-              alt="Item Photo"
+              :alt="photoAlt"
               class="photo-image"
               :width="640"
               :height="480"
@@ -116,7 +116,7 @@
               provider="uploadcare"
               :src="currentAttachment.externaluid"
               :modifiers="currentAttachment.externalmods"
-              alt="Item Photo"
+              :alt="photoAlt"
               class="photo-image"
               :width="640"
               :height="480"
@@ -124,7 +124,7 @@
             <ProxyImage
               v-else-if="currentAttachment?.path"
               class-name="photo-image"
-              alt="Item picture"
+              :alt="photoAlt"
               :src="currentAttachment.path"
               :width="640"
               :height="480"
@@ -743,6 +743,19 @@ const {
   categoryIcon,
   poster,
 } = useMessageDisplay(props.id)
+
+/* Alt text for the item photos. It used to be the literal "Item Photo" / "Thumbnail"
+on every image on the site, which tells a screen reader nothing and gives Google Images
+nothing to match a search against. */
+const photoAlt = computed(() => subjectItemName.value || 'Item photo')
+
+function thumbnailAlt(index) {
+  const name = subjectItemName.value || 'Item'
+
+  return attachmentCount.value > 1
+    ? `${name} - photo ${index + 1} of ${attachmentCount.value}`
+    : name
+}
 
 // All the communities this post is on (it can be on several once it has rippled
 // out or been cross-posted). Resolve each to the group record for its display

--- a/iznik-nuxt3/components/MessageSummary.vue
+++ b/iznik-nuxt3/components/MessageSummary.vue
@@ -40,7 +40,7 @@
           v-if="message.attachments[0]?.ouruid"
           :src="message.attachments[0].ouruid"
           :modifiers="message.attachments[0].externalmods"
-          alt="Item Photo"
+          :alt="photoAlt"
           class="photo-image"
           :width="400"
           fit="inside"
@@ -53,7 +53,7 @@
           provider="uploadcare"
           :src="message.attachments[0].externaluid"
           :modifiers="message.attachments[0].externalmods"
-          alt="Item Photo"
+          :alt="photoAlt"
           class="photo-image"
           :width="400"
           fit="inside"
@@ -64,7 +64,7 @@
         <ProxyImage
           v-else-if="message.attachments[0]?.path"
           class-name="photo-image"
-          alt="Item picture"
+          :alt="photoAlt"
           :src="message.attachments[0].path"
           :width="400"
           fit="inside"
@@ -193,6 +193,10 @@ const {
   placeholderClass,
   categoryIcon,
 } = useMessageDisplay(idRef)
+
+/* Name the item in the alt text rather than the literal "Item Photo" that used to be
+on every photo on the site. */
+const photoAlt = computed(() => subjectItemName.value || 'Item photo')
 
 // Bulk offer ("clearance") indicator. bulkCount only gates the badge (is this a
 // bulk offer?); the badge itself shows the TOTAL quantity available, matching the

--- a/iznik-nuxt3/components/OurMessage.vue
+++ b/iznik-nuxt3/components/OurMessage.vue
@@ -10,19 +10,12 @@
       },
     }"
     class="position-relative"
-    itemscope
-    itemtype="http://schema.org/Product"
   >
-    <div
-      itemprop="offers"
-      itemscope
-      itemtype="http://schema.org/Offer"
-      class="d-none"
-    >
-      <meta itemprop="priceCurrency" content="GBP" />
-      <span itemprop="price">0</span> |
-      <span itemprop="availability">Instock</span>
-    </div>
+    <!-- Structured data lives in the JSON-LD block emitted by the message page
+    (composables/useMessageJsonLd.js). The microdata that used to sit here declared a
+    schema.org/Product but carried no name, image or description, so Google discarded
+    it, and it was inside a d-none element, which their guidelines don't allow for
+    microdata. -->
     <div v-if="startExpanded">
       <MessageExpanded
         :id="message.id"

--- a/iznik-nuxt3/composables/useBuildHead.js
+++ b/iznik-nuxt3/composables/useBuildHead.js
@@ -1,25 +1,103 @@
 import { useMiscStore } from '~/stores/misc'
 
+/* The tags our WYSIWYG group descriptions actually contain. We strip only these,
+rather than anything shaped like <word>, so that item descriptions mentioning e.g.
+"fits <angle> brackets" survive intact. */
+const HTML_TAGS =
+  'p|br|strong|b|em|i|u|s|div|span|a|ul|ol|li|dl|dt|dd|h[1-6]|blockquote|img|hr|pre|code|table|thead|tbody|tfoot|tr|td|th|font|small|sub|sup'
+
+const TAG_RE = new RegExp(`</?(?:${HTML_TAGS})(?:\\s[^>]*)?/?>`, 'gi')
+
+const ENTITIES = {
+  '&nbsp;': ' ',
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&apos;': "'",
+  '&hellip;': '...',
+  '&ndash;': '-',
+  '&mdash;': '-',
+  '&pound;': '£',
+}
+
+/**
+ * Turn arbitrary text (a group's HTML description, a post's plain-text body) into
+ * something fit for a meta description: no markup, no runaway whitespace, and short
+ * enough that Google shows it rather than truncating it mid-word.
+ */
+export function seoDescription(text, maxLength = 160) {
+  if (!text) {
+    return ''
+  }
+
+  let ret = String(text).replace(TAG_RE, ' ')
+
+  for (const [entity, char] of Object.entries(ENTITIES)) {
+    ret = ret.split(entity).join(char)
+  }
+
+  ret = ret.replace(/\s+/g, ' ').trim()
+
+  if (ret.length <= maxLength) {
+    return ret
+  }
+
+  /* Cut at a word boundary so we don't end mid-word. */
+  const cut = ret.slice(0, maxLength)
+  const lastSpace = cut.lastIndexOf(' ')
+
+  return (lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd() + '...'
+}
+
+/**
+ * The URL we want search engines to treat as the one true address for this page:
+ * no query string (tracking params like ?src= must not fragment our signals) and
+ * no hash.
+ */
+export function canonicalUrl(route, runtimeConfig, override = null) {
+  const site = runtimeConfig.public.USER_SITE
+
+  if (override) {
+    return override.startsWith('http') ? override : site + override
+  }
+
+  if (!route) {
+    return site
+  }
+
+  const path = route.path || (route.fullPath || '').split(/[?#]/)[0]
+
+  return site + (path || '')
+}
+
 export function buildHead(
   route,
   runtimeConfig,
   title,
   description,
   image = null,
-  bodyAttrs = {}
+  bodyAttrs = {},
+  options = {}
 ) {
+  /* Descriptions reach us from all sorts of places - group descriptions are WYSIWYG
+  HTML, post bodies are free text - and they all end up in a meta tag, so clean them
+  here rather than at every call site. */
+  const cleanDescription = seoDescription(description)
+
   // Pain to have to pass in runtimeConfig but you can't use that in a composable.
   const meta = [
     {
       hid: 'description',
       name: 'description',
-      content: description,
+      content: cleanDescription,
     },
     { hid: 'og:title', property: 'og:title', content: title },
     {
       hid: 'og:description',
       property: 'og:description',
-      content: description,
+      content: cleanDescription,
     },
 
     {
@@ -30,15 +108,23 @@ export function buildHead(
     {
       hid: 'twitter:description',
       name: 'twitter:description',
-      content: description,
+      content: cleanDescription,
     },
   ]
 
   let retImage = image || runtimeConfig.public.USER_SITE + '/icon.png'
 
+  /* Attachment paths from the API come through as both `<delivery>?url=...` and
+  `<delivery>/?url=...`, so accept either. The original condition here was
+  `retImage?.includes(DELIVERY) + '/?url='`, which is a string concatenation and so
+  always truthy - meaning any image URL containing an `=` got mangled. */
+  const delivery = runtimeConfig.public.IMAGE_DELIVERY
+
   if (
     typeof retImage === 'string' &&
-    retImage?.includes(runtimeConfig.public.IMAGE_DELIVERY) + '/?url='
+    delivery &&
+    (retImage.includes(delivery + '?url=') ||
+      retImage.includes(delivery + '/?url='))
   ) {
     // We've seen problems with Facebook preview failing to fetch images from weserv, so strip this back to the
     // original image URL.
@@ -60,17 +146,47 @@ export function buildHead(
     retImage = decodeURIComponent(retImage)
   }
 
+  /* The uploads host is published with an internal :8080 on it. Crawlers and social
+  preview fetchers are wary of images on non-standard ports, and the same file serves
+  fine on 443, so drop it. */
+  if (typeof retImage === 'string') {
+    retImage = retImage.replace(
+      /^(https:\/\/[^/:]+):(?:8080|8192)(?=\/|$)/,
+      '$1'
+    )
+  }
+
   meta.push({
     hid: 'og:image',
     property: 'og:image',
     content: retImage,
   })
 
+  /* og:url and rel=canonical should agree, and both should be the clean address -
+  not whatever tracking params (?src=...) the visitor happened to arrive with. */
+  const canonical = canonicalUrl(route, runtimeConfig, options.canonical)
+
   meta.push({
     hid: 'og:url',
     property: 'og:url',
-    content: runtimeConfig.public.USER_SITE + (route ? route.fullPath : ''),
+    content: canonical,
   })
+
+  if (options.ogType) {
+    meta.push({
+      hid: 'og:type',
+      property: 'og:type',
+      content: options.ogType,
+    })
+  }
+
+  if (options.noindex) {
+    meta.push({
+      hid: 'robots',
+      name: 'robots',
+      content: 'noindex, follow',
+    })
+  }
 
   meta.push({
     hid: 'twitter:image',
@@ -96,6 +212,7 @@ export function buildHead(
     title,
     meta,
     link: [
+      { rel: 'canonical', href: canonical },
       {
         rel: 'apple-touch-icon',
         sizes: '180x180',

--- a/iznik-nuxt3/composables/useMessageJsonLd.js
+++ b/iznik-nuxt3/composables/useMessageJsonLd.js
@@ -1,0 +1,87 @@
+import { seoDescription } from '~/composables/useBuildHead'
+
+/* Subjects are stored with the type on the front, e.g. "OFFER: Dining chairs
+(Moulton NN3)". Google wants the product name, not our posting convention. */
+const TYPE_PREFIX = /^\s*(OFFER|WANTED|TAKEN|RECEIVED)\s*:\s*/i
+
+export function productName(subject) {
+  if (!subject) {
+    return ''
+  }
+
+  return String(subject).replace(TYPE_PREFIX, '').trim()
+}
+
+/* The uploads host is published with an internal port on it, which crawlers dislike
+in image URLs and which isn't needed - the same file serves on 443. */
+function tidyImageUrl(url) {
+  if (!url) {
+    return null
+  }
+
+  return String(url).replace(/^(https:\/\/[^/:]+):(?:8080|8192)(?=\/|$)/, '$1')
+}
+
+/**
+ * Structured data for a post, as JSON-LD.
+ *
+ * This replaces microdata which never worked: it declared schema.org/Product but
+ * carried only price/currency/availability, with no name, image or description, so
+ * Google discarded the lot. It also sat inside a `d-none` element, which their
+ * guidelines don't allow for microdata.
+ *
+ * Returns null where structured data would be wrong or misleading:
+ *  - WANTED posts, which are requests rather than something available;
+ *  - posts that are finished, which we serve as 410 and noindex anyway.
+ */
+export function messageJsonLd(message, siteUrl, options = {}) {
+  if (!message || options.gone) {
+    return null
+  }
+
+  if (message.type !== 'Offer') {
+    return null
+  }
+
+  const name = productName(message.subject)
+
+  if (!name) {
+    return null
+  }
+
+  const images = (message.attachments || [])
+    .map((a) => tidyImageUrl(a.path))
+    .filter(Boolean)
+
+  const ld = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name,
+    url: siteUrl + '/message/' + message.id,
+    offers: {
+      '@type': 'Offer',
+      price: 0,
+      priceCurrency: 'GBP',
+      availability: 'https://schema.org/InStock',
+      itemCondition: 'https://schema.org/UsedCondition',
+      url: siteUrl + '/message/' + message.id,
+      seller: {
+        '@type': 'Organization',
+        name: 'Freegle',
+        url: siteUrl,
+      },
+    },
+  }
+
+  const description = seoDescription(message.textbody, 5000)
+
+  if (description) {
+    ld.description = description
+  }
+
+  if (images.length) {
+    ld.image = images
+  }
+
+  return ld
+}

--- a/iznik-nuxt3/modtools/components/ModMessageSummary.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageSummary.vue
@@ -62,6 +62,7 @@
           :attachments="message.attachments"
           :sample-image="message.sampleimage"
           :disabled="message.successful"
+          :subject="message.subject"
           thumbnail
           :preload="preload"
         />

--- a/iznik-nuxt3/nuxt.config.ts
+++ b/iznik-nuxt3/nuxt.config.ts
@@ -210,7 +210,10 @@ export default defineNuxtConfig({
     '/explore/region/**': { isr: 3600 },
     '/communityevent/**': { isr: 3600 },
     '/communityevents/**': { isr: 3600 },
-    '/explore/**': { isr: 3600 },
+    // A community page is the crawl path into that community's new posts, so an
+    // hour of cache meant a new post could sit invisible to a crawler for an hour
+    // after it landed. Ten minutes matches how fast the board actually moves.
+    '/explore/**': { isr: 600 },
     '/message/**': { isr: 600 },
     '/story/**': { isr: 3600 },
     '/shortlink/**': { isr: 600 },
@@ -220,6 +223,12 @@ export default defineNuxtConfig({
     // Static comparison pages ("Freegle vs ..."). Server-rendered so crawlers and
     // AI answer engines can read them; cached on the CDN until the next deploy.
     '/compare/**': { isr: true },
+
+    // Sitemaps. The post list turns over as fast as the board does, so it gets the
+    // same short window as the posts themselves; the community list barely moves.
+    '/sitemap.xml': { isr: 600 },
+    '/sitemap-posts/**': { isr: 600 },
+    '/sitemap-pages.xml': { isr: 3600 },
 
     // Allow CORS for chunk fetches - required for Netlify hosting.
     // Immutable cache for hashed assets — these filenames change on every build.
@@ -240,7 +249,12 @@ export default defineNuxtConfig({
 
     prerender: prerenderRoutes
       ? {
-          routes: ['/404.html', '/sitemap.xml'],
+          // /sitemap.xml is deliberately NOT prerendered. It now lists live posts,
+          // which turn over constantly, so a copy baked at deploy time would be
+          // stale within minutes and would keep pointing Google at posts that have
+          // since been taken. It's served on demand with a short ISR window instead
+          // (see routeRules).
+          routes: ['/404.html'],
 
           // Don't prerender the messages - too many.
           // Also ignore asset paths and CDN URLs - these are built separately and don't need prerendering

--- a/iznik-nuxt3/pages/explore/[groupid]/[[msgid]].vue
+++ b/iznik-nuxt3/pages/explore/[groupid]/[[msgid]].vue
@@ -1,23 +1,58 @@
 <template>
-  <client-only>
-    <div>
-      <b-row v-if="id && !group" class="m-0">
-        <b-col cols="12" md="6" lg="6" class="p-0" offset-md="3" offset-lg="3">
-          <NoticeMessage variant="danger" class="mt-2">
-            Sorry, we don't recognise that community name.
-          </NoticeMessage>
-        </b-col>
-      </b-row>
-      <b-row v-else class="m-0">
-        <b-col cols="12" md="6" lg="6" class="p-0" offset-md="3" offset-lg="3">
-          <ExploreGroup :id="group.id" :msgid="msgid" :show-give-find="!me" />
-        </b-col>
-      </b-row>
-    </div>
-  </client-only>
+  <div>
+    <client-only>
+      <div>
+        <b-row v-if="id && !group" class="m-0">
+          <b-col
+            cols="12"
+            md="6"
+            lg="6"
+            class="p-0"
+            offset-md="3"
+            offset-lg="3"
+          >
+            <NoticeMessage variant="danger" class="mt-2">
+              Sorry, we don't recognise that community name.
+            </NoticeMessage>
+          </b-col>
+        </b-row>
+        <b-row v-else class="m-0">
+          <b-col
+            cols="12"
+            md="6"
+            lg="6"
+            class="p-0"
+            offset-md="3"
+            offset-lg="3"
+          >
+            <ExploreGroup :id="group.id" :msgid="msgid" :show-give-find="!me" />
+          </b-col>
+        </b-row>
+      </div>
+    </client-only>
+    <!-- Everything above is client-only, which meant the HTML a crawler received
+    contained no links to posts at all. This list is rendered on the server so that
+    each community page is a real crawl path into its own posts. It's hidden from
+    sighted users - the interactive list above is the one they use - but it is in the
+    DOM and in the served HTML, with genuine links and real link text. -->
+    <nav
+      v-if="summaries.length"
+      class="visually-hidden"
+      aria-label="Recent posts"
+    >
+      <h2>Recent posts on {{ group?.namedisplay }}</h2>
+      <ul>
+        <li v-for="summary in summaries" :key="summary.id">
+          <NuxtLink :to="'/message/' + summary.id">
+            {{ summary.subject }}
+          </NuxtLink>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </template>
 <script setup>
-import { computed, useHead, useRuntimeConfig, useRoute } from '#imports'
+import { computed, ref, useHead, useRuntimeConfig, useRoute } from '#imports'
 import { buildHead } from '~/composables/useBuildHead'
 import { useGroupStore } from '~/stores/group'
 import ExploreGroup from '~/components/ExploreGroup'
@@ -36,6 +71,30 @@ const group = computed(() => {
   return groupStore.get(id)
 })
 
+/* Post subjects and ids for the server-rendered crawl path. Fetched directly rather
+than through the message store because we want the smallest possible payload, and
+we're rendering it on the server on every ISR regeneration. */
+const summaries = ref([])
+
+async function fetchSummaries(groupId) {
+  if (!groupId) {
+    return
+  }
+
+  try {
+    const rsp = await fetch(
+      runtimeConfig.public.APIv2 + '/group/' + groupId + '/message/summary'
+    )
+
+    if (rsp.ok) {
+      summaries.value = (await rsp.json()) || []
+    }
+  } catch (e) {
+    /* Not worth failing the page over - the interactive list still works. */
+    console.log('Failed to fetch post summaries', e)
+  }
+}
+
 if (id) {
   // Fetch the specific group.
   try {
@@ -45,6 +104,8 @@ if (id) {
   }
 
   if (group.value) {
+    await fetchSummaries(group.value.id)
+
     const head = buildHead(
       route,
       runtimeConfig,
@@ -52,12 +113,17 @@ if (id) {
       group.value.description
         ? group.value.description
         : "Give and get stuff for free. Offer things you don't need, and ask for things you'd like. Don't just recycle - reuse with Freegle!",
-      group.value.profile ? group.value.profile : '/icon.png'
+      group.value.profile ? group.value.profile : '/icon.png',
+      {},
+      {
+        /* /explore/<group>/<msgid> is the same community page with one post opened,
+        so point both forms at the plain community URL. */
+        canonical: '/explore/' + id,
+        /* Setting head.meta here used to REPLACE the array, throwing away the
+        description and every og: and twitter: tag along with it. */
+        noindex: !group.value.publish,
+      }
     )
-
-    if (!group.value.publish) {
-      head.meta = [{ name: 'robots', content: 'noindex' }]
-    }
 
     useHead(head)
   } else {

--- a/iznik-nuxt3/pages/message/[id].vue
+++ b/iznik-nuxt3/pages/message/[id].vue
@@ -23,20 +23,7 @@
         </client-only>
       </b-col>
       <b-col cols="12" lg="6" class="p-0">
-        <div
-          v-if="
-            !showtaken &&
-            (failed ||
-              !message ||
-              (message &&
-                (message.outcomes?.length > 0 ||
-                  message.deleted ||
-                  (message.groups &&
-                    message.groups.length &&
-                    message.groups.every((g) => g.collection === 'Rejected')))))
-          "
-          class="error-page"
-        >
+        <div v-if="gone" class="error-page">
           <div class="error-content">
             <div class="error-card">
               <v-icon icon="heart" class="error-icon" />
@@ -98,11 +85,15 @@
         </div>
         <div v-else class="botpad">
           <GlobalMessage />
+          <!-- The post subject is the page's heading. It's visually handled inside
+          MessageExpanded, so keep this out of the way but present for crawlers and
+          screen readers, which otherwise find no heading at all on this page. -->
+          <h1 class="visually-hidden">{{ message?.subject }}</h1>
           <OurMessage
             :id="id"
             class="mt-3"
             :start-expanded="true"
-            :view-source="$route.query.src || 'message_page'"
+            :view-source="viewSource"
             hide-close
             record-view
             @not-found="error = true"
@@ -134,7 +125,8 @@
   </b-col>
 </template>
 <script setup>
-import { buildHead } from '~/composables/useBuildHead'
+import { buildHead, seoDescription } from '~/composables/useBuildHead'
+import { messageJsonLd } from '~/composables/useMessageJsonLd'
 import {
   ref,
   computed,
@@ -142,6 +134,7 @@ import {
   useHead,
   useRuntimeConfig,
   useRoute,
+  setResponseStatus,
 } from '#imports'
 import { useMessageStore } from '~/stores/message'
 import { useAuthStore } from '~/stores/auth'
@@ -165,6 +158,11 @@ const id = route?.params?.id ? parseInt(route.params.id) : 0
 
 // Get showtaken query parameter
 const showtaken = route?.query?.showtaken
+
+/* Read through the same optional chaining the rest of this file uses. The template
+used to reach for `$route.query.src` directly, which throws during the SSR hydration
+race where route is briefly undefined - the very case the guards above exist for. */
+const viewSource = route?.query?.src || 'message_page'
 
 const failed = ref(false)
 const error = ref(false)
@@ -190,15 +188,44 @@ const message = computed(() => {
   return messageStore.byId(id)
 })
 
-if (message.value) {
-  let snip = null
+/* Has this post finished its life - taken, received, withdrawn, deleted or rejected
+everywhere? Roughly 8.3m of our message URLs are in this state against ~42k live ones,
+and they used to answer 200 with the item's subject as the title, which reads to a
+crawler as millions of near-identical thin pages. */
+const gone = computed(() => {
+  if (showtaken) {
+    /* Someone followed a deliberate "show me it anyway" link. */
+    return false
+  }
 
+  if (failed.value || !message.value) {
+    return true
+  }
+
+  const m = message.value
+
+  return Boolean(
+    m.outcomes?.length > 0 ||
+      m.deleted ||
+      (m.groups?.length && m.groups.every((g) => g.collection === 'Rejected'))
+  )
+})
+
+if (gone.value) {
+  /* 410 rather than 404: these are posts that genuinely existed and are deliberately
+  and permanently finished, which is exactly what Gone means. No-op on the client. */
+  setResponseStatus(410)
+}
+
+if (message.value) {
   try {
-    if (message.value.snippet) {
-      snip = twem(message.value.snippet) + '...'
-    } else {
-      snip = 'Click for more details'
-    }
+    /* The API doesn't return a `snippet` field, so this used to fall through to the
+    literal "Click for more details" on every post page on the site - telling Google
+    that every post was a duplicate of every other one. Derive it from the body. */
+    const snip = message.value.snippet
+      ? twem(message.value.snippet) + '...'
+      : seoDescription(twem(message.value.textbody || '')) ||
+        'Click for more details'
 
     const headData = buildHead(
       route,
@@ -207,14 +234,42 @@ if (message.value) {
       snip,
       message.value.attachments && message.value.attachments?.length > 0
         ? message.value.attachments[0].path
-        : null
+        : null,
+      {},
+      {
+        /* Always the bare post URL: a post is reached with all sorts of ?src=
+        tracking on it, and from the group pages too. */
+        canonical: '/message/' + id,
+        ogType: gone.value ? 'website' : 'product',
+        /* A post that's been taken, withdrawn or deleted is not something we want
+        in the index - there are millions of them and only tens of thousands live. */
+        noindex: gone.value,
+      }
     )
+    const ld = messageJsonLd(message.value, runtimeConfig.public.USER_SITE, {
+      gone: gone.value,
+    })
+
+    if (ld) {
+      headData.script = [
+        {
+          type: 'application/ld+json',
+          innerHTML: JSON.stringify(ld),
+        },
+      ]
+    }
+
     useHead(headData)
   } catch (e) {
     console.error('Error in head setup', e)
     // Fallback to basic head
     useHead({ title: message.value.subject || 'Message' })
   }
+} else if (gone.value) {
+  /* Nothing to describe, but still keep it out of the index. */
+  useHead({
+    meta: [{ hid: 'robots', name: 'robots', content: 'noindex, follow' }],
+  })
 }
 
 /* We want to delay render of MyMessage until the mount fetch is complete, as it would otherwise not

--- a/iznik-nuxt3/public/robots.txt
+++ b/iznik-nuxt3/public/robots.txt
@@ -1,5 +1,23 @@
 User-agent: *
 Allow: /
+
+# Logged-in areas. Nothing here is useful in a search result, and crawling it burns
+# crawl budget that should be going on posts.
+Disallow: /chats
+Disallow: /chats/
+Disallow: /settings
+Disallow: /settings/
+Disallow: /myposts
+Disallow: /mypost/
+Disallow: /merge/
+Disallow: /unsubscribe
+Disallow: /one-click-unsubscribe
+Disallow: /marketing-optout
+Disallow: /shortlink/
+Disallow: /qr
+Disallow: /adtest
+Disallow: /adtest2
+
 Sitemap: https://www.ilovefreegle.org/sitemap.xml
 
 User-agent: AmazonAdBot

--- a/iznik-nuxt3/server/routes/sitemap-pages.xml.ts
+++ b/iznik-nuxt3/server/routes/sitemap-pages.xml.ts
@@ -1,0 +1,23 @@
+import { staticLinks, groupLinks, renderUrlset } from '../utils/sitemap'
+
+// The stable part of the site: landing and policy pages, plus one page per community.
+
+export default defineEventHandler(async (event) => {
+  const runtimeConfig = useRuntimeConfig()
+
+  // eslint-disable-next-line no-undef
+  appendResponseHeader(event, 'Content-Type', 'text/xml')
+
+  const links = staticLinks()
+
+  try {
+    const rsp = await fetch(runtimeConfig.public.APIv2 + '/group')
+    const groups = await rsp.json()
+
+    links.push(...groupLinks(groups))
+  } catch (e) {
+    console.log('Failed to fetch groups for sitemap', e)
+  }
+
+  return renderUrlset(links, runtimeConfig.public.USER_SITE)
+})

--- a/iznik-nuxt3/server/routes/sitemap-posts/[chunk].ts
+++ b/iznik-nuxt3/server/routes/sitemap-posts/[chunk].ts
@@ -1,0 +1,37 @@
+import {
+  chunk as chunkList,
+  messageLinks,
+  renderUrlset,
+  SITEMAP_CHUNK_SIZE,
+} from '../../utils/sitemap'
+
+// One file per chunk of live posts, e.g. /sitemap-posts/0. The index at /sitemap.xml
+// declares how many of these exist; each holds up to SITEMAP_CHUNK_SIZE post URLs
+// with their lastmod.
+//
+// No .xml on the end because the route param has to be a whole path segment - what
+// matters to a crawler is the content type, which we set below.
+
+export default defineEventHandler(async (event) => {
+  const runtimeConfig = useRuntimeConfig()
+
+  // eslint-disable-next-line no-undef
+  appendResponseHeader(event, 'Content-Type', 'text/xml')
+
+  // eslint-disable-next-line no-undef
+  const index = parseInt(getRouterParam(event, 'chunk') || '0', 10)
+
+  let messages = []
+
+  try {
+    const rsp = await fetch(runtimeConfig.public.APIv2 + '/message/sitemap')
+    messages = await rsp.json()
+  } catch (e) {
+    console.log('Failed to fetch posts for sitemap', e)
+  }
+
+  const chunks = chunkList(messages || [], SITEMAP_CHUNK_SIZE)
+  const wanted = Number.isNaN(index) ? [] : chunks[index] || []
+
+  return renderUrlset(messageLinks(wanted), runtimeConfig.public.USER_SITE)
+})

--- a/iznik-nuxt3/server/routes/sitemap.xml.ts
+++ b/iznik-nuxt3/server/routes/sitemap.xml.ts
@@ -1,10 +1,11 @@
-import { Readable } from 'stream'
-import { SitemapStream, streamToPromise } from 'sitemap'
-import { comparisonList } from '../../constants/comparisons'
+import { chunk, renderSitemapIndex, SITEMAP_CHUNK_SIZE } from '../utils/sitemap'
 
-// We want to return a sitemap which has the normal page routes, but also our dynamic routes.
-// So far as I can tell Nuxt3 isn't evolved enough for use with a sitemap, so we have to do this
-// manually.
+// The top-level sitemap is an index pointing at the child sitemaps, because the post
+// list is far too big to sit alongside everything else in one file. Google reads this
+// first (it's what robots.txt advertises) and then fetches each child.
+//
+// Until this change the sitemap listed only the 496 community pages and 26 static
+// pages, and nothing at all told Google that an individual post existed.
 
 export default defineEventHandler(async (event) => {
   const runtimeConfig = useRuntimeConfig()
@@ -12,55 +13,23 @@ export default defineEventHandler(async (event) => {
   // eslint-disable-next-line no-undef
   appendResponseHeader(event, 'Content-Type', 'text/xml')
 
-  const links = [
-    { url: '/', changefreq: 'monthly', priority: 1.0 },
-    { url: '/give', changefreq: 'monthly', priority: 1.0 },
-    { url: '/find', changefreq: 'monthly', priority: 1.0 },
-    { url: '/explore', changefreq: 'weekly', priority: 0.8 },
-    { url: '/unsubscribe', changefreq: 'monthly', priority: 0.7 },
-    { url: '/donate', changefreq: 'monthly', priority: 0.7 },
-    { url: '/help', changefreq: 'monthly', priority: 0.5 },
-    { url: '/stories', changefreq: 'weekly', priority: 0.5 },
-    { url: '/communityevents', changefreq: 'monthly', priority: 0.1 },
-    { url: '/volunteerings', changefreq: 'monthly', priority: 0.1 },
-    { url: '/mobile', changefreq: 'monthly', priority: 0.3 },
-    { url: '/about', changefreq: 'monthly', priority: 0.3 },
-    { url: '/compare', changefreq: 'monthly', priority: 0.5 },
-    { url: '/disclaimer', changefreq: 'monthly', priority: 0.1 },
-    { url: '/terms', changefreq: 'monthly', priority: 0.1 },
-    { url: '/privacy', changefreq: 'monthly', priority: 0.1 },
-    { url: '/forgot', changefreq: 'monthly', priority: 0.1 },
-    { url: '/giftaid', changefreq: 'monthly', priority: 0.1 },
-    { url: '/stories/summary', changefreq: 'weekly', priority: 0.1 },
-  ]
+  const site = runtimeConfig.public.USER_SITE
+  const children = [site + '/sitemap-pages.xml']
 
-  // The "Freegle vs ..." comparison pages, driven off the same data as the pages
-  // themselves so the two can't drift apart.
-  comparisonList.forEach((comparison) => {
-    links.push({
-      url: '/compare/' + comparison.slug,
-      changefreq: 'monthly',
-      priority: 0.5,
-    })
-  })
-
-  // Fetch all the groups.
+  // Ask how many live posts there are, so we know how many post sitemaps to declare.
+  // If the API is unreachable we still serve a valid index covering the pages rather
+  // than failing the sitemap altogether.
   try {
-    const rsp = await fetch(runtimeConfig.public.APIv2 + '/group')
-    const groups = await rsp.json()
+    const rsp = await fetch(runtimeConfig.public.APIv2 + '/message/sitemap')
+    const messages = await rsp.json()
+    const chunks = chunk(messages || [], SITEMAP_CHUNK_SIZE)
 
-    groups.forEach((group) => {
-      links.push({
-        url: '/explore/' + group.nameshort,
-        changefreq: 'daily',
-        priority: 0.8,
-      })
-    })
-  } catch (e) {}
+    for (let i = 0; i < chunks.length; i++) {
+      children.push(site + '/sitemap-posts/' + i)
+    }
+  } catch (e) {
+    console.log('Failed to size post sitemaps', e)
+  }
 
-  const stream = new SitemapStream({ hostname: runtimeConfig.public.USER_SITE })
-
-  return streamToPromise(Readable.from(links).pipe(stream)).then((data) =>
-    data.toString()
-  )
+  return renderSitemapIndex(children, new Date().toISOString())
 })

--- a/iznik-nuxt3/server/utils/sitemap.js
+++ b/iznik-nuxt3/server/utils/sitemap.js
@@ -1,0 +1,153 @@
+import { comparisonList } from '../../constants/comparisons'
+
+/* One sitemap file may hold at most 50,000 URLs. We chunk well below that so a
+surge in posts can't tip us over, and so each file stays quick to generate. */
+export const SITEMAP_CHUNK_SIZE = 20000
+
+/**
+ * The pages that exist regardless of what's been posted: landing pages, policy
+ * pages, and the "Freegle vs ..." comparisons.
+ */
+export function staticLinks() {
+  const links = [
+    { url: '/', changefreq: 'daily', priority: 1.0 },
+    { url: '/give', changefreq: 'monthly', priority: 1.0 },
+    { url: '/find', changefreq: 'monthly', priority: 1.0 },
+    { url: '/explore', changefreq: 'daily', priority: 0.8 },
+    { url: '/unsubscribe', changefreq: 'monthly', priority: 0.7 },
+    { url: '/donate', changefreq: 'monthly', priority: 0.7 },
+    { url: '/help', changefreq: 'monthly', priority: 0.5 },
+    { url: '/stories', changefreq: 'weekly', priority: 0.5 },
+    { url: '/communityevents', changefreq: 'monthly', priority: 0.1 },
+    { url: '/volunteerings', changefreq: 'monthly', priority: 0.1 },
+    { url: '/mobile', changefreq: 'monthly', priority: 0.3 },
+    { url: '/about', changefreq: 'monthly', priority: 0.3 },
+    { url: '/compare', changefreq: 'monthly', priority: 0.5 },
+    { url: '/disclaimer', changefreq: 'monthly', priority: 0.1 },
+    { url: '/terms', changefreq: 'monthly', priority: 0.1 },
+    { url: '/privacy', changefreq: 'monthly', priority: 0.1 },
+    { url: '/forgot', changefreq: 'monthly', priority: 0.1 },
+    { url: '/giftaid', changefreq: 'monthly', priority: 0.1 },
+    { url: '/stories/summary', changefreq: 'weekly', priority: 0.1 },
+  ]
+
+  // The "Freegle vs ..." comparison pages, driven off the same data as the pages
+  // themselves so the two can't drift apart.
+  comparisonList.forEach((comparison) => {
+    links.push({
+      url: '/compare/' + comparison.slug,
+      changefreq: 'monthly',
+      priority: 0.5,
+    })
+  })
+
+  return links
+}
+
+/**
+ * One entry per community. These change every time someone posts, hence daily.
+ */
+export function groupLinks(groups) {
+  return (groups || [])
+    .filter((group) => group?.nameshort)
+    .map((group) => ({
+      url: '/explore/' + group.nameshort,
+      changefreq: 'daily',
+      priority: 0.8,
+    }))
+}
+
+/**
+ * One entry per live post.
+ *
+ * This is the change that matters most: until now the sitemap listed only the 496
+ * community pages and 26 static pages, so nothing ever told Google that an individual
+ * post existed. Trash Nothing publish every post, which is why their copy of a
+ * Freegle post outranks ours.
+ *
+ * `changefreq: hourly` is honest here - a post can be taken at any moment, at which
+ * point the URL starts answering 410 and we want it re-crawled promptly.
+ */
+export function messageLinks(messages) {
+  return (messages || [])
+    .filter((m) => m?.id)
+    .map((m) => ({
+      url: '/message/' + m.id,
+      changefreq: 'hourly',
+      priority: 0.7,
+      lastmod: m.lastmod ? new Date(m.lastmod).toISOString() : undefined,
+    }))
+}
+
+export function chunk(items, size = SITEMAP_CHUNK_SIZE) {
+  if (!items.length) {
+    return []
+  }
+
+  const ret = []
+
+  for (let i = 0; i < items.length; i += size) {
+    ret.push(items.slice(i, i + size))
+  }
+
+  return ret
+}
+
+function escapeXml(s) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+export function renderUrlset(links, hostname) {
+  const body = links
+    .map((l) => {
+      const parts = ['    <loc>' + escapeXml(hostname + l.url) + '</loc>']
+
+      if (l.lastmod) {
+        parts.push('    <lastmod>' + l.lastmod + '</lastmod>')
+      }
+
+      if (l.changefreq) {
+        parts.push('    <changefreq>' + l.changefreq + '</changefreq>')
+      }
+
+      if (l.priority !== undefined) {
+        parts.push('    <priority>' + l.priority.toFixed(1) + '</priority>')
+      }
+
+      return '  <url>\n' + parts.join('\n') + '\n  </url>'
+    })
+    .join('\n')
+
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+    body +
+    '\n</urlset>\n'
+  )
+}
+
+export function renderSitemapIndex(urls, lastmod) {
+  const body = urls
+    .map((u) => {
+      const parts = ['    <loc>' + escapeXml(u) + '</loc>']
+
+      if (lastmod) {
+        parts.push('    <lastmod>' + lastmod + '</lastmod>')
+      }
+
+      return '  <sitemap>\n' + parts.join('\n') + '\n  </sitemap>'
+    })
+    .join('\n')
+
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+    body +
+    '\n</sitemapindex>\n'
+  )
+}

--- a/iznik-nuxt3/tests/unit/components/OurMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/OurMessage.spec.js
@@ -119,18 +119,25 @@ describe('OurMessage', () => {
       expect(wrapper.find('#msg-1').exists()).toBe(true)
     })
 
-    it('renders schema.org Product markup', async () => {
+    /* Structured data moved out of here and into the JSON-LD block the message page
+    emits (composables/useMessageJsonLd.js). The microdata that used to live here
+    declared a schema.org/Product but carried no name, image or description, so
+    Google discarded it, and it sat in a d-none element, which their guidelines
+    don't allow for microdata. These assert it hasn't crept back. */
+    it('does not emit microdata item types', async () => {
       const wrapper = await createWrapper()
-      expect(
-        wrapper.find('[itemtype="http://schema.org/Product"]').exists()
-      ).toBe(true)
+      expect(wrapper.find('[itemtype]').exists()).toBe(false)
+      expect(wrapper.find('[itemscope]').exists()).toBe(false)
     })
 
-    it('renders schema.org Offer markup', async () => {
+    it('does not emit microdata properties', async () => {
       const wrapper = await createWrapper()
-      expect(
-        wrapper.find('[itemtype="http://schema.org/Offer"]').exists()
-      ).toBe(true)
+      expect(wrapper.find('[itemprop]').exists()).toBe(false)
+    })
+
+    it('does not emit the invalid "Instock" availability value', async () => {
+      const wrapper = await createWrapper()
+      expect(wrapper.text()).not.toContain('Instock')
     })
 
     it('shows MessageSummary when not startExpanded', async () => {

--- a/iznik-nuxt3/tests/unit/composables/useBuildHead.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useBuildHead.spec.js
@@ -16,10 +16,14 @@ const mockRuntimeConfig = {
   },
 }
 
-const mockRoute = { fullPath: '/mypage' }
+const mockRoute = { fullPath: '/mypage', path: '/mypage' }
 
 function getMeta(result, hid) {
   return result.meta.find((m) => m.hid === hid)
+}
+
+function getCanonical(result) {
+  return result.link.find((l) => l.rel === 'canonical')
 }
 
 describe('buildHead', () => {
@@ -83,9 +87,9 @@ describe('buildHead', () => {
       expect(getMeta(result, 'twitter:description').content).toBe('TW desc')
     })
 
-    it('sets og:url to USER_SITE + route.fullPath', () => {
+    it('sets og:url to USER_SITE + route path', () => {
       const result = buildHead(
-        { fullPath: '/groups/testgroup' },
+        { fullPath: '/groups/testgroup', path: '/groups/testgroup' },
         mockRuntimeConfig,
         'T',
         'D'
@@ -98,6 +102,184 @@ describe('buildHead', () => {
     it('sets og:url to just USER_SITE when route is null', () => {
       const result = buildHead(null, mockRuntimeConfig, 'T', 'D')
       expect(getMeta(result, 'og:url').content).toBe(MOCK_USER_SITE)
+    })
+
+    it('drops tracking params from og:url so arrivals do not fragment the signal', () => {
+      const result = buildHead(
+        { fullPath: '/message/1?src=digest', path: '/message/1' },
+        mockRuntimeConfig,
+        'T',
+        'D'
+      )
+      expect(getMeta(result, 'og:url').content).toBe(
+        `${MOCK_USER_SITE}/message/1`
+      )
+    })
+
+    it('does not emit og:type unless asked, so the global default stands', () => {
+      const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D')
+      expect(getMeta(result, 'og:type')).toBeUndefined()
+    })
+
+    it('emits og:type when given one', () => {
+      const result = buildHead(
+        mockRoute,
+        mockRuntimeConfig,
+        'T',
+        'D',
+        null,
+        {},
+        { ogType: 'product' }
+      )
+      expect(getMeta(result, 'og:type').content).toBe('product')
+    })
+
+    it('does not emit a robots tag unless asked', () => {
+      const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D')
+      expect(getMeta(result, 'robots')).toBeUndefined()
+    })
+
+    it('emits noindex when asked, keeping the other meta tags intact', () => {
+      const result = buildHead(
+        mockRoute,
+        mockRuntimeConfig,
+        'T',
+        'My description',
+        null,
+        {},
+        { noindex: true }
+      )
+      expect(getMeta(result, 'robots').content).toBe('noindex, follow')
+      /* Regression: setting robots used to mean replacing head.meta wholesale at the
+      call site, which threw away the description and every og:/twitter: tag. */
+      expect(getMeta(result, 'description').content).toBe('My description')
+      expect(getMeta(result, 'og:title').content).toBe('T')
+    })
+  })
+
+  describe('canonical', () => {
+    it('emits a canonical link', () => {
+      const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D')
+      expect(getCanonical(result).href).toBe(`${MOCK_USER_SITE}/mypage`)
+    })
+
+    it('strips query strings from the canonical', () => {
+      const result = buildHead(
+        { fullPath: '/message/1?src=email&foo=bar', path: '/message/1' },
+        mockRuntimeConfig,
+        'T',
+        'D'
+      )
+      expect(getCanonical(result).href).toBe(`${MOCK_USER_SITE}/message/1`)
+    })
+
+    it('falls back to splitting fullPath when the route has no path', () => {
+      const result = buildHead(
+        { fullPath: '/message/1?src=email' },
+        mockRuntimeConfig,
+        'T',
+        'D'
+      )
+      expect(getCanonical(result).href).toBe(`${MOCK_USER_SITE}/message/1`)
+    })
+
+    it('honours an explicit canonical path', () => {
+      const result = buildHead(
+        { fullPath: '/explore/Group/12345', path: '/explore/Group/12345' },
+        mockRuntimeConfig,
+        'T',
+        'D',
+        null,
+        {},
+        { canonical: '/explore/Group' }
+      )
+      expect(getCanonical(result).href).toBe(`${MOCK_USER_SITE}/explore/Group`)
+    })
+
+    it('honours an explicit absolute canonical', () => {
+      const result = buildHead(
+        mockRoute,
+        mockRuntimeConfig,
+        'T',
+        'D',
+        null,
+        {},
+        { canonical: 'https://elsewhere.example/page' }
+      )
+      expect(getCanonical(result).href).toBe('https://elsewhere.example/page')
+    })
+
+    it('canonical and og:url always agree', () => {
+      const result = buildHead(
+        { fullPath: '/message/1?src=x', path: '/message/1' },
+        mockRuntimeConfig,
+        'T',
+        'D',
+        null,
+        {},
+        { canonical: '/message/1' }
+      )
+      expect(getCanonical(result).href).toBe(getMeta(result, 'og:url').content)
+    })
+  })
+
+  describe('description cleaning', () => {
+    it('strips the HTML that group descriptions arrive wrapped in', () => {
+      const result = buildHead(
+        mockRoute,
+        mockRuntimeConfig,
+        'T',
+        '<p><strong>Welcome to Northampton Freegle</strong>.</p><p>Please join.</p>'
+      )
+      expect(getMeta(result, 'description').content).toBe(
+        'Welcome to Northampton Freegle . Please join.'
+      )
+    })
+
+    it('decodes the entities the WYSIWYG leaves behind', () => {
+      const result = buildHead(
+        mockRuntimeConfig && mockRoute,
+        mockRuntimeConfig,
+        'T',
+        'your&nbsp;old stuff&nbsp;useful &amp; free'
+      )
+      expect(getMeta(result, 'description').content).toBe(
+        'your old stuff useful & free'
+      )
+    })
+
+    it('leaves non-HTML angle brackets alone', () => {
+      const result = buildHead(
+        mockRoute,
+        mockRuntimeConfig,
+        'T',
+        'Description with <angle> brackets'
+      )
+      expect(getMeta(result, 'description').content).toBe(
+        'Description with <angle> brackets'
+      )
+    })
+
+    it('truncates long descriptions at a word boundary', () => {
+      const long = 'word '.repeat(100).trim()
+      const content = getMeta(
+        buildHead(mockRoute, mockRuntimeConfig, 'T', long),
+        'description'
+      ).content
+      expect(content.length).toBeLessThanOrEqual(163)
+      expect(content.endsWith('...')).toBe(true)
+      expect(content).not.toMatch(/wo\.\.\.$/)
+    })
+
+    it('applies the same cleaning to og: and twitter: descriptions', () => {
+      const result = buildHead(
+        mockRoute,
+        mockRuntimeConfig,
+        'T',
+        '<p>Hello</p>'
+      )
+      expect(getMeta(result, 'og:description').content).toBe('Hello')
+      expect(getMeta(result, 'twitter:description').content).toBe('Hello')
     })
 
     it('includes msapplication and theme-color meta tags', () => {
@@ -114,9 +296,7 @@ describe('buildHead', () => {
   describe('link tags', () => {
     it('includes apple-touch-icon link', () => {
       const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D')
-      const appleIcon = result.link.find(
-        (l) => l.rel === 'apple-touch-icon'
-      )
+      const appleIcon = result.link.find((l) => l.rel === 'apple-touch-icon')
       expect(appleIcon).toBeDefined()
       expect(appleIcon.href).toContain('apple-touch-icon')
     })
@@ -191,27 +371,17 @@ describe('buildHead', () => {
 
     it('passes plain image URL through unchanged when no = sign', () => {
       const imageUrl = 'https://example.com/photo.jpg'
-      const result = buildHead(
-        mockRoute,
-        mockRuntimeConfig,
-        'T',
-        'D',
-        imageUrl
-      )
+      const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D', imageUrl)
       expect(getMeta(result, 'og:image').content).toBe(imageUrl)
     })
 
     it('extracts and decodes the original URL from an IMAGE_DELIVERY proxy URL', () => {
       // The proxy wraps original URLs as: wsrv.nl/?url=<encoded-original>
       const originalUrl = 'https://original.example.com/photo.jpg'
-      const proxyUrl = `https://${MOCK_IMAGE_DELIVERY}/?url=${encodeURIComponent(originalUrl)}`
-      const result = buildHead(
-        mockRoute,
-        mockRuntimeConfig,
-        'T',
-        'D',
-        proxyUrl
-      )
+      const proxyUrl = `https://${MOCK_IMAGE_DELIVERY}/?url=${encodeURIComponent(
+        originalUrl
+      )}`
+      const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D', proxyUrl)
       expect(getMeta(result, 'og:image').content).toBe(originalUrl)
     })
 
@@ -219,13 +389,7 @@ describe('buildHead', () => {
       // Original URL has transform params: photo.jpg?w=800&h=600
       const originalPath = 'https://original.example.com/photo.jpg'
       const proxyUrl = `https://${MOCK_IMAGE_DELIVERY}/?url=${originalPath}?w=800&h=600`
-      const result = buildHead(
-        mockRoute,
-        mockRuntimeConfig,
-        'T',
-        'D',
-        proxyUrl
-      )
+      const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D', proxyUrl)
       // After the first = strip we get: `${originalPath}?w=800&h=600`
       // Then ? strip gives us: `${originalPath}`
       expect(getMeta(result, 'og:image').content).toBe(originalPath)
@@ -234,48 +398,107 @@ describe('buildHead', () => {
     it('strips literal & params from the extracted URL when no ? is present', () => {
       const originalPath = 'https://original.example.com/photo.jpg'
       const proxyUrl = `https://${MOCK_IMAGE_DELIVERY}/?url=${originalPath}&w=800`
-      const result = buildHead(
-        mockRoute,
-        mockRuntimeConfig,
-        'T',
-        'D',
-        proxyUrl
-      )
+      const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D', proxyUrl)
       // After = strip: `${originalPath}&w=800`, then & strip: `${originalPath}`
       expect(getMeta(result, 'og:image').content).toBe(originalPath)
     })
 
-    // TODO: latent bug — a plain image URL containing '=' (not from IMAGE_DELIVERY)
-    // is incorrectly processed because the condition evaluates `includes() + '/?url='`
-    // which is always truthy for any string. The indexOf('=') then finds the = in the
-    // plain URL and strips everything before it, corrupting the URL.
-    // Fix: change the condition to `retImage?.includes(runtimeConfig.public.IMAGE_DELIVERY + '/?url=')`
-    it.skip('leaves non-IMAGE_DELIVERY URLs with = signs intact', () => {
+    // Was a latent bug: the condition evaluated `includes(DELIVERY) + '/?url='`,
+    // a string concatenation and so always truthy, meaning any image URL with an
+    // '=' in it got sliced at the first '=' and corrupted.
+    it('leaves non-IMAGE_DELIVERY URLs with = signs intact', () => {
       const imageUrl = 'https://otherprovider.com/photos?format=jpg'
+      const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D', imageUrl)
+      expect(getMeta(result, 'og:image').content).toBe(imageUrl)
+    })
+
+    it('unwraps proxy URLs written without a slash before the query', () => {
+      // This is the form the API actually returns for attachments.
+      const proxyUrl = `https://${MOCK_IMAGE_DELIVERY}?url=https://uploads.ilovefreegle.org/abc&ro=0`
+      const result = buildHead(mockRoute, mockRuntimeConfig, 'T', 'D', proxyUrl)
+      expect(getMeta(result, 'og:image').content).toBe(
+        'https://uploads.ilovefreegle.org/abc'
+      )
+    })
+
+    it('drops the internal :8080 port, which crawlers are wary of', () => {
       const result = buildHead(
         mockRoute,
         mockRuntimeConfig,
         'T',
         'D',
-        imageUrl
+        'https://uploads.ilovefreegle.org:8080/abc'
       )
-      // Currently broken: retImage.indexOf('=') finds the = in 'format=jpg',
-      // slices to 'jpg', giving a corrupted og:image.
-      expect(getMeta(result, 'og:image').content).toBe(imageUrl)
+      expect(getMeta(result, 'og:image').content).toBe(
+        'https://uploads.ilovefreegle.org/abc'
+      )
+    })
+  })
+
+  describe('seoDescription', () => {
+    let seoDescription
+
+    beforeEach(async () => {
+      const mod = await import('~/composables/useBuildHead')
+      seoDescription = mod.seoDescription
+    })
+
+    it('returns empty for nothing', () => {
+      expect(seoDescription(null)).toBe('')
+      expect(seoDescription('')).toBe('')
+      expect(seoDescription(undefined)).toBe('')
+    })
+
+    it('collapses runaway whitespace and newlines', () => {
+      expect(seoDescription('one\n\n  two\t three')).toBe('one two three')
+    })
+
+    it('strips block and inline HTML', () => {
+      expect(
+        seoDescription('<div><p>Hello <strong>there</strong></p></div>')
+      ).toBe('Hello there')
+    })
+
+    it('strips self-closing and attributed tags', () => {
+      expect(seoDescription('a<br/>b<a href="x" rel="y">c</a>')).toBe('a b c')
+    })
+
+    it('respects a custom max length', () => {
+      expect(seoDescription('one two three four five', 12)).toBe('one two...')
+    })
+
+    it('leaves text at exactly the limit untouched', () => {
+      const exact = 'a'.repeat(160)
+      expect(seoDescription(exact)).toBe(exact)
     })
   })
 
   describe('table-driven: title/description permutations', () => {
     const cases = [
       { title: 'Short', description: 'Brief' },
-      { title: 'A very long page title that goes on and on', description: 'Detailed description for SEO purposes with lots of content' },
+      {
+        title: 'A very long page title that goes on and on',
+        description:
+          'Detailed description for SEO purposes with lots of content',
+      },
       { title: '', description: '' },
-      { title: 'Title with "quotes"', description: 'Description with <angle> brackets' },
+      {
+        title: 'Title with "quotes"',
+        description: 'Description with <angle> brackets',
+      },
     ]
 
     for (const { title, description } of cases) {
-      it(`mirrors title="${title.slice(0, 20)}" into all title meta tags`, () => {
-        const result = buildHead(mockRoute, mockRuntimeConfig, title, description)
+      it(`mirrors title="${title.slice(
+        0,
+        20
+      )}" into all title meta tags`, () => {
+        const result = buildHead(
+          mockRoute,
+          mockRuntimeConfig,
+          title,
+          description
+        )
         expect(result.title).toBe(title)
         expect(getMeta(result, 'og:title').content).toBe(title)
         expect(getMeta(result, 'twitter:title').content).toBe(title)

--- a/iznik-nuxt3/tests/unit/composables/useMessageJsonLd.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMessageJsonLd.spec.js
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { messageJsonLd, productName } from '~/composables/useMessageJsonLd'
+
+const SITE = 'https://www.ilovefreegle.org'
+
+function offer(extra = {}) {
+  return {
+    id: 121054975,
+    type: 'Offer',
+    subject: 'OFFER: Kitchen cupboard units (Moulton NN3)',
+    textbody: 'Solid oak doors. Some glazed as in photo. Good condition.',
+    attachments: [
+      {
+        path: 'https://delivery.ilovefreegle.org/?url=https://uploads.ilovefreegle.org/abc',
+      },
+    ],
+    ...extra,
+  }
+}
+
+describe('productName', () => {
+  it('strips the OFFER: prefix we put on subjects', () => {
+    expect(productName('OFFER: Dining chairs (Moulton NN3)')).toBe(
+      'Dining chairs (Moulton NN3)'
+    )
+  })
+
+  it('strips WANTED, TAKEN and RECEIVED prefixes too', () => {
+    expect(productName('WANTED: Bike')).toBe('Bike')
+    expect(productName('TAKEN: Bike')).toBe('Bike')
+    expect(productName('RECEIVED: Bike')).toBe('Bike')
+  })
+
+  it('is case insensitive and tolerates odd spacing', () => {
+    expect(productName('offer :  Bike')).toBe('Bike')
+  })
+
+  it('leaves a subject with no prefix alone', () => {
+    expect(productName('Just a bike')).toBe('Just a bike')
+  })
+
+  it('copes with nothing', () => {
+    expect(productName(null)).toBe('')
+    expect(productName('')).toBe('')
+  })
+})
+
+describe('messageJsonLd', () => {
+  it('describes an offer as a schema.org Product', () => {
+    const ld = messageJsonLd(offer(), SITE)
+    expect(ld['@context']).toBe('https://schema.org')
+    expect(ld['@type']).toBe('Product')
+  })
+
+  it('names the product without our OFFER: convention', () => {
+    const ld = messageJsonLd(offer(), SITE)
+    expect(ld.name).toBe('Kitchen cupboard units (Moulton NN3)')
+  })
+
+  it('includes the description, which the old microdata never did', () => {
+    const ld = messageJsonLd(offer(), SITE)
+    expect(ld.description).toBe(
+      'Solid oak doors. Some glazed as in photo. Good condition.'
+    )
+  })
+
+  it('includes the photos, which the old microdata never did', () => {
+    const ld = messageJsonLd(offer(), SITE)
+    expect(ld.image).toEqual([
+      'https://delivery.ilovefreegle.org/?url=https://uploads.ilovefreegle.org/abc',
+    ])
+  })
+
+  it('uses a valid schema.org availability URL, not the bare "Instock" string', () => {
+    const ld = messageJsonLd(offer(), SITE)
+    expect(ld.offers.availability).toBe('https://schema.org/InStock')
+  })
+
+  it('prices the offer at zero pounds', () => {
+    const ld = messageJsonLd(offer(), SITE)
+    expect(ld.offers.price).toBe(0)
+    expect(ld.offers.priceCurrency).toBe('GBP')
+  })
+
+  it('marks items as used, which they almost always are', () => {
+    const ld = messageJsonLd(offer(), SITE)
+    expect(ld.offers.itemCondition).toBe('https://schema.org/UsedCondition')
+  })
+
+  it('points at the canonical post URL', () => {
+    const ld = messageJsonLd(offer(), SITE)
+    expect(ld.url).toBe(SITE + '/message/121054975')
+    expect(ld.offers.url).toBe(SITE + '/message/121054975')
+  })
+
+  it('strips the internal :8080 port from photo URLs', () => {
+    const ld = messageJsonLd(
+      offer({
+        attachments: [{ path: 'https://uploads.ilovefreegle.org:8080/abc' }],
+      }),
+      SITE
+    )
+    expect(ld.image).toEqual(['https://uploads.ilovefreegle.org/abc'])
+  })
+
+  it('lists every photo, not just the first', () => {
+    const ld = messageJsonLd(
+      offer({
+        attachments: [
+          { path: 'https://uploads.ilovefreegle.org/a' },
+          { path: 'https://uploads.ilovefreegle.org/b' },
+          { path: 'https://uploads.ilovefreegle.org/c' },
+        ],
+      }),
+      SITE
+    )
+    expect(ld.image).toHaveLength(3)
+  })
+
+  it('omits image entirely when there are no photos, rather than emitting an empty array', () => {
+    const ld = messageJsonLd(offer({ attachments: [] }), SITE)
+    expect(ld.image).toBeUndefined()
+  })
+
+  it('omits description when the post has no body', () => {
+    const ld = messageJsonLd(offer({ textbody: '' }), SITE)
+    expect(ld.description).toBeUndefined()
+  })
+
+  describe('when structured data would be wrong', () => {
+    it('emits nothing for a WANTED, which is a request not something available', () => {
+      expect(messageJsonLd(offer({ type: 'Wanted' }), SITE)).toBeNull()
+    })
+
+    it('emits nothing for a post that has finished', () => {
+      expect(messageJsonLd(offer(), SITE, { gone: true })).toBeNull()
+    })
+
+    it('emits nothing when there is no message', () => {
+      expect(messageJsonLd(null, SITE)).toBeNull()
+    })
+
+    it('emits nothing when the subject is only our prefix', () => {
+      expect(messageJsonLd(offer({ subject: 'OFFER:' }), SITE)).toBeNull()
+    })
+  })
+
+  it('serialises to JSON without throwing', () => {
+    const ld = messageJsonLd(offer(), SITE)
+    expect(() => JSON.stringify(ld)).not.toThrow()
+    expect(JSON.parse(JSON.stringify(ld)).name).toBe(
+      'Kitchen cupboard units (Moulton NN3)'
+    )
+  })
+})

--- a/iznik-nuxt3/tests/unit/mocks/nuxt-app.js
+++ b/iznik-nuxt3/tests/unit/mocks/nuxt-app.js
@@ -34,6 +34,14 @@ export function useRuntimeConfig() {
 // Stub for components that import useHead from #imports directly
 export function useHead() {}
 
+// Sets the HTTP status of the SSR response; a no-op on the client, and so here too.
+// Tests that care what status a page asks for can spy via globalThis. Forwards
+// exactly the arguments it was given, so a spy sees the real call shape.
+export function setResponseStatus(...args) {
+  if (typeof globalThis.__testSetResponseStatus === 'function')
+    globalThis.__testSetResponseStatus(...args)
+}
+
 // Default mock for useRouter - tests override via vi.mock('#imports') or globalThis
 export function useRouter() {
   if (typeof globalThis.__testUseRouter === 'function')

--- a/iznik-nuxt3/tests/unit/pages/message/id.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/message/id.spec.js
@@ -28,10 +28,22 @@ vi.mock('~/components/ExternalDa', () => ({
 vi.mock('~/components/MicroVolunteering', () => ({
   default: { template: '<div />' },
 }))
+// Renders once a message is present, and pulls in the observe-visibility directive.
+vi.mock('~/components/SimilarPosts', () => ({
+  default: { template: '<div />', props: ['msgid'] },
+}))
 
-// Mock composables
+// Mock composables. buildHead is spied on so tests can assert what SEO options the
+// page asks for; seoDescription keeps its real behaviour because the point of the
+// description tests is what it actually produces.
+const mockBuildHead = vi.fn().mockReturnValue({})
 vi.mock('~/composables/useBuildHead', () => ({
-  buildHead: vi.fn().mockReturnValue({}),
+  buildHead: (...args) => mockBuildHead(...args),
+  seoDescription: (text, max = 160) => {
+    if (!text) return ''
+    const s = String(text).replace(/\s+/g, ' ').trim()
+    return s.length <= max ? s : s.slice(0, max).trimEnd() + '...'
+  },
 }))
 vi.mock('~/composables/useTwem', () => ({
   twem: vi.fn((s) => s),
@@ -64,11 +76,16 @@ vi.hoisted(() => {
   vi.resetModules()
 })
 
+// The page imports useHead from #imports, so spy on it there rather than on
+// globalThis - that's where the call actually lands.
+const mockHead = vi.fn()
+
 vi.mock('#imports', async () => {
   const actual = await vi.importActual('#imports')
   return {
     ...actual,
     useRoute: () => mockRouteReturn,
+    useHead: (...args) => mockHead(...args),
     ref: actual.ref,
     computed: actual.computed,
     onMounted: actual.onMounted,
@@ -76,10 +93,27 @@ vi.mock('#imports', async () => {
 })
 
 // Nuxt auto-imports
+const mockStatus = vi.fn()
 globalThis.__testUseRoute = () => mockRouteReturn
+globalThis.__testSetResponseStatus = (...args) => mockStatus(...args)
 globalThis.definePageMeta = vi.fn()
 globalThis.useHead = vi.fn()
-globalThis.useRuntimeConfig = () => ({ public: { BUILD_DATE: '2026-01-01' } })
+globalThis.useRuntimeConfig = () => ({
+  public: {
+    BUILD_DATE: '2026-01-01',
+    USER_SITE: 'https://www.ilovefreegle.org',
+  },
+})
+
+// A live post, and the various ways one stops being live.
+const LIVE = {
+  id: 123,
+  type: 'Offer',
+  subject: 'OFFER: Dining chairs (Moulton NN3)',
+  textbody: 'Four solid oak dining chairs. Good condition.',
+  groups: [{ collection: 'Approved' }],
+  attachments: [],
+}
 
 describe('pages/message/[id].vue', () => {
   // Wrap in Suspense since message page has top-level await in setup
@@ -109,6 +143,8 @@ describe('pages/message/[id].vue', () => {
     mockRouteReturn = { params: { id: '123' }, query: {} }
     mockFetch.mockResolvedValue({})
     mockById.mockReturnValue(null)
+    mockBuildHead.mockReturnValue({})
+    mockStatus.mockClear()
   })
 
   it('mounts without error when route is undefined (SSR hydration race)', async () => {
@@ -221,5 +257,152 @@ describe('pages/message/[id].vue', () => {
     }
 
     expect(mountError).toBeNull()
+  })
+
+  /* There are roughly 8.3 million finished posts against ~42,000 live ones. They
+  used to answer 200 with the item subject as the title, which reads to a crawler as
+  millions of near-identical thin pages. */
+  describe('finished posts', () => {
+    const gone = [
+      ['taken', { ...LIVE, outcomes: [{ outcome: 'Taken' }] }],
+      ['received', { ...LIVE, outcomes: [{ outcome: 'Received' }] }],
+      ['withdrawn', { ...LIVE, outcomes: [{ outcome: 'Withdrawn' }] }],
+      ['deleted', { ...LIVE, deleted: '2026-07-01' }],
+      [
+        'rejected everywhere',
+        { ...LIVE, groups: [{ collection: 'Rejected' }] },
+      ],
+    ]
+
+    for (const [label, message] of gone) {
+      it(`answers 410 for a ${label} post`, async () => {
+        mockById.mockReturnValue(message)
+
+        mountPage()
+        await flushPromises()
+
+        expect(mockStatus).toHaveBeenCalledWith(410)
+      })
+
+      it(`asks for noindex on a ${label} post`, async () => {
+        mockById.mockReturnValue(message)
+
+        mountPage()
+        await flushPromises()
+
+        expect(mockBuildHead.mock.calls[0][6].noindex).toBe(true)
+      })
+    }
+
+    it('answers 410 when the post does not exist at all', async () => {
+      mockFetch.mockResolvedValueOnce(null).mockResolvedValue({})
+      mockById.mockReturnValue(null)
+
+      mountPage()
+      await flushPromises()
+
+      expect(mockStatus).toHaveBeenCalledWith(410)
+    })
+
+    it('leaves a live post alone', async () => {
+      mockById.mockReturnValue(LIVE)
+
+      mountPage()
+      await flushPromises()
+
+      expect(mockStatus).not.toHaveBeenCalled()
+      expect(mockBuildHead.mock.calls[0][6].noindex).toBe(false)
+    })
+
+    it('honours ?showtaken, which deliberately shows a finished post', async () => {
+      mockRouteReturn = { params: { id: '123' }, query: { showtaken: 1 } }
+      mockById.mockReturnValue({ ...LIVE, outcomes: [{ outcome: 'Taken' }] })
+
+      mountPage()
+      await flushPromises()
+
+      expect(mockStatus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('SEO head', () => {
+    it('describes the post from its body rather than the old "Click for more details"', async () => {
+      mockById.mockReturnValue(LIVE)
+
+      mountPage()
+      await flushPromises()
+
+      expect(mockBuildHead.mock.calls[0][3]).toBe(
+        'Four solid oak dining chairs. Good condition.'
+      )
+    })
+
+    it('prefers a snippet when the API ever starts sending one', async () => {
+      mockById.mockReturnValue({ ...LIVE, snippet: 'Short version' })
+
+      mountPage()
+      await flushPromises()
+
+      expect(mockBuildHead.mock.calls[0][3]).toBe('Short version...')
+    })
+
+    it('falls back to the generic line only when there is no body at all', async () => {
+      mockById.mockReturnValue({ ...LIVE, textbody: '' })
+
+      mountPage()
+      await flushPromises()
+
+      expect(mockBuildHead.mock.calls[0][3]).toBe('Click for more details')
+    })
+
+    it('canonicalises to the bare post URL, dropping any ?src tracking', async () => {
+      mockRouteReturn = { params: { id: '123' }, query: { src: 'digest' } }
+      mockById.mockReturnValue(LIVE)
+
+      mountPage()
+      await flushPromises()
+
+      expect(mockBuildHead.mock.calls[0][6].canonical).toBe('/message/123')
+    })
+
+    it('marks a live post as og:type product', async () => {
+      mockById.mockReturnValue(LIVE)
+
+      mountPage()
+      await flushPromises()
+
+      expect(mockBuildHead.mock.calls[0][6].ogType).toBe('product')
+    })
+
+    it('does not claim a finished post is a product', async () => {
+      mockById.mockReturnValue({ ...LIVE, outcomes: [{ outcome: 'Taken' }] })
+
+      mountPage()
+      await flushPromises()
+
+      expect(mockBuildHead.mock.calls[0][6].ogType).toBe('website')
+    })
+
+    it('attaches JSON-LD for a live offer', async () => {
+      mockById.mockReturnValue(LIVE)
+
+      mountPage()
+      await flushPromises()
+
+      const head = mockHead.mock.calls[0][0]
+      const ld = JSON.parse(head.script[0].innerHTML)
+      expect(ld['@type']).toBe('Product')
+      expect(ld.name).toBe('Dining chairs (Moulton NN3)')
+    })
+
+    it('attaches no JSON-LD for a wanted', async () => {
+      mockById.mockReturnValue({ ...LIVE, type: 'Wanted' })
+
+      mountPage()
+      await flushPromises()
+
+      const head = mockHead.mock.calls[0][0]
+      expect(head.script).toBeUndefined()
+    })
   })
 })

--- a/iznik-nuxt3/tests/unit/server/sitemap.spec.js
+++ b/iznik-nuxt3/tests/unit/server/sitemap.spec.js
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SITEMAP_CHUNK_SIZE,
+  chunk,
+  groupLinks,
+  messageLinks,
+  renderSitemapIndex,
+  renderUrlset,
+  staticLinks,
+} from '~/server/utils/sitemap'
+
+const SITE = 'https://www.ilovefreegle.org'
+
+describe('sitemap', () => {
+  describe('staticLinks', () => {
+    it('includes the landing pages', () => {
+      const urls = staticLinks().map((l) => l.url)
+      expect(urls).toContain('/')
+      expect(urls).toContain('/give')
+      expect(urls).toContain('/find')
+      expect(urls).toContain('/explore')
+    })
+
+    it('includes a page per comparison competitor', () => {
+      const urls = staticLinks().map((l) => l.url)
+      const comparisons = urls.filter((u) => u.startsWith('/compare/'))
+      expect(comparisons.length).toBeGreaterThan(0)
+    })
+
+    it('gives every link a priority and a changefreq', () => {
+      for (const link of staticLinks()) {
+        expect(link.priority).toBeDefined()
+        expect(link.changefreq).toBeDefined()
+      }
+    })
+  })
+
+  describe('groupLinks', () => {
+    it('maps groups to explore URLs', () => {
+      const links = groupLinks([
+        { nameshort: 'Northampton-Freegle' },
+        { nameshort: 'EdinburghFreegle' },
+      ])
+      expect(links.map((l) => l.url)).toEqual([
+        '/explore/Northampton-Freegle',
+        '/explore/EdinburghFreegle',
+      ])
+    })
+
+    it('skips groups with no short name rather than emitting /explore/undefined', () => {
+      const links = groupLinks([{ nameshort: 'Good' }, { id: 1 }, null])
+      expect(links).toHaveLength(1)
+      expect(links[0].url).toBe('/explore/Good')
+    })
+
+    it('copes with no groups at all', () => {
+      expect(groupLinks(null)).toEqual([])
+      expect(groupLinks([])).toEqual([])
+    })
+  })
+
+  describe('messageLinks', () => {
+    it('maps posts to message URLs', () => {
+      const links = messageLinks([{ id: 121002880 }, { id: 121054975 }])
+      expect(links.map((l) => l.url)).toEqual([
+        '/message/121002880',
+        '/message/121054975',
+      ])
+    })
+
+    it('carries lastmod through as an ISO timestamp', () => {
+      const links = messageLinks([{ id: 1, lastmod: '2026-07-17T17:15:33Z' }])
+      expect(links[0].lastmod).toBe('2026-07-17T17:15:33.000Z')
+    })
+
+    it('omits lastmod when the API did not give us one', () => {
+      const links = messageLinks([{ id: 1 }])
+      expect(links[0].lastmod).toBeUndefined()
+    })
+
+    it('skips entries with no id', () => {
+      const links = messageLinks([{ id: 1 }, {}, null])
+      expect(links).toHaveLength(1)
+    })
+
+    it('copes with no posts at all', () => {
+      expect(messageLinks(null)).toEqual([])
+    })
+  })
+
+  describe('chunk', () => {
+    it('splits a list into files below the 50,000 URL sitemap limit', () => {
+      expect(SITEMAP_CHUNK_SIZE).toBeLessThanOrEqual(50000)
+    })
+
+    it('returns one chunk when everything fits', () => {
+      expect(chunk([1, 2, 3], 10)).toEqual([[1, 2, 3]])
+    })
+
+    it('splits evenly divisible lists without a trailing empty chunk', () => {
+      expect(chunk([1, 2, 3, 4], 2)).toEqual([
+        [1, 2],
+        [3, 4],
+      ])
+    })
+
+    it('puts the remainder in a final short chunk', () => {
+      expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+    })
+
+    it('returns no chunks for an empty list, so we declare no post sitemaps', () => {
+      expect(chunk([], 10)).toEqual([])
+    })
+  })
+
+  describe('renderUrlset', () => {
+    it('produces a valid urlset with absolute locations', () => {
+      const xml = renderUrlset([{ url: '/message/1' }], SITE)
+      expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+      expect(xml).toContain(
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+      )
+      expect(xml).toContain('<loc>https://www.ilovefreegle.org/message/1</loc>')
+      expect(xml).toContain('</urlset>')
+    })
+
+    it('emits lastmod, changefreq and priority when given', () => {
+      const xml = renderUrlset(
+        [
+          {
+            url: '/message/1',
+            lastmod: '2026-07-17T17:15:33.000Z',
+            changefreq: 'hourly',
+            priority: 0.7,
+          },
+        ],
+        SITE
+      )
+      expect(xml).toContain('<lastmod>2026-07-17T17:15:33.000Z</lastmod>')
+      expect(xml).toContain('<changefreq>hourly</changefreq>')
+      expect(xml).toContain('<priority>0.7</priority>')
+    })
+
+    it('leaves out optional elements rather than emitting empty ones', () => {
+      const xml = renderUrlset([{ url: '/give' }], SITE)
+      expect(xml).not.toContain('<lastmod>')
+      expect(xml).not.toContain('<changefreq>')
+      expect(xml).not.toContain('<priority>')
+    })
+
+    it('escapes ampersands so the XML stays well formed', () => {
+      const xml = renderUrlset([{ url: '/explore/Bath&NE' }], SITE)
+      expect(xml).toContain('Bath&amp;NE')
+      expect(xml).not.toMatch(/Bath&NE/)
+    })
+  })
+
+  describe('renderSitemapIndex', () => {
+    it('produces a sitemapindex listing each child', () => {
+      const xml = renderSitemapIndex([
+        SITE + '/sitemap-pages.xml',
+        SITE + '/sitemap-posts/0',
+      ])
+      expect(xml).toContain(
+        '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+      )
+      expect(xml).toContain(
+        '<loc>https://www.ilovefreegle.org/sitemap-pages.xml</loc>'
+      )
+      expect(xml).toContain(
+        '<loc>https://www.ilovefreegle.org/sitemap-posts/0</loc>'
+      )
+    })
+
+    it('stamps lastmod on each child when given one', () => {
+      const xml = renderSitemapIndex(
+        [SITE + '/sitemap-pages.xml'],
+        '2026-07-27T00:00:00.000Z'
+      )
+      expect(xml).toContain('<lastmod>2026-07-27T00:00:00.000Z</lastmod>')
+    })
+  })
+
+  describe('end to end shape', () => {
+    it('a full post sitemap round-trips ids into locations', () => {
+      const posts = Array.from({ length: 5 }, (_, i) => ({
+        id: 100 + i,
+        lastmod: '2026-07-17T17:15:33Z',
+      }))
+      const xml = renderUrlset(messageLinks(posts), SITE)
+      const locs = [...xml.matchAll(/<loc>([^<]*)<\/loc>/g)].map((m) => m[1])
+      expect(locs).toEqual([
+        SITE + '/message/100',
+        SITE + '/message/101',
+        SITE + '/message/102',
+        SITE + '/message/103',
+        SITE + '/message/104',
+      ])
+    })
+  })
+})

--- a/iznik-server-go/group/groupMessages.go
+++ b/iznik-server-go/group/groupMessages.go
@@ -37,3 +37,54 @@ func GetGroupMessages(c *fiber.Ctx) error {
 
 	return c.JSON(ret)
 }
+
+// GroupMessageSummary is just enough of a post to render a crawlable link to it.
+type GroupMessageSummary struct {
+	ID      uint64    `json:"id"`
+	Subject string    `json:"subject"`
+	Arrival time.Time `json:"arrival"`
+}
+
+// The community page renders this list server-side, so keep it to a page's worth.
+const groupMessageSummaryLimit = 200
+
+// GetGroupMessageSummaries returns id + subject for a community's live posts.
+//
+// This backs the server-rendered list of posts on /explore/<group>. That page's
+// interactive content is all inside <client-only>, so the HTML a crawler receives
+// used to contain no links to posts at all - which meant Google could only find a
+// post by running our JavaScript, on a delayed second pass, and not for every
+// community every time. A post could therefore surface under some communities and
+// not the one it was actually posted to.
+//
+// Unlike GetGroupMessages this is anonymous: it never includes the caller's own
+// pending posts, because it is rendered into a page that gets cached and served to
+// everyone.
+func GetGroupMessageSummaries(c *fiber.Ctx) error {
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+
+	db := database.DBConn
+
+	ret := []GroupMessageSummary{}
+
+	now := time.Now()
+	then := now.AddDate(0, 0, -31)
+
+	db.Raw("SELECT messages.id, messages.subject, messages_groups.arrival FROM messages_groups "+
+		"LEFT JOIN messages_outcomes ON messages_outcomes.msgid = messages_groups.msgid "+
+		"INNER JOIN messages ON messages.id = messages_groups.msgid "+
+		"INNER JOIN users ON users.id = messages.fromuser "+
+		"WHERE groupid = ? AND messages_groups.arrival >= ? AND collection = ? AND messages_groups.deleted = 0 "+
+		"AND users.deleted IS NULL AND messages.deleted IS NULL AND messages_outcomes.id IS NULL "+
+		"AND messages.type IN (?, ?) "+
+		"ORDER BY messages_groups.arrival DESC LIMIT ?",
+		id, then.Format(time.RFC3339), utils.COLLECTION_APPROVED,
+		utils.OFFER, utils.WANTED, groupMessageSummaryLimit,
+	).Scan(&ret)
+
+	if ret == nil {
+		ret = make([]GroupMessageSummary, 0)
+	}
+
+	return c.JSON(ret)
+}

--- a/iznik-server-go/message/sitemap.go
+++ b/iznik-server-go/message/sitemap.go
@@ -1,0 +1,59 @@
+package message
+
+import (
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/gofiber/fiber/v2"
+)
+
+// SitemapEntry is one post's worth of what a sitemap needs: which URL, and when it
+// last changed. Deliberately tiny - the site has tens of thousands of live posts and
+// the whole list is fetched in one go each time the sitemap is rebuilt.
+type SitemapEntry struct {
+	ID      uint64    `json:"id"`
+	Lastmod time.Time `json:"lastmod"`
+}
+
+// Sitemap returns every post that is currently live, for the search-engine sitemap.
+//
+// We read messages_spatial rather than messages/messages_groups because it is already
+// exactly the set the site treats as currently visible: the daily batch prunes expired
+// posts out of it, it holds one row per message (msgid is UNIQUE), and it is small.
+// The alternative - joining messages to messages_groups and messages_outcomes across
+// 8m rows - is a much heavier query to run for every sitemap fetch.
+//
+// Excluded:
+//   - successful posts (taken/received). Those pages answer 410 and are noindex, so
+//     listing them would be asking Google to crawl dead URLs.
+//   - anything that isn't an Offer or a Wanted. Admin/Other posts aren't items, and
+//     rows with no type set aren't worth pointing a crawler at.
+func Sitemap(c *fiber.Ctx) error {
+	db := database.DBConn
+
+	entries := []SitemapEntry{}
+
+	db.Raw(""+
+		"SELECT msgid AS id, "+
+		// modified tracks edits; arrival is when it landed. Either is a fair lastmod,
+		// so take whichever is later, and fall back to arrival when modified is null.
+		"GREATEST(COALESCE(modified, arrival), arrival) AS lastmod "+
+		"FROM messages_spatial "+
+		"WHERE successful = 0 "+
+		"AND msgtype IN (?, ?) "+
+		"AND arrival IS NOT NULL "+
+		"ORDER BY arrival DESC",
+		utils.OFFER, utils.WANTED,
+	).Scan(&entries)
+
+	if entries == nil {
+		entries = make([]SitemapEntry, 0)
+	}
+
+	// This is fetched by our own sitemap builder on a schedule, not per visitor, but
+	// it's public and cheap to cache.
+	c.Set("Cache-Control", "public, max-age=600")
+
+	return c.JSON(entries)
+}

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -653,6 +653,16 @@ func SetupRoutes(app *fiber.App) {
 		// @Success 200 {array} message.Message
 		rg.Get("/group/:id/message", group.GetGroupMessages)
 
+		// Group Message Summaries
+		// @Router /group/{id}/message/summary [get]
+		// @Summary Get id + subject for a group's live posts
+		// @Description Backs the server-rendered, crawlable post list on the community page
+		// @Tags group,message
+		// @Produce json
+		// @Param id path integer true "Group ID"
+		// @Success 200 {array} group.GroupMessageSummary
+		rg.Get("/group/:id/message/summary", group.GetGroupMessageSummaries)
+
 		// Group PATCH
 		// @Router /group [patch]
 		// @Summary Update group settings
@@ -881,6 +891,15 @@ func SetupRoutes(app *fiber.App) {
 		// @Tags message
 		rg.Get("/messages", deprecation.Marker("GET /messages", "2026-08-01"), message.ListMessages)
 		rg.Get("/modtools/messages", message.ListMessagesMT)
+
+		// Message Sitemap
+		// @Router /message/sitemap [get]
+		// @Summary Live posts for the search-engine sitemap
+		// @Description Returns id + lastmod for every currently-live Offer/Wanted post, for building sitemap.xml
+		// @Tags message
+		// @Produce json
+		// @Success 200 {array} message.SitemapEntry
+		rg.Get("/message/sitemap", message.Sitemap)
 
 		// Message Count
 		// @Router /message/count [get]

--- a/plans/2026-07-27-seo-post-indexation-and-image-search.md
+++ b/plans/2026-07-27-seo-post-indexation-and-image-search.md
@@ -1,0 +1,303 @@
+# SEO — post indexation and image search
+
+Design only. Nothing here has been implemented. Written 2026-07-27 in response to a
+report that a Freegle post ("OFFER: Kitchen cupboard units (Moulton NN3)") surfaced on
+Google via **Trash Nothing** rather than ilovefreegle.org, did not show on the
+Northampton group page where it originated, and whose photos appear nowhere in Google
+image search.
+
+Everything below was verified against the live site and the production database on
+2026-07-27, not inferred from the code.
+
+## The reported post
+
+`messages.id = 121054975`, subject `OFFER: Kitchen cupboard units (Moulton NN3)`,
+date `2026-07-17 17:15:33`.
+
+```
+groupid | nameshort                  | arrival                    | collection | rippled_in
+  21538 | Northampton-Freegle        | 2026-07-17 17:15:33        | Approved   | 0
+  21684 | Wellingboroughfreegle      | 2026-07-17 17:16:21        | Approved   | 1
+ 126602 | KetteringUKFreegle         | 2026-07-17 17:16:21        | Approved   | 1
+ 253448 | rothwell-desboroughfreegle | 2026-07-18 06:02:16        | Approved   | 1
+ 253451 | freegle_seleicestershire   | 2026-07-22 13:01:01        | Approved   | 1
+  21599 | RushdenHighamFreegle       | 2026-07-22 17:15:59        | Approved   | 1
+ 253499 | towcester-freegle          | 2026-07-24 17:16:29        | Approved   | 1
+```
+
+Northampton is the **origin** group (`rippled_in = 0`, arrival identical to the post
+date). So "it didn't show on Northampton" is not a rippling propagation delay. It is an
+indexation problem.
+
+The page itself is fine. `GET /message/121054975` as Googlebot returns HTTP 200 and the
+item description **is** in the server-rendered HTML ("Solid oak doors. Some glazed as in
+photo. Good condition."). The content is there. The problem is entirely discovery,
+signal quality, and crawl economics.
+
+## Scale
+
+```
+messages total                      8,305,754
+live (approved, no outcome, 90d)       42,054
+with photo (90d live)                  40,370
+```
+
+Two numbers drive most of this document: **~42k live posts** is a trivially
+sitemappable set, and **8.3M total** is the size of the dead-URL problem.
+
+## Findings
+
+### 1. Item photos are robots-blocked on our own image host
+
+Root cause of "the images don't come up through image searches". Categorical, not
+partial.
+
+`https://delivery.ilovefreegle.org/robots.txt` ends with:
+
+```
+User-agent: *
+Disallow: /*?*
+Allow: /$
+```
+
+Every Freegle item photo is served query-string-only:
+
+```
+https://delivery.ilovefreegle.org/?filename=<hash>&we&w=640&h=480&output=jpg&fit=cover&url=https://uploads.ilovefreegle.org/<hash>
+```
+
+Under RFC 9309 longest-match-wins, `Disallow: /*?*` (length 5) beats `Allow: /`
+(length 1), and `Allow: /$` does not match a URL carrying a query. So **Googlebot-Image
+is disallowed from every item photo on the site**, all 40,370 of them.
+
+The file is not ours by intent. We self-host images.weserv
+(`delivery-imagesweserv.conf:45`, `root /var/www/imagesweserv/public`) and inherited
+their `public/robots.txt` verbatim. Upstream ship that block deliberately so their free
+public proxy is not crawled. Diffing `images.weserv.nl/robots.txt` against ours, the
+trailing block is byte-identical. It came along onto our own domain, where it means
+something very different.
+
+Not the cause, for the record: the images serve correctly with `content-type:
+image/jpeg` and return 200 to a `Googlebot-Image/1.0` user agent. Only robots.txt stops
+them.
+
+### 2. No post URLs in the sitemap
+
+`https://www.ilovefreegle.org/sitemap.xml` contains **522 URLs**: 496
+`/explore/<group>` pages plus 26 static pages. Zero `/message/` URLs. No `lastmod` on
+any entry.
+
+Trash Nothing, for contrast, publishes `sitemap_index.xml` fanning out to 11 child
+sitemaps including `posts.xml` and `posts2.xml`, 50,000 post URLs each, with `lastmod`.
+
+This is the clearest single difference between us and them, and it is why their copy of
+our post is the one Google surfaced.
+
+Source: `server/routes/sitemap.xml.ts`.
+
+### 3. No crawlable link from a group page to its posts
+
+`GET /explore/Northampton-Freegle` server HTML contains **zero** `href="/message/..."`.
+`pages/explore/[groupid]/[[msgid]].vue:2` wraps the whole page in `<client-only>`, so
+the raw HTML is the group blurb and nothing else.
+
+Google renders JavaScript, but on a delayed second pass and not uniformly across every
+page of a large site. Which group pages happen to surface a given post is therefore
+close to arbitrary. That matches the report exactly: it appeared under a couple of
+groups and not the one it was actually posted to.
+
+Combined with finding 2, there is currently **no reliable path at all** by which Google
+learns a Freegle post exists.
+
+### 4. 8.3 million soft 404s
+
+Every post ever made remains at `/message/<id>` returning:
+
+- HTTP **200**
+- `<title>` set to the item subject
+- no `noindex`, no `X-Robots-Tag`
+- body "This post isn't available"
+
+Verified on a withdrawn 2023 post (`97562973`): HTTP 200, title `OFFER: Kitchen cupboard
+units with worktop (BS16)`, body "This post isn't available / This post was withdrawn by
+the poster."
+
+That is 8.3M thin, near-identical pages against ~42k real ones, a ratio of roughly
+200:1. This is the textbook pattern that causes Google to throttle crawl of a path and
+discount the section as a whole. It also means crawl budget that could be spent on live
+posts is spent on dead ones.
+
+Source: `pages/message/[id].vue:39-89`.
+
+### 5. Every post page carries the same meta description
+
+Sitewide, every `/message/<id>` returns:
+
+```html
+<meta name="description" content="Click for more details">
+```
+
+Verified on four unrelated posts (121002880, 120758051, 120917758, 121054975).
+
+Cause: `pages/message/[id].vue:197-201` reads `message.value.snippet` and falls back to
+the literal string `'Click for more details'`. APIv2 `GET /message/<id>` returns no
+`snippet` field at all. The payload keys are
+`id, arrival, date, fromuser, subject, type, textbody, lat, lng, ...` — the text is
+there as `textbody`, just not under the name the page looks for. So the fallback fires
+100% of the time.
+
+The effect is that our most numerous page type tells Google every post is a duplicate of
+every other post.
+
+### 6. Structured data is present but invalid, so Google discards it
+
+`components/OurMessage.vue:11-27` emits microdata:
+
+```html
+<div itemscope itemtype="http://schema.org/Product">
+  <div itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="d-none">
+    <meta itemprop="priceCurrency" content="GBP" />
+    <span itemprop="price">0</span> |
+    <span itemprop="availability">Instock</span>
+```
+
+Four problems:
+
+- The only `itemprop`s anywhere on the rendered page are `offers`, `price`,
+  `priceCurrency`, `availability`. There is **no `name`, no `image`, no
+  `description`**. A `Product` without `name` and `image` is dropped by Google entirely,
+  so this markup currently does nothing at all.
+- `availability` is `"Instock"`, which is not a schema.org value. It must be
+  `https://schema.org/InStock`.
+- The block is `class="d-none"`. Google's guidelines permit hidden JSON-LD but not
+  hidden microdata describing content the user cannot see.
+- `http://schema.org` rather than `https://`.
+
+Trash Nothing emit a single valid JSON-LD block instead. We emit JSON-LD on exactly one
+route, `pages/compare/[competitor].vue:91`.
+
+### 7. No canonical tag anywhere on the site
+
+`grep` across the repo finds no `rel="canonical"` on any page. A post is reachable at
+`/message/<id>`, at `/explore/<group>/<id>`, and with tracking params such as `?src=`.
+Nothing consolidates those. The message page response also carries `netlify-vary: query`,
+so query variants are distinct CDN entries as well.
+
+Source: `composables/useBuildHead.js` builds the whole head and emits no `link[rel=canonical]`.
+
+### 8. No `<h1>` on post pages
+
+Zero `h1`, `h2` or `h3` tags in the rendered post page. The subject appears as unmarked
+text. TN's equivalent page has `<h1>IKEA EKENABBEN Shelving Unit (East Croydon CR0)</h1>`.
+
+### 9. Generic image alt text
+
+Item photos render as `alt="Item Photo"` and `alt="Thumbnail"`. Alt text is a primary
+ranking input for image search specifically, so this compounds finding 1: even once the
+robots block is lifted, the photos carry no descriptive text.
+
+### 10. Numeric post URLs
+
+`/message/121054975` versus TN's
+`/post/47071013/ikea-ekenabben-shelving-unit-east-croydon-cr0`. A minor ranking factor,
+but it also affects click-through from the results page.
+
+### 11. Group page meta description contains raw HTML
+
+`GET /explore/Northampton-Freegle`:
+
+```html
+<meta name="description" content="<p><strong>Welcome to Northampton Freegle</strong>.</p><p>Please don't throw things away!...">
+```
+
+The group description is passed through to `buildHead` untouched
+(`pages/explore/[groupid]/[[msgid]].vue:52-54`). Correctly quoted, so not a markup bug,
+but it wastes the description budget on markup and reads badly wherever it is shown raw.
+
+## Proposed work, in priority order
+
+### Tier 1 — cheap, high value, each an hour or less
+
+**1.1 Replace the robots.txt on `delivery.ilovefreegle.org`.**
+Serve `User-agent: *` / `Allow: /` from the delivery vhost, overriding the inherited
+weserv `public/robots.txt`. Nothing else on this list moves image search until this is
+done. Note the file is Cloudflare-cached (`x-cache-status: HIT`), so purge after.
+
+**1.2 Give each post page a real meta description.**
+Either add `snippet` to the APIv2 message response, or change `buildHead`'s caller to
+fall back to a trimmed `textbody` before falling back to the literal string. Prefer the
+latter: it is one file and does not need an API change. Keep the literal only for the
+genuinely empty case.
+
+**1.3 Set image alt text to the item subject.**
+Replace `"Item Photo"` / `"Thumbnail"` with the post subject, ideally with a photo index
+where there are several.
+
+**1.4 Add `lastmod` to the existing sitemap entries.**
+
+### Tier 2 — the structural fixes that actually close the gap
+
+**2.1 Publish post URLs in the sitemap.**
+Move to a sitemap index with chunked children, live posts only (approved, not
+taken/withdrawn/deleted), with `lastmod` from `messages.arrival`. ~42k URLs, comfortably
+inside the 50k-per-file limit, so two or three children with headroom. This is the single
+biggest indexation change available to us and it is precisely what TN does that we do
+not.
+
+Open question worth deciding up front: whether to generate this at request time from the
+API (simple, but a heavy query every time Google fetches it) or on a schedule into static
+files (more moving parts, much kinder to the DB). Given the current sitemap already
+fetches `/group` at request time and is cheap, and the post query is not, a scheduled
+build is probably right.
+
+**2.2 Serve 410 for posts that are taken, withdrawn or deleted.**
+Keep the friendly "This post isn't available" page for humans, but send it with status
+410 rather than 200. That retires 8.3M soft 404s and stops Google throttling crawl of
+`/message/*`. 410 rather than 404 because these are deliberately and permanently gone.
+Deleted-because-abusive posts should also carry `noindex` regardless.
+
+Sequencing note: do this **before** 2.1, or at least in the same release. Submitting 42k
+good URLs into a path Google has already learned to distrust wastes the submission.
+
+**2.3 Server-render the post list on `/explore/<group>`.**
+The page does not need to come out of `<client-only>` wholesale. A plain server-rendered
+list of post subjects linking to `/message/<id>`, rendered above or behind the
+interactive component, is enough to give Google a real crawl path into every group. This
+is the direct fix for "it didn't show on the Northampton page".
+
+### Tier 3 — polish, worth doing once tiers 1 and 2 land
+
+**3.1 Replace the microdata with valid JSON-LD.**
+A single `Product` block per post page carrying `name` (subject), `image` (all
+attachment URLs), `description` (textbody), `offers` with `price: 0`,
+`priceCurrency: "GBP"`, `availability: "https://schema.org/InStock"`, and `areaServed`
+from the post location. This is what would earn a rich result with a photo thumbnail.
+Delete the existing `d-none` microdata block at the same time rather than leaving both.
+
+**3.2 Add `rel="canonical"` in `buildHead`.**
+Clean path, query params stripped. Applies sitewide, not just to posts.
+
+**3.3 Add an `<h1>`** with the item subject to the post page.
+
+**3.4 Add a descriptive slug to post URLs**, `/message/<id>/<slug>`, with the bare
+numeric form 301ing to it. Keep the numeric form working forever; it is in millions of
+emails.
+
+**3.5 Strip HTML from group descriptions** before they reach meta tags.
+
+## What to measure
+
+Before starting, capture from Search Console: indexed count for `/message/*`, "Crawled
+but not indexed" and "Discovered but not indexed" counts, and total image impressions.
+Tier 1.1 alone should move image impressions off zero within a few weeks. Tier 2.1 plus
+2.2 should show up as a fall in "Discovered but not indexed" and a rise in indexed
+`/message/*`.
+
+## Related
+
+- `server/routes/sitemap.xml.ts` — sitemap generation
+- `composables/useBuildHead.js` — all meta tag construction
+- `pages/message/[id].vue` — post page, expired-post handling
+- `pages/explore/[groupid]/[[msgid]].vue` — group page, the `<client-only>` wrapper
+- `components/OurMessage.vue` — the microdata block
+- `delivery-imagesweserv.conf` — image delivery vhost


### PR DESCRIPTION
A member searched for one of our own posts ("OFFER: Kitchen cupboard units (Moulton NN3)") and Google returned the **Trash Nothing** copy of it rather than ours. It also didn't show on the Northampton community page it was actually posted to, and the photos appear nowhere in image search.

Investigating turned up several independent problems. All are fixed here.

## Photos were robots-blocked on our own image host

We self-host images.weserv, and its `public/` directory ships **upstream's** `robots.txt`, which ends:

```
User-agent: *
Disallow: /*?*
Allow: /$
```

Upstream use that to keep their free public proxy from being crawled. Every Freegle photo URL is query-string only (`/?filename=...&url=...`), so under longest-match-wins that rule blocked **Googlebot-Image from all ~40,000 live post photos**. The delivery vhost now serves its own `robots.txt` from a `location = /robots.txt` block.

This is the whole reason the images never appear in image search.

## Nothing told Google a post existed

Two gaps, both closed:

- **The sitemap listed no posts.** 496 community pages and 26 static pages, and that was it. TN publish every post via `posts.xml`/`posts2.xml`, which is why their copy is the one that ranks.
- **Community pages had no links to posts.** `/explore/<group>` renders inside `<client-only>`, so the HTML a crawler receives contained zero `href="/message/..."`. Google can run our JS, but on a delayed second pass and not for every page every time, so which communities surfaced a post was effectively arbitrary. That's exactly what was reported.

So:

- `/sitemap.xml` is now an **index** over `/sitemap-pages.xml` and chunked `/sitemap-posts/<n>`, covering every live post with `lastmod`. Fed by a new `GET /message/sitemap` reading `messages_spatial` (already the pruned currently-visible set, one row per message, 51k rows against 8.3m in `messages`). Verified against production: 24,366 rows.
- **It is no longer prerendered.** It was, which meant a copy baked at deploy time; harmless for static pages, useless for a list that turns over hourly. ISR 600s instead.
- Community pages render a hidden but crawlable list of post links, from a new anonymous `GET /group/:id/message/summary`, and drop from ISR 3600s to 600s.

## Finished posts answered 200

Taken, withdrawn and deleted posts kept serving the item's subject as `<title>` with no `noindex`: roughly **8.3m thin near-identical pages against ~42k live ones**. That's the pattern that gets a whole path discounted and crawled less. They now answer **410** with `noindex`, keeping the friendly page for people. `?showtaken` still overrides.

## Every post page had the same meta description

Literally `content="Click for more details"`, sitewide, because `buildHead` read `message.snippet` and the API has no such field. Derived from `textbody` now.

## Also in here

- Valid JSON-LD `Product`, replacing microdata that declared a Product with no `name`, `image` or `description` (so Google discarded it entirely) and an invalid `"Instock"` availability, inside a `d-none` element. Deliberately emits nothing for Wanteds, which are requests rather than something available.
- `rel=canonical` sitewide, agreeing with `og:url`, stripping `?src=` tracking.
- An `<h1>` on post pages, which had no heading at all.
- Item subjects as photo alt text, replacing the literal `"Item Photo"` on every image.
- HTML stripped from group meta descriptions, which were emitting raw `<p><strong>...`.

## Two latent bugs found on the way

- `buildHead`'s image condition was `retImage?.includes(DELIVERY) + '/?url='` — a string concatenation, so always truthy, corrupting any image URL containing `=`. There was a skipped test documenting it; it is fixed and unskipped.
- Setting `head.meta` at a call site to add `robots: noindex` **replaced** the array, silently discarding the description and every `og:`/`twitter:` tag. Now an option on `buildHead`.
- The post page template read `$route.query.src` unguarded, which throws in the SSR hydration race the script's `route?.` guards exist for. Surfaced by the new tests.

## Testing

- Go: **3634 pass**
- Frontend unit: **14554 pass**, no unhandled errors
- Both new SQL queries validated against the production database
- New endpoints probed live (200, correct payload shape)
- `check-docs-freshness` OK

New tests: 23 sitemap, 22 JSON-LD, and extensions to buildHead (50), the message page (30) and OurMessage (25), covering 410 for each way a post can finish, canonical/description/og:type, and the microdata not creeping back.

## Docs

`docs/developers/reference/seo.md` — how a post gets found, why each decision was made, and the commands to check it. Design notes in `plans/2026-07-27-seo-post-indexation-and-image-search.md`.

## Note for deploy

The delivery `robots.txt` is Cloudflare-cached, so it needs a purge after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh83VCDSD43k8DP9u8t4t5
