### PR TITLE
fix(batch): stop duplicate chat notification emails from double-inserted rows

### DIFF
--- a/iznik-batch/app/Services/ChatNotificationService.php
+++ b/iznik-batch/app/Services/ChatNotificationService.php
@@ -180,7 +180,28 @@ class ChatNotificationService
 
         return $query->orderBy('chat_messages.id', 'asc')
             ->with(['chatRoom', 'user', 'refMessage'])
-            ->get();
+            ->get()
+            // Collapse duplicate rows created for a single send. A single chat
+            // send occasionally inserts two (or more) identical chat_messages
+            // rows ~1s apart (double-submit / retry with no dedup guard at
+            // insert). Because we email once per row, each duplicate would send
+            // its own notification — the "two copies of one message, seconds
+            // apart" reports. V1's chatdups cron (now cleanup:chat-duplicates)
+            // deletes them keyed on chatid+message+refmsgid, but it runs only
+            // every 2h whereas this notifier runs within ~30s of a send, so it
+            // always loses the race. Dedup here on the same key, keeping the
+            // lowest id (the query is ordered id asc, so unique keeps the first
+            // occurrence — the row whose notification advances the roster).
+            ->unique(function (ChatMessage $message) {
+                return implode('|', [
+                    $message->chatid,
+                    $message->userid,
+                    $message->type,
+                    md5((string) $message->message),
+                    $message->refmsgid ?? '',
+                ]);
+            })
+            ->values();
     }
 
     /**

--- a/iznik-batch/tests/Unit/Services/ChatNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChatNotificationServiceTest.php
@@ -66,6 +66,49 @@ class ChatNotificationServiceTest extends TestCase
         $this->assertGreaterThanOrEqual(0, $count);
     }
 
+    public function test_notify_by_email_deduplicates_identical_rows_from_single_send(): void
+    {
+        // A single chat send occasionally inserts two identical chat_messages
+        // rows ~1s apart (double-submit / retry with no dedup guard at insert).
+        // We email once per row, so without dedup the recipient gets two copies
+        // of the same message seconds apart. Only one notification should go out.
+        $sender = $this->createTestUser();
+        $recipient = $this->createTestUser();
+
+        $room = $this->createTestChatRoom($sender, $recipient, [
+            'latestmessage' => now(),
+        ]);
+
+        ChatRoster::create([
+            'chatid' => $room->id,
+            'userid' => $sender->id,
+            'lastmsgemailed' => null,
+        ]);
+        ChatRoster::create([
+            'chatid' => $room->id,
+            'userid' => $recipient->id,
+            'lastmsgemailed' => null,
+        ]);
+
+        // Two identical rows for a single logical send (same body/type/refmsgid).
+        $this->createTestChatMessage($room, $sender, [
+            'message' => 'Are these still available?',
+            'date' => now()->subMinutes(5),
+        ]);
+        $this->createTestChatMessage($room, $sender, [
+            'message' => 'Are these still available?',
+            'date' => now()->subMinutes(5)->addSecond(),
+        ]);
+
+        $this->service->notifyByEmail(ChatRoom::TYPE_USER2USER, $room->id);
+
+        // The recipient must receive exactly one notification, not one per row.
+        $toRecipient = Mail::sent(ChatNotification::class)->filter(
+            fn (ChatNotification $mail) => $mail->hasTo($recipient->email_preferred)
+        );
+        $this->assertCount(1, $toRecipient);
+    }
+
     public function test_notify_by_email_with_specific_chat(): void
     {
         $sender = $this->createTestUser();


### PR DESCRIPTION
## Problem

Users occasionally receive **two copies of one ModTools chat message**, seconds apart. Reported by Neville (Newham mod) — two identical "Member conversation" emails timed 6s apart in the Yahoo receipt headers (18:09:05 / 18:09:11 on 2026-07-17).

## Root cause (confirmed against prod)

A single chat send occasionally inserts **two (or more) identical `chat_messages` rows ~1s apart** (double-submit / retry, no dedup guard at insert). `ChatNotificationService` iterates one email **per row**, so each duplicate row fires its own notification.

Verified on prod:
- Neville's surviving row `109681609` (ModMail, chat 21017011) sits directly before `109681615` — IDs `…610–…614` were deleted; the duplicate sibling lived in that gap.
- Live and ongoing: ~16 true single-send duplicate events in 24h (ModMail, Completed, Image, Interested) — identical body, 0–1s apart, adjacent IDs, both `mailedtoall=0` → both notifiable.

**Why the existing cleanup doesn't help:** `cleanup:chat-duplicates` (V1 `chatdups.php`) deletes these rows keyed on `chatid+message+refmsgid`, but runs only **every 2h** while the notifier runs within ~30s of a send — it always loses the race (44 rows swept at noon today, long after the emails went out). The May `getPreviousMessages` fix only stopped a message repeating *within one* email; it never touched the two-separate-emails case.

## Fix

Collapse duplicate rows in `getUnmailedMessages` on `chatid+userid+type+message+refmsgid`, keeping the **lowest id** (the row whose notification advances the roster). One logical message → one email, regardless of duplicate rows. The query is already ordered `id asc`, so `unique()` keeps the first occurrence.

Root-cause dedup at the insert path (`CreateChatMessage`) is a sensible separate follow-up; this is the immediate safety net in the notification layer.

## Test

`test_notify_by_email_deduplicates_identical_rows_from_single_send` — two identical rows for one send ⇒ recipient receives exactly one notification.

_Not run locally (prod host — CI is the validator)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)