### PR TITLE
fix(rippling): gate held replies out of the My Posts reply list

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -545,6 +545,15 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 				//
 				// Check that the reply isn't too long ago compared to the most recent post of it.  That can happen
 				// very occasionally if someone posts, an item for a long time, and there is a reply
+				//
+				// Gate rippling held replies: an email/TN reply from outside the post's current reach is
+				// held (rippling_held_replies, status <> 'released') so it doesn't reach the poster before
+				// the post ripples to the replier. Every delivery channel honours this - the in-app chat
+				// list/count and message fetch (chat/chatmessage.go), the poster-notification email and
+				// push, and the chat-list badge/snippet/roster (PR #927). This own-posts reply list feeds
+				// the "My Posts" replies + replycount, so it must gate too or the poster sees a held reply
+				// there (name + snippet + count) while it's still hidden everywhere else. Unconditional
+				// (no mod exemption), matching the #927 count-surface gates.
 				db.Raw("SELECT DISTINCT chat_messages.id, refmsgid, chat_messages.date, userid, fromuser, "+
 					"CASE WHEN users.fullname IS NOT NULL THEN users.fullname ELSE CONCAT(users.firstname, ' ', users.lastname) END AS displayname "+
 					"FROM chat_messages "+
@@ -553,6 +562,7 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 					"INNER JOIN users ON users.id = chat_messages.userid "+
 					"WHERE refmsgid = ? AND chat_messages.type = ? AND (messages.fromuser != ? OR chat_messages.userid != ?) "+
 					"AND reviewrequired = 0 AND reviewrejected = 0 "+
+					"AND NOT EXISTS (SELECT 1 FROM rippling_held_replies rhr WHERE rhr.chatmsgid = chat_messages.id AND rhr.status <> 'released') "+
 					"AND DATEDIFF(chat_messages.date, messages_groups.arrival) < ? "+
 					"GROUP BY userid;", id, utils.MESSAGE_INTERESTED, myid, myid, utils.OPEN_AGE).Scan(&messageReply)
 

