### PR TITLE
fix(rippling): fixed-horizon analytics trends so recent days don't draw as decline

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -347,6 +347,17 @@ timeout:
 - `/rippling/analytics` (`rippling/analytics.go`) - the KPIs, trends and "is rippling helping?"
   section. Every query anchors on `rippling_reach` (one row per rippled post, bounded by
   `created_at`), which is what keeps it selective.
+
+  The trend series use **fixed accrual horizons** measured from `rippling_reach.created_at`:
+  replies and mean-replies within 36 hours (`ReplyHorizonHours`), taken within 14 days
+  (`TakenHorizonDays`). Counting replies/takes *ever* made recent days - which simply hadn't
+  finished accruing - draw as a steep mechanical decline (taken outcomes are marked a mean of
+  ~19 days after the post enters rippling, so the taken-ever line fell to near zero over the
+  trailing fortnight regardless of reality). Each trend row also carries `replied_mature` /
+  `taken_mature` flags - false until the day's whole horizon has elapsed - which the component
+  renders through a Google Charts `certainty` role, so a still-provisional tail draws dashed
+  rather than as a decline. The clock is reach creation, not `messages_groups.arrival`, because
+  autorepost bumps `arrival` forward, silently granting older posts longer windows.
 - `/rippling/metrics` (`rippling/metrics.go`) - reply attribution channels, geographic hotspots,
   held-reply friction. Small rippling-owned tables only, plus the live-capture boundary date,
   which is cached per process because its query ORs three unindexed nullable columns and so

--- a/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
@@ -137,7 +137,10 @@
       <!-- Section 2 - trends -->
       <h5 class="section-h">Trends</h5>
       <p class="text-muted small mb-2">
-        Each headline number over time, by post arrival day.
+        Each headline number over time, by the day the post entered rippling.
+        Figures use fixed windows (replies within 36h, taken within 14 days) so
+        every day is measured the same way — a dashed tail marks days too
+        recent for the window to have finished, not a real decline.
       </p>
       <div class="kpi-grid trends">
         <div v-for="t in trendCharts" :key="t.title" class="panel">
@@ -645,19 +648,38 @@ const rippledTakersPie = computed(() =>
     : null
 )
 
