### PR TITLE
ci(orb): capture Playwright logs on failure so the failing spec is visible

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.356
+  freegle: freegle/tests@1.1.360
 
 jobs:
   mark-ci-passed:

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -2677,21 +2677,28 @@ jobs:
             wait $PLAYWRIGHT_PID 2>/dev/null || true
             [ -n "${VITEST_PID:-}" ] && wait $VITEST_PID 2>/dev/null || true
 
-            # For killed tests, fetch final logs from the status API
-            if [ "$TESTS_KILLED_EARLY" = "true" ]; then
-              echo "📋 Capturing final logs for killed tests..."
-              for test_type in laravel go playwright; do
-                outfile=~/test-output/${test_type}.out
-                result=$(cat /tmp/${test_type}-result 2>/dev/null || echo "unknown")
-                if [ "$result" = "running" ] || [ "$result" = "unknown" ]; then
-                  echo "📋 Fetching final logs for $test_type..."
-                  status_response=$(curl -s http://localhost:${PORT_STATUS:-8081}/api/tests/${test_type}/status || echo '{}')
-                  echo "" >> "$outfile"
-                  echo "=== Test killed by fail-fast ===" >> "$outfile"
-                  echo "$status_response" | jq -r '.logs // "No logs available"' >> "$outfile" 2>/dev/null || true
-                fi
-              done
-            fi
+            # Ensure each suite's output file actually has content, then fall
+            # back to the status API otherwise. Playwright runs via a backgrounded
+            # status-API poller whose buffered stdout is torn down (unflushed)
+            # when the monitoring loop breaks — on fail-fast OR when all suites
+            # complete — so on a Playwright failure playwright.out was left EMPTY,
+            # hiding the failing spec (the artifact uploaded 0 bytes). Re-fetch the
+            # logs from the status API for any suite that did not pass or whose
+            # .out file is empty. Runs unconditionally now (was gated on
+            # TESTS_KILLED_EARLY and only captured 'running'/'unknown', which
+            # skipped a Playwright 'fail').
+            echo "📋 Ensuring final test logs are captured..."
+            for test_type in laravel go playwright; do
+              outfile=~/test-output/${test_type}.out
+              result=$(cat /tmp/${test_type}-result 2>/dev/null || echo "unknown")
+              if [ "$result" != "pass" ] || [ ! -s "$outfile" ]; then
+                echo "📋 Fetching final logs for $test_type (result=$result)..."
+                status_response=$(curl -s http://localhost:${PORT_STATUS:-8081}/api/tests/${test_type}/status || echo '{}')
+                echo "" >> "$outfile"
+                echo "=== Final status-API logs (result=$result) ===" >> "$outfile"
+                echo "$status_response" | jq -r '.logs // "No logs available"' >> "$outfile" 2>/dev/null || true
+              fi
+            done
 
             # Check results from files
             LARAVEL_RESULT=$(cat /tmp/laravel-result 2>/dev/null || echo "fail")


### PR DESCRIPTION
## Problem
When Playwright fails in the parallel-test job, `~/test-output/playwright.out` uploads as **0 bytes**, so the specific failing spec and its error are invisible — every intermittent Playwright failure this session could only be cleared by a blind rerun, never named.

## Root cause
Playwright runs via a backgrounded status-API poller subshell (`... ) > ~/test-output/playwright.out 2>&1 &`). Its stdout to that file is bash-buffered. When the monitoring loop breaks — on fail-fast (a Playwright `fail` marker) or when all suites complete — the subshell is torn down before it flushes, so the file ends up empty. The post-loop "capture final logs" fallback only re-fetched logs for suites left in `running`/`unknown` state **and** was gated on `TESTS_KILLED_EARLY`, so a Playwright `fail` was skipped.

## Fix
Re-fetch each suite's logs from the status API for any suite that **did not pass or whose `.out` file is empty**, run **unconditionally** after the wait (not only on fail-fast). This puts the failing Playwright spec + error back into `playwright.out`. No change to test execution or pass/fail semantics — diagnostics only.

Published as `freegle/tests@1.1.360`; `continue-config.yml` pin bumped `1.1.356 → 1.1.360`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_012RoB9qVCxwKjFmQzB7qSF2
