### PR TITLE
fix(rippling): stop /rippling/metrics timing out - drop the KPI queries nothing reads

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -337,3 +337,36 @@ Design spec: `docs/superpowers/specs/2026-06-22-digest-rippling-score-ordering-d
 - `messages_groups.rippled_in = 1` - marks a rippled-in copy (vs the origin membership).
 - `rippling_proximity` - cached "quicker to get to" P/Q points per (msgid, groupid).
 - `logs` `text='Rippled'` - the ripple-join marker used for rejoin suppression.
+
+## 10. The sysadmin analytics tab
+
+One ModTools component (`modtools/components/ModSysAdminRipplingAnalytics.vue`) reads three
+apiv2 surfaces, deliberately split so no single request can exceed the production gateway's
+timeout:
+
+- `/rippling/analytics` (`rippling/analytics.go`) - the KPIs, trends and "is rippling helping?"
+  section. Every query anchors on `rippling_reach` (one row per rippled post, bounded by
+  `created_at`), which is what keeps it selective.
+- `/rippling/metrics` (`rippling/metrics.go`) - reply attribution channels, geographic hotspots,
+  held-reply friction. Small rippling-owned tables only.
+- `/rippling/analytics/drivetime[/score|/aggregate]` - the sampled routing pass, driven from the
+  client one chunk at a time.
+
+**A gateway timeout here does not look like a timeout.** The 504 carries no
+`Access-Control-Allow-Origin` header, so the browser reports a CORS policy error and the real
+cause (slow SQL) is invisible from the console. Two rules follow, both learned the hard way:
+
+1. Never add a query that scans `messages_groups` or `chat_messages` over the dashboard's window
+   to these endpoints. Rippling now writes 5-8k `rippled_in` rows a day, so ~75% of a 30-day
+   `messages_groups` slice is rippled-in rows: per-day reply-rate / taken-rate / distance KPIs
+   built that way measured 40-190s **each** on production. Anchor on `rippling_reach` instead, or
+   drive the work from the client in chunks.
+2. Bound the DB work with a deadline, not just the request context. fasthttp closes
+   `RequestCtx.Done()` only when the **server** shuts down - never on a client disconnect - so a
+   browser or gateway that gives up cancels nothing, and each retry stacks another full set of
+   queries on top of the ones still running. `/rippling/metrics` therefore wraps the request
+   context in a 20s `context.WithTimeout` and names any section that hits it in a `degraded`
+   array, so "we gave up" reaches the dashboard instead of rendering as "no data".
+
+The component loads the three surfaces independently: a failure or delay in one fills in its own
+panels late (or reports its own error there) rather than blanking the tab.

--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -348,7 +348,9 @@ timeout:
   section. Every query anchors on `rippling_reach` (one row per rippled post, bounded by
   `created_at`), which is what keeps it selective.
 - `/rippling/metrics` (`rippling/metrics.go`) - reply attribution channels, geographic hotspots,
-  held-reply friction. Small rippling-owned tables only.
+  held-reply friction. Small rippling-owned tables only, plus the live-capture boundary date,
+  which is cached per process because its query ORs three unindexed nullable columns and so
+  full-scans `rippling_reply_attribution`.
 - `/rippling/analytics/drivetime[/score|/aggregate]` - the sampled routing pass, driven from the
   client one chunk at a time.
 

--- a/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
@@ -384,6 +384,17 @@
             :options="channelStackOptions()"
             style="width: 100%; height: 320px"
           />
+          <p v-else-if="metricsLoading" class="sub">Loading…</p>
+          <p v-else-if="metricsError" class="sub text-danger">
+            Couldn't load reply attribution: {{ metricsError }}
+          </p>
+          <p
+            v-else-if="metricsDegraded.includes('reply_source_split')"
+            class="sub text-danger"
+          >
+            Reply attribution timed out on the server — not "no data", we don't
+            know.
+          </p>
           <p v-else class="sub">
             No attribution data yet — accrues from reply-time capture.
           </p>
@@ -423,7 +434,21 @@
             </b-td>
           </b-tr>
           <b-tr v-if="!hotspots.length">
-            <b-td colspan="6" class="text-muted">
+            <b-td v-if="metricsLoading" colspan="6" class="text-muted">
+              Loading…
+            </b-td>
+            <b-td v-else-if="metricsError" colspan="6" class="text-danger">
+              Couldn't load hotspots: {{ metricsError }}
+            </b-td>
+            <b-td
+              v-else-if="metricsDegraded.includes('hotspots')"
+              colspan="6"
+              class="text-danger"
+            >
+              Hotspots timed out on the server — not "no hotspots", we don't
+              know.
+            </b-td>
+            <b-td v-else colspan="6" class="text-muted">
               No hotspots flagged — nothing unusual to act on.
             </b-td>
           </b-tr>
@@ -454,7 +479,7 @@ const strata = [
 
 const loading = ref(true)
 const error = ref(null)
-// Time-based progress for the initial KPI + metrics fetch. The backend runs it as
+// Time-based progress for the KPI fetch. The backend runs it as
 // one request with no progress feed, so we ease a bar toward ~95% over the
 // expected duration (real completion snaps it to 100%) to show a wide, slow
 // window is working rather than frozen.
@@ -484,11 +509,21 @@ const drivePct = computed(() =>
 // large enough to keep the number of round-trips (and the progress bar's granularity) sensible.
 const DRIVE_CHUNK = 5
 // Folded in from the retired dashboard: reply-source attribution + geographic hotspots
-// (fetched in parallel from the metrics endpoint, which already computes them).
+// (fetched alongside the KPIs from the metrics endpoint, which already computes them).
 const replySource = ref([])
 const hotspots = ref([])
 const attributionCaptureFrom = ref('')
 const heldBySource = ref([])
+// The metrics request feeds only those panels, so it gets its own loading/error state: a failure
+// there must not blank the KPIs, the trends or the drive-time pass, which come from a different
+// endpoint. The panels say what went wrong instead of silently reading as "no data".
+const metricsLoading = ref(false)
+const metricsError = ref(null)
+// Sections the server gave up on (its query hit the endpoint's deadline). They come back empty,
+// which would otherwise read as "nothing to show" rather than "we don't know".
+const metricsDegraded = ref([])
+// The start|end the loaded metrics sections belong to, so a density change doesn't refetch them.
+let metricsWindow = null
 
 const stratumLabel = computed(() =>
   stratum.value === 'all' ? 'all-density' : stratum.value
@@ -745,23 +780,20 @@ async function fetchAnalytics() {
   loading.value = true
   error.value = null
   startLoadProgress()
+  // Kick the metrics request off alongside the KPIs but do NOT await it here. It only feeds the
+  // reply-attribution and hotspot panels; awaiting it as part of the tab's success meant one slow
+  // or failed metrics call took the whole tab down with it (and skipped the drive-time pass).
+  loadMetrics()
   try {
-    const [result, metrics] = await Promise.all([
-      apiInstance.rippling.fetchAnalytics(
-        stratum.value,
-        startDate.value,
-        endDate.value
-      ),
-      apiInstance.rippling.fetchMetrics(0, startDate.value, endDate.value),
-    ])
+    const result = await apiInstance.rippling.fetchAnalytics(
+      stratum.value,
+      startDate.value,
+      endDate.value
+    )
     s1.value = result?.section1 || null
     s2.value = result?.section2 || { kpis: [], drive_time: [] }
     s3.value = result?.section3 || null
     bull.value = result?.bullseye || []
-    replySource.value = metrics?.reply_source_split || []
-    hotspots.value = metrics?.hotspots || []
-    attributionCaptureFrom.value = metrics?.attribution_capture_from || ''
-    heldBySource.value = metrics?.held_reply_by_source || []
   } catch (e) {
     error.value = e.message || 'Unknown error'
   } finally {
@@ -772,6 +804,44 @@ async function fetchAnalytics() {
   // KPIs are on screen, not blocking them — the drive panels show their own spinner meanwhile.
   // Skip it if the KPIs failed: there are no panels to fill, so don't hit the routing graph.
   if (!error.value && s1.value) loadDriveTimes()
+}
+
+// Reply attribution + hotspots, from the metrics endpoint. Independent of the KPI request above,
+// so it fills its panels in when it arrives and reports its own failure if it doesn't.
+async function loadMetrics() {
+  // Remember which window this pass is for, so a slow in-flight response can't overwrite the
+  // panels after the user has moved to a different one.
+  const forStart = startDate.value
+  const forEnd = endDate.value
+  const isStale = () => forStart !== startDate.value || forEnd !== endDate.value
+  // These sections vary by window only - not by density - so a density change reuses what is
+  // already on screen rather than blanking the panels and refetching the same rows. A previous
+  // failure is worth retrying, though.
+  const window = forStart + '|' + forEnd
+  if (metricsWindow === window && !metricsError.value) return
+  metricsWindow = window
+  metricsLoading.value = true
+  metricsError.value = null
+  metricsDegraded.value = []
+  replySource.value = []
+  hotspots.value = []
+  attributionCaptureFrom.value = ''
+  heldBySource.value = []
+  try {
+    const metrics = await apiInstance.rippling.fetchMetrics(0, forStart, forEnd)
+    if (isStale()) return
+    replySource.value = metrics?.reply_source_split || []
+    hotspots.value = metrics?.hotspots || []
+    attributionCaptureFrom.value = metrics?.attribution_capture_from || ''
+    heldBySource.value = metrics?.held_reply_by_source || []
+    metricsDegraded.value = metrics?.degraded || []
+  } catch (e) {
+    if (isStale()) return
+    metricsError.value = e.message || 'Unknown error'
+  } finally {
+    // Only clear the spinner if a newer request hasn't already taken over.
+    if (!isStale()) metricsLoading.value = false
+  }
 }
 
 async function loadDriveTimes() {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
@@ -218,6 +218,8 @@ describe('ModSysAdminRipplingAnalytics', () => {
     mockFetchAnalyticsDriveTimes.mockReset()
     mockScoreAnalyticsDriveTimes.mockReset()
     mockAggregateAnalyticsDriveTimes.mockReset()
+    mockFetchMetrics.mockReset()
+    mockFetchMetrics.mockResolvedValue({})
     mockFetchAnalyticsDriveTimes.mockResolvedValue({
       posts: [DRIVE_SAMPLE_POST],
       total: 1,
@@ -327,6 +329,78 @@ describe('ModSysAdminRipplingAnalytics', () => {
     wrapper.unmount()
   })
 
+  // The metrics endpoint feeds only the attribution + hotspot panels. It used to be awaited in the
+  // same Promise.all as the KPIs, so when it 504'd on production (its heavy KPI queries ran for
+  // minutes, and a gateway timeout reads to the browser as a CORS failure) the whole tab showed
+  // "Failed to load" and the drive-time pass never started.
+  it('still renders the KPIs when the metrics request fails, and says so in its panels', async () => {
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
+    mockFetchMetrics.mockRejectedValue(new Error('Network Error'))
+    const wrapper = mountComponent()
+    await flushPromises()
+    const html = wrapper.html()
+
+    expect(html).toContain('51.2%') // Section 1 KPI still rendered
+    expect(html).not.toContain('Failed to load:') // the tab-level error banner stays away
+    // The panels that DID depend on it report the failure rather than reading as "no data".
+    expect(html).toContain("Couldn't load reply attribution")
+    expect(html).toContain("Couldn't load hotspots")
+    // ...and the slow drive-time pass still ran.
+    expect(mockFetchAnalyticsDriveTimes).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  // The server names any section whose query hit its deadline, so an empty panel is not passed
+  // off as "nothing to show" when it means "we gave up".
+  it('distinguishes a section the server gave up on from one with no data', async () => {
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
+    mockFetchMetrics.mockResolvedValue({
+      reply_source_split: [],
+      hotspots: [],
+      degraded: ['reply_source_split', 'hotspots'],
+    })
+    const wrapper = mountComponent()
+    await flushPromises()
+    const html = wrapper.html()
+    expect(html).toContain('Reply attribution timed out on the server')
+    expect(html).toContain('Hotspots timed out on the server')
+    expect(html).not.toContain('No attribution data yet')
+    expect(html).not.toContain('No hotspots flagged')
+    wrapper.unmount()
+  })
+
+  it('renders the KPIs before the metrics request has resolved', async () => {
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
+    let resolveMetrics
+    mockFetchMetrics.mockReturnValue(
+      new Promise((resolve) => {
+        resolveMetrics = resolve
+      })
+    )
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    // KPIs are on screen with the metrics call still in flight.
+    expect(wrapper.html()).toContain('51.2%')
+    expect(wrapper.html()).not.toContain('Anomaly Town')
+
+    resolveMetrics({
+      hotspots: [
+        {
+          area_name: 'Anomaly Town',
+          metric: 'secondary_reject_rate',
+          value: 0.9,
+          baseline: 0.1,
+          deviation: 12.3,
+          severity: 'alert',
+        },
+      ],
+    })
+    await flushPromises()
+    expect(wrapper.html()).toContain('Anomaly Town')
+    wrapper.unmount()
+  })
+
   it('draws the reliability bullseye: a ring per drive-time band, empty rings greyed', async () => {
     mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
     const wrapper = mountComponent()
@@ -364,6 +438,7 @@ describe('ModSysAdminRipplingAnalytics', () => {
     expect(buttons[1].classes()).not.toContain('active')
 
     mockFetchAnalytics.mockClear()
+    mockFetchMetrics.mockClear()
     await buttons[1].trigger('click') // Rural
     await flushPromises()
     expect(mockFetchAnalytics).toHaveBeenCalledWith(
@@ -371,7 +446,22 @@ describe('ModSysAdminRipplingAnalytics', () => {
       '2026-06-24',
       '2026-07-08'
     )
+    // The metrics sections vary by window, not density, so they are not refetched (and the
+    // panels don't blank) just because the density changed.
+    expect(mockFetchMetrics).not.toHaveBeenCalled()
     expect(wrapper.findAll('.seg-btn')[1].classes()).toContain('active')
+    wrapper.unmount()
+  })
+
+  it('refetches the metrics sections when the date window changes', async () => {
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    mockFetchMetrics.mockClear()
+    wrapper.vm.onFilterFetch({ start: '2026-05-01', end: '2026-05-31' })
+    await flushPromises()
+    expect(mockFetchMetrics).toHaveBeenCalledWith(0, '2026-05-01', '2026-05-31')
     wrapper.unmount()
   })
 

--- a/iznik-server-go/rippling/analytics.go
+++ b/iznik-server-go/rippling/analytics.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
 )
 
 // Package-level analytics endpoint for the sysadmin rippling tab. Everything here is computed
@@ -300,8 +301,7 @@ func bullseyeFromObs(obs []driveObs) []BullseyeBand {
 // stratum, tagging each reply rippled-out server-side. rippled-out = the replier reached the
 // post via rippling: not an established member of an ORIGIN group before arrival, on a post that
 // had a rippled_in copy by reply time. (The same durable signal the attribution ladder uses.)
-func fetchDriveSample(start, end, stratumSQL string, sampleN int) []samplePost {
-	db := database.DBConn
+func fetchDriveSample(db *gorm.DB, start, end, stratumSQL string, sampleN int) []samplePost {
 	type row struct {
 		Msgid   uint64
 		Plat    float64
@@ -408,7 +408,9 @@ func analyticsWindow(c *fiber.Ctx) (stratum, start, end, stratumSQL string) {
 }
 
 func Analytics(c *fiber.Ctx) error {
-	db := database.DBConn
+	// Bound to the request context so an abandoned request (the gateway giving up, the user
+	// switching window) stops its DB work rather than running on behind a response nobody reads.
+	db := database.DBConn.WithContext(c.Context())
 	stratum, start, end, stratumSQL := analyticsWindow(c)
 
 	// Section 1 counts - pure SQL, full set. Per-post nreplies/taken/freeglers, then aggregate.
@@ -480,13 +482,13 @@ func Analytics(c *fiber.Ctx) error {
 	// per arrival day. The sample-based drive-time trend is merged in client-side from the
 	// separate drive-time request.
 	trend := fiber.Map{
-		"kpis":       trendSeries(start, end, stratumSQL),
+		"kpis":       trendSeries(db, start, end, stratumSQL),
 		"drive_time": []DriveTrendPoint{},
 	}
 
 	// Section 3 - is rippling helping? Server-derived rippled-out shares, the rescue floor and
 	// contribution range, and the home-vs-rippled comparison. RippleDrive fills in separately.
-	s3 := rippledOutSection(start, end, stratumSQL)
+	s3 := rippledOutSection(db, start, end, stratumSQL)
 
 	return c.JSON(fiber.Map{
 		"stratum":       stratum,
@@ -530,7 +532,7 @@ func Analytics(c *fiber.Ctx) error {
 // Fast (one sampling query, no routing).
 func AnalyticsDriveTimes(c *fiber.Ctx) error {
 	stratum, start, end, stratumSQL := analyticsWindow(c)
-	posts := fetchDriveSample(start, end, stratumSQL, driveSampleSize())
+	posts := fetchDriveSample(database.DBConn.WithContext(c.Context()), start, end, stratumSQL, driveSampleSize())
 	wire := make([]samplePostWire, len(posts))
 	for i, p := range posts {
 		wire[i] = samplePostWire{Lat: p.lat, Lng: p.lng, Points: p.points, Rippled: p.rippled, Days: p.days, Takers: p.takers}
@@ -627,9 +629,9 @@ type TrendRow struct {
 }
 
 // trendSeries returns per-day KPI points (ascending) over the window + stratum. Pure SQL.
-func trendSeries(start, end, stratumSQL string) []TrendRow {
+func trendSeries(db *gorm.DB, start, end, stratumSQL string) []TrendRow {
 	rows := []TrendRow{}
-	database.DBConn.Raw(`
+	db.Raw(`
 		SELECT DATE_FORMAT(created, '%Y-%m-%d') AS day,
 		       COUNT(*) AS posts,
 		       100 * SUM(nreplies > 0) / COUNT(*) AS replied_pct,
@@ -688,7 +690,7 @@ type Section3RippledOut struct {
 
 // rippledOutSection computes the server-derived rippled-out reply/taker shares (pure SQL) over
 // replies to rippled posts in the window + stratum.
-func rippledOutSection(start, end, stratumSQL string) Section3RippledOut {
+func rippledOutSection(db *gorm.DB, start, end, stratumSQL string) Section3RippledOut {
 	var raw struct {
 		Replies        int
 		RippledReplies int
@@ -696,7 +698,7 @@ func rippledOutSection(start, end, stratumSQL string) Section3RippledOut {
 		RippledTakers  int
 		ClientRippled  int
 	}
-	database.DBConn.Raw(`
+	db.Raw(`
 		SELECT COUNT(*) AS replies,
 		       SUM(rippled) AS rippled_replies,
 		       SUM(is_taker) AS takers,
@@ -722,7 +724,7 @@ func rippledOutSection(start, end, stratumSQL string) Section3RippledOut {
 	// Rescue floor: DISTINCT posts that were taken AND had at least one reply AND had NO reply
 	// from an established home-group member - so the take could only have come via rippling.
 	var rescued int
-	database.DBConn.Raw(`
+	db.Raw(`
 		SELECT COUNT(*) FROM (
 		    SELECT rr.msgid
 		    FROM rippling_reach rr

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
 )
 
 // MetricsDeadline caps the DB work behind /rippling/metrics. Every section reads a small
@@ -183,6 +184,61 @@ func ReplySourceSplitSQL(wide bool, srcGroup string) string {
 		) b
 		GROUP BY day
 		ORDER BY day DESC`
+}
+
+// captureFromCached holds the live-capture boundary once we have found it. Guarded by
+// captureFromMu; empty means "not found yet", never "known to be none".
+var captureFromMu sync.RWMutex
+var captureFromCached string
+
+// attributionCaptureFrom returns the first day (YYYY-MM-DD) carrying evidence that only the
+// reply-time capture writes - location containment or a client-reported surface, which the
+// backfill never sets. The dashboard draws it as a boundary on the attribution chart: before it
+// the location channels are structurally zero (those replies sit in unknown), after it the full
+// split applies. Deliberately unscoped by ?groupid= - it marks a deploy moment, not a per-group
+// property.
+//
+// Cached for the life of the process, because the query cannot use an index: it ORs three
+// nullable columns, so it full-scans rippling_reply_attribution - a table that grows with every
+// reply, and the next thing here that would have crept past the gateway timeout. Caching is safe
+// because the answer cannot change once found: it is a MIN over an append-only table whose new
+// rows are always later, and an existing row never gains capture evidence afterwards.
+//
+// An empty answer is NOT cached - it means capture has not written anything yet, so the boundary
+// is still to come and must be looked for again.
+func attributionCaptureFrom(db *gorm.DB) (string, error) {
+	if cached := cachedCaptureFrom(); cached != "" {
+		return cached, nil
+	}
+
+	var day string
+	err := db.Raw("SELECT COALESCE(DATE_FORMAT(MIN(replied_at), '%Y-%m-%d'), '') " +
+		"FROM rippling_reply_attribution " +
+		"WHERE in_origin_catchment IS NOT NULL OR in_reach IS NOT NULL " +
+		"OR client_source IS NOT NULL").Scan(&day).Error
+	if err != nil {
+		return "", err
+	}
+	rememberCaptureFrom(day)
+	return day, nil
+}
+
+func cachedCaptureFrom() string {
+	captureFromMu.RLock()
+	defer captureFromMu.RUnlock()
+	return captureFromCached
+}
+
+// rememberCaptureFrom keeps a found boundary for the rest of the process. An empty day is
+// deliberately not remembered: it means capture has written nothing yet, so the boundary is still
+// to come and caching it would leave the chart unmarked until the next restart.
+func rememberCaptureFrom(day string) {
+	if day == "" {
+		return
+	}
+	captureFromMu.Lock()
+	defer captureFromMu.Unlock()
+	captureFromCached = day
 }
 
 // Metrics returns the rippling-out event counters plus the §15/§16 rollout-health metrics.
@@ -404,20 +460,15 @@ func Metrics(c *fiber.Ctx) error {
 			ORDER BY count DESC`, gargs()...).Scan(&clientSources).Error
 	})
 
-	// (1c) When did LIVE capture start? The first row carrying evidence only the reply-time
-	//      capture can write (location containment or a client-reported surface - the backfill
-	//      never sets those). The dashboard draws this as a boundary on the attribution chart:
-	//      before it the location channels are structurally zero (those replies sit in
-	//      unknown), after it the full split applies. Deliberately unscoped by ?groupid=
-	//      (it marks a deploy moment, not a per-group property).
+	// (1c) When did LIVE capture start? See attributionCaptureFrom - answered from cache after
+	//      the first time, because the query behind it cannot use an index.
 	section("attribution_capture_from", func() error {
 		if !attributionWide {
 			return nil
 		}
-		return db.Raw("SELECT COALESCE(DATE_FORMAT(MIN(replied_at), '%Y-%m-%d'), '') " +
-			"FROM rippling_reply_attribution " +
-			"WHERE in_origin_catchment IS NOT NULL OR in_reach IS NOT NULL " +
-			"OR client_source IS NOT NULL").Scan(&captureFrom).Error
+		var err error
+		captureFrom, err = attributionCaptureFrom(db)
+		return err
 	})
 
 	// (2) Groups whose posts rippled inside the window - the ?groupid= filter options.

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -3,12 +3,21 @@
 package rippling
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/gofiber/fiber/v2"
 )
+
+// MetricsDeadline caps the DB work behind /rippling/metrics. Every section reads a small
+// rippling-owned table, so a healthy request is orders of magnitude inside this; it exists to
+// make sure a pathological one fails fast and visibly (see the `degraded` response field)
+// instead of holding queries open behind a response the gateway has already given up on.
+// A var rather than a const so tests can shrink it to prove the degraded path.
+var MetricsDeadline = 20 * time.Second
 
 // EventMetric is one (day, event, count) counter row. For the totals roll-up `Day` is empty.
 type EventMetric struct {
@@ -69,18 +78,6 @@ type HeldBySource struct {
 	Count  int64  `json:"count"  gorm:"column:count"`
 }
 
-// CrossGroupSummary reports the share of post appearances that were rippled in by the engine
-// (messages_groups.rippled_in = 1) and what fraction of those were approved vs rejected. This
-// directly measures §16.3 — "cross-group reach: fraction of posts from groups the viewer was
-// not a member of before."
-type CrossGroupSummary struct {
-	PeriodDays    int     `json:"period_days"`
-	RippledIn     int64   `json:"rippled_in"`
-	Total         int64   `json:"total"`
-	CrossGroupPct float64 `json:"cross_group_pct"`
-	ApprovalRate  float64 `json:"approval_rate"`
-}
-
 // CaptureSummary is the most-recent week's timing/capture picture from the offline simulator
 // (rippling_algorithm_metrics, renamed from ripple_algorithm_metrics). Reports the 'all'-group
 // row for the latest week so the dashboard can answer "are repliers being reached in time?"
@@ -94,50 +91,6 @@ type CaptureSummary struct {
 	CaptureRate float64 `json:"capture_rate"` // computed in Go, not from DB
 	ReplyP50H   float64 `json:"reply_p50_hours" gorm:"column:reply_p50_hours"`
 	ReplyP75H   float64 `json:"reply_p75_hours" gorm:"column:reply_p75_hours"`
-}
-
-// ReplyRateRow is the headline KPI per arrival day: of Offers that arrived that day (and whose
-// full 36h window has elapsed, so the figure is complete), what fraction received at least one
-// Interested reply within 36h. This is the "are we turning 0-reply posts into 1-reply posts"
-// number. Computed live from messages + chat_messages, so it works over all history with no
-// instrumentation and no capture (reply timestamps don't change).
-// HomePosts/RipplePosts partition Posts by whether the post has any rippled-in messages_groups row.
-type ReplyRateRow struct {
-	Day      string  `json:"day"     gorm:"column:day"`
-	Posts    int     `json:"posts"   gorm:"column:posts"`
-	Replied  int     `json:"replied" gorm:"column:replied"`
-	ReplyPct float64 `json:"reply_pct"` // computed in Go
-
-	HomePosts   int     `json:"home_posts"   gorm:"column:home_posts"`
-	HomeReplied int     `json:"home_replied" gorm:"column:home_replied"`
-	HomePct     float64 `json:"home_pct"` // computed in Go
-
-	RipplePosts   int     `json:"ripple_posts"   gorm:"column:ripple_posts"`
-	RippleReplied int     `json:"ripple_replied" gorm:"column:ripple_replied"`
-	RipplePct     float64 `json:"ripple_pct"` // computed in Go
-
-	Provisional bool `json:"provisional"` // computed in Go (day within the 36h settling window)
-}
-
-// RepliesPerPostRow is the mean number of Interested replies a post got within 36h, per arrival day,
-// split into home-only vs rippled-out cohorts. Where reply RATE (ReplyRateRow) asks "did a post get
-// any reply", this asks "how many" - so it shows whether rippling lifts the depth of interest, not
-// just its presence. Means are computed in Go; counts come from SQL.
-type RepliesPerPostRow struct {
-	Day         string  `json:"day"          gorm:"column:day"`
-	Posts       int     `json:"posts"        gorm:"column:posts"`
-	Replies     int     `json:"replies"      gorm:"column:replies"`
-	MeanReplies float64 `json:"mean_replies"` // computed in Go (Replies / Posts)
-
-	HomePosts   int     `json:"home_posts"   gorm:"column:home_posts"`
-	HomeReplies int     `json:"home_replies" gorm:"column:home_replies"`
-	HomeMean    float64 `json:"home_mean"` // computed in Go
-
-	RipplePosts   int     `json:"ripple_posts"   gorm:"column:ripple_posts"`
-	RippleReplies int     `json:"ripple_replies" gorm:"column:ripple_replies"`
-	RippleMean    float64 `json:"ripple_mean"` // computed in Go
-
-	Provisional bool `json:"provisional"` // computed in Go (day within the 36h settling window)
 }
 
 // ReplySourceRow is the daily split of Interested replies by attribution channel (the graded
@@ -172,42 +125,8 @@ type ClientSourceCount struct {
 	Count  int    `json:"count"  gorm:"column:count"`
 }
 
-// ReplyDistanceRow is the daily median crow-flies distance (km) from a post's location to the
-// replier's home location, over Interested replies - how far rippling is pulling replies from.
-// HomeMedianKm/RippleMedianKm split the median by whether the post was rippled-out.
-type ReplyDistanceRow struct {
-	Day      string  `json:"day"       gorm:"column:day"`
-	Replies  int     `json:"replies"   gorm:"column:replies"`
-	MedianKm float64 `json:"median_km" gorm:"column:median_km"`
-
-	HomeReplies    int     `json:"home_replies"     gorm:"column:home_replies"`
-	HomeMedianKm   float64 `json:"home_median_km"   gorm:"column:home_median_km"`
-	RippleReplies  int     `json:"ripple_replies"   gorm:"column:ripple_replies"`
-	RippleMedianKm float64 `json:"ripple_median_km" gorm:"column:ripple_median_km"`
-}
-
-// TakenRateRow is the daily reuse outcome: of posts that arrived that day (and have had a settling
-// window to find a taker), what fraction reached a Taken (offer) or Received (wanted) outcome.
-// HomePosts/RipplePosts partition Posts by whether the post has any rippled-in messages_groups row.
-type TakenRateRow struct {
-	Day      string  `json:"day"   gorm:"column:day"`
-	Posts    int     `json:"posts" gorm:"column:posts"`
-	Taken    int     `json:"taken" gorm:"column:taken"`
-	TakenPct float64 `json:"taken_pct"` // computed in Go
-
-	HomePosts int     `json:"home_posts" gorm:"column:home_posts"`
-	HomeTaken int     `json:"home_taken" gorm:"column:home_taken"`
-	HomePct   float64 `json:"home_pct"` // computed in Go
-
-	RipplePosts int     `json:"ripple_posts" gorm:"column:ripple_posts"`
-	RippleTaken int     `json:"ripple_taken" gorm:"column:ripple_taken"`
-	RipplePct   float64 `json:"ripple_pct"` // computed in Go
-
-	Provisional bool `json:"provisional"` // computed in Go (day within the 7-day settling window)
-}
-
-// GroupOption is one entry in the per-group KPI filter: a group whose posts have rippled, so its
-// KPIs are worth viewing on their own (the experiment groups surface here once they ripple).
+// GroupOption is one entry in the per-group filter: a group whose posts rippled inside the
+// requested window, so its reply-source split is worth viewing on its own.
 type GroupOption struct {
 	ID   uint64 `json:"id"   gorm:"column:id"`
 	Name string `json:"name" gorm:"column:name"`
@@ -270,11 +189,31 @@ func ReplySourceSplitSQL(wide bool, srcGroup string) string {
 // Events: reply_blocked (#2), held/released/taken_gone (#3), secondary_reject (#6),
 // immediate_mailed (#0), rippled_in (#6). Support/Admin only.
 //
-// New §16 fields (all defensive — empty/zero when source tables are not yet populated):
+// §16 fields (all defensive — empty/zero when source tables are not yet populated):
 //   - live_metrics: volume_posts p50/p90 + secondary_reject_rate from the weekly batch rollup.
 //   - held_reply_summary: counts by status + median hold duration (§15 friction).
-//   - cross_group_summary: rippled-in share + approval rate over the last 30 days (§16.3).
 //   - capture_summary: latest offline-simulator week for timing / capture rate (§16.4).
+//   - reply_source_split: per-day reply attribution channels (§16.3 cross-group reach).
+//
+// EVERY query here reads a small rippling-owned table (or a window-bounded slice of
+// rippling_reply_attribution), so the whole endpoint returns in well under the production
+// gateway's timeout. That is a constraint, not an accident: the per-day reply-rate,
+// replies-per-post, reply-distance, taken-rate and 30-day cross-group KPIs that used to be
+// computed here each scanned messages_groups/chat_messages over the window, and once rippling
+// scaled up (late June 2026 — 75% of a 30-day messages_groups slice is now rippled-in rows) they
+// took 40-190s EACH on production. The gateway killed the request, and its 504 carries no
+// Access-Control-Allow-Origin header, so the dashboard reported a misleading CORS error while
+// the abandoned queries kept running and the client retried on top of them.
+//
+// They are gone rather than split behind their own endpoints because nothing read them: the old
+// ModSysAdminRippling dashboard was retired in 6982b1ee3 (8 Jul 2026) and the equivalent
+// reply-rate / taken-rate / mean-replies KPIs now come from /rippling/analytics, which anchors on
+// rippling_reach instead of scanning messages_groups. Splitting would not have helped anyway —
+// each individual query was already over the gateway timeout on its own.
+//
+// If a heavyweight KPI is ever wanted back here, it needs the /rippling/analytics treatment (a
+// selective anchor table) or client-driven chunking like AnalyticsDriveTimes — not a bigger
+// timeout.
 //
 // @Router /rippling/metrics [get]
 // @Summary Rippling-out live event counters and §16 rollout-health metrics (sysadmin)
@@ -284,14 +223,22 @@ func ReplySourceSplitSQL(wide bool, srcGroup string) string {
 // @Success 200 {object} map[string]interface{}
 // @Failure 403 {object} fiber.Error "Support or Admin role required"
 func Metrics(c *fiber.Ctx) error {
-	db := database.DBConn
+	// Hard deadline on the DB work, comfortably inside the production gateway's timeout, so this
+	// endpoint always answers rather than leaving queries grinding behind a request that has
+	// already been abandoned. It cannot be left to the request context alone: fasthttp closes
+	// RequestCtx.Done() only when the SERVER shuts down, never on a client disconnect (see the
+	// note on RequestCtx.Err in fasthttp/server.go), so a client that gives up cancels nothing.
+	// That is how one slow load became a pile-up - the dashboard retried, and each retry stacked
+	// another full set of queries on top of the ones still running.
+	ctx, cancel := context.WithTimeout(c.Context(), MetricsDeadline)
+	defer cancel()
+	db := database.DBConn.WithContext(ctx)
 
-	// ---- Reply + reuse KPIs: parse params first so arg-builder closures can capture them ----
-	// Optional ?groupid= scopes every KPI below to posts ORIGINATING in that group (its
-	// rippled_in=0 messages_groups row), so results read per place - dense Croydon won't look
-	// like rural Ribble Valley. 0 = all groups. Each scoped query takes one gid arg.
+	// Optional ?groupid= scopes the reply-source split to replies on posts ORIGINATING in that
+	// group (its rippled_in=0 messages_groups row), so results read per place - dense Croydon
+	// won't look like rural Ribble Valley. 0 = all groups. Each scoped query takes one gid arg.
 	gid := c.QueryInt("groupid", 0)
-	// Optional ?start= & ?end= date range bounds every KPI below; default to the last 30 days.
+	// Optional ?start= & ?end= bound the windowed sections; default to the last 30 days.
 	// This is what lets you read a group's before vs after rippling went on.
 	start := c.Query("start")
 	end := c.Query("end")
@@ -303,13 +250,14 @@ func Metrics(c *fiber.Ctx) error {
 	}
 	// Whether the graded-attribution columns exist yet (production may lag the migration):
 	// picks the reply-source query variant and is surfaced to the dashboard so it can note
-	// that the location-based channels are pending.
-	attributionWide := AttributionSchemaReady(db)
-	rateGroup, srcGroup, distGroup := "", "", ""
+	// that the location-based channels are pending. Deliberately NOT on the deadline-bound
+	// handle: it is a one-off information_schema lookup whose answer is cached for the life of
+	// the process, so letting a deadline make it fail would stick this API on the legacy variant
+	// until the next restart.
+	attributionWide := AttributionSchemaReady(database.DBConn)
+	srcGroup := ""
 	if gid > 0 {
-		rateGroup = " AND mg.groupid = ? AND mg.rippled_in = 0"
 		srcGroup = " JOIN messages_groups mg ON mg.msgid = rra.msgid AND mg.groupid = ? AND mg.rippled_in = 0 AND mg.deleted = 0"
-		distGroup = " JOIN messages_groups mg ON mg.msgid = m.id AND mg.groupid = ? AND mg.rippled_in = 0 AND mg.deleted = 0"
 	}
 	// Per-query args: the group filter (when set) sits in a JOIN before the date-bounded WHERE,
 	// so gid comes first, then start, end.
@@ -321,40 +269,6 @@ func Metrics(c *fiber.Ctx) error {
 		return append(a, start, end)
 	}
 
-	// replyRateArgs orders args to match the SQL: optional group filter, then the `rip`
-	// subquery lower bound (start), then the fr-subquery window (start, end), then the
-	// outer arrival window (start, end).
-	// Parallel in structure to takenRateArgs — keep the two in sync.
-	//
-	// The rip subquery (first ripple per msgid) is bounded to windowStart rather than a
-	// fixed NOW()-100 DAY: a post only appears in the outer set when its ORIGIN
-	// (rippled_in=0) row's arrival is in [start, end), and a ripple can only happen after
-	// the post is posted, so first_ripple >= origin arrival >= start. Bounding to start
-	// therefore never drops a first_ripple for an in-window post, but lets the optimiser
-	// use the arrival index (a selective range) instead of scanning most of
-	// messages_groups via the deleted index to find the ~1.6% of rows that are
-	// rippled_in=1 — the difference between this query taking ~20s and ~4s.
-	replyRateArgs := func(groupID int, windowStart, windowEnd string) []interface{} {
-		a := []interface{}{}
-		if groupID > 0 {
-			a = append(a, groupID)
-		}
-		return append(a, windowStart, windowStart, windowEnd, windowStart, windowEnd)
-	}
-
-	// takenRateArgs orders args to match the SQL: optional group filter, then the `rip`
-	// subquery lower bound (start), then the outcomes subquery lower bound (start), then
-	// the outer arrival window (start, end).
-	// Parallel in structure to replyRateArgs — keep the two in sync. See replyRateArgs for
-	// why the rip subquery is bounded to windowStart.
-	takenRateArgs := func(groupID int, windowStart, windowEnd string) []interface{} {
-		a := []interface{}{}
-		if groupID > 0 {
-			a = append(a, groupID)
-		}
-		return append(a, windowStart, windowStart, windowStart, windowEnd)
-	}
-
 	// ---- Declare all result variables up front so goroutines can capture them --------
 	totals := []EventMetric{}
 	recent := []EventMetric{}
@@ -363,198 +277,103 @@ func Metrics(c *fiber.Ctx) error {
 	liveMetrics := []LiveMetricRow{}
 	heldReplySummary := []HeldReplySummary{}
 	heldBySource := []HeldBySource{}
-	type crossGroupRaw struct {
-		Total           int64 `gorm:"column:total"`
-		RippledIn       int64 `gorm:"column:rippled_in"`
-		ApprovedRippled int64 `gorm:"column:approved_rippled"`
-	}
-	var cg crossGroupRaw
 	var capture CaptureSummary
-	replyRates := []ReplyRateRow{}
-	repliesPerPost := []RepliesPerPostRow{}
 	replySources := []ReplySourceRow{}
 	clientSources := []ClientSourceCount{}
 	captureFrom := ""
-	replyDistances := []ReplyDistanceRow{}
-	takenRates := []TakenRateRow{}
 	groupOpts := []GroupOption{}
 
 	// ---- Run all independent DB queries concurrently --------------------------------
+	// A section's query error is ignored on purpose: a table or column may not exist yet on a DB
+	// that lags the migrations, and the panel simply omits that piece. The one error worth
+	// reporting is the deadline - "we gave up" must not be served as an empty "nothing to show",
+	// so those sections are named in `degraded` and the dashboard says so.
 	var wg sync.WaitGroup
+	var mu sync.Mutex
+	degraded := []string{}
+	section := func(name string, run func() error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := run()
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+				mu.Lock()
+				degraded = append(degraded, name)
+				mu.Unlock()
+			}
+		}()
+	}
 
-	// §15 raw event counters – errors ignored on purpose (table may not exist yet).
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT '' AS day, event, COALESCE(SUM(count), 0) AS count " +
-			"FROM rippling_event_metrics GROUP BY event ORDER BY event").Scan(&totals)
-	}()
+	// §15 raw event counters.
+	section("totals", func() error {
+		return db.Raw("SELECT '' AS day, event, COALESCE(SUM(count), 0) AS count " +
+			"FROM rippling_event_metrics GROUP BY event ORDER BY event").Scan(&totals).Error
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT DATE_FORMAT(day, '%Y-%m-%d') AS day, event, count " +
+	section("recent", func() error {
+		return db.Raw("SELECT DATE_FORMAT(day, '%Y-%m-%d') AS day, event, count " +
 			"FROM rippling_event_metrics WHERE day >= CURDATE() - INTERVAL 30 DAY " +
-			"ORDER BY day DESC, event").Scan(&recent)
-	}()
+			"ORDER BY day DESC, event").Scan(&recent).Error
+	})
 
 	// §16 tuner hotspots – defensive; empty until PR G ships the table.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT DATE_FORMAT(period_start, '%Y-%m-%d') AS period_start, area_type, area_id, " +
+	section("hotspots", func() error {
+		return db.Raw("SELECT DATE_FORMAT(period_start, '%Y-%m-%d') AS period_start, area_type, area_id, " +
 			"COALESCE(area_name, '') AS area_name, metric, value, baseline, deviation, direction, severity " +
 			"FROM rippling_hotspots WHERE detected_at >= NOW() - INTERVAL 30 DAY " +
-			"ORDER BY (severity = 'alert') DESC, ABS(deviation) DESC LIMIT 100").Scan(&hotspots)
-	}()
+			"ORDER BY (severity = 'alert') DESC, ABS(deviation) DESC LIMIT 100").Scan(&hotspots).Error
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT ons_category, max_minutes, COALESCE(rationale, '') AS rationale, " +
+	section("proposed_params", func() error {
+		return db.Raw("SELECT ons_category, max_minutes, COALESCE(rationale, '') AS rationale, " +
 			"DATE_FORMAT(proposed_at, '%Y-%m-%d %H:%i') AS proposed_at " +
-			"FROM rippling_params WHERE status = 'proposed' ORDER BY ons_category").Scan(&proposed)
-	}()
+			"FROM rippling_params WHERE status = 'proposed' ORDER BY ons_category").Scan(&proposed).Error
+	})
 
 	// §16.1 / §16.2 volume + reach: overall live-metrics from weekly batch rollup.
 	// Returns the two most recent weekly periods' overall rows so the dashboard can show a
 	// trend. Defensive: returns empty if rippling_live_metrics doesn't exist yet.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT DATE_FORMAT(period_start, '%Y-%m-%d') AS period_start, metric, value, sample_size " +
+	section("live_metrics", func() error {
+		return db.Raw("SELECT DATE_FORMAT(period_start, '%Y-%m-%d') AS period_start, metric, value, sample_size " +
 			"FROM rippling_live_metrics " +
 			"WHERE stratum_type = 'overall' AND period_type = 'weekly' " +
 			"AND period_start >= CURDATE() - INTERVAL 14 DAY " +
-			"ORDER BY period_start DESC, metric").Scan(&liveMetrics)
-	}()
+			"ORDER BY period_start DESC, metric").Scan(&liveMetrics).Error
+	})
 
 	// §15 / §16.5 held-reply friction summary.
 	// Live aggregate of rippling_held_replies by status, with median hold duration for
 	// released rows. Defensive: returns empty if rippling_held_replies doesn't exist yet.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT status, COUNT(*) AS count, " +
+	section("held_reply_summary", func() error {
+		return db.Raw("SELECT status, COUNT(*) AS count, " +
 			"COALESCE(AVG(TIMESTAMPDIFF(SECOND, created_at, COALESCE(releasedat, NOW())) / 3600.0), 0) AS median_hold_hours " +
 			"FROM rippling_held_replies " +
-			"GROUP BY status ORDER BY status").Scan(&heldReplySummary)
-	}()
+			"GROUP BY status ORDER BY status").Scan(&heldReplySummary).Error
+	})
 
 	// Held replies broken down by origin channel (email / tn / web). Defensive: the `source`
 	// column is added by migration 2026_07_08_000001 — before it runs the query errors and the
 	// slice stays empty (the panel just omits the breakdown), which is fine.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT source, status, COUNT(*) AS count " +
-			"FROM rippling_held_replies GROUP BY source, status ORDER BY source, status").Scan(&heldBySource)
-	}()
-
-	// §16.3 cross-group reach summary (last 30 days).
-	// Uses messages_groups.rippled_in (added by migration 2026_06_18_000004). Measures
-	// what fraction of post appearances were rippled in by the engine, and of those, what
-	// fraction were approved (not rejected). Defensive: returns zero struct if column absent.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT " +
-			"COUNT(*) AS total, " +
-			"COALESCE(SUM(rippled_in), 0) AS rippled_in, " +
-			"COALESCE(SUM(CASE WHEN rippled_in = 1 AND collection = 'Approved' THEN 1 ELSE 0 END), 0) AS approved_rippled " +
-			"FROM messages_groups " +
-			"WHERE arrival >= CURDATE() - INTERVAL 30 DAY " +
-			"AND deleted = 0").Scan(&cg)
-	}()
+	section("held_reply_by_source", func() error {
+		return db.Raw("SELECT source, status, COUNT(*) AS count " +
+			"FROM rippling_held_replies GROUP BY source, status ORDER BY source, status").Scan(&heldBySource).Error
+	})
 
 	// §16.4 timing / capture: latest offline-simulator week.
 	// Reads the most recent 'all'-group row from rippling_algorithm_metrics (renamed from
 	// ripple_algorithm_metrics by migration 2026_06_18_000002). Returns zero struct if the
 	// table is empty or doesn't exist yet.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT DATE_FORMAT(week_start, '%Y-%m-%d') AS week_start, curve, " +
+	section("capture_summary", func() error {
+		return db.Raw("SELECT DATE_FORMAT(week_start, '%Y-%m-%d') AS week_start, curve, " +
 			"pairs_total, pairs_in_time, pairs_late, " +
 			"COALESCE(reply_p50_hours, 0) AS reply_p50_hours, " +
 			"COALESCE(reply_p75_hours, 0) AS reply_p75_hours " +
 			"FROM rippling_algorithm_metrics " +
 			"WHERE `group` = 'all' " +
-			"ORDER BY week_start DESC LIMIT 1").Scan(&capture)
-	}()
+			"ORDER BY week_start DESC LIMIT 1").Scan(&capture).Error
+	})
 
-	// (1) % of Offers with a reply within 36h, per arrival day.
-	// The fr subquery is bounded to the requested window (+ 36h slack) so it doesn't
-	// scan the full chat_messages history. The young-cut (arrival < NOW()-36h) is removed
-	// because the window end already controls which days are complete.
-	// Parallel in structure to query (4) (taken rate) — keep the two in sync.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw(`
-			SELECT day,
-			       COUNT(*) AS posts,
-			       SUM(replied) AS replied,
-			       SUM(1 - is_rippled) AS home_posts, -- is_rippled is 0/1 from EXISTS (never NULL)
-			       SUM(CASE WHEN is_rippled = 0 THEN replied ELSE 0 END) AS home_replied,
-			       SUM(is_rippled) AS ripple_posts,
-			       SUM(CASE WHEN is_rippled = 1 THEN replied ELSE 0 END) AS ripple_replied
-			FROM (
-			    SELECT m.id,
-			           DATE_FORMAT(COALESCE(rip.first_ripple, mg.arrival), '%Y-%m-%d') AS day,
-			           MAX(CASE WHEN fr.first_reply <= COALESCE(rip.first_ripple, mg.arrival) + INTERVAL 36 HOUR THEN 1 ELSE 0 END) AS replied,
-			           (rip.first_ripple IS NOT NULL) AS is_rippled
-			    FROM messages m
-			    JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0 AND mg.rippled_in = 0`+rateGroup+`
-			    LEFT JOIN (SELECT msgid, MIN(arrival) AS first_ripple FROM messages_groups WHERE rippled_in = 1 AND deleted = 0 AND arrival >= ? GROUP BY msgid) rip ON rip.msgid = m.id
-			    LEFT JOIN (
-			        SELECT refmsgid, MIN(date) AS first_reply FROM chat_messages
-			        WHERE type = 'Interested' AND date >= ? AND date < (? + INTERVAL 36 HOUR) GROUP BY refmsgid
-			    ) fr ON fr.refmsgid = m.id
-			    WHERE m.type = 'Offer'
-			      AND mg.arrival >= ? AND mg.arrival < ?
-			    GROUP BY m.id, COALESCE(rip.first_ripple, mg.arrival)
-			) per_msg
-			GROUP BY day
-			ORDER BY day DESC`, replyRateArgs(gid, start, end)...).Scan(&replyRates)
-	}()
-
-	// (1b) Mean number of Interested replies per Offer within 36h, per arrival day, split by cohort.
-	// Mirrors query (1) exactly (same arg order via replyRateArgs) but COUNTs replies instead of
-	// asking did-any-reply. COUNT(DISTINCT cm.id) because a post sits in several messages_groups rows
-	// (it can ripple into many groups), which would otherwise multiply the reply count.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw(`
-			SELECT day,
-			       COUNT(*) AS posts,
-			       SUM(reply_count) AS replies,
-			       SUM(1 - is_rippled) AS home_posts, -- is_rippled is 0/1 from EXISTS (never NULL)
-			       SUM(CASE WHEN is_rippled = 0 THEN reply_count ELSE 0 END) AS home_replies,
-			       SUM(is_rippled) AS ripple_posts,
-			       SUM(CASE WHEN is_rippled = 1 THEN reply_count ELSE 0 END) AS ripple_replies
-			FROM (
-			    SELECT m.id,
-			           DATE_FORMAT(COALESCE(rip.first_ripple, mg.arrival), '%Y-%m-%d') AS day,
-			           COUNT(DISTINCT cm.id) AS reply_count,
-			           (rip.first_ripple IS NOT NULL) AS is_rippled
-			    FROM messages m
-			    JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0 AND mg.rippled_in = 0`+rateGroup+`
-			    LEFT JOIN (SELECT msgid, MIN(arrival) AS first_ripple FROM messages_groups WHERE rippled_in = 1 AND deleted = 0 AND arrival >= ? GROUP BY msgid) rip ON rip.msgid = m.id
-			    LEFT JOIN chat_messages cm
-			           ON cm.refmsgid = m.id AND cm.type = 'Interested'
-			          AND cm.date >= ? AND cm.date < (? + INTERVAL 36 HOUR)
-			          AND cm.date >= COALESCE(rip.first_ripple, mg.arrival) AND cm.date < COALESCE(rip.first_ripple, mg.arrival) + INTERVAL 36 HOUR
-			    WHERE m.type = 'Offer'
-			      AND mg.arrival >= ? AND mg.arrival < ?
-			    GROUP BY m.id, COALESCE(rip.first_ripple, mg.arrival)
-			) per_msg
-			GROUP BY day
-			ORDER BY day DESC`, replyRateArgs(gid, start, end)...).Scan(&repliesPerPost)
-	}()
-
-	// (2) Reply attribution channels, per day, from rippling_reply_attribution (captured at
+	// (1) Reply attribution channels, per day, from rippling_reply_attribution (captured at
 	//     reply time - the only sound attribution, since replying joins the member to the group).
 	//     Two variants sharing one output shape:
 	//     - wide: read the attribution channel the Go reply handler derived at capture time.
@@ -566,168 +385,58 @@ func Metrics(c *fiber.Ctx) error {
 	//       are not derivable retrospectively (locations drift, polygons grow) so they read 0
 	//       and those replies sit in unknown - attribution_channels_available tells the
 	//       dashboard to say so.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw(ReplySourceSplitSQL(attributionWide, srcGroup), gargs()...).Scan(&replySources)
-	}()
+	section("reply_source_split", func() error {
+		return db.Raw(ReplySourceSplitSQL(attributionWide, srcGroup), gargs()...).Scan(&replySources).Error
+	})
 
-	// (2b) Client-reported reply surfaces over the same window (wide schema only - the column
-	//      arrives with the graded-attribution migration). Advisory cross-check of (2).
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	// (1b) Client-reported reply surfaces over the same window (wide schema only - the column
+	//      arrives with the graded-attribution migration). Advisory cross-check of (1).
+	section("client_source_summary", func() error {
 		if !attributionWide {
-			return
+			return nil
 		}
-		db.Raw(`
+		return db.Raw(`
 			SELECT COALESCE(rra.client_source, '(not reported)') AS source,
 			       COUNT(*) AS count
 			FROM rippling_reply_attribution rra`+srcGroup+`
 			WHERE rra.replied_at >= ? AND rra.replied_at < ?
 			GROUP BY source
-			ORDER BY count DESC`, gargs()...).Scan(&clientSources)
-	}()
+			ORDER BY count DESC`, gargs()...).Scan(&clientSources).Error
+	})
 
-	// (2c) When did LIVE capture start? The first row carrying evidence only the reply-time
+	// (1c) When did LIVE capture start? The first row carrying evidence only the reply-time
 	//      capture can write (location containment or a client-reported surface - the backfill
 	//      never sets those). The dashboard draws this as a boundary on the attribution chart:
 	//      before it the location channels are structurally zero (those replies sit in
 	//      unknown), after it the full split applies. Deliberately unscoped by ?groupid=
 	//      (it marks a deploy moment, not a per-group property).
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	section("attribution_capture_from", func() error {
 		if !attributionWide {
-			return
+			return nil
 		}
-		db.Raw("SELECT COALESCE(DATE_FORMAT(MIN(replied_at), '%Y-%m-%d'), '') " +
+		return db.Raw("SELECT COALESCE(DATE_FORMAT(MIN(replied_at), '%Y-%m-%d'), '') " +
 			"FROM rippling_reply_attribution " +
 			"WHERE in_origin_catchment IS NOT NULL OR in_reach IS NOT NULL " +
-			"OR client_source IS NOT NULL").Scan(&captureFrom)
-	}()
+			"OR client_source IS NOT NULL").Scan(&captureFrom).Error
+	})
 
-	// (3) Median crow-flies distance (km) from post to replier, per reply day. The origin-group
-	//     join is added only when filtering (avoids multi-group row inflation in the all view).
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw(`
-			SELECT day,
-			       MAX(cnt_all) AS replies,
-			       AVG(CASE WHEN rn_all IN (FLOOR((cnt_all + 1) / 2), FLOOR((cnt_all + 2) / 2)) THEN dist_km END) AS median_km,
-			       MAX(CASE WHEN is_rippled = 0 THEN cnt_coh ELSE 0 END) AS home_replies,
-			       AVG(CASE WHEN is_rippled = 0 AND rn_coh IN (FLOOR((cnt_coh + 1) / 2), FLOOR((cnt_coh + 2) / 2)) THEN dist_km END) AS home_median_km,
-			       MAX(CASE WHEN is_rippled = 1 THEN cnt_coh ELSE 0 END) AS ripple_replies,
-			       AVG(CASE WHEN is_rippled = 1 AND rn_coh IN (FLOOR((cnt_coh + 1) / 2), FLOOR((cnt_coh + 2) / 2)) THEN dist_km END) AS ripple_median_km
-			FROM (
-			  SELECT day, dist_km, is_rippled,
-			         ROW_NUMBER() OVER (PARTITION BY day ORDER BY dist_km)              AS rn_all,
-			         COUNT(*)     OVER (PARTITION BY day)                                AS cnt_all,
-			         ROW_NUMBER() OVER (PARTITION BY day, is_rippled ORDER BY dist_km)   AS rn_coh,
-			         COUNT(*)     OVER (PARTITION BY day, is_rippled)                     AS cnt_coh
-			  FROM (
-			    SELECT DATE_FORMAT(cm.date, '%Y-%m-%d') AS day,
-			           ST_Distance_Sphere(POINT(ml.lng, ml.lat), POINT(ul.lng, ul.lat)) / 1000 AS dist_km,
-			           EXISTS (SELECT 1 FROM messages_groups mgr
-			                   WHERE mgr.msgid = m.id AND mgr.rippled_in = 1 AND mgr.deleted = 0 AND mgr.arrival <= cm.date) AS is_rippled
-			    FROM chat_messages cm
-			    JOIN messages m   ON m.id = cm.refmsgid AND m.type = 'Offer'`+distGroup+`
-			    JOIN locations ml ON ml.id = m.locationid
-			    JOIN users u      ON u.id = cm.userid
-			    JOIN locations ul ON ul.id = u.lastlocation
-			    WHERE cm.type = 'Interested' AND cm.date >= ? AND cm.date < ?
-			      AND ml.lat IS NOT NULL AND ul.lat IS NOT NULL
-			  ) d
-			) r
-			GROUP BY day
-			ORDER BY day DESC`, gargs()...).Scan(&replyDistances)
-	}()
-
-	// (4) Reuse outcome: % of posts (Offers taken / Wanteds received) per arrival day.
-	// The outcomes subquery is bounded to the requested window so it doesn't scan all
-	// history. The young-cut (arrival < NOW()-7d) is removed; the window end controls
-	// which days are complete.
-	// Parallel in structure to query (1) (reply rate) — keep the two in sync.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw(`
-			SELECT day,
-			       COUNT(*) AS posts,
-			       SUM(taken) AS taken,
-			       SUM(1 - is_rippled) AS home_posts, -- is_rippled is 0/1 from EXISTS (never NULL)
-			       SUM(CASE WHEN is_rippled = 0 THEN taken ELSE 0 END) AS home_taken,
-			       SUM(is_rippled) AS ripple_posts,
-			       SUM(CASE WHEN is_rippled = 1 THEN taken ELSE 0 END) AS ripple_taken
-			FROM (
-			    SELECT m.id,
-			           DATE_FORMAT(COALESCE(rip.first_ripple, mg.arrival), '%Y-%m-%d') AS day,
-			           MAX(CASE WHEN o.msgid IS NOT NULL THEN 1 ELSE 0 END) AS taken,
-			           (rip.first_ripple IS NOT NULL) AS is_rippled
-			    FROM messages m
-			    JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0 AND mg.rippled_in = 0`+rateGroup+`
-			    LEFT JOIN (SELECT msgid, MIN(arrival) AS first_ripple FROM messages_groups WHERE rippled_in = 1 AND deleted = 0 AND arrival >= ? GROUP BY msgid) rip ON rip.msgid = m.id
-			    LEFT JOIN (SELECT DISTINCT msgid FROM messages_outcomes
-			               WHERE outcome IN ('Taken','Received') AND timestamp >= ?) o
-			           ON o.msgid = m.id
-			    WHERE m.type IN ('Offer','Wanted')
-			      AND mg.arrival >= ? AND mg.arrival < ?
-			    GROUP BY m.id, COALESCE(rip.first_ripple, mg.arrival)
-			) per_msg
-			GROUP BY day
-			ORDER BY day DESC`, takenRateArgs(gid, start, end)...).Scan(&takenRates)
-	}()
-
-	// Groups whose posts have rippled - the per-group filter options (the experiment groups appear
-	// here once they ripple). Defensive: empty while rippling is dark.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		db.Raw("SELECT DISTINCT g.id AS id, g.nameshort AS name " +
-			"FROM rippling_reach rr " +
-			"JOIN messages_groups mg ON mg.msgid = rr.msgid AND mg.rippled_in = 0 AND mg.deleted = 0 " +
-			"JOIN `groups` g ON g.id = mg.groupid " +
-			"ORDER BY g.nameshort").Scan(&groupOpts)
-	}()
+	// (2) Groups whose posts rippled inside the window - the ?groupid= filter options.
+	// Bounded by the window (rippling_reach.created_at, its clustered-by-time column) rather than
+	// scanning every reach row ever written: the list is a filter for the windowed sections above,
+	// so groups that did not ripple in the window have nothing to filter to. Defensive: empty
+	// while rippling is dark.
+	section("groups", func() error {
+		return db.Raw("SELECT DISTINCT g.id AS id, g.nameshort AS name "+
+			"FROM rippling_reach rr "+
+			"JOIN messages_groups mg ON mg.msgid = rr.msgid AND mg.rippled_in = 0 AND mg.deleted = 0 "+
+			"JOIN `groups` g ON g.id = mg.groupid "+
+			"WHERE rr.created_at >= ? AND rr.created_at < ? "+
+			"ORDER BY g.nameshort", start, end).Scan(&groupOpts).Error
+	})
 
 	wg.Wait()
 
 	// ---- Post-processing (serial; all goroutines done) --------------------------------
-
-	// Compute derived percentage fields for reply-rate rows (overall + home/ripple cohorts).
-	// Days whose arrival is within 36h of now are still maturing (their 36h reply window hasn't
-	// fully elapsed) — flag them so the client dashes the tail. Day-granularity is enough for the
-	// visual; compare the ISO day string against the cutoff date. This is intentionally cautious:
-	// a day may be flagged provisional for a short window around midnight even once its settling
-	// window has fully elapsed (errs toward dashing one extra day, which is safe).
-	reply36hCutoff := time.Now().Add(-36 * time.Hour).Format("2006-01-02")
-	for i := range replyRates {
-		if replyRates[i].Posts > 0 {
-			replyRates[i].ReplyPct = float64(replyRates[i].Replied) / float64(replyRates[i].Posts) * 100
-		}
-		if replyRates[i].HomePosts > 0 {
-			replyRates[i].HomePct = float64(replyRates[i].HomeReplied) / float64(replyRates[i].HomePosts) * 100
-		}
-		if replyRates[i].RipplePosts > 0 {
-			replyRates[i].RipplePct = float64(replyRates[i].RippleReplied) / float64(replyRates[i].RipplePosts) * 100
-		}
-		replyRates[i].Provisional = replyRates[i].Day >= reply36hCutoff
-	}
-
-	// Mean replies per post (overall + cohorts). Same 36h settling window as the reply rate.
-	for i := range repliesPerPost {
-		if repliesPerPost[i].Posts > 0 {
-			repliesPerPost[i].MeanReplies = float64(repliesPerPost[i].Replies) / float64(repliesPerPost[i].Posts)
-		}
-		if repliesPerPost[i].HomePosts > 0 {
-			repliesPerPost[i].HomeMean = float64(repliesPerPost[i].HomeReplies) / float64(repliesPerPost[i].HomePosts)
-		}
-		if repliesPerPost[i].RipplePosts > 0 {
-			repliesPerPost[i].RippleMean = float64(repliesPerPost[i].RippleReplies) / float64(repliesPerPost[i].RipplePosts)
-		}
-		repliesPerPost[i].Provisional = repliesPerPost[i].Day >= reply36hCutoff
-	}
 
 	// Compute derived fields for reply-source rows. The headline ripple share counts only the
 	// channels that are DEFINITELY rippling - unknown is not credited (the old replies-minus-home
@@ -737,33 +446,6 @@ func Metrics(c *fiber.Ctx) error {
 		if replySources[i].Replies > 0 {
 			replySources[i].RipplePct = float64(replySources[i].Ripple) / float64(replySources[i].Replies) * 100
 		}
-	}
-
-	// Compute derived percentage fields for taken-rate rows (overall + home/ripple cohorts).
-	// The provisional flag is intentionally cautious: a day may be flagged provisional for a
-	// short window around midnight even once its settling window has fully elapsed (errs toward
-	// dashing one extra day, which is safe).
-	taken7dCutoff := time.Now().AddDate(0, 0, -7).Format("2006-01-02")
-	for i := range takenRates {
-		if takenRates[i].Posts > 0 {
-			takenRates[i].TakenPct = float64(takenRates[i].Taken) / float64(takenRates[i].Posts) * 100
-		}
-		if takenRates[i].HomePosts > 0 {
-			takenRates[i].HomePct = float64(takenRates[i].HomeTaken) / float64(takenRates[i].HomePosts) * 100
-		}
-		if takenRates[i].RipplePosts > 0 {
-			takenRates[i].RipplePct = float64(takenRates[i].RippleTaken) / float64(takenRates[i].RipplePosts) * 100
-		}
-		takenRates[i].Provisional = takenRates[i].Day >= taken7dCutoff
-	}
-
-	// Assemble the cross-group summary struct from the raw scan.
-	crossGroup := CrossGroupSummary{PeriodDays: 30, Total: cg.Total, RippledIn: cg.RippledIn}
-	if cg.Total > 0 {
-		crossGroup.CrossGroupPct = float64(cg.RippledIn) / float64(cg.Total) * 100
-	}
-	if cg.RippledIn > 0 {
-		crossGroup.ApprovalRate = float64(cg.ApprovedRippled) / float64(cg.RippledIn) * 100
 	}
 
 	// Compute capture rate from the offline-simulator summary.
@@ -779,10 +461,7 @@ func Metrics(c *fiber.Ctx) error {
 		"live_metrics":          liveMetrics,
 		"held_reply_summary":    heldReplySummary,
 		"held_reply_by_source":  heldBySource,
-		"cross_group_summary":   crossGroup,
 		"capture_summary":       capture,
-		"reply_rate_36h":        replyRates,
-		"replies_per_post":      repliesPerPost,
 		"reply_source_split":    replySources,
 		"client_source_summary": clientSources,
 		// False until the graded-attribution migration has run on this DB: the location
@@ -791,11 +470,12 @@ func Metrics(c *fiber.Ctx) error {
 		// First day with reply-time-captured evidence ('' until the capture deploy has seen
 		// a reply): the boundary the dashboard marks on the attribution chart.
 		"attribution_capture_from": captureFrom,
-		"reply_distance_median":    replyDistances,
-		"taken_rate":               takenRates,
 		"groups":                   groupOpts,
 		"groupid":                  gid,
 		"start":                    start,
 		"end":                      end,
+		// Sections whose query hit the deadline and so came back empty because we gave up, not
+		// because there is nothing to show. Normally empty; the dashboard says so when it isn't.
+		"degraded": degraded,
 	})
 }

--- a/iznik-server-go/rippling/metrics_test.go
+++ b/iznik-server-go/rippling/metrics_test.go
@@ -90,3 +90,30 @@ func TestReplySourceSplitSQL_BothWideValuesProduceDifferentSQL(t *testing.T) {
 	wide := ReplySourceSplitSQL(true, "")
 	assert.NotEqual(t, narrow, wide)
 }
+
+// The live-capture boundary is cached for the life of the process because the query behind it
+// full-scans rippling_reply_attribution (it ORs three unindexed nullable columns). Caching is
+// only sound one way round: a found date is fixed for ever, but a blank means capture has not
+// written anything YET - remembering that would leave the attribution chart unmarked until the
+// next restart, long after the first captured reply arrived.
+func TestCaptureFromCacheKeepsAFoundDate(t *testing.T) {
+	captureFromCached = ""
+	defer func() { captureFromCached = "" }()
+
+	rememberCaptureFrom("2026-07-07")
+	assert.Equal(t, "2026-07-07", cachedCaptureFrom(),
+		"a found boundary is served from cache instead of re-running the scan")
+}
+
+func TestCaptureFromCacheDoesNotRememberBlank(t *testing.T) {
+	captureFromCached = ""
+	defer func() { captureFromCached = "" }()
+
+	rememberCaptureFrom("")
+	assert.Empty(t, cachedCaptureFrom(), "no boundary yet means keep looking, not 'there is none'")
+
+	rememberCaptureFrom("2026-07-07")
+	rememberCaptureFrom("")
+	assert.Equal(t, "2026-07-07", cachedCaptureFrom(),
+		"a blank must never wipe a boundary already found")
+}

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
@@ -41,11 +40,20 @@ func TestRipplingMetricsEndpoint(t *testing.T) {
 	assert.True(t, found, "reply_blocked total present in the rollup")
 }
 
-// The mean-replies-per-post metric is surfaced as a well-formed cohort series. (Like the other
-// per-day reply metrics it carries no seeded fixture here; this guards the wiring + the response
-// shape - the SQL is validated separately, and the query mirrors the proven reply-rate one.)
-func TestRipplingMetricsRepliesPerPost(t *testing.T) {
-	prefix := uniquePrefix("ripplerpp")
+// This endpoint must only read small rippling-owned tables (or a window-bounded slice of
+// rippling_reply_attribution), so it always answers well inside the production gateway's
+// timeout. The per-day reply-rate / replies-per-post / reply-distance / taken-rate series and
+// the 30-day cross-group summary used to be computed here by scanning messages_groups and
+// chat_messages; once rippling scaled up they took 40-190s EACH on production, the gateway
+// 504'd (which the browser reports as a bogus CORS failure), and the client's retry piled more
+// of the same queries on top. Nothing read them - the dashboard that charted them was retired
+// in 6982b1ee3 and /rippling/analytics serves the equivalent KPIs from rippling_reach - so they
+// were removed rather than split behind their own (still-too-slow) endpoints.
+//
+// This guards that: those keys must not come back without the analytics-style rework, and the
+// sections the dashboard actually reads must still be there.
+func TestRipplingMetricsOmitsHeavyScanKPIs(t *testing.T) {
+	prefix := uniquePrefix("ripplefast")
 	adminID := CreateTestUser(t, prefix+"_admin", "Support")
 	_, token := CreateTestSession(t, adminID)
 
@@ -55,16 +63,52 @@ func TestRipplingMetricsRepliesPerPost(t *testing.T) {
 	var result map[string]interface{}
 	json.Unmarshal(rsp(resp), &result)
 
-	rpp, ok := result["replies_per_post"].([]interface{})
-	assert.True(t, ok, "replies_per_post field present in the response")
-	for _, row := range rpp {
-		m, ok := row.(map[string]interface{})
-		assert.True(t, ok, "each replies_per_post row is an object")
-		assert.Contains(t, m, "day")
-		assert.Contains(t, m, "mean_replies")
-		assert.Contains(t, m, "home_mean")
-		assert.Contains(t, m, "ripple_mean")
+	for _, key := range []string{"reply_rate_36h", "replies_per_post", "reply_distance_median",
+		"taken_rate", "cross_group_summary"} {
+		_, present := result[key]
+		assert.False(t, present, key+" is not computed here - it scanned messages_groups/chat_messages "+
+			"and blew the gateway timeout; /rippling/analytics serves the equivalent KPI")
 	}
+
+	// The sections ModSysAdminRipplingAnalytics.vue reads must still be served.
+	for _, key := range []string{"reply_source_split", "hotspots", "attribution_capture_from",
+		"held_reply_by_source"} {
+		_, present := result[key]
+		assert.True(t, present, key+" is read by the sysadmin analytics tab")
+	}
+
+	// Nothing should be hitting the endpoint's deadline on a healthy request.
+	degraded, ok := result["degraded"].([]interface{})
+	assert.True(t, ok, "degraded list present")
+	assert.Empty(t, degraded, "no section gave up")
+}
+
+// When a section's query does hit the deadline it comes back empty, which would read as
+// "nothing to show" - so the endpoint names it in `degraded` and the dashboard reports it as a
+// timeout rather than as no data. Proved by shrinking the deadline so every section trips it.
+func TestRipplingMetricsReportsDegradedSectionsOnDeadline(t *testing.T) {
+	prefix := uniquePrefix("rippledeadline")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	// Settle the graded-attribution schema check BEFORE shrinking the deadline. It caches its
+	// answer in a sync.Once for the life of the process, so letting it run first against the
+	// expired context would cache "legacy schema" and break every later test that expects the
+	// wide variant.
+	rippling.AttributionSchemaReady(database.DBConn)
+
+	restore := rippling.MetricsDeadline
+	rippling.MetricsDeadline = time.Nanosecond
+	defer func() { rippling.MetricsDeadline = restore }()
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
+	// Still a 200 with a well-formed body: the sections that made it are worth showing.
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	degraded, _ := result["degraded"].([]interface{})
+	assert.NotEmpty(t, degraded, "sections that gave up are named, not served as empty results")
 }
 
 // A non-admin must be forbidden from the sysadmin metrics endpoint.
@@ -150,31 +194,6 @@ func TestRipplingMetricsSurfacesLiveMetrics(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "volume_posts_p50 live metric surfaced in response")
-}
-
-// The endpoint returns a cross_group_summary computed live from messages_groups.rippled_in,
-// answering §16.3: what fraction of post appearances were rippled-in by the engine.
-func TestRipplingMetricsCrossGroupSummary(t *testing.T) {
-	prefix := uniquePrefix("ripplecross")
-	adminID := CreateTestUser(t, prefix+"_admin", "Support")
-	_, token := CreateTestSession(t, adminID)
-
-	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
-	assert.Equal(t, 200, resp.StatusCode)
-
-	var result map[string]interface{}
-	json.Unmarshal(rsp(resp), &result)
-
-	// cross_group_summary must always be present (it queries messages_groups which always exists)
-	// and period_days must be 30.
-	cg, ok := result["cross_group_summary"].(map[string]interface{})
-	assert.True(t, ok, "cross_group_summary field present in response")
-	assert.Equal(t, float64(30), cg["period_days"], "period_days is 30")
-	// totals/pcts are numeric (we can't assert exact values against a shared test DB)
-	_, hasTotal := cg["total"]
-	_, hasPct := cg["cross_group_pct"]
-	assert.True(t, hasTotal, "total field present")
-	assert.True(t, hasPct, "cross_group_pct field present")
 }
 
 // The endpoint returns a capture_summary from rippling_algorithm_metrics (§16.4 timing /
@@ -277,10 +296,8 @@ func TestRipplingMetricsHeldReplySummary(t *testing.T) {
 	assert.GreaterOrEqual(t, statusCounts["released"], float64(1), "at least 1 released row counted")
 }
 
-// The endpoint surfaces the three reply KPIs. reply_source_split is sourced from
-// rippling_reply_attribution (captured at reply time): a home row and a rippling row on the same
-// day must yield a 50% rippling share. reply_rate_36h and reply_distance_median are computed live
-// from messages/chat_messages and are always present arrays.
+// reply_source_split is sourced from rippling_reply_attribution (captured at reply time): a home
+// row and a rippling row on the same day must yield a 50% rippling share.
 func TestRipplingMetricsReplyKPIs(t *testing.T) {
 	prefix := uniquePrefix("ripplereply")
 	adminID := CreateTestUser(t, prefix+"_admin", "Support")
@@ -304,12 +321,8 @@ func TestRipplingMetricsReplyKPIs(t *testing.T) {
 	var result map[string]interface{}
 	json.Unmarshal(rsp(resp), &result)
 
-	// All three reply-KPI keys are present (arrays), and the graded columns are flagged live.
-	_, hasRate := result["reply_rate_36h"].([]interface{})
-	_, hasDist := result["reply_distance_median"].([]interface{})
+	// The split is present (an array), and the graded columns are flagged live.
 	split, hasSplit := result["reply_source_split"].([]interface{})
-	assert.True(t, hasRate, "reply_rate_36h present")
-	assert.True(t, hasDist, "reply_distance_median present")
 	assert.True(t, hasSplit, "reply_source_split present")
 	assert.Equal(t, true, result["attribution_channels_available"],
 		"graded columns exist on the migrated test DB")
@@ -375,220 +388,6 @@ func TestRipplingMetricsDateRange(t *testing.T) {
 	json.Unmarshal(rsp(respDefault), &rd)
 	assert.NotEmpty(t, rd["start"], "start defaults when absent")
 	assert.NotEmpty(t, rd["end"], "end defaults when absent")
-}
-
-// Stage A guard: bounding the outcomes subquery to the window must still count an
-// in-window Taken outcome. Seeds one Offer 3 days ago, marks it Taken, and asserts the
-// taken_rate row for that day reports posts>=1 and taken>=1.
-func TestRipplingMetricsTakenInWindowCounted(t *testing.T) {
-	prefix := uniquePrefix("rippletaken")
-	adminID := CreateTestUser(t, prefix+"_admin", "Support")
-	_, token := CreateTestSession(t, adminID)
-	posterID := CreateTestUser(t, prefix+"_poster", "User")
-	groupID := CreateTestGroup(t, prefix+"_grp")
-
-	db := database.DBConn
-	msgID := CreateTestMessage(t, posterID, groupID, prefix+" sofa", 51.5, -0.1)
-	db.Exec("UPDATE messages SET arrival = NOW() - INTERVAL 3 DAY WHERE id = ?", msgID)
-	db.Exec("UPDATE messages_groups SET arrival = NOW() - INTERVAL 3 DAY WHERE msgid = ?", msgID)
-	db.Exec("INSERT INTO messages_outcomes (timestamp, msgid, outcome) VALUES (NOW() - INTERVAL 2 DAY, ?, 'Taken')", msgID)
-	defer db.Exec("DELETE FROM messages_outcomes WHERE msgid = ?", msgID)
-	defer db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
-	defer db.Exec("DELETE FROM messages WHERE id = ?", msgID)
-
-	var wantDay string
-	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 3 DAY, '%Y-%m-%d')").Scan(&wantDay)
-
-	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
-	assert.Equal(t, 200, resp.StatusCode)
-	var result map[string]interface{}
-	json.Unmarshal(rsp(resp), &result)
-
-	taken, _ := result["taken_rate"].([]interface{})
-	found := false
-	for _, r := range taken {
-		if m, ok := r.(map[string]interface{}); ok && m["day"] == wantDay {
-			found = true
-			assert.GreaterOrEqual(t, m["posts"].(float64), float64(1), "the seeded post is counted")
-			assert.GreaterOrEqual(t, m["taken"].(float64), float64(1), "the Taken outcome is counted within the window")
-		}
-	}
-	assert.True(t, found, "the seeded day appears in taken_rate")
-}
-
-// Cohort split on reply_rate_36h: a home-only Offer (no rippled_in=1 row) and a rippled-out Offer
-// (has a rippled_in=1 row) arriving the same day. The rippled one gets an Interested reply within
-// 36h; the home one does not. Asserts the counts partition (home+ripple=posts) and the rippled
-// cohort shows the reply.
-func TestRipplingMetricsReplyRateCohorts(t *testing.T) {
-	prefix := uniquePrefix("ripplerc")
-	adminID := CreateTestUser(t, prefix+"_admin", "Support")
-	_, token := CreateTestSession(t, adminID)
-	posterID := CreateTestUser(t, prefix+"_poster", "User")
-	replierID := CreateTestUser(t, prefix+"_replier", "User")
-	homeGrp := CreateTestGroup(t, prefix+"_home")
-	awayGrp := CreateTestGroup(t, prefix+"_away")
-
-	db := database.DBConn
-	homeMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" homechair", 51.5, -0.1)
-	rippMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" rippchair", 51.5, -0.1)
-	for _, id := range []uint64{homeMsg, rippMsg} {
-		db.Exec("UPDATE messages SET arrival = NOW() - INTERVAL 5 DAY WHERE id = ?", id)
-		db.Exec("UPDATE messages_groups SET arrival = NOW() - INTERVAL 5 DAY WHERE msgid = ?", id)
-	}
-	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, rippled_in, autoreposts) "+
-		"VALUES (?, ?, NOW() - INTERVAL 5 DAY, 'Approved', 1, 0)", rippMsg, awayGrp)
-	chatID := CreateTestChatRoom(t, replierID, &posterID, &homeGrp, "User2User")
-	cmID := CreateTestChatMessage(t, chatID, replierID, "I'd like it")
-	db.Exec("UPDATE chat_messages SET type = 'Interested', refmsgid = ?, date = NOW() - INTERVAL 5 DAY + INTERVAL 1 HOUR WHERE id = ?", rippMsg, cmID)
-
-	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", homeMsg, rippMsg)
-	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
-	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", cmID)
-
-	var wantDay string
-	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 5 DAY, '%Y-%m-%d')").Scan(&wantDay)
-
-	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
-	assert.Equal(t, 200, resp.StatusCode)
-	var result map[string]interface{}
-	json.Unmarshal(rsp(resp), &result)
-
-	rate, _ := result["reply_rate_36h"].([]interface{})
-	var row map[string]interface{}
-	for _, r := range rate {
-		if m, ok := r.(map[string]interface{}); ok && m["day"] == wantDay {
-			row = m
-		}
-	}
-	assert.NotNil(t, row, "the seeded day appears in reply_rate_36h")
-	assert.Equal(t, row["posts"], row["home_posts"].(float64)+row["ripple_posts"].(float64), "post counts partition")
-	assert.GreaterOrEqual(t, row["ripple_posts"].(float64), float64(1), "the rippled-out post is in the ripple cohort")
-	assert.GreaterOrEqual(t, row["home_posts"].(float64), float64(1), "the home-only post is in the home cohort")
-	assert.GreaterOrEqual(t, row["ripple_replied"].(float64), float64(1), "the rippled-out post's reply is counted")
-	assert.Equal(t, float64(0), row["home_replied"], "the home-only post had no reply")
-}
-
-// Cohort split on taken_rate: a home-only Offer and a rippled-out Offer the same day; only the
-// rippled-out one is Taken. Asserts counts partition and the ripple cohort carries the take.
-func TestRipplingMetricsTakenRateCohorts(t *testing.T) {
-	prefix := uniquePrefix("rippletc")
-	adminID := CreateTestUser(t, prefix+"_admin", "Support")
-	_, token := CreateTestSession(t, adminID)
-	posterID := CreateTestUser(t, prefix+"_poster", "User")
-	homeGrp := CreateTestGroup(t, prefix+"_home")
-	awayGrp := CreateTestGroup(t, prefix+"_away")
-
-	db := database.DBConn
-	homeMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" homedesk", 51.5, -0.1)
-	rippMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" rippdesk", 51.5, -0.1)
-	for _, id := range []uint64{homeMsg, rippMsg} {
-		db.Exec("UPDATE messages SET arrival = NOW() - INTERVAL 5 DAY WHERE id = ?", id)
-		db.Exec("UPDATE messages_groups SET arrival = NOW() - INTERVAL 5 DAY WHERE msgid = ?", id)
-	}
-	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, rippled_in, autoreposts) "+
-		"VALUES (?, ?, NOW() - INTERVAL 5 DAY, 'Approved', 1, 0)", rippMsg, awayGrp)
-	db.Exec("INSERT INTO messages_outcomes (timestamp, msgid, outcome) VALUES (NOW() - INTERVAL 4 DAY, ?, 'Taken')", rippMsg)
-
-	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", homeMsg, rippMsg)
-	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
-	defer db.Exec("DELETE FROM messages_outcomes WHERE msgid IN (?, ?)", homeMsg, rippMsg)
-
-	var wantDay string
-	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 5 DAY, '%Y-%m-%d')").Scan(&wantDay)
-
-	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
-	assert.Equal(t, 200, resp.StatusCode)
-	var result map[string]interface{}
-	json.Unmarshal(rsp(resp), &result)
-
-	taken, _ := result["taken_rate"].([]interface{})
-	var row map[string]interface{}
-	for _, r := range taken {
-		if m, ok := r.(map[string]interface{}); ok && m["day"] == wantDay {
-			row = m
-		}
-	}
-	assert.NotNil(t, row, "the seeded day appears in taken_rate")
-	assert.Equal(t, row["posts"], row["home_posts"].(float64)+row["ripple_posts"].(float64), "post counts partition")
-	assert.GreaterOrEqual(t, row["ripple_taken"].(float64), float64(1), "the rippled-out take is in the ripple cohort")
-	assert.Equal(t, float64(0), row["home_taken"], "the home-only post was not taken")
-}
-
-// Cohort medians on reply_distance_median: a home-only post whose replier is near the post
-// and a rippled-out post whose replier is far away, replying the same day. Asserts both cohort
-// medians are present and ripple_median_km > home_median_km.
-// Uses explicit locations inserted at known coordinates so the test does not depend on what
-// locations happen to exist in the test DB at runtime.
-func TestRipplingMetricsDistanceCohorts(t *testing.T) {
-	prefix := uniquePrefix("rippledc")
-	adminID := CreateTestUser(t, prefix+"_admin", "Support")
-	_, token := CreateTestSession(t, adminID)
-	posterID := CreateTestUser(t, prefix+"_poster", "User")
-	nearReplier := CreateTestUser(t, prefix+"_near", "User")
-	farReplier := CreateTestUser(t, prefix+"_far", "User")
-	homeGrp := CreateTestGroup(t, prefix+"_home")
-	awayGrp := CreateTestGroup(t, prefix+"_away")
-
-	db := database.DBConn
-
-	// Insert explicit locations at known coordinates. Post location: London (51.5, -0.1).
-	// Near replier: same location as the post (~0 km away).
-	// Far replier: Edinburgh (55.95, -3.19) — ~535 km from London.
-	// Using name prefixed by uniquePrefix to avoid collisions.
-	// 'type' is required (NOT NULL); 'Point' is valid per the enum.
-	var postLocID, nearLocID, farLocID uint64
-	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Point', 51.5, -0.1)", prefix+"_postloc")
-	db.Raw("SELECT id FROM locations WHERE name = ?", prefix+"_postloc").Scan(&postLocID)
-	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Point', 51.5, -0.1)", prefix+"_nearloc")
-	db.Raw("SELECT id FROM locations WHERE name = ?", prefix+"_nearloc").Scan(&nearLocID)
-	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Point', 55.95, -3.19)", prefix+"_farloc")
-	db.Raw("SELECT id FROM locations WHERE name = ?", prefix+"_farloc").Scan(&farLocID)
-
-	defer db.Exec("DELETE FROM locations WHERE name IN (?, ?, ?)", prefix+"_postloc", prefix+"_nearloc", prefix+"_farloc")
-
-	// Set replier home locations.
-	db.Exec("UPDATE users SET lastlocation = ? WHERE id = ?", nearLocID, nearReplier)
-	db.Exec("UPDATE users SET lastlocation = ? WHERE id = ?", farLocID, farReplier)
-	defer db.Exec("UPDATE users SET lastlocation = NULL WHERE id IN (?, ?)", nearReplier, farReplier)
-
-	homeMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" homebike", 51.5, -0.1)
-	rippMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" rippbike", 51.5, -0.1)
-	// Override the locationid to the explicit post location we inserted.
-	db.Exec("UPDATE messages SET locationid = ? WHERE id IN (?, ?)", postLocID, homeMsg, rippMsg)
-	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, rippled_in, autoreposts) "+
-		"VALUES (?, ?, NOW() - INTERVAL 5 DAY, 'Approved', 1, 0)", rippMsg, awayGrp)
-	hChat := CreateTestChatRoom(t, nearReplier, &posterID, &homeGrp, "User2User")
-	hCm := CreateTestChatMessage(t, hChat, nearReplier, "near")
-	db.Exec("UPDATE chat_messages SET type='Interested', refmsgid=?, date=NOW() - INTERVAL 5 DAY WHERE id=?", homeMsg, hCm)
-	rChat := CreateTestChatRoom(t, farReplier, &posterID, &homeGrp, "User2User")
-	rCm := CreateTestChatMessage(t, rChat, farReplier, "far")
-	db.Exec("UPDATE chat_messages SET type='Interested', refmsgid=?, date=NOW() - INTERVAL 5 DAY WHERE id=?", rippMsg, rCm)
-
-	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", homeMsg, rippMsg)
-	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
-	defer db.Exec("DELETE FROM chat_messages WHERE id IN (?, ?)", hCm, rCm)
-
-	var wantDay string
-	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 5 DAY, '%Y-%m-%d')").Scan(&wantDay)
-
-	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
-	assert.Equal(t, 200, resp.StatusCode)
-	var result map[string]interface{}
-	json.Unmarshal(rsp(resp), &result)
-
-	dist, _ := result["reply_distance_median"].([]interface{})
-	var row map[string]interface{}
-	for _, r := range dist {
-		if m, ok := r.(map[string]interface{}); ok && m["day"] == wantDay {
-			row = m
-		}
-	}
-	assert.NotNil(t, row, "the seeded day appears in reply_distance_median")
-	assert.GreaterOrEqual(t, row["home_replies"].(float64), float64(1), "home cohort has a reply")
-	assert.GreaterOrEqual(t, row["ripple_replies"].(float64), float64(1), "ripple cohort has a reply")
-	// Near replier is at the same spot as the post (~0 km); far replier is in Edinburgh (~535 km).
-	assert.Greater(t, row["ripple_median_km"].(float64), row["home_median_km"].(float64), "rippled replies are further away")
 }
 
 // The trial is over - rippling is fully live - so the trial scoping is retired: the endpoint
@@ -727,55 +526,4 @@ func TestReplySourceSplitLegacyVariant(t *testing.T) {
 		assert.GreaterOrEqual(t, wideRow.RippleNotified, 1, "NULL-attribution notified reply derived per row")
 		assert.GreaterOrEqual(t, wideRow.RippleGroup, 1, "NULL-attribution rippled-group reply derived per row")
 	}
-}
-
-// Anchor regression (Discourse #9808): a RIPPLED post's reply-rate day/window must key on its
-// FIRST-RIPPLE date (MIN rippled_in arrival) — when rippling actually started — not on
-// messages.arrival (frozen at first-ever post) nor even its home appearance. A home-only post
-// stays anchored on its appearance (origin messages_groups.arrival). This dates rippled posts by
-// when the treatment began, and keeps the rippled cohort empty before go-live.
-func TestRipplingMetricsAnchorsRippledCohortOnFirstRippleDate(t *testing.T) {
-	prefix := uniquePrefix("ripanchor")
-	adminID := CreateTestUser(t, prefix+"_admin", "Support")
-	_, token := CreateTestSession(t, adminID)
-	db := database.DBConn
-
-	poster := CreateTestUser(t, prefix, "Poster")
-	group := CreateTestGroup(t, prefix)
-	other := CreateTestGroup(t, prefix+"b")
-	mid := CreateTestMessage(t, poster, group, "OFFER: anchor "+prefix, 51.5, -0.1)
-
-	// Three distinct dates: stale original post (30d ago), home appearance (3d ago), and the
-	// FIRST ripple (2d ago). The rippled cohort must be dated on the ripple date (2d ago).
-	db.Exec("UPDATE messages SET arrival = NOW() - INTERVAL 30 DAY WHERE id = ?", mid)
-	db.Exec("UPDATE messages_groups SET arrival = NOW() - INTERVAL 3 DAY WHERE msgid = ? AND rippled_in = 0", mid)
-	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) "+
-		"VALUES (?, ?, NOW() - INTERVAL 2 DAY, 'Approved', 0, 1)", mid, other)
-
-	start := time.Now().AddDate(0, 0, -5).Format("2006-01-02 15:04:05")
-	end := time.Now().AddDate(0, 0, 1).Format("2006-01-02 15:04:05")
-	req := httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s&start=%s&end=%s",
-		token, url.QueryEscape(start), url.QueryEscape(end)), nil)
-	resp, _ := getApp().Test(req)
-	assert.Equal(t, 200, resp.StatusCode)
-
-	var result map[string]interface{}
-	json.Unmarshal(rsp(resp), &result)
-	rows, ok := result["reply_rate_36h"].([]interface{})
-	assert.True(t, ok, "reply_rate_36h present")
-
-	// The post's home appearance (3d ago) and stale original arrival (30d ago) both differ from
-	// its first-ripple date (2d ago); the rippled cohort must land on the first-ripple date.
-	rippleDay := time.Now().AddDate(0, 0, -2).Format("2006-01-02")
-	foundOnRippleDay := false
-	for _, r := range rows {
-		m, _ := r.(map[string]interface{})
-		if m["day"] == rippleDay {
-			foundOnRippleDay = true
-			assert.GreaterOrEqual(t, m["ripple_posts"].(float64), float64(1),
-				"rippled post is in the rippled cohort on its first-ripple day")
-		}
-	}
-	assert.True(t, foundOnRippleDay,
-		"rippled post appears on its first-ripple day, proving the cohort anchors on the ripple date")
 }


### PR DESCRIPTION
## Summary

The sysadmin rippling tab fails on production with what the browser reports as a CORS error. CORS is fine. `/apiv2/rippling/metrics` was taking 40-190s of SQL, the gateway killed the request, and a gateway 504 carries no `Access-Control-Allow-Origin` header - so the browser blamed CORS and the real cause (slow SQL) was invisible from the console. The client's retry then stacked another full set of queries on top of the ones still running, which is why the same query measured 48s, then 111s, then 192s across successive attempts.

- **Every query production logged as SLOW SQL fed a field no client reads.** The five offenders (`metrics.go` 467/519/554/644/679 = the 30-day cross-group count, reply rate, replies-per-post, reply distance, taken rate) all scanned `messages_groups`/`chat_messages` over the window. `6982b1ee3` (8 Jul) retired the `ModSysAdminRippling` dashboard that charted them and folded only four things into the analytics component: `reply_source_split`, `hotspots`, `attribution_capture_from`, `held_reply_by_source`. `ModSysAdminRipplingAnalytics.vue` is the only caller of `fetchMetrics` and reads exactly those four. So they are **removed**, not split behind their own endpoints.
- **Why not split them, as originally planned?** Splitting would have moved the 504, not fixed it: each of those queries was already over the gateway timeout *on its own*. The equivalent reply-rate / taken-rate / mean-replies KPIs are already served by `/rippling/analytics`, which anchors on `rippling_reach` (one row per rippled post, bounded by `created_at`) instead of scanning `messages_groups` - the pattern any future heavyweight KPI here should follow.
- **Deadline the remaining work.** `db.WithContext(c.Context())` alone would not have helped: fasthttp closes `RequestCtx.Done()` only when the **server** shuts down, never on a client disconnect (`fasthttp@v1.55.0/server.go:2745` and the note above it), so an abandoned request cancels nothing. The handler now wraps the request context in a 20s `context.WithTimeout` and names any section that trips it in a `degraded` array, so "we gave up" reaches the dashboard rather than rendering as "no data".
- **Cached the live-capture boundary.** `attribution_capture_from` ORs three unindexed nullable columns, so it full-scans `rippling_reply_attribution` - under the slow-query threshold today, but a table that grows with every reply and the next thing here that would have crept past the timeout. Its answer cannot change once found (a MIN over an append-only table whose existing rows never gain capture evidence), so it is cached per process. A blank is deliberately **not** cached: that means capture has written nothing yet, and remembering it would leave the attribution chart unmarked until the next restart.
- **Window-bounded the group-options query** (it scanned every `rippling_reach` row ever written to build a filter list for windowed sections).
- **Bound the analytics endpoint's queries to the request context** as well, so they stop on shutdown.
- **Dashboard loads the metrics sections independently of the KPIs.** They were awaited in the same `Promise.all`, so one failed metrics call blanked the entire tab *and* skipped the drive-time pass. Now the attribution and hotspot panels fill in on their own and report their own failure (or a server-side timeout) instead of reading as "no data". They also no longer refetch on a density change - they vary by window only.

Net: `metrics.go` loses ~440 lines of SQL and derived-field maths; the endpoint now reads only small rippling-owned tables plus a window-bounded slice of `rippling_reply_attribution`.

## Why the index in the original plan is not here

The plan called for a covering index on `messages_groups (arrival, deleted, rippled_in, collection)` to take the 30-day cross-group count from 43s to milliseconds. That query is gone, and nothing else in the changed code needs the index - so this does not schedule a DDL change on a very large table on the Galera cluster for a query that no longer exists. If that KPI is ever wanted back, it should come from `rippling_reach` like the analytics endpoint does.

## Code quality review

- The `degraded` list only reports context deadline/cancellation. Ordinary query errors stay ignored on purpose: a table or column may not exist yet on a DB that lags the migrations (e.g. `rippling_held_replies.source` on production), and the panel simply omits that piece - that is not degradation.
- `MetricsDeadline` is a `var`, not a `const`, so the test can shrink it to prove the degraded path end to end.
- Trap found and handled while writing that test: `AttributionSchemaReady` caches its answer in a `sync.Once` for the life of the process, so a deadline-poisoned first call would have stuck the whole test run (and, in production, the whole process) on the legacy attribution variant. The handler now runs that one-off schema lookup off the un-deadlined handle, and the test warms it before shrinking the deadline.
- The 12 result queries were converted from repeated `wg.Add(1); go func(){ defer wg.Done(); ... }()` blocks to a `section(name, fn)` helper - less repetition, and it is what records the degraded sections.
- The capture-boundary cache is split into `cachedCaptureFrom` / `rememberCaptureFrom` so the asymmetry that matters (keep a date, never keep a blank) is unit-tested without a DB.

## Future improvements

- Production logs `Unknown column 'source'` from the held-replies-by-source query on db1: migration `2026_07_08_000001` has not run there. The code handles it defensively (the panel omits that breakdown), but the migration is still outstanding.

## Test plan

- `iznik-server-go/test/rippling_metrics_test.go`: `TestRipplingMetricsOmitsHeavyScanKPIs` asserts the five heavy keys are absent and the four the dashboard reads are present, so they cannot come back without the analytics-style rework. `TestRipplingMetricsReportsDegradedSectionsOnDeadline` shrinks the deadline and asserts the response is still a 200 that names the sections it gave up on. Six tests covering the removed sections are deleted.
- `iznik-server-go/rippling/metrics_test.go`: `TestCaptureFromCacheKeepsAFoundDate` and `TestCaptureFromCacheDoesNotRememberBlank` pin the cache's asymmetry.
- `ModSysAdminRipplingAnalytics.spec.js`: KPIs still render when the metrics request fails (and the panels say so); KPIs render before the metrics request resolves; a `degraded` section reads as a timeout, not as no data; a density change does not refetch the metrics sections; a window change does.
- Both suites run locally via the status API against the final code: Go 3696 pass / 0 fail, unit suite 14540 pass / 0 fail.
- Not browser-tested: the tab is Support/Admin-only and the worktree DB has no rippling data, so the panel states are covered by the unit assertions above.
