### PR TITLE
feat(support): reach the AI support helper same-origin in production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -567,8 +567,11 @@ services:
       - "traefik.http.routers.ai-support-helper.entrypoints=web"
       - "traefik.http.services.ai-support-helper.loadbalancer.server.port=3000"
     environment:
-      # Claude auth: set ANTHROPIC_API_KEY for api mode (edge/prod). Leave it unset and
+      # Claude auth: set CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`, bills to the
+      # subscription) or ANTHROPIC_API_KEY for api mode (bills to API credits). The OAuth
+      # token wins when both are set (see claude-agent-sdk/auth.js). Leave both unset and
       # mount ~/.claude (see volumes) for session mode (local testing on the logged-in session).
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       # Unpinned alias, not a dated snapshot (snapshots get retired and the SDK
       # then 404s). On the Claude subscription (session mode) Opus is available.

--- a/iznik-nuxt3/modtools/netlify.toml
+++ b/iznik-nuxt3/modtools/netlify.toml
@@ -5,6 +5,11 @@
 [build.environment]
 NODE_VERSION = "22"
 NPM_FLAGS = "--legacy-peer-deps"
+# AI support helper, same-origin path per config.js's AI_SUPPORT_URL contract:
+# HAProxy routes modtools.org/api/ai-support/* to the helper and strips the
+# prefix. Same-origin means no CORS and no separate DNS/cert; access control is
+# the helper's own Support/Admin JWT gate.
+AI_SUPPORT_URL = "/api/ai-support"
 
 [build]
 command = "export NODE_OPTIONS=--max_old_space_size=6000 && cd .. && npm ci --legacy-peer-deps && npx nuxi prepare && cd modtools && npm run build"


### PR DESCRIPTION
## What

Makes the ModTools AI Support Assistant work from production ModTools. It previously hardcoded `http://ai-support-helper.localhost` (local-dev traefik hostname), so on modtools.org the fetch went to the user's own machine and the UI showed "The AI log analysis service is not currently running".

- **ModSupportAIAssistant.vue**: use same-origin `/api/ai-support` in production; keep the traefik hostname on `*.localhost` dev.
- **docker-compose.yml**: pass `CLAUDE_CODE_OAUTH_TOKEN` through to the ai-support-helper container (subscription billing; wins over `ANTHROPIC_API_KEY` per `claude-agent-sdk/auth.js`).

## Infrastructure (already live, done outside this PR)

HAProxy on the ha host routes `modtools.org/api/ai-support/*` → ai-support-helper on the FD host (:8083), stripping the prefix. Same-origin (no CORS/DNS/cert work), rides the existing API rate limiting, streams SSE (no Netlify proxy buffering), 300s server/tunnel timeouts for long analyses. Config backup at `/etc/haproxy/haproxy.cfg.bak-aisupport`.

## Security

Unchanged and verified end-to-end: the helper resolves the forwarded JWT via the Go API and only admits systemrole **Support/Admin** (fails closed); anonymous POST through the new public route → 403. Only `/health` is unauthenticated.

## Testing

- `https://modtools.org/api/ai-support/health` → helper health JSON (auth valid) ✔
- Anonymous `POST /api/ai-support/api/log-analysis` → 403 ✔
- modtools.org homepage still 200 via Netlify backend ✔
- CI to validate lint/tests; needs a real Support login on production ModTools for the full end-to-end check after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRjCb4A1z8meCk46kK6BVd