### PR TITLE
fix(monitor-fsm): prune old workflow instances so the store doesn't grow unbounded

### DIFF
--- a/monitor-fsm/src/__tests__/prune-instances.test.ts
+++ b/monitor-fsm/src/__tests__/prune-instances.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { pruneInstances } from '../prune-instances'
+
+function makeInstances(n: number) {
+  // Genuinely ascending, valid ISO timestamps (lexically sortable): index 0 is oldest,
+  // index n-1 is newest. i seconds past a fixed base.
+  const base = Date.parse('2026-07-01T00:00:00.000Z')
+  return Array.from({ length: n }, (_, i) => ({
+    id: `id-${i}`,
+    updatedAt: new Date(base + i * 1000).toISOString(),
+  }))
+}
+
+describe('pruneInstances', () => {
+  it('deletes all but the `keep` most recent, oldest first', async () => {
+    const lister = { listInstances: vi.fn().mockResolvedValue(makeInstances(25)) }
+    const deleted: string[] = []
+    const deleter = {
+      deleteInstance: vi.fn(async (id: string) => {
+        deleted.push(id)
+      }),
+    }
+
+    const count = await pruneInstances(lister, deleter, 20)
+
+    expect(count).toBe(5)
+    // The 5 OLDEST (id-0..id-4) are deleted; the 20 most recent are kept.
+    expect(deleted.sort()).toEqual(['id-0', 'id-1', 'id-2', 'id-3', 'id-4'])
+  })
+
+  it('deletes nothing when at or under the keep threshold', async () => {
+    const lister = { listInstances: vi.fn().mockResolvedValue(makeInstances(20)) }
+    const deleter = { deleteInstance: vi.fn() }
+    expect(await pruneInstances(lister, deleter, 20)).toBe(0)
+    expect(deleter.deleteInstance).not.toHaveBeenCalled()
+  })
+
+  it('reduces a large backlog down to exactly `keep`', async () => {
+    const kept: string[] = makeInstances(1165).map((i) => i.id)
+    const lister = { listInstances: vi.fn().mockResolvedValue(makeInstances(1165)) }
+    const deleter = {
+      deleteInstance: vi.fn(async (id: string) => {
+        const idx = kept.indexOf(id)
+        if (idx >= 0) kept.splice(idx, 1)
+      }),
+    }
+    const count = await pruneInstances(lister, deleter, 20)
+    expect(count).toBe(1145)
+    expect(kept).toHaveLength(20)
+    // The survivors are the 20 most recent.
+    expect(kept).toContain('id-1164')
+    expect(kept).not.toContain('id-0')
+  })
+
+  it('keeps going when a single delete fails (best-effort)', async () => {
+    const lister = { listInstances: vi.fn().mockResolvedValue(makeInstances(23)) }
+    const deleter = {
+      deleteInstance: vi.fn(async (id: string) => {
+        if (id === 'id-1') throw new Error('locked')
+      }),
+    }
+    // 3 candidates (id-0,1,2); id-1 throws, so 2 succeed.
+    const count = await pruneInstances(lister, deleter, 20)
+    expect(count).toBe(2)
+    expect(deleter.deleteInstance).toHaveBeenCalledTimes(3)
+  })
+
+  it('tolerates missing updatedAt (sorts them oldest, prunes them first)', async () => {
+    const insts = [
+      { id: 'no-date-a', updatedAt: '' },
+      { id: 'recent', updatedAt: '2026-07-27T12:00:00.000Z' },
+      { id: 'no-date-b', updatedAt: '' },
+    ] as any
+    const lister = { listInstances: vi.fn().mockResolvedValue(insts) }
+    const deleted: string[] = []
+    const deleter = { deleteInstance: vi.fn(async (id: string) => void deleted.push(id)) }
+    await pruneInstances(lister, deleter, 1)
+    // 'recent' kept; the two undated ones pruned.
+    expect(deleted.sort()).toEqual(['no-date-a', 'no-date-b'])
+  })
+})

--- a/monitor-fsm/src/driver.ts
+++ b/monitor-fsm/src/driver.ts
@@ -57,6 +57,7 @@ import { ClaudeCodeAdapter } from 'ai-flower/adapters/claude-code'
 import { actions } from './actions/index.js'
 import { sanitizeLLMDecision } from './llm-json.js'
 import { ensureUsableInstanceStore } from './instance-store.js'
+import { pruneInstances } from './prune-instances.js'
 import { partitionFailedChecks } from './coverage-checks.js'
 import { getDb, startIteration, endIteration } from './db/index.js'
 import { renderAllViews } from './db/views.js'
