### PR TITLE
fix(modtools-teams): accept userid/id as JSON string in PATCH /team

### DIFF
--- a/iznik-server-go/team/team.go
+++ b/iznik-server-go/team/team.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/freegle/iznik-server-go/auth"
 	"github.com/freegle/iznik-server-go/database"
-	"github.com/freegle/iznik-server-go/utils"
 	"github.com/freegle/iznik-server-go/user"
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -310,21 +310,25 @@ func PatchTeam(c *fiber.Ctx) error {
 	}
 
 	type PatchRequest struct {
-		ID          uint64 `json:"id"`
-		Action      string `json:"action"`
-		Userid      uint64 `json:"userid"`
-		Name        string `json:"name"`
-		Description string `json:"description"`
-		Email       string `json:"email"`
-		Wikiurl     string `json:"wikiurl"`
+		ID          utils.FlexUint64 `json:"id"`
+		Action      string           `json:"action"`
+		Userid      utils.FlexUint64 `json:"userid"`
+		Name        string           `json:"name"`
+		Description string           `json:"description"`
+		Email       string           `json:"email"`
+		Wikiurl     string           `json:"wikiurl"`
 	}
 
 	var req PatchRequest
+	// FlexUint64 unmarshals both string and numeric JSON values, so BodyParser
+	// handles ModTools teams.vue sending userid from a <b-form-input
+	// type="number"> v-model, which yields a JSON string.
 	if strings.Contains(c.Get("Content-Type"), "application/json") {
 		c.BodyParser(&req)
 	}
 	if req.ID == 0 {
-		req.ID, _ = strconv.ParseUint(c.FormValue("id", c.Query("id", "0")), 10, 64)
+		id, _ := strconv.ParseUint(c.FormValue("id", c.Query("id", "0")), 10, 64)
+		req.ID = utils.FlexUint64(id)
 	}
 
 	if req.ID == 0 {

--- a/iznik-server-go/test/team_test.go
+++ b/iznik-server-go/test/team_test.go
@@ -132,6 +132,34 @@ func TestPatchTeamAddMember(t *testing.T) {
 	assert.Equal(t, int64(1), count)
 }
 
+func TestPatchTeamAddMemberStringUserid(t *testing.T) {
+	// ModTools teams.vue binds the "Add member by ID" field to a
+	// <b-form-input type="number"> via v-model, which yields a JS string
+	// (e.g. "123"), not a number. $patchv2 JSON-encodes that straight into
+	// the request body, so the API must accept userid as a JSON string.
+	prefix := uniquePrefix("TeamPatchStr")
+	adminID := CreateTestUser(t, prefix+"_admin", "Admin")
+	_, token := CreateTestSession(t, adminID)
+
+	teamID := createTestTeam(t, prefix+"_team")
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+
+	body := fmt.Sprintf(`{"id":"%d","action":"Add","userid":"%d"}`, teamID, memberID)
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/team?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	db := database.DBConn
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM teams_members WHERE teamid = ? AND userid = ?", teamID, memberID).Scan(&count)
+	assert.Equal(t, int64(1), count)
+}
+
 func TestPatchTeamRemoveMember(t *testing.T) {
 	prefix := uniquePrefix("TeamRemove")
 	adminID := CreateTestUser(t, prefix+"_admin", "Admin")


### PR DESCRIPTION
## Root Cause
ModTools `teams.vue` binds the "Add member by ID" field to a `<b-form-input type="number">` via `v-model`, which yields a JS **string** (e.g. `"123"`), not a number (`iznik-nuxt3/modtools/pages/teams.vue`). `TeamAPI.add()` passes that straight through `$patchv2('/team', { action: 'Add', id, userid })`, which JSON-encodes the params object as the PATCH body (`iznik-nuxt3/api/BaseAPI.js` `$requestv2`, non-GET/non-POST branch).

In `iznik-server-go/team/team.go`, `PatchTeam`'s `PatchRequest.Userid`/`ID` were declared as plain `uint64`. Go's `encoding/json` cannot unmarshal a JSON string into a `uint64` field — it returns an `*json.UnmarshalTypeError` for that field and leaves it at its zero value, but `c.BodyParser(&req)`'s error return was never checked. So `req.Userid` silently stayed `0`, and the `Add` case's `if req.Userid == 0` branch fired, returning `400 {"ret":2,"status":"Missing userid"}` — exactly Jos's reported error.

## Evidence
New test `TestPatchTeamAddMemberStringUserid` sends the exact body shape the frontend produces (`{"id":"<n>","action":"Add","userid":"<n>"}`). Against the unfixed code:
```
=== RUN   TestPatchTeamAddMemberStringUserid
    team_test.go:151: Error Trace: /app/test/team_test.go:151
        Error: Not equal: expected: 200, actual: 400
    team_test.go:155: Error Trace: /app/test/team_test.go:155
        Error: Not equal: expected: 0, actual: 2
    team_test.go:160: Error Trace: /app/test/team_test.go:160
        Error: Not equal: expected: 1, actual: 0
--- FAIL: TestPatchTeamAddMemberStringUserid (0.05s)
```
After the fix, the same test and all other `team` tests pass.

## Fix
Changed `PatchRequest.ID` and `PatchRequest.Userid` from `uint64` to `utils.FlexUint64` — the codebase's existing helper (already used in `isochrone.go`, `user.go`, `session.go`) that unmarshals both numeric and string JSON values for exactly this "Vue `v-model` on `<input type=\"number\">`" pattern. No other lines changed; `req.ID`/`req.Userid` continue to be used as before (zero-value checks and `db.Exec` args both work unchanged against the new type, matching the existing `isochrone.go` precedent).

Also fixed a pre-existing `gofmt` import-ordering issue in the same import block (unrelated whitespace-only diff, caught because the file was already open).

## Other Call Sites
Grepped for the same `Userid uint64 \`json:"userid"\`` pattern elsewhere — these are separate, unaffected endpoints, out of scope for this fix but noted for awareness:
- `iznik-server-go/membership/membership.go:1099,1301`
- `iznik-server-go/spammers/spammers.go:138`
- `iznik-server-go/auth/auth.go:57`
- `iznik-server-go/chat/chatmessage.go:104`
- `iznik-server-go/chat/chatroom.go:334,670`

## Test
- File: `iznik-server-go/test/team_test.go` (`TestPatchTeamAddMemberStringUserid`)
- Command: `go test ./test/... -run TestPatchTeamAddMemberStringUserid -v` (run inside the `apiv2` container against `iznik_go_test`)
- Proves fail-before (400/ret:2, no row inserted) / pass-after (200/ret:0, member row inserted) — see Evidence above. Also re-ran the full existing `team` test suite (27 tests) after the fix — all pass, no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9974/1