### PR TITLE
fix(mail): respect users' anonymous-profile setting in email avatars

### DIFF
--- a/iznik-batch/app/Models/User.php
+++ b/iznik-batch/app/Models/User.php
@@ -891,6 +891,16 @@ class User extends Model implements Auditable
      */
     public function getProfileImageUrl(bool $thumbnail = TRUE): ?string
     {
+        // Users can turn off "use profile picture" (settings.useprofile), which the
+        // website honours by showing a generated avatar instead.  Emails must honour
+        // it too — the stored image is often harvested from their Google/Gravatar
+        // account, which an anonymous user never chose to publish.  Deleted users'
+        // profiles are suppressed as well, matching iznik-server-go.
+        $settings = $this->settings ?? [];
+        if (!($settings['useprofile'] ?? TRUE) || $this->deleted) {
+            return NULL;
+        }
+
         // Find the user's profile image, preferring the default one.
         $profileImage = UserImage::where('userid', $this->id)
             ->orderByDesc('default')

--- a/iznik-batch/app/Services/StoriesNewsletterService.php
+++ b/iznik-batch/app/Services/StoriesNewsletterService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Mail\Stories\StoriesNewsletterMail;
 use App\Mail\Traits\FeatureFlags;
 use App\Models\Group;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
@@ -93,7 +94,7 @@ class StoriesNewsletterService
                 }
             }
 
-            $userRecord = DB::table('users')->where('id', $story->userid)->first();
+            $userRecord = User::find($story->userid);
             $userName = null;
             if ($userRecord) {
                 $userName = $userRecord->fullname
@@ -101,19 +102,10 @@ class StoriesNewsletterService
                     ?: null;
             }
 
