### PR TITLE
fix(digest): seed the batch-local spatial index before remapping a new area

### DIFF
--- a/iznik-batch/app/Services/PostcodeRemapService.php
+++ b/iznik-batch/app/Services/PostcodeRemapService.php
@@ -22,7 +22,7 @@ class PostcodeRemapService
 {
     private string $spatialServerUrl;
 
-    public function __construct()
+    public function __construct(private SpatialAdminService $spatialAdmin)
     {
         $this->spatialServerUrl = config('freegle.spatial_server_url', 'http://localhost:8194');
     }
@@ -30,12 +30,24 @@ class PostcodeRemapService
     /**
      * Remap postcodes within a given WKT polygon to their nearest area.
      *
-     * @param int|null $locationId The location that was modified (unused, kept for interface compatibility).
+     * @param int|null $locationId The area whose geometry changed. When given, the
+     *   area is seeded into THIS process's spatial index before the KNN lookups
+     *   below, so a brand-new area is found immediately (see seedArea()).
      * @param string|null $polygon WKT polygon to scope the remap. NULL = remap all.
      * @return int Number of postcodes remapped.
      */
     public function remapPostcodes(?int $locationId = NULL, ?string $polygon = NULL): int
     {
+        // In production each container runs its own spatial-knn instance with an
+        // independent in-memory index (one per DB server, plus one on the batch
+        // container). The write-time upsert in the Go API seeds the API's instance,
+        // NOT the one this remap queries, so without seeding here findNearestArea()
+        // cannot see a just-drawn area until the 15-minute delta. The area then gets
+        // no postcodes and looks unsaved until the nightly full remap (Discourse #9950).
+        if ($locationId) {
+            $this->seedArea($locationId);
+        }
+
         $pcQuery = DB::table('locations_spatial')
             ->join('locations', 'locations_spatial.locationid', '=', 'locations.id')
             ->where('locations.type', 'Postcode')
@@ -92,6 +104,30 @@ class PostcodeRemapService
         Log::info("PostcodeRemapService: remapped {$updated}/{$count} postcodes");
 
         return $updated;
+    }
+
+    /**
+     * Seed one area's current geometry into the spatial index this process
+     * queries, so findNearestArea() can return it straight away instead of
+     * waiting for the next delta sync. Non-fatal: a failure just falls back to
+     * the delta and the nightly full remap.
+     */
+    private function seedArea(int $locationId): void
+    {
+        $row = DB::table('locations')
+            ->where('id', $locationId)
+            ->selectRaw('name, `type`, ST_AsText(COALESCE(ourgeometry, geometry)) AS wkt')
+            ->first();
+
+        if (!$row || empty($row->wkt)) {
+            return;
+        }
+
+        $this->spatialAdmin->upsertItems('locations', [[
+            'id'    => $locationId,
+            'wkt'   => $row->wkt,
+            'extra' => ['name' => $row->name, 'type' => $row->type],
+        ]]);
     }
 
     /**

--- a/iznik-batch/app/Services/SpatialAdminService.php
+++ b/iznik-batch/app/Services/SpatialAdminService.php
@@ -70,4 +70,43 @@ class SpatialAdminService
             Log::warning("SpatialAdmin: rebuild {$dataset} failed: {$e->getMessage()}");
         }
     }
+
+    /**
+     * Insert or replace specific items in a dataset's in-memory index straight
+     * away, without waiting for the periodic delta sync.
+     *
+     * Needed because each container runs its OWN spatial-knn instance with an
+     * independent in-memory index. A caller that must query the index it just
+     * changed a row in (e.g. PostcodeRemapService remapping a brand-new area,
+     * Discourse #9950) has to seed THIS process's instance first; the write-time
+     * upsert done elsewhere lands on a different instance and never reaches here.
+     *
+     * $items: [['id' => int, 'wkt' => string, 'extra' => ['name' => ?, 'type' => ?]], ...].
+     *
+     * Failures are logged as warnings and do not throw — the periodic delta and
+     * the nightly rebuild remain as backstops.
+     */
+    public function upsertItems(string $dataset, array $items): void
+    {
+        if (empty($items)) {
+            return;
+        }
+
+        try {
+            $response = Http::timeout(5)->post(
+                "{$this->adminUrl}/v1/{$dataset}/upsert",
+                ['items' => array_values($items)]
+            );
+
+            if (!$response->successful()) {
+                Log::warning("SpatialAdmin: upsert {$dataset} HTTP {$response->status()}", [
+                    'items_count' => count($items),
+                ]);
+            }
+        } catch (\Throwable $e) {
+            Log::warning("SpatialAdmin: upsert {$dataset} failed: {$e->getMessage()}", [
+                'items_count' => count($items),
+            ]);
+        }
+    }
 }

--- a/iznik-batch/tests/Unit/Services/PostcodeRemapServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PostcodeRemapServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Services;
 
 use App\Services\PostcodeRemapService;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -101,5 +102,45 @@ class PostcodeRemapServiceTest extends TestCase
         $result  = $this->service->remapPostcodes(null, $polygon);
 
         $this->assertEquals(0, $result);