--- a/iznik-server-go/test/message_myposts_held_reply_test.go
+++ b/iznik-server-go/test/message_myposts_held_reply_test.go
@@ -1,0 +1,102 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fetchMessage fetches GET /api/message/:id as the given token and decodes it. This is the
+// endpoint that backs the "My Posts" page - its `replies` + `replycount` list who has
+// expressed Interest in the poster's own post.
+func fetchMessage(t *testing.T, token string, msgID uint64) message.Message {
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d?jwt=%s", msgID, token), nil)
+	resp, err := getApp().Test(req, 10000)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	var m message.Message
+	require.NoError(t, json.Unmarshal(rsp(resp), &m))
+	return m
+}
+
+// TestMessageReplies_HeldReplyHiddenFromPoster verifies that a rippling-held reply
+// (rippling_held_replies, status='held') to the poster's own post does NOT appear in the
+// message `replies` list or inflate `replycount` on GET /api/message/:id - the endpoint that
+// backs "My Posts". This own-posts reply path had no held-reply gate, so the poster saw the
+// held reply there (replier name + count) while every delivery channel (chat list, poster
+// email, push - and the chat-list badge/snippet/roster fixed by PR #927) correctly withheld
+// it. The reply must stay hidden while held and reappear once the hold is released.
+func TestMessageReplies_HeldReplyHiddenFromPoster(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mypostsheld")
+
+	// rippling_held_replies ships with the reach engine; stand it up so this test is self-sufficient.
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_held_replies (
+		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		chatid BIGINT UNSIGNED NOT NULL,
+		chatmsgid BIGINT UNSIGNED NOT NULL,
+		msgid BIGINT UNSIGNED NOT NULL,
+		replieruserid BIGINT UNSIGNED NOT NULL,
+		source ENUM('email','tn','web') NOT NULL DEFAULT 'email',
+		lat DOUBLE, lng DOUBLE,
+		status ENUM('held','released','dropped','taken-gone') NOT NULL DEFAULT 'held',
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		releasedat TIMESTAMP NULL,
+		INDEX (msgid), INDEX (chatid), INDEX (status)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	replierID := CreateTestUser(t, prefix+"_replier", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, replierID, groupID, "Member")
+
+	// The poster's own post (FK target for rippling_held_replies.msgid and refmsgid).
+	postMsgID := CreateTestMessage(t, posterID, groupID, "OFFER: myposts held reply test", 51.5, -0.1)
+
+	// Replier expressed Interest via a chat room. type='Interested' + refmsgid = this post is
+	// exactly what the message `replies` query selects.
+	chatID := CreateTestChatRoom(t, replierID, &posterID, nil, "User2User")
+	const replyText = "Interested please, can I collect?"
+	db.Exec(
+		"INSERT INTO chat_messages (chatid, userid, message, type, date, refmsgid, "+
+			"reviewrequired, reviewrejected, processingrequired, processingsuccessful) "+
+			"VALUES (?, ?, ?, 'Interested', NOW(), ?, 0, 0, 0, 1)",
+		chatID, replierID, replyText, postMsgID,
+	)
+	var replyMsgID uint64
+	db.Raw("SELECT id FROM chat_messages WHERE chatid = ? ORDER BY id DESC LIMIT 1", chatID).Scan(&replyMsgID)
+	require.NotZero(t, replyMsgID, "failed to create the Interested reply chat message")
+	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", replyMsgID)
+
+	_, posterToken := CreateTestSession(t, posterID)
+
+	// Baseline: with no hold, the poster sees the Interested reply in My Posts.
+	m := fetchMessage(t, posterToken, postMsgID)
+	require.Equal(t, 1, m.Replycount, "sanity: an un-held Interested reply should show in My Posts")
+	require.Len(t, m.MessageReply, 1)
+
+	// Hold the reply - the replier is outside the post's current reach.
+	db.Exec("INSERT INTO rippling_held_replies (chatid, chatmsgid, msgid, replieruserid, status) "+
+		"VALUES (?, ?, ?, ?, 'held')", chatID, replyMsgID, postMsgID, replierID)
+	defer db.Exec("DELETE FROM rippling_held_replies WHERE chatmsgid = ?", replyMsgID)
+
+	// While held: the poster must NOT see it in My Posts - no replier, no count.
+	m = fetchMessage(t, posterToken, postMsgID)
+	assert.Equal(t, 0, m.Replycount, "held reply must not be counted in the My Posts replycount")
+	assert.Empty(t, m.MessageReply, "held reply must not appear in the My Posts replies list")
+
+	// Releasing the hold makes the reply deliverable - it reappears in My Posts with the
+	// replier's identity (the viewer is the poster of this post).
+	db.Exec("UPDATE rippling_held_replies SET status = 'released', releasedat = NOW() WHERE chatmsgid = ?", replyMsgID)
+	m = fetchMessage(t, posterToken, postMsgID)
+	if assert.Equal(t, 1, m.Replycount, "released reply must be counted again") && assert.Len(t, m.MessageReply, 1) {
+		assert.Equal(t, replierID, m.MessageReply[0].Userid, "poster sees the replier's identity on their own post")
+	}
+}


### PR DESCRIPTION
## Summary

- `GET /message/:id` (`GetMessagesByIds` in `iznik-server-go/message/message.go`) builds the message `replies` array and `replycount` — the data behind the **My Posts** page — by selecting all `Interested` replies, but **without** the rippling held-reply gate that every other channel applies.
- A reply held pending rippling (`rippling_held_replies`, `status <> 'released'`) therefore surfaced to the poster in My Posts (replier name, snippet **and** count) while the in-app chat list, the poster email, push, and the chat-list badge/snippet/roster (PR #927) all correctly withheld it.
- Fix: add the same `NOT EXISTS (… rippling_held_replies … status <> 'released')` gate to that query. Held replies stay hidden until the post ripples to the replier, and reappear once released.

This is the sibling of #927, on the own-posts reply path that #927 did not cover. Reply-holding itself is intended behaviour; this PR only stops a held reply leaking into the own-posts view.

### Live case
Confirmed on production, post `#121187198` (an Ipswich offer): two TrashNothing replies were held (both still `status='held'`, both outside the reach polygon at tick 6/9), yet showed as "2 replies" on the poster's My Posts page. Every delivery channel was correctly silent; only this list/count leaked.

## Code Quality Review

- **Unconditional gate (no mod exemption).** This is a count/list surface, matching the `chatroom.go` gates #927 added (also unconditional), rather than the content-review path in `FetchChatMessages` which exempts mods. Unconditional also covers the edge case of a moderator who is themselves the poster. ModTools uses separate endpoints for oversight.
- `replycount = len(messageReply)`, so gating the single query fixes both the list and the count.
- Gate is parameter-free and index-friendly (`rippling_held_replies` has an index on `status`); it defaults open when there is no held row, so non-rippling posts are unaffected.

## Future Improvements (out of scope here)

- Investigation for the live case surfaced a separate, arguably larger gap: `RippleReplyService::shouldHold` holds by the replier's **home location vs the reach polygon only**, ignoring group membership. In the live case both repliers were **native members of the origin group** the post was made to (`rippled_in=0`, reachable from tick 1), so their replies should arguably not have been held at all. Worth deciding separately whether to exempt Approved members of a group the post is natively on.

## Test Plan

- New `iznik-server-go/test/message_myposts_held_reply_test.go`:
  - un-held Interested reply shows in `replies`/`replycount` (baseline),
  - held reply (`rippling_held_replies` status='held') is excluded from both the list and the count,
  - releasing the hold (`status='released'`) makes it reappear with the replier's identity (viewer is the poster).
- Full Go suite run via the status API: **3699 passed, 0 failed**; `TestMessageReplies_HeldReplyHiddenFromPoster` PASS.