### PR TITLE
fix(support-ai): don't show 'no sessions' for members who are active but send no telemetry

### DIFF
--- a/claude-agent-sdk/server.js
+++ b/claude-agent-sdk/server.js
@@ -274,12 +274,35 @@ app.get('/api/device-summary', async (req, res) => {
     const currentVersion = currentMobileVersion()
     const devices = buildDeviceSummary(records, currentVersion)
 
+    // A member can be fully active with NO client telemetry at all: ad/tracker
+    // blockers eat the unauthenticated /clientlog POST, and app builds from
+    // before client logging never send it. Fall back to their newest api-source
+    // line (also a cheap indexed-label lookup) so "no sessions" can't read as
+    // "not active" when the member was on the site hours ago.
+    let lastApiActivity = null
+    if (!devices.length) {
+      try {
+        const apiRows = await lokiQuery({
+          query: `{app="freegle", source="api", user_id="${userId}"}`,
+          start: window,
+          limit: 1,
+        })
+        if (apiRows.length) {
+          lastApiActivity = new Date(Number(BigInt(apiRows[0].ts) / 1000000n)).toISOString()
+        }
+      } catch (e) {
+        console.error('[DeviceSummary] api-activity fallback failed:', e.message)
+      }
+    }
+
     res.json({
       userId,
       window,
       generatedAt: new Date().toISOString(),
-      // Newest device sighting doubles as "last active on a device".
-      lastaccess: devices[0]?.lastSeen || null,
+      // Newest device sighting doubles as "last active on a device"; if the
+      // device never reports, fall back to server-side API activity.
+      lastaccess: devices[0]?.lastSeen || lastApiActivity,
+      lastApiActivity,
       currentVersion,
       deviceCount: devices.length,
       devices,

--- a/docs/developers/reference/ai-support-helper.md
+++ b/docs/developers/reference/ai-support-helper.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-13
+last_reviewed: 2026-07-29
 owner: Freegle dev team
 covers:
   - claude-agent-sdk/support-agent.js
@@ -80,6 +80,18 @@ SDK's `Read`/`Grep`/`Glob` confined to the codebase checkout:
 The investigation playbook (held chat replies, duplicate conversations, purged accounts,
 rippling auto-joins, stale-deploy chunks, etc.) lives in the system prompt in
 `support-agent.js`.
+
+## Device summary panel
+
+`GET /api/device-summary?userId=` (`server.js`) is a deterministic, no-AI view shown as
+soon as a member is selected: their recent devices (browser/OS/viewport, freshness badge)
+built from client `session_start` telemetry in Loki (`device-summary.js`). Telemetry is
+**best-effort** — the `/clientlog` POST is an unauthenticated fire-and-forget fetch that
+ad/tracker blockers routinely eat, and app builds from before client logging never send
+it — so a member can be fully active with zero device sessions. When that happens the
+endpoint falls back to the member's newest `source="api"` Loki line (`lastApiActivity`)
+and the panel says so explicitly, rather than showing a bare "no sessions" that misreads
+as "not active".
 
 ## Security controls
 

--- a/iznik-nuxt3/modtools/components/ModSupportAIAssistant.vue
+++ b/iznik-nuxt3/modtools/components/ModSupportAIAssistant.vue
@@ -195,7 +195,15 @@
           v-else-if="!deviceSummary?.devices?.length"
           class="text-muted small"
         >
-          No device sessions found in the last 7 days.
+          <template v-if="deviceSummary?.lastApiActivity">
+            Active on the server side {{ formatLastSeen(deviceSummary.lastApiActivity) }},
+            but their device sends no telemetry &mdash; usually an ad/tracker
+            blocker, or an app from before client logging. Device details
+            aren't available for this member.
+          </template>
+          <template v-else>
+            No device sessions found in the last 7 days.
+          </template>
         </div>
         <div v-else class="device-cards d-flex flex-wrap gap-2">
           <div


### PR DESCRIPTION
## Problem

Support looked up member 44554593: the device panel said **"No device sessions found in the last 7 days"** while the user section showed them active 7 hours ago. Both were true: the member made 928 authenticated API calls in 7 days (chat, browse, notification polling — last at 02:42 UTC), but their device has never POSTed to `/apiv2/clientlog` (zero hits by user_id label, by full-text userid, and by their IP over the whole window, while other clients' telemetry streams in constantly from the same carrier range).

The device panel is built solely on client `session_start` telemetry, and that telemetry is an unauthenticated fire-and-forget `fetch` — ad/tracker blockers routinely block it, and app builds from before client logging never send it. So "no sessions" misreads as "not active".

## Fix

- `server.js /api/device-summary`: when no devices are found, fall back to the member's newest `source="api"` Loki line (user_id is an indexed label — one cheap targeted query) and return it as `lastApiActivity`, also feeding `lastaccess` so the "Last active" header shows.
- `ModSupportAIAssistant.vue`: the empty state now says *"Active on the server side 7h ago, but their device sends no telemetry — usually an ad/tracker blocker, or an app from before client logging"* instead of the bare "no sessions" line. Members with genuinely no activity keep the old text.
- Documented the device panel (previously undocumented) in `docs/developers/reference/ai-support-helper.md`, including the best-effort nature of client telemetry.

## Verification

- Diagnosed against prod Loki: the exact panel query returns 0 streams for this member; api-source query returns their activity with the correct last-seen time.
- `node --check server.js` passes; eslint --fix run on the Vue component; `scripts/check-docs-freshness.mjs` passes.
- CI runs the full suites (not run locally per project convention on this host).

After merge the helper container needs a rebuild on the FD host (`docker compose build ai-support-helper && docker compose up -d --no-deps ai-support-helper`); the ModTools change ships via the normal CI → production → Netlify flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)