-function series(rows, key) {
+// A trend series, optionally carrying a per-day maturity flag as a Google Charts 'certainty'
+// role: days too recent for their fixed accrual window to have finished draw dashed/pale, so a
+// still-accruing tail reads as provisional rather than as a decline. A missing flag (older API)
+// is treated as mature.
+function series(rows, key, matureKey) {
   if (!rows || !rows.length) return null
-  return [['Date', 'v'], ...rows.map((r) => [new Date(r.day), r[key] || 0])]
+  if (!matureKey) {
+    return [['Date', 'v'], ...rows.map((r) => [new Date(r.day), r[key] || 0])]
+  }
+  return [
+    ['Date', 'v', { type: 'boolean', role: 'certainty' }],
+    ...rows.map((r) => [new Date(r.day), r[key] || 0, r[matureKey] !== false]),
+  ]
 }
 const trendCharts = computed(() => {
   const k = s2.value.kpis
   const dt = s2.value.drive_time
   return [
-    { title: 'Reply rate (%)', data: series(k, 'replied_pct'), color: POS },
-    { title: 'Taken rate (%)', data: series(k, 'taken_pct'), color: '#146c43' },
     {
-      title: 'Mean replies / offer',
-      data: series(k, 'mean_replies'),
+      title: 'Reply rate within 36h (%)',
+      data: series(k, 'replied_pct', 'replied_mature'),
+      color: POS,
+    },
+    {
+      title: 'Taken within 14 days (%)',
+      data: series(k, 'taken_pct', 'taken_mature'),
+      color: '#146c43',
+      note: 'Outcomes are marked weeks late, so the dashed provisional tail is long.',
+    },
+    {
+      title: 'Mean replies within 36h / offer',
+      data: series(k, 'mean_replies', 'replied_mature'),
       color: '#17a2b8',
     },
     {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
@@ -84,6 +84,8 @@ const FULL = {
         taken_pct: 45.3,
         mean_replies: 1.23,
         mean_freeglers: 2547,
+        replied_mature: true,
+        taken_mature: true,
       },
       {
         day: '2026-06-25',
@@ -92,6 +94,8 @@ const FULL = {
         taken_pct: 30.0,
         mean_replies: 1.3,
         mean_freeglers: 2600,
+        replied_mature: true,
+        taken_mature: false,
       },
     ],
     drive_time: [
@@ -282,6 +286,38 @@ describe('ModSysAdminRipplingAnalytics', () => {
     expect(areas.length).toBe(5)
     expect(wrapper.html()).toContain('Active freeglers reached')
     expect(wrapper.html()).toContain('Mean reply travel (min)')
+    wrapper.unmount()
+  })
+
+  // The reply/taken/mean-replies trends are fixed-horizon figures with a per-day maturity flag.
+  // Immature days ride into the chart as a Google Charts 'certainty' role column (drawn dashed/
+  // pale) so a still-accruing tail reads as provisional, never as a decline. Freeglers-reached
+  // has no accrual window, so it stays a plain two-column series.
+  it('marks immature trend days uncertain so they draw dashed, not as a decline', async () => {
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
+    const wrapper = mountComponent()
+    await flushPromises()
+    const areas = wrapper
+      .findAllComponents({ name: 'GChart' })
+      .filter((c) => c.props('type') === 'AreaChart')
+    // Order matches trendCharts: reply rate, taken rate, mean replies, freeglers, drive-time.
+    const [reply, taken, meanReplies, freeglers] = areas.map((a) =>
+      a.props('data')
+    )
+    for (const data of [reply, taken, meanReplies]) {
+      expect(data[0][2]).toEqual({ type: 'boolean', role: 'certainty' })
+    }
+    // Both fixture days are reply-mature; only the first is taken-mature (14-day window).
+    expect(reply[1][2]).toBe(true)
+    expect(reply[2][2]).toBe(true)
+    expect(taken[1][2]).toBe(true)
+    expect(taken[2][2]).toBe(false)
+    expect(freeglers[0]).toHaveLength(2)
+    // The titles say what the fixed windows are.
+    const html = wrapper.html()
+    expect(html).toContain('Reply rate within 36h (%)')
+    expect(html).toContain('Taken within 14 days (%)')
+    expect(html).toContain('Mean replies within 36h / offer')
     wrapper.unmount()
   })
 

--- a/iznik-server-go/rippling/analytics.go
+++ b/iznik-server-go/rippling/analytics.go
@@ -3,6 +3,7 @@ package rippling
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"os"
@@ -49,6 +50,30 @@ var routingClient = &http.Client{Timeout: 25 * time.Second}
 // driveMaxMinutes caps the isochrone. 45 is far cheaper to compute than 60 and covers virtually
 // all real reply travel; anything beyond reads as "unreachable" and is excluded from the mean.
 const driveMaxMinutes = 45
+
+// Fixed accrual horizons for the settling-clock KPIs, measured from reach creation
+// (rippling_reach.created_at - a clock that never moves, unlike messages_groups.arrival, which
+// autorepost bumps forward). Replies settle fast, so the long-standing 36h convention fits the
+// reply-rate and mean-replies figures. TAKEN is recorded long after the event (offerers mark
+// outcomes a mean of ~19 days after the post enters rippling on prod), so a short window would
+// read near zero: the taken series uses a 14-day horizon. Without fixed horizons the trend
+// series counted replies/takes EVER, so recent days - which simply hadn't finished accruing -
+// always drew as a steep mechanical decline.
+const (
+	ReplyHorizonHours = 36
+	TakenHorizonDays  = 14
+)
+
+// trendMature reports whether every post on a trend day (YYYY-MM-DD) has had the full horizon
+// elapse by now, i.e. the day's fixed-horizon figure can no longer grow. Immature days are still
+// returned (flagged false) so the UI can draw them as provisional rather than as a decline.
+func trendMature(day string, horizon time.Duration, now time.Time) bool {
+	t, err := time.Parse("2006-01-02", day)
+	if err != nil {
+		return false
+	}
+	return !now.Before(t.AddDate(0, 0, 1).Add(horizon))
+}
 
 // envInt reads a positive int env var, falling back to def. Lets the drive-time sample size and
 // concurrency be tuned per-environment WITHOUT a rebuild - prod's routing is on the local network
@@ -431,11 +456,14 @@ func Analytics(c *fiber.Ctx) error {
 	var wg sync.WaitGroup
 	wg.Add(4)
 
-	// replied_36h: got a reply within 36h of the settling clock (first ripple, else origin
-	// arrival) - the headline convention. replied_ever: any reply eventually - the total.
+	// replied_36h: got a reply within 36h of the settling clock - the headline convention. The
+	// clock is reach creation (rippling_reach.created_at), which in practice coincides with the
+	// first ripple and, unlike messages_groups.arrival, never moves: autorepost bumps arrival
+	// forward, which used to hand older posts ever-longer 36h windows. replied_ever: any reply
+	// eventually - the total.
 	go func() {
 		defer wg.Done()
-		db.Raw(`
+		db.Raw(fmt.Sprintf(`
 		SELECT COUNT(*) AS posts,
 		       SUM(replied_36h) AS replied36h,
 		       SUM(nreplies > 0) AS replied_ever,
@@ -446,12 +474,9 @@ func Analytics(c *fiber.Ctx) error {
 		    SELECT rr.total_freeglers AS freeglers,
 		           (SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = rr.msgid AND cm.type = 'Interested') AS nreplies,
 		           EXISTS(SELECT 1 FROM chat_messages c2 WHERE c2.refmsgid = rr.msgid AND c2.type = 'Interested'
-		                  AND c2.date <= COALESCE(
-		                       (SELECT MIN(arrival) FROM messages_groups WHERE msgid = rr.msgid AND rippled_in = 1 AND deleted = 0),
-		                       (SELECT MIN(arrival) FROM messages_groups WHERE msgid = rr.msgid AND rippled_in = 0 AND deleted = 0)
-		                  ) + INTERVAL 36 HOUR) AS replied_36h,
+		                  AND c2.date <= rr.created_at + INTERVAL %d HOUR) AS replied_36h,
 		           EXISTS(SELECT 1 FROM messages_by mb WHERE mb.msgid = rr.msgid) AS taken
-		    FROM rippling_reach rr
+		    FROM rippling_reach rr`, ReplyHorizonHours)+`
 		    JOIN messages m ON m.id = rr.msgid AND m.type = 'Offer'
 		    WHERE rr.created_at >= ? AND rr.created_at < ? AND rr.total_freeglers > 0`+stratumSQL+`
 		      AND EXISTS(SELECT 1 FROM messages_groups mgr WHERE mgr.msgid = rr.msgid AND mgr.rippled_in = 1 AND mgr.deleted = 0)
@@ -480,9 +505,9 @@ func Analytics(c *fiber.Ctx) error {
 	// kpi.ReplyDrive and s3.RippleDrive keep their zero value (Available:false), so the UI shows a
 	// "sampling..." placeholder until the drive-time request fills them in.
 
-	// Section 2 - trends: the SQL KPIs (reply rate, taken rate, mean replies, freeglers reached)
-	// per arrival day. The sample-based drive-time trend is merged in client-side from the
-	// separate drive-time request.
+	// Section 2 - trends: the SQL KPIs (fixed-horizon reply rate, taken rate and mean replies,
+	// plus freeglers reached) per day the post entered rippling. The sample-based drive-time
+	// trend is merged in client-side from the separate drive-time request.
 	var trendRows []TrendRow
 	go func() {
 		defer wg.Done()
@@ -645,7 +670,10 @@ func AnalyticsDriveAggregate(c *fiber.Ctx) error {
 	})
 }
 
-// TrendRow is one arrival-day point for the Section 2 time series.
+// TrendRow is one day's point for the Section 2 time series, by the day the post entered
+// rippling. The reply/taken/mean-replies figures are FIXED-HORIZON (see ReplyHorizonHours /
+// TakenHorizonDays): every day is measured the same way, so a lower recent point is a real
+// change, not just less accrual time.
 type TrendRow struct {
 	Day           string  `json:"day"            gorm:"column:day"`
 	Posts         int     `json:"posts"          gorm:"column:posts"`
@@ -653,28 +681,44 @@ type TrendRow struct {
 	TakenPct      float64 `json:"taken_pct"      gorm:"column:taken_pct"`
 	MeanReplies   float64 `json:"mean_replies"   gorm:"column:mean_replies"`
 	MeanFreeglers float64 `json:"mean_freeglers" gorm:"column:mean_freeglers"`
+	// Whether the day is old enough for its fixed-horizon figures to be final. RepliedMature
+	// covers replied_pct + mean_replies (36h); taken_pct matures much later (14 days), so the
+	// taken trend's provisional tail is weeks long, not hours.
+	RepliedMature bool `json:"replied_mature" gorm:"-"`
+	TakenMature   bool `json:"taken_mature"   gorm:"-"`
 }
 
-// trendSeries returns per-day KPI points (ascending) over the window + stratum. Pure SQL.
+// trendSeries returns per-day KPI points (ascending) over the window + stratum. Pure SQL plus
+// the maturity flags, which depend on the wall clock, not the data.
 func trendSeries(db *gorm.DB, start, end, stratumSQL string) []TrendRow {
 	rows := []TrendRow{}
-	db.Raw(`
-		SELECT DATE_FORMAT(created, '%Y-%m-%d') AS day,
+	db.Raw(fmt.Sprintf(`
+		SELECT DATE_FORMAT(created, '%%Y-%%m-%%d') AS day,
 		       COUNT(*) AS posts,
-		       100 * SUM(nreplies > 0) / COUNT(*) AS replied_pct,
+		       100 * SUM(replied) / COUNT(*) AS replied_pct,
 		       100 * SUM(taken) / COUNT(*) AS taken_pct,
 		       SUM(nreplies) / COUNT(*) AS mean_replies,
 		       AVG(freeglers) AS mean_freeglers
 		FROM (
 		    SELECT rr.created_at AS created, rr.total_freeglers AS freeglers,
-		           (SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = rr.msgid AND cm.type = 'Interested') AS nreplies,
-		           EXISTS(SELECT 1 FROM messages_by mb WHERE mb.msgid = rr.msgid) AS taken
+		           (SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = rr.msgid AND cm.type = 'Interested'
+		            AND cm.date <= rr.created_at + INTERVAL %d HOUR) AS nreplies,
+		           EXISTS(SELECT 1 FROM chat_messages c2 WHERE c2.refmsgid = rr.msgid AND c2.type = 'Interested'
+		            AND c2.date <= rr.created_at + INTERVAL %d HOUR) AS replied,
+		           EXISTS(SELECT 1 FROM messages_by mb WHERE mb.msgid = rr.msgid
+		            AND mb.timestamp <= rr.created_at + INTERVAL %d DAY) AS taken
 		    FROM rippling_reach rr
 		    JOIN messages m ON m.id = rr.msgid AND m.type = 'Offer'
-		    WHERE rr.created_at >= ? AND rr.created_at < ? AND rr.total_freeglers > 0`+stratumSQL+`
+		    WHERE rr.created_at >= ? AND rr.created_at < ? AND rr.total_freeglers > 0`,
+		ReplyHorizonHours, ReplyHorizonHours, TakenHorizonDays)+stratumSQL+`
 		      AND EXISTS(SELECT 1 FROM messages_groups mgr WHERE mgr.msgid = rr.msgid AND mgr.rippled_in = 1 AND mgr.deleted = 0)
 		) d
 		GROUP BY day ORDER BY day`, start, end).Scan(&rows)
+	now := time.Now()
+	for i := range rows {
+		rows[i].RepliedMature = trendMature(rows[i].Day, ReplyHorizonHours*time.Hour, now)
+		rows[i].TakenMature = trendMature(rows[i].Day, TakenHorizonDays*24*time.Hour, now)
+	}
 	return rows
 }
 

--- a/iznik-server-go/rippling/analytics_test.go
+++ b/iznik-server-go/rippling/analytics_test.go
@@ -2,9 +2,37 @@ package rippling
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// A trend day is mature once EVERY post on it has had the full horizon elapse: day end (midnight
+// after) + horizon must be at or before now. The boundary itself counts as mature - at exactly
+// day-end+horizon the figure can no longer grow.
+func TestTrendMature(t *testing.T) {
+	horizon := time.Duration(ReplyHorizonHours) * time.Hour
+	// Day 2026-07-01 ends 2026-07-02 00:00; +36h horizon -> final from 2026-07-03 12:00.
+	final := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+
+	assert.False(t, trendMature("2026-07-01", horizon, final.Add(-time.Second)),
+		"one second before the last post's horizon elapses the figure can still grow")
+	assert.True(t, trendMature("2026-07-01", horizon, final), "mature exactly at the boundary")
+	assert.True(t, trendMature("2026-07-01", horizon, final.Add(time.Hour)))
+
+	// The taken horizon is much longer, so the same day matures much later.
+	takenHorizon := time.Duration(TakenHorizonDays) * 24 * time.Hour
+	assert.False(t, trendMature("2026-07-01", takenHorizon, final))
+	assert.True(t, trendMature("2026-07-01", takenHorizon,
+		time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)))
+}
+
+// A malformed day never reads as final - drawing garbage as settled would be worse than drawing
+// it as provisional.
+func TestTrendMature_BadDayIsNeverMature(t *testing.T) {
+	assert.False(t, trendMature("not-a-date", time.Hour, time.Now()))
+	assert.False(t, trendMature("", time.Hour, time.Now()))
+}
 
 // bullseyeEdges = [0, 10, 15, 20, 25, 30, 45] -> bands [0,10) [10,15) [15,20)
 // [20,25) [25,30) [30,45]. Every band except the last is hi-exclusive; the


### PR DESCRIPTION
## Summary
- The rippling analytics trend series counted replies/takes **ever**, so recent days — which simply hadn't finished accruing — always drew as a steep mechanical decline. Taken outcomes are marked a mean of ~19 days after a post enters rippling, so the taken-ever trend fell to near zero over the trailing fortnight regardless of reality.
- Trend KPIs now use **fixed accrual horizons** from reach creation (`rippling_reach.created_at`): replies + mean replies within 36h (`ReplyHorizonHours`), taken within 14 days (`TakenHorizonDays`). Every day is measured the same way, so a lower recent point is a real change.
- Each trend row carries `replied_mature` / `taken_mature` flags (false until the day's whole horizon has elapsed). The ModTools component feeds them to a Google Charts `certainty` role so a still-provisional tail draws dashed/pale; chart titles and section copy name the windows.
- Section 1's replied-36h clock moves from `COALESCE(MIN(rippled arrival), MIN(origin arrival))` to `rippling_reach.created_at`: autorepost bumps `messages_groups.arrival` forward, silently handing older posts ever-longer 36h windows. Also drops two correlated `messages_groups` subqueries per post.
- Docs: `docs/developers/reference/rippling-algorithm.md` section 10 updated in the same PR.

Verified against production data (2026-07-29): with fixed horizons the apparent July decline in reply rate shrinks from −28pts (ever-based) to a real −5pts, and the 72%→18% taken cliff disappears entirely.

## Code Quality Review
- The trend SQL keeps the `rippling_reach` anchor and only adds indexed-range conditions to the existing correlated subqueries (`chat_messages.refmsgid`, `messages_by.msgid`), respecting the "never scan `messages_groups`/`chat_messages` over the window" rule in the docs; Section 1 gets cheaper (two subqueries removed).
- Maturity is a pure wall-clock function (`trendMature`), unit-tested at the boundary; a malformed day never reads as final.
- Frontend treats a missing maturity flag as mature, so an older API response still renders.

## Future Improvements
- Section 1's window-level taken/replied-ever KPIs are still accrual-based (labelled "underestimate" in the UI); they could gain a mature-posts-only variant.

## Test Plan
- New Go unit tests: `TestTrendMature`, `TestTrendMature_BadDayIsNeverMature`.
- Updated Vitest spec: fixture carries maturity flags; new test asserts the certainty column, per-day flags, plain 2-column freeglers series, and the new titles.
- This host has no dev-profile containers (status API cannot run suites here), so CI validates the full Go + Vitest suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)