-            $profileImg = DB::table('users_images')
-                ->where('userid', $story->userid)
-                ->orderByDesc('default')
-                ->orderBy('id')
-                ->first(['id', 'url']);
-            $profileUrl = null;
-            if ($profileImg) {
-                if (!empty($profileImg->url) && !str_contains($profileImg->url, 'defaultprofile.png')) {
-                    $profileUrl = $profileImg->url;
-                } elseif (empty($profileImg->url)) {
-                    $imagesDomain = config('freegle.images.domain', 'https://images.ilovefreegle.org');
-                    $profileUrl = "{$imagesDomain}/tuimg_{$profileImg->id}.jpg";
-                }
+            // getProfileImageUrl respects the user's useprofile (anonymous) setting.
+            $profileUrl = $userRecord?->getProfileImageUrl();
+            if ($profileUrl && str_contains($profileUrl, 'defaultprofile.png')) {
+                $profileUrl = null;
             }
 
             $storyData[] = [

--- a/iznik-batch/tests/Unit/Mail/Traits/AvatarResolverTest.php
+++ b/iznik-batch/tests/Unit/Mail/Traits/AvatarResolverTest.php
@@ -82,6 +82,28 @@ class AvatarResolverTest extends TestCase
         $this->assertStringContainsString('user.png', $url);
     }
 
+    public function test_uploaded_image_not_used_when_useprofile_false(): void
+    {
+        // Regression: a member with an anonymous profile (settings.useprofile =
+        // false) received a digest showing the image harvested from their Google
+        // account. Emails must fall back to the generated avatar, like the website.
+        config(['freegle.avatar_server_url' => 'https://avatars.example.com/api']);
+
+        $user = $this->createTestUser();
+        $user->settings = ['useprofile' => false];
+        $user->save();
+        \App\Models\UserImage::create([
+            'userid' => $user->id,
+            'url' => 'https://lh3.googleusercontent.com/harvested.jpg',
+            'default' => 0,
+        ]);
+
+        $url = $this->host->resolveAvatarUrl($user, 36);
+
+        $this->assertStringNotContainsString('googleusercontent', $url);
+        $this->assertStringStartsWith('https://avatars.example.com/api/', $url);
+    }
+
     public function test_avatar_server_url_is_configured_so_avatars_resolve_to_real_endpoint(): void
     {
         // Regression: config/freegle.php had no avatar_server_url key, so config()

--- a/iznik-batch/tests/Unit/Models/UserModelTest.php
+++ b/iznik-batch/tests/Unit/Models/UserModelTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use App\Models\Membership;
 use App\Models\User;
 use App\Models\UserEmail;
+use App\Models\UserImage;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -468,6 +469,64 @@ class UserModelTest extends TestCase
         $result = $user->getProfileImageUrl();
 
         $this->assertNull($result);
+    }
+
+    public function test_get_profile_image_url_returns_image_by_default(): void
+    {
+        $user = $this->createTestUser();
+        UserImage::create([
+            'userid' => $user->id,
+            'url' => 'https://example.com/harvested.jpg',
+            'default' => 0,
+        ]);
+
+        $this->assertEquals('https://example.com/harvested.jpg', $user->getProfileImageUrl());
+    }
+
+    public function test_get_profile_image_url_returns_image_when_useprofile_true(): void
+    {
+        $user = $this->createTestUser();
+        $user->settings = ['useprofile' => true];
+        $user->save();
+        UserImage::create([
+            'userid' => $user->id,
+            'url' => 'https://example.com/harvested.jpg',
+            'default' => 0,
+        ]);
+
+        $this->assertEquals('https://example.com/harvested.jpg', $user->getProfileImageUrl());
+    }
+
+    public function test_get_profile_image_url_null_when_useprofile_false(): void
+    {
+        // Matches iznik-server-go GetProfileRecord: a user who has turned off
+        // "use profile picture" (an anonymous profile on the website) must not
+        // have their image used in emails either.
+        $user = $this->createTestUser();
+        $user->settings = ['useprofile' => false];
+        $user->save();
+        UserImage::create([
+            'userid' => $user->id,
+            'url' => 'https://example.com/harvested.jpg',
+            'default' => 0,
+        ]);
+
+        $this->assertNull($user->getProfileImageUrl());
+    }
+
+    public function test_get_profile_image_url_null_when_user_deleted(): void
+    {
+        // Matches iznik-server-go: deleted users' profiles are suppressed.
+        $user = $this->createTestUser();
+        $user->deleted = now();
+        $user->save();
+        UserImage::create([
+            'userid' => $user->id,
+            'url' => 'https://example.com/harvested.jpg',
+            'default' => 0,
+        ]);
+
+        $this->assertNull($user->getProfileImageUrl());
     }
 
     public function test_get_user_key_creates_new_key(): void


### PR DESCRIPTION
## Summary
- Members can turn off "use profile picture" (`settings.useprofile`) — the website honours it (iznik-server-go `GetProfileRecord`), but the Laravel mailers never checked it. `User::getProfileImageUrl()` returned the `users_images` row — often a photo harvested from the member's Google/Gravatar account at login — so digests, chat notifications, matched-post and stories emails showed an image the member had chosen not to publish, to every recipient.
- Fixed at the model choke point: `getProfileImageUrl()` now returns null when `useprofile` is false or the user is deleted, mirroring iznik-server-go `user.go` (line ~761). All callers (`AvatarResolver` trait → UnifiedDigest / MatchedPosts / NotificationChaseUp / NewsfeedModNotif, `ChatNotification`, `SendAdminCommand`) then fall back to the generated boring-avatar, matching what the website shows for an anonymous profile.
- `StoriesNewsletterService` read `users_images` directly, bypassing the model — switched to `getProfileImageUrl()` (keeps the existing `defaultprofile.png` guard).

Reported by a Wilmslow member (user 43200004) whose first daily digest showed their Google account photo despite an anonymous profile; verified their record resolves to the generated avatar with this change.

## Code Quality Review
- Default when the setting is absent is TRUE, matching Go's `CASE WHEN ... IS NULL THEN 1`.
- Audited every `users_images` consumer: UserDataExportService (self-export) and DumpUserCommand (support dump) intentionally untouched; UserManagementService only deletes rows; VisualiseService already had its own `allowsProfile()` check.
- No existing tests asserted the old behaviour.

## Test Plan
- `UserModelTest`: image returned by default / with `useprofile=true`; null with `useprofile=false`; null when deleted.
- `AvatarResolverTest`: end-to-end regression — user with harvested image + `useprofile=false` resolves to the avatar server, never the uploaded URL.
- Suite not runnable on this host (prod-only batch container) — CI validates; `php -l` clean on all four files.