### PR TITLE
Size browse feed photos from the screen height so six posts fit

### DIFF
--- a/file-sync.sh
+++ b/file-sync.sh
@@ -76,8 +76,12 @@ get_container_info() {
             targets="$targets"$'\n'"${CN}-modtools-dev-live /app/${relative_path#iznik-nuxt3/} ModTools-Dev-Live"
         fi
         echo "$targets"
-    elif [[ "$relative_path" == iznik-nuxt3/plugins/* || "$relative_path" == iznik-nuxt3/composables/* || "$relative_path" == iznik-nuxt3/stores/* || "$relative_path" == iznik-nuxt3/utils/* || "$relative_path" == iznik-nuxt3/components/* ]]; then
-        # Shared code used by both Freegle and ModTools - sync to all containers
+    elif [[ "$relative_path" == iznik-nuxt3/plugins/* || "$relative_path" == iznik-nuxt3/composables/* || "$relative_path" == iznik-nuxt3/stores/* || "$relative_path" == iznik-nuxt3/utils/* || "$relative_path" == iznik-nuxt3/components/* || "$relative_path" == iznik-nuxt3/assets/* ]]; then
+        # Shared code used by both Freegle and ModTools - sync to all containers.
+        # assets/ is here rather than in the generic iznik-nuxt3/* branch below because that
+        # branch skips modtools-dev-local, which is where vitest runs: a unit test that reads
+        # a stylesheet (e.g. for the feed card sizing constants) would otherwise see the
+        # copy baked into the image rather than the edit on disk.
         local targets="${CN}-dev-local /app/${relative_path#iznik-nuxt3/} Freegle-Dev-Local"
         if docker ps --format '{{.Names}}' | grep -q "^${CN}-dev-live$"; then
             targets="$targets"$'\n'"${CN}-dev-live /app/${relative_path#iznik-nuxt3/} Freegle-Dev-Live"

--- a/iznik-nuxt3/assets/css/_feed-card.scss
+++ b/iznik-nuxt3/assets/css/_feed-card.scss
@@ -1,0 +1,68 @@
+@import 'assets/css/sticky-banner.scss';
+
+/* Browse-feed card sizing.
+ *
+ * At lg+ a feed card (MessageSummary, and MessageSkeleton which has to match it to
+ * avoid CLS) is a horizontal row whose photo is a square, so the square's side IS the
+ * card height. That side used to be a fixed 200px, which meant a short screen only fitted
+ * two or three posts. Instead we derive the side from the viewport height, aiming to show
+ * $feed-cards-target cards in the space between the fixed navbar and the sticky bottom ad.
+ *
+ * Clamped at both ends: never larger than the 200px it used to be, and never so small that
+ * the title, location and meta line beside the photo stop fitting. Where the clamp bites -
+ * viewports under about 710px tall - we show fewer than the target rather than render an
+ * unreadable card.
+ *
+ * The sticky ad zone grows to $sticky-banner-height-desktop-tall on tall viewports, but
+ * budgeting for that would make cards SHRINK as the window grew. We always budget the
+ * standard height, so the size only ever increases with the viewport.
+ */
+$feed-cards-target: 6;
+/* .singlecolumn margin-bottom in ScrollGrid. */
+$feed-card-gap: 8px;
+$feed-card-min: 80px;
+$feed-card-max: 200px;
+/* --header-navbar-height, as a literal because media queries can't read custom properties. */
+$feed-card-navbar: 76px;
+$feed-card-chrome: $feed-card-navbar + $sticky-banner-height-desktop +
+  ($feed-cards-target - 1) * $feed-card-gap;
+
+/* How much of the description survives depends on the row height. Beside the photo sit a
+ * header (subject + location + the gap under them, 46px at default font size), a meta line
+ * (distance + age, 17px) and whatever description fits in between. MessageSummary's vertical
+ * padding is calc((row - 64px) / 6) a side, so
+ *
+ *   description space = row - 2 x (row - 64px) / 6 - 46px - 17px = (2 x row + 64px) / 3 - 63px
+ *
+ * which reaches one 17px line at a 89px row and two at a 115px row. Turn those back into
+ * viewport heights (row x target + chrome) to get the breakpoints below.
+ *
+ * - Above $feed-card-oneline-max: two or more lines, faded out at the bottom as before.
+ * - Down to $feed-card-compact-max: exactly one line, so clamp it with an ellipsis - a fade
+ *   over the only line there is just turns it grey.
+ * - Below that: no room at all, so drop it. Subject, location, distance and age remain. */
+$feed-card-desc-oneline-row: 89px;
+$feed-card-desc-twoline-row: 115px;
+$feed-card-compact-max: $feed-cards-target * $feed-card-desc-oneline-row +
+  $feed-card-chrome - 1px;
+$feed-card-oneline-max: $feed-cards-target * $feed-card-desc-twoline-row +
+  $feed-card-chrome - 1px;
+
+/* Set --summary-row-size. Used on :root so MessageSummary and MessageSkeleton can never
+ * drift apart. Callers that render a summary in a narrow container (e.g. WantedMatches)
+ * override the photo box directly and are unaffected. */
+@mixin feed-card-size-var {
+  --summary-row-size: clamp(
+    #{$feed-card-min},
+    calc((100vh - #{$feed-card-chrome}) / #{$feed-cards-target}),
+    #{$feed-card-max}
+  );
+
+  @supports (height: 100dvh) {
+    --summary-row-size: clamp(
+      #{$feed-card-min},
+      calc((100dvh - #{$feed-card-chrome}) / #{$feed-cards-target}),
+      #{$feed-card-max}
+    );
+  }
+}

--- a/iznik-nuxt3/assets/css/global.scss
+++ b/iznik-nuxt3/assets/css/global.scss
@@ -1,4 +1,5 @@
 @import 'assets/css/sticky-banner.scss';
+@import 'assets/css/_feed-card.scss';
 
 #serverloader {
   z-index: 1000;
@@ -581,4 +582,8 @@ form {
   --popper-theme-padding: 10px;
   --popper-theme-box-shadow: 0 6px 30px -6px rgba(0, 0, 0, 0.25);
   --header-navbar-height: 76px;
+
+  /* Side of the square photo in a lg+ feed card, which is also the card's height.
+     See assets/css/_feed-card.scss. */
+  @include feed-card-size-var;
 }

--- a/iznik-nuxt3/components/MessageSkeleton.vue
+++ b/iznik-nuxt3/components/MessageSkeleton.vue
@@ -27,7 +27,10 @@
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins/_breakpoints';
 @import 'assets/css/_color-vars.scss';
+@import 'assets/css/_feed-card.scss';
 
+/* Sizes here must track MessageSummary's, or the card jumps size when the real one
+   replaces the skeleton. Both read --summary-row-size (assets/css/_feed-card.scss). */
 .message-skeleton {
   position: relative;
   overflow: hidden;
@@ -37,7 +40,7 @@
   @include media-breakpoint-up(lg) {
     display: flex;
     flex-direction: row;
-    max-height: 200px;
+    max-height: var(--summary-row-size, #{$feed-card-max});
     border: 1px solid $color-gray--light;
     box-shadow: var(--shadow-sm);
   }
@@ -56,8 +59,8 @@
   }
 
   @include media-breakpoint-up(lg) {
-    width: 200px;
-    height: 200px;
+    width: var(--summary-row-size, #{$feed-card-max});
+    height: var(--summary-row-size, #{$feed-card-max});
     padding-bottom: 0;
     flex-shrink: 0;
   }
@@ -79,7 +82,16 @@
   }
 
   @include media-breakpoint-up(lg) {
-    padding: 1rem 1.5rem;
+    padding: clamp(
+        0.25rem,
+        calc((var(--summary-row-size, #{$feed-card-max}) - 64px) / 6),
+        1rem
+      )
+      clamp(
+        0.75rem,
+        calc(var(--summary-row-size, #{$feed-card-max}) * 0.12),
+        1.5rem
+      );
     gap: 0.5rem;
     border: none;
     border-left: 1px solid $color-gray--light;
@@ -96,6 +108,12 @@
   gap: 0.5rem;
   align-items: center;
   margin-bottom: 0.35rem;
+
+  @include media-breakpoint-up(lg) {
+    @media (max-height: $feed-card-compact-max) {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .skeleton-tag {
@@ -133,12 +151,26 @@
     height: 0.75rem;
   }
 
+  /* MessageSummary shows fewer description lines as the row shrinks, so the skeleton has
+     to lose them at the same points or the card jumps size on hydration. */
   &--text {
     width: 90%;
+
+    @include media-breakpoint-up(lg) {
+      @media (max-height: $feed-card-compact-max) {
+        display: none;
+      }
+    }
   }
 
   &--short {
     width: 55%;
+
+    @include media-breakpoint-up(lg) {
+      @media (max-height: $feed-card-oneline-max) {
+        display: none;
+      }
+    }
   }
 
   &--meta {

--- a/iznik-nuxt3/components/MessageSummary.vue
+++ b/iznik-nuxt3/components/MessageSummary.vue
@@ -285,6 +285,7 @@ function expand(e) {
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins/_breakpoints';
 @import 'assets/css/_color-vars.scss';
+@import 'assets/css/_feed-card.scss';
 
 /* Use very specific selectors to override MessageList.vue's deep selectors */
 .message-summary-mobile {
@@ -303,7 +304,8 @@ function expand(e) {
     display: flex;
     flex-direction: row;
     align-items: stretch;
-    max-height: 200px;
+    /* The square photo sets the row height - see assets/css/_feed-card.scss. */
+    max-height: var(--summary-row-size, #{$feed-card-max});
     border: 1px solid $color-gray--light;
     box-shadow: var(
       --shadow-md,
@@ -344,10 +346,11 @@ function expand(e) {
     padding-bottom: 75%;
   }
 
-  /* Horizontal layout on lg+ - fixed square photo */
+  /* Horizontal layout on lg+ - square photo sized from the viewport height so that a
+     short screen still shows a useful number of posts. */
   @include media-breakpoint-up(lg) {
-    width: 200px;
-    height: 200px;
+    width: var(--summary-row-size, #{$feed-card-max});
+    height: var(--summary-row-size, #{$feed-card-max});
     padding-bottom: 0;
     flex-shrink: 0;
   }
@@ -450,11 +453,12 @@ function expand(e) {
   pointer-events: none;
   height: auto;
 
-  /* In list view (lg+), photo is 200px wide on left - position badge within that area */
+  /* In list view (lg+) the photo is a square on the left whose side varies with the
+     viewport height, so centre the stamp on that square rather than on a fixed 200px. */
   @include media-breakpoint-up(lg) {
-    left: 100px; /* Center of 200px photo area */
-    top: 100px; /* Center of 200px photo area */
-    width: 120px;
+    left: calc(var(--summary-row-size, #{$feed-card-max}) / 2);
+    top: calc(var(--summary-row-size, #{$feed-card-max}) / 2);
+    width: calc(var(--summary-row-size, #{$feed-card-max}) * 0.6);
     max-width: 120px;
   }
 
@@ -586,7 +590,18 @@ function expand(e) {
   }
 
   @include media-breakpoint-up(lg) {
-    padding: 1rem 1.5rem;
+    /* Padding shrinks with the row so that the title, location and meta line still fit
+       beside a small photo; at the 200px maximum it lands back on 1rem 1.5rem. */
+    padding: clamp(
+        0.25rem,
+        calc((var(--summary-row-size, #{$feed-card-max}) - 64px) / 6),
+        1rem
+      )
+      clamp(
+        0.75rem,
+        calc(var(--summary-row-size, #{$feed-card-max}) * 0.12),
+        1.5rem
+      );
     border: none;
     border-left: 1px solid $color-gray--light;
     box-shadow: none;
@@ -614,6 +629,13 @@ function expand(e) {
   gap: 0.5rem;
   margin-bottom: 0.35rem;
   align-items: center;
+
+  /* Compact rows have no description underneath, so don't reserve the gap for one. */
+  @include media-breakpoint-up(lg) {
+    @media (max-height: $feed-card-compact-max) {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .content-tag {
@@ -699,6 +721,30 @@ function expand(e) {
       height: 1.5em;
       background: linear-gradient(transparent, $color-white);
       pointer-events: none;
+    }
+  }
+
+  /* Only one line fits, so ellipsise it - the fade would just grey out the only line there
+     is. Line clamping can't be used here because flex: 1 stretches the box past the line it
+     is meant to cap, so this is a plain single-line ellipsis with the box sized to its
+     content. See assets/css/_feed-card.scss for where these heights come from. */
+  @include media-breakpoint-up(lg) {
+    @media (max-height: $feed-card-oneline-max) {
+      display: block;
+      flex: 0 0 auto;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
+      &::after {
+        content: none;
+      }
+    }
+  }
+
+  /* Not even one line fits, so drop it. Subject, location, distance and age all stay. */
+  @include media-breakpoint-up(lg) {
+    @media (max-height: $feed-card-compact-max) {
+      display: none;
     }
   }
 }

--- a/iznik-nuxt3/modtools/assets/css/_feed-card.scss
+++ b/iznik-nuxt3/modtools/assets/css/_feed-card.scss
@@ -1,0 +1,68 @@
+@import 'assets/css/sticky-banner.scss';
+
+/* Browse-feed card sizing.
+ *
+ * At lg+ a feed card (MessageSummary, and MessageSkeleton which has to match it to
+ * avoid CLS) is a horizontal row whose photo is a square, so the square's side IS the
+ * card height. That side used to be a fixed 200px, which meant a short screen only fitted
+ * two or three posts. Instead we derive the side from the viewport height, aiming to show
+ * $feed-cards-target cards in the space between the fixed navbar and the sticky bottom ad.
+ *
+ * Clamped at both ends: never larger than the 200px it used to be, and never so small that
+ * the title, location and meta line beside the photo stop fitting. Where the clamp bites -
+ * viewports under about 710px tall - we show fewer than the target rather than render an
+ * unreadable card.
+ *
+ * The sticky ad zone grows to $sticky-banner-height-desktop-tall on tall viewports, but
+ * budgeting for that would make cards SHRINK as the window grew. We always budget the
+ * standard height, so the size only ever increases with the viewport.
+ */
+$feed-cards-target: 6;
+/* .singlecolumn margin-bottom in ScrollGrid. */
+$feed-card-gap: 8px;
+$feed-card-min: 80px;
+$feed-card-max: 200px;
+/* --header-navbar-height, as a literal because media queries can't read custom properties. */
+$feed-card-navbar: 76px;
+$feed-card-chrome: $feed-card-navbar + $sticky-banner-height-desktop +
+  ($feed-cards-target - 1) * $feed-card-gap;
+
+/* How much of the description survives depends on the row height. Beside the photo sit a
+ * header (subject + location + the gap under them, 46px at default font size), a meta line
+ * (distance + age, 17px) and whatever description fits in between. MessageSummary's vertical
+ * padding is calc((row - 64px) / 6) a side, so
+ *
+ *   description space = row - 2 x (row - 64px) / 6 - 46px - 17px = (2 x row + 64px) / 3 - 63px
+ *
+ * which reaches one 17px line at a 89px row and two at a 115px row. Turn those back into
+ * viewport heights (row x target + chrome) to get the breakpoints below.
+ *
+ * - Above $feed-card-oneline-max: two or more lines, faded out at the bottom as before.
+ * - Down to $feed-card-compact-max: exactly one line, so clamp it with an ellipsis - a fade
+ *   over the only line there is just turns it grey.
+ * - Below that: no room at all, so drop it. Subject, location, distance and age remain. */
+$feed-card-desc-oneline-row: 89px;
+$feed-card-desc-twoline-row: 115px;
+$feed-card-compact-max: $feed-cards-target * $feed-card-desc-oneline-row +
+  $feed-card-chrome - 1px;
+$feed-card-oneline-max: $feed-cards-target * $feed-card-desc-twoline-row +
+  $feed-card-chrome - 1px;
+
+/* Set --summary-row-size. Used on :root so MessageSummary and MessageSkeleton can never
+ * drift apart. Callers that render a summary in a narrow container (e.g. WantedMatches)
+ * override the photo box directly and are unaffected. */
+@mixin feed-card-size-var {
+  --summary-row-size: clamp(
+    #{$feed-card-min},
+    calc((100vh - #{$feed-card-chrome}) / #{$feed-cards-target}),
+    #{$feed-card-max}
+  );
+
+  @supports (height: 100dvh) {
+    --summary-row-size: clamp(
+      #{$feed-card-min},
+      calc((100dvh - #{$feed-card-chrome}) / #{$feed-cards-target}),
+      #{$feed-card-max}
+    );
+  }
+}

--- a/iznik-nuxt3/tests/e2e/test-browse.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-browse.spec.js
@@ -6,6 +6,50 @@
 const { test, expect } = require('./fixtures')
 const { timeouts } = require('./config')
 const { signUpViaHomepage, loginViaHomepage } = require('./utils/user')
+const { dismissLoginModalIfPresent } = require('./utils/reply-helpers')
+
+// Measure the first feed card, the square photo in it, and the chrome above and below the
+// feed, so a test can work out how many cards actually fit on screen.
+async function measureFeedCard(page) {
+  return await page.evaluate(() => {
+    const card = document.querySelector('.message-summary-mobile')
+    const photo = card.querySelector('.photo-area')
+    const navbar = document.querySelector('nav.fixed-top')
+    const stickyAd = document.querySelector('.sticky')
+    const cardBox = card.getBoundingClientRect()
+    const photoBox = photo.getBoundingClientRect()
+
+    return {
+      viewportHeight: window.innerHeight,
+      cardHeight: cardBox.height,
+      photoWidth: photoBox.width,
+      photoHeight: photoBox.height,
+      navbarHeight: navbar ? navbar.getBoundingClientRect().height : 0,
+      stickyAdHeight: stickyAd ? stickyAd.getBoundingClientRect().height : 0,
+    }
+  })
+}
+
+// Wait for the desktop row layout, then measure. The card appears before VisibleWhen has
+// settled on the breakpoint, and until it does the card is still in the portrait grid
+// layout with a taller-than-wide photo, so wait for the photo to be square first.
+async function measureDesktopFeedCard(page) {
+  await page.waitForSelector('.message-summary-mobile', {
+    timeout: timeouts.ui.appearance,
+  })
+
+  await expect
+    .poll(
+      async () => {
+        const { photoWidth, photoHeight } = await measureFeedCard(page)
+        return Math.round(photoWidth) === Math.round(photoHeight)
+      },
+      { timeout: timeouts.ui.appearance }
+    )
+    .toBe(true)
+
+  return await measureFeedCard(page)
+}
 
 // Helper: sign up and join a group.
 async function signUpAndJoinGroup(page, testEmail, userName, groupName) {
@@ -273,6 +317,56 @@ test.describe('Browse Page Tests', () => {
         await container.waitFor({ state: 'attached', timeout: 5000 })
       }
     }
+  })
+
+  test('should size feed photos from the screen height so six posts fit', async ({
+    page,
+    testEnv,
+  }) => {
+    // The lg+ feed card is a row whose photo is a square, so the square's side is the
+    // card's height. It used to be a fixed 200px, which put only two or three posts on a
+    // short screen; it now comes from the viewport height so six fit. Uses /explore, which
+    // shows the same cards and reliably has the seeded posts on it.
+    const CARDS_WANTED = 6
+    const CARD_GAP = 8 // .singlecolumn margin-bottom in ScrollGrid
+    const MAX_PHOTO = 200 // what the size used to be fixed at, and still caps at
+
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await page.gotoAndVerify(`/explore/${testEnv.group.name}`, {
+      timeout: timeouts.navigation.default,
+    })
+    await dismissLoginModalIfPresent(page)
+
+    const short = await measureDesktopFeedCard(page)
+    console.log('Short screen card:', JSON.stringify(short))
+
+    // The photo is square, so its side really is the row height.
+    expect(Math.abs(short.photoWidth - short.photoHeight)).toBeLessThan(1)
+    expect(Math.abs(short.cardHeight - short.photoHeight)).toBeLessThan(1)
+
+    // It has reacted to the short screen rather than staying at the old fixed size.
+    expect(short.photoHeight).toBeLessThan(MAX_PHOTO)
+
+    // Six cards and the gaps between them fit between the navbar and the sticky ad.
+    const usable =
+      short.viewportHeight - short.navbarHeight - short.stickyAdHeight
+    const needed =
+      CARDS_WANTED * short.cardHeight + (CARDS_WANTED - 1) * CARD_GAP
+    console.log(`Six cards need ${needed}px, ${usable}px available`)
+    expect(needed).toBeLessThanOrEqual(usable + 1)
+
+    // A taller screen gets a bigger photo, but never bigger than it used to be.
+    await page.setViewportSize({ width: 1280, height: 1200 })
+    await page.gotoAndVerify(`/explore/${testEnv.group.name}`, {
+      timeout: timeouts.navigation.default,
+    })
+    await dismissLoginModalIfPresent(page)
+
+    const tall = await measureDesktopFeedCard(page)
+    console.log('Tall screen card:', JSON.stringify(tall))
+    expect(tall.photoHeight).toBeGreaterThan(short.photoHeight)
+    expect(tall.photoHeight).toBeLessThanOrEqual(MAX_PHOTO)
+    expect(Math.abs(tall.photoWidth - tall.photoHeight)).toBeLessThan(1)
   })
 
   test('should load browse page with existing messages', async ({

--- a/iznik-nuxt3/tests/unit/components/MessageSummaryRowSize.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageSummaryRowSize.spec.js
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * The lg+ feed card is a horizontal row whose photo is a square, so the square's side is
+ * also the card's height. It used to be a fixed 200px, which meant a short screen only
+ * fitted two or three posts. It is now derived from the viewport height so that six fit.
+ *
+ * assets/css/_feed-card.scss is the single source of truth; this reads the constants back
+ * out of it and checks the sizing they produce still meets that goal, so that raising, say,
+ * the minimum row height fails here rather than quietly costing a card.
+ */
+
+const cssDir = resolve(__dirname, '../../../assets/css')
+const feedCardScss = readFileSync(resolve(cssDir, '_feed-card.scss'), 'utf-8')
+const stickyBannerScss = readFileSync(
+  resolve(cssDir, 'sticky-banner.scss'),
+  'utf-8'
+)
+
+function px(source, name) {
+  const match = source.match(new RegExp(`\\$${name}:\\s*(\\d+)px`))
+  expect(match, `expected $${name} to be declared in px`).toBeTruthy()
+  return parseInt(match[1], 10)
+}
+
+function count(source, name) {
+  const match = source.match(new RegExp(`\\$${name}:\\s*(\\d+)\\s*;`))
+  expect(match, `expected $${name} to be declared`).toBeTruthy()
+  return parseInt(match[1], 10)
+}
+
+const TARGET = count(feedCardScss, 'feed-cards-target')
+const GAP = px(feedCardScss, 'feed-card-gap')
+const MIN = px(feedCardScss, 'feed-card-min')
+const MAX = px(feedCardScss, 'feed-card-max')
+const NAVBAR = px(feedCardScss, 'feed-card-navbar')
+const STICKY = px(stickyBannerScss, 'sticky-banner-height-desktop')
+
+/* The chrome the CSS budgets for: the fixed navbar, the sticky bottom ad, and the gaps
+   between the target number of cards. */
+const CHROME = NAVBAR + STICKY + (TARGET - 1) * GAP
+
+/* What the clamp() in _feed-card.scss evaluates to at a given viewport height. */
+function rowSize(viewportHeight) {
+  return Math.min(MAX, Math.max(MIN, (viewportHeight - CHROME) / TARGET))
+}
+
+/* Feed height left between the fixed navbar and the sticky bottom ad. */
+function usableHeight(viewportHeight) {
+  return viewportHeight - NAVBAR - STICKY
+}
+
+/* Height that n cards and the gaps between them take up. */
+function heightFor(n, viewportHeight) {
+  return n * rowSize(viewportHeight) + (n - 1) * GAP
+}
+
+describe('feed card row sizing', () => {
+  it('fits the target number of cards on a short laptop screen', () => {
+    /* 720 is the viewport a 1280x720 laptop actually gives you, and the case that prompted
+       this change: at a fixed 200px only two or three posts were on screen at once. */
+    expect(heightFor(TARGET, 720)).toBeLessThanOrEqual(usableHeight(720) + 0.5)
+  })
+
+  it('fits the target number of cards on taller screens too', () => {
+    for (const height of [768, 800, 900, 1000, 1080, 1440, 2160]) {
+      expect(heightFor(TARGET, height)).toBeLessThanOrEqual(
+        usableHeight(height) + 0.5
+      )
+    }
+  })
+
+  it('never grows past the original size, however large the screen', () => {
+    for (const height of [1440, 2160, 4320]) {
+      expect(rowSize(height)).toBe(MAX)
+    }
+    expect(MAX).toBe(200)
+  })
+
+  it('shows fewer cards rather than an unreadable one on a very short screen', () => {
+    /* Below about 710px of viewport the target would need a photo too small for the text
+       beside it, so the clamp holds the row at its minimum and we show fewer. */
+    expect(rowSize(600)).toBe(MIN)
+    expect(heightFor(TARGET, 600)).toBeGreaterThan(usableHeight(600))
+  })
+
+  it('grows monotonically with the viewport, so a taller window never shows less', () => {
+    let previous = 0
+    for (let height = 300; height <= 2000; height += 10) {
+      const size = rowSize(height)
+      expect(size).toBeGreaterThanOrEqual(previous)
+      previous = size
+    }
+  })
+
+  it('leaves room beside the smallest photo for the text that stays visible', () => {
+    /* At the minimum row the description is dropped, but the header (subject + location,
+       46px at default font size) and the meta line (distance + age, 17px) must still fit
+       within the row's minimum vertical padding of 0.25rem a side. */
+    const HEADER = 46
+    const META = 17
+    const MIN_PADDING = 4
+    expect(MIN - 2 * MIN_PADDING).toBeGreaterThanOrEqual(HEADER + META)
+  })
+
+  it('drops description lines in the right order as the row shrinks', () => {
+    const oneLineRow = px(feedCardScss, 'feed-card-desc-oneline-row')
+    const twoLineRow = px(feedCardScss, 'feed-card-desc-twoline-row')
+
+    /* Two lines have to give way before the last one does, and both thresholds must sit
+       inside the range the row actually takes, or a tier is unreachable. */
+    expect(oneLineRow).toBeLessThan(twoLineRow)
+    expect(oneLineRow).toBeGreaterThan(MIN)
+    expect(twoLineRow).toBeLessThan(MAX)
+  })
+})
+
+describe('feed card and skeleton stay the same size', () => {
+  const summary = readFileSync(
+    resolve(__dirname, '../../../components/MessageSummary.vue'),
+    'utf-8'
+  )
+  const skeleton = readFileSync(
+    resolve(__dirname, '../../../components/MessageSkeleton.vue'),
+    'utf-8'
+  )
+
+  it('sizes the summary photo from the row variable rather than a fixed height', () => {
+    const photoArea = summary.slice(
+      summary.indexOf('.photo-area {'),
+      summary.indexOf('.photo-container {')
+    )
+    expect(photoArea).toContain('var(--summary-row-size')
+    /* The lg+ block used to hard-code 200px for both width and height. */
+    expect(photoArea).not.toContain('width: 200px')
+    expect(photoArea).not.toContain('height: 200px')
+  })
+
+  it('sizes the skeleton photo the same way, so the card does not jump on hydration', () => {
+    const photoArea = skeleton.slice(
+      skeleton.indexOf('.skeleton-photo-area {'),
+      skeleton.indexOf('.skeleton-content {')
+    )
+    expect(photoArea).toContain('var(--summary-row-size')
+    expect(photoArea).not.toContain('width: 200px')
+    expect(photoArea).not.toContain('height: 200px')
+  })
+
+  it('caps both the card and the skeleton at the same row height', () => {
+    expect(summary).toContain('max-height: var(--summary-row-size')
+    expect(skeleton).toContain('max-height: var(--summary-row-size')
+  })
+})


### PR DESCRIPTION
## The problem

At lg+ a browse card is a horizontal row whose photo is a **square**, so the square's side *is* the card height. That side was hard-coded to 200px, which meant a short screen showed only two or three posts at a time.

## The change

The side now comes from the viewport height:

```
--summary-row-size: clamp(80px, calc((100dvh - 229px) / 6), 200px)
```

229px = fixed navbar (76) + sticky bottom ad (113) + the 5 gaps between 6 cards. Measured in a real browser:

| Viewport | Photo | Cards on screen |
|---|---|---|
| 640px | 80px (floor) | 5 |
| 720px | 82px | **6** (was 2-3) |
| 1000px | 128px | 6 |
| 1200px | 162px | 5-6 |
| >=1429px | 200px (cap) | unchanged from today |

**200px remains the ceiling**, so a very large screen renders exactly as it does now.

## Keeping the rest of the card usable

The text column degrades with the row rather than being crushed or clipped:

- **Padding** scales with the photo, landing back on `1rem 1.5rem` at 200px.
- **Description**: multi-line with the existing bottom fade, then a single ellipsised line when only one fits (a fade over the *only* line just greys it out), then dropped entirely when none fits.
- **Subject, location, distance and age always survive**, even at the 80px floor.
- The freegled/promised stamp was positioned on a hard-coded 200px square and now centres on whatever size the photo is.
- `MessageSkeleton` tracks the same sizes and the same tiers, so the card does not change size when the real one replaces it.

The thresholds are derived from the measured heights of the header (46px), meta line (17px) and one 17px description line, and the derivation is written out in `assets/css/_feed-card.scss`.

## Deliberate trade-offs

- **The sticky ad zone grows from 113px to 273px above a 950px viewport.** Budgeting for the tall one made photos *shrink* as the window grew, which reads as broken, so the standard height is always budgeted. Above 950px you see 5 rather than 6 (still up from 4), and 6 when ads are off.
- **Below about 710px of viewport the clamp holds at 80px** and we show fewer than six rather than render an unreadable card.
- **Portrait layouts are unchanged** (xs/sm/md grid, mobile landscape). There the photo's width comes from the grid column, not the screen height, so "square, sized by height" does not apply. Fitting six on a portrait phone would need a 3-column grid, which is a separate change.

## Also in here

`file-sync.sh` never synced `assets/` to the container the unit suite runs in, so a unit test that reads a stylesheet saw the copy baked into the image rather than the edit on disk. `assets/` moves to the shared-code branch alongside `components/`.

## Coverage

- **New unit spec** (`MessageSummaryRowSize.spec.js`) reads the constants back out of the SCSS and asserts six fit at a 720px viewport, the cap stays 200px, the size grows monotonically with the viewport, the floor leaves room for the text that stays visible, and the skeleton stays in sync with the card.
- **New e2e case** measures the real card in a real browser at two viewport heights: photo square, card height equal to photo height, six cards plus gaps fitting between the navbar and the sticky ad, and a taller screen giving a bigger photo capped at 200px.
- Locally: 689 unit files / 14546 assertions green; `test-browse.spec.js` 6/6 green, logging `720px -> 81.8px square, six cards need 531px of 553px available` and `1200px -> 161.8px square`.
- Verified visually at 640, 720, 870, 930, 1000 and 1334px, plus md portrait and mobile landscape unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mrih9qw8XXt1va2g6pMqN5