+    }
+
+    public function test_remap_postcodes_seeds_the_area_into_the_local_index(): void
+    {
+        // In production each container runs its OWN spatial-knn instance with an
+        // independent in-memory index. The remap must seed the area into the
+        // instance it is about to query, or a brand-new area gets no postcodes
+        // until the nightly full remap (Discourse #9950).
+        Http::fake([
+            '*/v1/locations/upsert' => Http::response(['upserted' => 1], 200),
+            '*/v1/locations/knn*'   => Http::response(['results' => []], 200),
+        ]);
+
+        $id  = 990000001;
+        $wkt = 'POLYGON((-1 53, -0.9 53, -0.9 53.1, -1 53.1, -1 53))';
+        DB::table('locations')->insert([
+            'id'       => $id,
+            'name'     => 'Seedville',
+            'type'     => 'Polygon',
+            'geometry' => DB::raw("ST_GeomFromText('{$wkt}', 3857)"),
+        ]);
+
+        $this->service->remapPostcodes($id, $wkt);
+
+        Http::assertSent(fn ($request) => str_ends_with($request->url(), '/v1/locations/upsert')
+            && $request['items'][0]['id'] === $id
+            && str_contains($request['items'][0]['wkt'], 'POLYGON')
+            && $request['items'][0]['extra']['type'] === 'Polygon');
+    }
+
+    public function test_remap_postcodes_without_location_id_does_not_seed(): void
+    {
+        Http::fake([
+            '*/v1/locations/upsert' => Http::response(['upserted' => 1], 200),
+            '*/v1/locations/knn*'   => Http::response(['results' => []], 200),
+        ]);
+
+        $this->service->remapPostcodes(null, 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))');
+
+        Http::assertNotSent(fn ($request) => str_contains($request->url(), '/v1/locations/upsert'));
     }
 }

--- a/iznik-batch/tests/Unit/Services/SpatialAdminServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/SpatialAdminServiceTest.php
@@ -40,4 +40,42 @@ class SpatialAdminServiceTest extends TestCase
 
         $this->assertTrue(true);
     }
+
+    public function test_upsert_items_posts_items_to_upsert_endpoint(): void
+    {
+        Http::fake(['*/v1/locations/upsert' => Http::response(['upserted' => 1], 200)]);
+
+        (new SpatialAdminService())->upsertItems('locations', [[
+            'id'    => 4242,
+            'wkt'   => 'POLYGON((0 0, 0.01 0, 0.01 0.01, 0 0.01, 0 0))',
+            'extra' => ['name' => 'Testville', 'type' => 'Polygon'],
+        ]]);
+
+        Http::assertSent(fn ($request) => str_ends_with($request->url(), '/v1/locations/upsert')
+            && $request->method() === 'POST'
+            && $request['items'][0]['id'] === 4242
+            && $request['items'][0]['extra']['type'] === 'Polygon');
+    }
+
+    public function test_upsert_items_is_noop_on_empty_array(): void
+    {
+        Http::fake();
+
+        (new SpatialAdminService())->upsertItems('locations', []);
+
+        Http::assertNothingSent();
+    }
+
+    public function test_upsert_items_swallows_http_error(): void
+    {
+        Http::fake(['*/v1/locations/upsert' => Http::response('boom', 500)]);
+
+        // A failed seed must not throw — the periodic delta and nightly rebuild
+        // remain as backstops.
+        (new SpatialAdminService())->upsertItems('locations', [[
+            'id' => 1, 'wkt' => 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))', 'extra' => [],
+        ]]);
+
+        Http::assertSent(fn ($request) => str_ends_with($request->url(), '/v1/locations/upsert'));
+    }
 }


### PR DESCRIPTION
## Problem
A moderator draws a new area in ModTools Mapping and it becomes visible only **overnight** (Discourse #9950). PR #1135 tried to fix this but cannot in production.

## Root cause
For a new area to show in the Mapping editor, a postcode must have `areaid` pointing at it, and only a postcode **remap** sets that. The ~40s "immediate" remap asks the spatial KNN index which area is nearest.

In production each container runs its OWN `spatial-knn` instance with an independent in-memory index (one per DB server, plus one on the batch container). PR #1135 made the Go API upsert the new area into the **API's** instance at write time — but the remap runs in the **batch** container and queries the **batch container's own** instance, which never received that upsert. The batch-local index only learns the area on its 15-minute delta, and nothing re-runs a remap afterwards, so the area waits for the nightly `01:00` `locations:remap-postcodes` full remap. Hence "overnight".

(The Go API never itself queries the `locations`/`Area` KNN — only `postcodes`/`newsfeed`/`jobs` — so #1135's upsert seeds an index nothing reads for area remapping.)

## Fix
Seed the area into the instance the remap itself queries. When `PostcodeRemapService::remapPostcodes()` is given a `locationId`, it now upserts that area's current geometry into the **batch-local** spatial index before the KNN lookups. `SpatialAdminService`'s admin URL and the remap's query URL both derive from the batch's `SPATIAL_KNN_URL`, so they hit the same instance by construction. Non-fatal: the 15-minute delta and nightly remap remain as backstops.

- `SpatialAdminService::upsertItems()` — `POST /v1/{dataset}/upsert` (new).
- `PostcodeRemapService::seedArea()` — fetch `COALESCE(ourgeometry, geometry)` and upsert it; called from `remapPostcodes()` when a `locationId` is supplied.

## Tests
- `upsertItems`: posts items / no-ops on empty / swallows HTTP error.
- `remapPostcodes`: seeds the area on `locationId`, does not seed without one.
- Full Laravel suite green locally (4927 passed, 0 failures, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_012RoB9qVCxwKjFmQzB7qSF2
