### PR TITLE
fix(rippling): stop /rippling/analytics 504ing on the sysadmin KPIs

### DIFF
--- a/iznik-batch/database/migrations/2026_07_29_000001_add_rippling_reach_created_index.php
+++ b/iznik-batch/database/migrations/2026_07_29_000001_add_rippling_reach_created_index.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * rippling_reach(created_at, total_freeglers) index for the ModTools sysadmin rippling
+ * analytics tab (iznik-server-go/rippling/analytics.go). Every analytics query anchors
+ * on "posts rippled in the [start,end) window, split by density stratum", i.e. a range
+ * on created_at filtered by total_freeglers.
+ *
+ * Without this index each query full-scans rippling_reach. The table is only ~52k rows
+ * but ~17GB, because each row carries the reach polygons, so the scan costs ~15s — and
+ * the endpoint runs four such queries serially, tipping /rippling/analytics past the
+ * gateway timeout (seen live as 504s on the sysadmin KPIs). The covering index (msgid
+ * is the PK so it rides along) answers the window predicate without touching a single
+ * polygon page: the base scan drops from ~15s to ~1s.
+ *
+ * PRODUCTION NOTE: prod is Percona/Galera with wsrep_OSU_method=TOI, so a plain ALTER
+ * serialises cluster-wide for the index build. Applied to prod 2026-07-29 node-by-node
+ * under RSU (see companion _migration.sql); this migration is guarded on
+ * information_schema so it no-ops there. NOTE: rippling_reach has a SPATIAL index, so
+ * MySQL refuses LOCK=NONE for INPLACE builds on it — LOCK=SHARED is the least locking
+ * mode available (a few seconds on this table).
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        $exists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'rippling_reach'
+               AND index_name = 'rippling_reach_created_freeglers'"
+        );
+        if ((int) ($exists->n ?? 0) === 0) {
+            DB::statement(
+                'ALTER TABLE rippling_reach ADD INDEX rippling_reach_created_freeglers (created_at, total_freeglers), ALGORITHM=INPLACE, LOCK=SHARED'
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        $exists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'rippling_reach'
+               AND index_name = 'rippling_reach_created_freeglers'"
+        );
+        if ((int) ($exists->n ?? 0) > 0) {
+            DB::statement('ALTER TABLE rippling_reach DROP INDEX rippling_reach_created_freeglers');
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_29_000001_add_rippling_reach_created_index_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_29_000001_add_rippling_reach_created_index_migration.sql
@@ -1,0 +1,22 @@
+-- Production idempotent SQL: rippling_reach(created_at, total_freeglers) index for the
+-- ModTools sysadmin rippling analytics tab (iznik-server-go/rippling/analytics.go).
+-- Without it every analytics query full-scans rippling_reach — only ~52k rows but ~17GB
+-- because each row carries the reach polygons — costing ~15s per query, four queries
+-- serially, tipping /rippling/analytics past the gateway timeout (504s).
+--
+-- Prod is Galera (wsrep_OSU_method=TOI): a plain ALTER serialises cluster-wide writes
+-- for the index build. Run this node-by-node under RSU so no single node blocks the
+-- cluster (RSU is session-scoped; it reverts when the session ends):
+--   SET SESSION wsrep_OSU_method = 'RSU';
+--   -- run the guarded ALTER below on this node
+--
+-- rippling_reach has a SPATIAL index, so MySQL refuses LOCK=NONE for INPLACE builds on
+-- it — LOCK=SHARED is the least locking mode available (build took 2-14s per node when
+-- applied to prod 2026-07-29). Guarded so a re-run is a no-op.
+SET @idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'rippling_reach'
+      AND index_name = 'rippling_reach_created_freeglers');
+SET @ddl := IF(@idx_exists = 0,
+    'ALTER TABLE rippling_reach ADD INDEX rippling_reach_created_freeglers (created_at, total_freeglers), ALGORITHM=INPLACE, LOCK=SHARED',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-nuxt3/composables/useFetchRetry.js
+++ b/iznik-nuxt3/composables/useFetchRetry.js
@@ -10,6 +10,12 @@ class FetchError extends Error {
 
 export function fetchRetry(fetch) {
   const retryDelay = function (attempt, error, response) {
+    if (response?.status === 504) {
+      // A gateway timeout means the server was still working on an expensive request when the
+      // gateway gave up, so back off much harder before adding more load.
+      return 10000
+    }
+
     // Slowly back off for longer each time.
     return attempt * 1000
   }
@@ -46,6 +52,21 @@ export function fetchRetry(fetch) {
     ) {
       console.log('Load failed - retry')
       return [true, false]
+    }
+
+    // A 504 means the gateway gave up on a request the server was probably still executing -
+    // typically an expensive endpoint that is slow for everyone, not a transient blip. Each
+    // retry stacks another full copy of that work on the server (seen live on the sysadmin
+    // rippling analytics tab, where the retry loop kept ~10 heavyweight query sets running),
+    // so allow only a single retry rather than the usual ten.
+    if (response?.status === 504 && attempt >= 1) {
+      console.log('Gateway timeout persisted after retry - give up')
+      return [
+        false,
+        false,
+        null,
+        new FetchError('Request failed with ' + response.status, response),
+      ]
     }
 
     // Retry on network errors or server errors (5xx).  Don't retry client errors (4xx) - these are legitimate

--- a/iznik-nuxt3/tests/unit/composables/useFetchRetry.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useFetchRetry.spec.js
@@ -168,6 +168,53 @@ describe('useFetchRetry', () => {
       vi.useRealTimers()
     })
 
+    it('should retry a 504 Gateway Timeout once, after a 10s delay', async () => {
+      const responseData = { success: true }
+
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 504,
+          statusText: 'Gateway Timeout',
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: vi.fn().mockResolvedValueOnce(responseData),
+        })
+
+      vi.useFakeTimers()
+      const retryFetch = fetchRetry(mockFetch)
+      const promise = retryFetch('http://test.com')
+
+      // The 504 backoff is 10s, much longer than the usual attempt * 1000ms.
+      await vi.advanceTimersByTimeAsync(9000)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1000)
+
+      const result = await promise
+      expect(result).toEqual([200, responseData])
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      vi.useRealTimers()
+    })
+
+    it('should give up after a second 504 rather than stacking more retries', async () => {
+      mockFetch.mockResolvedValue({
+        status: 504,
+        statusText: 'Gateway Timeout',
+        json: vi.fn().mockRejectedValue(new Error('no body')),
+      })
+
+      vi.useFakeTimers()
+      const retryFetch = fetchRetry(mockFetch)
+      const promise = retryFetch('http://test.com')
+      promise.catch(() => {}) // Avoid unhandled rejection noise before we assert.
+
+      await vi.advanceTimersByTimeAsync(30000)
+
+      await expect(promise).rejects.toThrow('Request failed with 504')
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      vi.useRealTimers()
+    })
+
     it('should retry on "load failed" error message', async () => {
       const responseData = { success: true }
 

--- a/iznik-server-go/rippling/analytics.go
+++ b/iznik-server-go/rippling/analytics.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/freegle/iznik-server-go/database"
@@ -422,9 +423,19 @@ func Analytics(c *fiber.Ctx) error {
 		TotalReplies  int
 		MeanFreeglers float64
 	}
+	// The four query blocks below (counts, held replies, trend, section 3) are independent, and
+	// each takes seconds even with the rippling_reach(created_at, total_freeglers) index (they
+	// aggregate per-post/per-reply subqueries over the whole window). Run them concurrently so the
+	// endpoint's wall time is the slowest block, not the sum - serially they added up past the
+	// gateway timeout (504s on the sysadmin KPIs).
+	var wg sync.WaitGroup
+	wg.Add(4)
+
 	// replied_36h: got a reply within 36h of the settling clock (first ripple, else origin
 	// arrival) - the headline convention. replied_ever: any reply eventually - the total.
-	db.Raw(`
+	go func() {
+		defer wg.Done()
+		db.Raw(`
 		SELECT COUNT(*) AS posts,
 		       SUM(replied_36h) AS replied36h,
 		       SUM(nreplies > 0) AS replied_ever,
@@ -445,30 +456,21 @@ func Analytics(c *fiber.Ctx) error {
 		    WHERE rr.created_at >= ? AND rr.created_at < ? AND rr.total_freeglers > 0`+stratumSQL+`
 		      AND EXISTS(SELECT 1 FROM messages_groups mgr WHERE mgr.msgid = rr.msgid AND mgr.rippled_in = 1 AND mgr.deleted = 0)
 		) d`, start, end).Scan(&agg)
-
-	kpi := Section1KPI{Stratum: stratum, Posts: agg.Posts, Replied36h: agg.Replied36h,
-		RepliedEver: agg.RepliedEver, Taken: agg.Taken, MeanFreeglers: agg.MeanFreeglers}
-	if agg.Posts > 0 {
-		kpi.Replied36hPct = float64(agg.Replied36h) / float64(agg.Posts) * 100
-		kpi.RepliedEverPct = float64(agg.RepliedEver) / float64(agg.Posts) * 100
-		kpi.TakenPct = float64(agg.Taken) / float64(agg.Posts) * 100
-		kpi.MeanReplies = float64(agg.TotalReplies) / float64(agg.Posts)
-	}
+	}()
 
 	// Reply friction: held replies over the window on rippled-out offers, as a share of all
 	// replies. rippling_held_replies has msgid + created_at so it scopes by post + stratum.
 	var held int
-	db.Raw(`
+	go func() {
+		defer wg.Done()
+		db.Raw(`
 		SELECT COUNT(*) FROM rippling_held_replies hr
 		JOIN rippling_reach rr ON rr.msgid = hr.msgid AND rr.total_freeglers > 0`+stratumSQL+`
 		JOIN messages m ON m.id = hr.msgid AND m.type = 'Offer'
 		WHERE hr.created_at >= ? AND hr.created_at < ?
 		  AND EXISTS(SELECT 1 FROM messages_groups mgr WHERE mgr.msgid = hr.msgid AND mgr.rippled_in = 1 AND mgr.deleted = 0)`,
-		start, end).Scan(&held)
-	kpi.HeldReplies = held
-	if agg.TotalReplies > 0 {
-		kpi.HeldRepliesPct = float64(held) / float64(agg.TotalReplies) * 100
-	}
+			start, end).Scan(&held)
+	}()
 
 	// The drive-time figures (the Section 1 overall mean, the Section 3 rippled-out mean, the
 	// per-day trend and the reliability bullseye) all come from a sampled routing pass - ~250
@@ -481,14 +483,39 @@ func Analytics(c *fiber.Ctx) error {
 	// Section 2 - trends: the SQL KPIs (reply rate, taken rate, mean replies, freeglers reached)
 	// per arrival day. The sample-based drive-time trend is merged in client-side from the
 	// separate drive-time request.
-	trend := fiber.Map{
-		"kpis":       trendSeries(db, start, end, stratumSQL),
-		"drive_time": []DriveTrendPoint{},
-	}
+	var trendRows []TrendRow
+	go func() {
+		defer wg.Done()
+		trendRows = trendSeries(db, start, end, stratumSQL)
+	}()
 
 	// Section 3 - is rippling helping? Server-derived rippled-out shares, the rescue floor and
 	// contribution range, and the home-vs-rippled comparison. RippleDrive fills in separately.
-	s3 := rippledOutSection(db, start, end, stratumSQL)
+	var s3 Section3RippledOut
+	go func() {
+		defer wg.Done()
+		s3 = rippledOutSection(db, start, end, stratumSQL)
+	}()
+
+	wg.Wait()
+
+	kpi := Section1KPI{Stratum: stratum, Posts: agg.Posts, Replied36h: agg.Replied36h,
+		RepliedEver: agg.RepliedEver, Taken: agg.Taken, MeanFreeglers: agg.MeanFreeglers}
+	if agg.Posts > 0 {
+		kpi.Replied36hPct = float64(agg.Replied36h) / float64(agg.Posts) * 100
+		kpi.RepliedEverPct = float64(agg.RepliedEver) / float64(agg.Posts) * 100
+		kpi.TakenPct = float64(agg.Taken) / float64(agg.Posts) * 100
+		kpi.MeanReplies = float64(agg.TotalReplies) / float64(agg.Posts)
+	}
+	kpi.HeldReplies = held
+	if agg.TotalReplies > 0 {
+		kpi.HeldRepliesPct = float64(held) / float64(agg.TotalReplies) * 100
+	}
+
+	trend := fiber.Map{
+		"kpis":       trendRows,
+		"drive_time": []DriveTrendPoint{},
+	}
 
 	return c.JSON(fiber.Map{
 		"stratum":       stratum,
@@ -698,7 +725,13 @@ func rippledOutSection(db *gorm.DB, start, end, stratumSQL string) Section3Rippl
 		RippledTakers  int
 		ClientRippled  int
 	}
-	db.Raw(`
+	// The shares query and the rescue-floor query are independent and both heavy (the rescue floor
+	// is the slowest single query on the tab), so run them concurrently.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		db.Raw(`
 		SELECT COUNT(*) AS replies,
 		       SUM(rippled) AS rippled_replies,
 		       SUM(is_taker) AS takers,
@@ -720,11 +753,14 @@ func rippledOutSection(db *gorm.DB, start, end, stratumSQL string) Section3Rippl
 		    WHERE cm.type = 'Interested' AND cm.date >= ? AND cm.date < ?
 		      AND EXISTS(SELECT 1 FROM messages_groups mgr WHERE mgr.msgid = cm.refmsgid AND mgr.rippled_in = 1 AND mgr.deleted = 0)
 		) d`, start, end).Scan(&raw)
+	}()
 
 	// Rescue floor: DISTINCT posts that were taken AND had at least one reply AND had NO reply
 	// from an established home-group member - so the take could only have come via rippling.
 	var rescued int
-	db.Raw(`
+	go func() {
+		defer wg.Done()
+		db.Raw(`
 		SELECT COUNT(*) FROM (
 		    SELECT rr.msgid
 		    FROM rippling_reach rr
@@ -740,6 +776,9 @@ func rippledOutSection(db *gorm.DB, start, end, stratumSQL string) Section3Rippl
 		            AND mem.collection = 'Approved' AND mem.added < og.arrival
 		          WHERE ch.refmsgid = rr.msgid AND ch.type = 'Interested')
 		) x`, start, end).Scan(&rescued)
+	}()
+
+	wg.Wait()
 
 	s := Section3RippledOut{Replies: raw.Replies, RippledReplies: raw.RippledReplies,
 		Takers: raw.Takers, RippledTakers: raw.RippledTakers, RescuedTakes: rescued}

--- a/iznik-server-go/test/rippling_analytics_test.go
+++ b/iznik-server-go/test/rippling_analytics_test.go
@@ -92,6 +92,39 @@ func TestBullseye(t *testing.T) {
 	assert.Equal(t, 0, empty[0].NReplies)
 }
 
+// The fast-SQL analytics endpoint runs its four query blocks concurrently (and the two inside
+// section 3 likewise) - serially they added up past the production gateway timeout. This guards
+// that the route is registered and that the concurrent handler assembles a complete, well-formed
+// payload (every section present, no panic from the goroutine fan-out) even on an empty test DB.
+func TestRipplingAnalyticsEndpoint(t *testing.T) {
+	prefix := uniquePrefix("rippleanalytics")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	url := fmt.Sprintf("/api/rippling/analytics?jwt=%s&stratum=rural", token)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil), 30000)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "analytics route must be registered and answer")
+
+	var body map[string]interface{}
+	json.Unmarshal(rsp(resp), &body)
+	assert.NotNil(t, body["sample_target"], "carries the drive-time sample target for the UI")
+	assert.Equal(t, "rural", body["stratum"], "echoes the requested stratum")
+
+	s1, ok := body["section1"].(map[string]interface{})
+	assert.True(t, ok, "section1 KPI block present")
+	assert.NotNil(t, s1["posts"], "section1 carries the post count")
+
+	s2, ok := body["section2"].(map[string]interface{})
+	assert.True(t, ok, "section2 trend block present")
+	_, hasKpis := s2["kpis"]
+	assert.True(t, hasKpis, "trend block carries the per-day kpis series")
+
+	s3, ok := body["section3"].(map[string]interface{})
+	assert.True(t, ok, "section3 rippled-out block present")
+	assert.NotNil(t, s3["rescued_takes"], "section3 carries the rescue floor")
+}
+
 // The sysadmin analytics UI loads drive-times from a SEPARATE set of endpoints so the slow routing
 // pass never blocks the fast panels and never 504s. The client drives it: fetch the SAMPLE, score
 // it one chunk after another (serial), then aggregate. This guards that all three routes are


### PR DESCRIPTION
## Problem

The sysadmin rippling analytics tab was 504ing at the gateway on `GET /apiv2/rippling/analytics` (surfacing client-side as a CORS error, since the gateway's 504 carries no `Access-Control-Allow-Origin` header).

## Root cause

`rippling_reach` has no index on `created_at`, so every analytics query full-scanned the table. It is only ~52k rows but **~17GB**, because each row carries the reach polygons — so the scan costs ~15s (`EXPLAIN` showed `type: ALL`). The endpoint runs four such queries serially: ~61s total, just past the gateway timeout.

## Fix

1. **Covering index** `rippling_reach (created_at, total_freeglers)` (msgid rides along as the PK), so the window predicate is answered index-only without touching a polygon page. Measured on prod: base scan ~15s → ~1.1s, serial total ~61s → ~14s.
   - **Already applied to prod** (2026-07-29) node-by-node under `wsrep_OSU_method=RSU`; all three nodes back to Synced. The table's SPATIAL index makes MySQL refuse `LOCK=NONE`, so the build used `LOCK=SHARED` (2–14s per node). The Laravel migration is guarded on `information_schema` so it no-ops on prod and creates the index on dev/test DBs.
2. **Concurrent queries** in the Go handler: the four independent blocks in `Analytics` (counts, held replies, trend, section 3) now run in parallel, as do the two queries inside `rippledOutSection`, so wall time is the slowest single query (~7s, the rescue floor) rather than the sum.

The 504 is already resolved in production by the index alone; the Go change brings the response down to ~7s and needs the normal deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)