@@ -67,6 +68,9 @@ const exec = promisify(execFile)
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const WORKFLOW_PATH = resolve(__dirname, '../workflow.json')
 const INSTANCE_STORE = resolve(__dirname, '../instance-store.json')
+// How many recent workflow instances to retain in the store. We never resume an old one,
+// so this is purely a debugging window; the rest are pruned each run to bound the file.
+const KEEP_INSTANCES = 20
 
 const MAX_STEPS = 40 // hard cap; real iterations should settle in ~15-25
 
@@ -378,6 +382,19 @@ async function main() {
     actions,
     maxLLMRetries: 2,
   })
+
+  // Bound the instance store BEFORE we add this run's instance. We never resume an old
+  // instance (see below), so completed/errored ones pile up in instance-store.json - it
+  // had bloated to ~100MB / 1165 instances, which slows every load+save and eventually
+  // killed the loop. Keep the most recent few for debugging; delete the rest. Non-fatal.
+  try {
+    const pruned = await pruneInstances(engine, storage, KEEP_INSTANCES)
+    if (pruned > 0) {
+      out(`pruned ${pruned} old workflow instances (kept ${KEEP_INSTANCES})`)
+    }
+  } catch (e: any) {
+    outWarn(`instance prune failed (non-fatal): ${e?.message ?? e}`)
+  }
 
   // Fresh instance per driver run — iterations should not resume.
   const iterationStartTs = new Date().toISOString()

--- a/monitor-fsm/src/prune-instances.ts
+++ b/monitor-fsm/src/prune-instances.ts
@@ -1,0 +1,52 @@
+// Bound the workflow instance store. The driver creates a FRESH instance every run and
+// never resumes an old one ("Fresh instance per driver run" in driver.ts), so completed /
+// errored / abandoned instances just accumulate in the JSON store. Left unchecked it bloated
+// to ~100MB / 1165 instances, which slows every load+save and eventually killed the loop.
+// Keep only the `keep` most recent instances (by updatedAt); delete the rest.
+
+export interface PrunableInstance {
+  id: string
+  updatedAt: string
+}
+
+export interface InstanceLister {
+  listInstances(): Promise<PrunableInstance[]>
+}
+
+export interface InstanceDeleter {
+  deleteInstance(id: string): Promise<void>
+}
+
+/**
+ * Delete all but the `keep` most-recent instances (by updatedAt). Returns the number
+ * deleted. Best-effort per delete: a single failing deleteInstance doesn't abort the rest.
+ * The caller runs this at startup BEFORE creating the run's new instance, so the current
+ * run is never a candidate for deletion.
+ */
+export async function pruneInstances(
+  lister: InstanceLister,
+  deleter: InstanceDeleter,
+  keep = 20,
+): Promise<number> {
+  const existing = await lister.listInstances()
+  if (existing.length <= keep) {
+    return 0
+  }
+
+  const stale = existing
+    .slice()
+    // Most recent first; missing/empty updatedAt sorts last (oldest), so it's pruned first.
+    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''))
+    .slice(keep)
+
+  let deleted = 0
+  for (const inst of stale) {
+    try {
+      await deleter.deleteInstance(inst.id)
+      deleted++
+    } catch {
+      // Best-effort: keep going so one bad row doesn't leave the store bloated.
+    }
+  }
+  return deleted
+}


### PR DESCRIPTION
## Problem
The monitor's `instance-store.json` grew to **~100MB / 1166 workflow instances**. Each driver run calls `engine.createInstance()` and never resumes an old one ("Fresh instance per driver run"), but completed/errored instances were never deleted — so they accumulate forever. Loading and re-saving a 100MB JSON every iteration slows the loop and eventually stopped it (the process died with the last iteration left dangling).

## Fix
`pruneInstances()` runs at the start of each driver run, **before** creating that run's instance: it keeps the `KEEP_INSTANCES` (20) most-recent instances by `updatedAt` and deletes the rest via the storage adapter. It's best-effort (one failing `deleteInstance` doesn't abort the rest) and non-fatal (a prune error is logged, not thrown), so it can never block an iteration.

Extracted as a pure helper (`src/prune-instances.ts`) with unit tests covering: backlog reduction to exactly `keep`, the at/under-threshold no-op, delete-failure tolerance, and missing-`updatedAt` rows.

The live store was also pruned **offline** (96MB → 1.2MB, keeping the same 20 most-recent) so the next start loads fast rather than re-reading 100MB once more.