### PR TITLE
fix(rspamd): bind milter worker to all interfaces, not the container hostname

### DIFF
--- a/conf/rspamd/local.d/worker-proxy.inc
+++ b/conf/rspamd/local.d/worker-proxy.inc
@@ -1,3 +1,12 @@
-# Milter worker — receives connections from Postfix on port 11332.
+# Milter worker: receives connections from Postfix on port 11332.
 # rspamd scores each message and returns a milter response.
-bind_socket = "rspamd:11332";
+#
+# Bind all interfaces ("*"), NOT the container hostname. bind_socket is the
+# LISTEN address; binding "rspamd:11332" made rspamd DNS-resolve its own name at
+# config-parse time, and when that resolution was not ready the worker died with
+# "cannot parse bind line: rspamd:11332" (Temporary failure in name resolution),
+# crash-looping the container and blocking everything that depends on it. Postfix
+# still reaches it via "inet:rspamd:11332" (conf/postfix/main.cf) because "*"
+# listens on the container IP that name resolves to. "*:11332" is also the rspamd
+# proxy-worker milter default.
+bind_socket = "*:11332";


### PR DESCRIPTION
## Problem
`freegle-rspamd` crash-loops with `cannot parse bind line: rspamd:11332`, so it never becomes healthy and `docker-compose up batch` (and anything else that depends on rspamd being healthy) can't start normally.

## Root cause
`conf/rspamd/local.d/worker-proxy.inc` set the milter worker's `bind_socket` to the container hostname `rspamd:11332`. rspamd resolves the bind address at config-parse time, and the rspamd container has no resolver configured (`cannot parse resolv.conf and no nameservers defined`), so resolving its own name fails (`Temporary failure in name resolution`) and the worker aborts before any worker forks.

## Fix
Bind all interfaces: `bind_socket = "*:11332"` (the rspamd proxy-worker milter default). This is the LISTEN address; Postfix still connects via `inet:rspamd:11332` (`conf/postfix/main.cf`), which `*` serves, so the milter wiring and ports are unchanged.

## Verification
- `docker restart freegle-rspamd` -> container reaches **healthy** (previously `Exited (1)`, crash-looping).
- Startup log shows the `rspamd_proxy` worker forking with no bind error and `rspamd ... is starting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_012RoB9qVCxwKjFmQzB7qSF2
