### PR TITLE
feat(rippling): show the ACTUAL stored reach in the mod reach modal

### DIFF
--- a/docs/moderators/rippling-out.md
+++ b/docs/moderators/rippling-out.md
@@ -69,11 +69,16 @@ On posts in your moderation screens there is a **"View rippling reach"** button 
 map-marker icon) that shows you on a map the area a post is currently visible in. This is
 useful for checking how far a post has spread or why it turned up on your list.
 
-The red area is the *projected* spread - where the schedule says the post should have
-reached by now. A **dashed blue outline** shows where the engine's reach *actually* is,
-which can differ: if the reach was frozen (for example the origin copy went back to
-Pending) a warning above the map says so, and the reach can also be trimmed where members
-have left a community or capped by the poster's own distance preference.
+The **blue area** is where the post has *actually* rippled out to, read from the engine
+rather than modelled from the schedule. That matters because the two can differ: if the
+reach was frozen (for example the origin copy went back to Pending) a warning above the map
+says so, and the reach can also be trimmed where members have left a community or capped by
+the poster's own distance preference. A post that has not rippled out yet says so instead of
+drawing an area.
+
+Any moderator can open this, not just moderators of the communities the post is on - since
+rippling is what carries posts beyond their original community, the person wondering how far
+one travelled is often not a mod of where it started.
 
 ### 3. A reminder when you edit a shared post
 

--- a/docs/moderators/rippling-out.md
+++ b/docs/moderators/rippling-out.md
@@ -69,6 +69,12 @@ On posts in your moderation screens there is a **"View rippling reach"** button 
 map-marker icon) that shows you on a map the area a post is currently visible in. This is
 useful for checking how far a post has spread or why it turned up on your list.
 
+The red area is the *projected* spread - where the schedule says the post should have
+reached by now. A **dashed blue outline** shows where the engine's reach *actually* is,
+which can differ: if the reach was frozen (for example the origin copy went back to
+Pending) a warning above the map says so, and the reach can also be trimmed where members
+have left a community or capped by the poster's own distance preference.
+
 ### 3. A reminder when you edit a shared post
 
 If you edit a post that is on more than one community, you will see a warning:

--- a/iznik-nuxt3/modtools/components/ModMessageReachMap.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageReachMap.vue
@@ -13,6 +13,21 @@
           This post has no location, so its rippling reach can't be shown.
         </div>
         <div v-else style="height: 100%">
+          <div
+            v-if="reachHeld"
+            class="alert alert-warning py-1 px-2 mb-0 small text-center"
+          >
+            This post's reach is <strong>frozen (held)</strong> — usually
+            because the origin copy went back to Pending. The dashed blue
+            outline is where it actually stopped.
+          </div>
+          <div
+            v-else-if="reach?.polygon"
+            class="text-muted small text-center py-1"
+          >
+            Dashed blue outline = the engine's actual reach right now; the red
+            area is the projected schedule.
+          </div>
           <RipplingExplorer
             v-if="rendered"
             minimal
@@ -21,6 +36,7 @@
             :initial-lng="lng"
             :initial-elapsed-hours="elapsedHours"
             :actual-elapsed-hours="actualElapsedHours"
+            :actual-reach="reach?.polygon || null"
             :spatial-url="spatialUrl"
             :jwt="jwt"
           />
@@ -61,6 +77,10 @@ const spatialUrl = computed(
   () => runtimeConfig.public.SPATIAL_SERVER_URL || 'http://localhost:8196'
 )
 const hasLocation = computed(() => props.lat != null && props.lng != null)
+
+// A held reach is frozen (e.g. the origin copy was pulled back to Pending), so the
+// projected schedule overstates it — flag that above the map.
+const reachHeld = computed(() => reach.value?.status === 'held')
 
 // How long the post has already been live: the EXPECTED point (where reach SHOULD be).
 // The map + scrubber open here; this is the "up to" marker.

--- a/iznik-nuxt3/modtools/components/ModMessageReachMap.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageReachMap.vue
@@ -18,24 +18,29 @@
             class="alert alert-warning py-1 px-2 mb-0 small text-center"
           >
             This post's reach is <strong>frozen (held)</strong> — usually
-            because the origin copy went back to Pending. The dashed blue
-            outline is where it actually stopped.
+            because the origin copy went back to Pending. The blue area is where
+            it actually stopped.
           </div>
           <div
             v-else-if="reach?.polygon"
             class="text-muted small text-center py-1"
           >
-            Dashed blue outline = the engine's actual reach right now; the red
-            area is the projected schedule.
+            Blue area = how far this post has actually rippled out.
+          </div>
+          <div
+            v-else-if="reach && !reach.rippling"
+            class="text-muted small text-center py-1"
+          >
+            This post hasn't rippled out yet, so there's no reach to show.
           </div>
           <RipplingExplorer
             v-if="rendered"
             minimal
+            hide-projection
             initial-view="outbound"
             :initial-lat="lat"
             :initial-lng="lng"
             :initial-elapsed-hours="elapsedHours"
-            :actual-elapsed-hours="actualElapsedHours"
             :actual-reach="reach?.polygon || null"
             :spatial-url="spatialUrl"
             :jwt="jwt"
@@ -78,37 +83,17 @@ const spatialUrl = computed(
 )
 const hasLocation = computed(() => props.lat != null && props.lng != null)
 
-// A held reach is frozen (e.g. the origin copy was pulled back to Pending), so the
-// projected schedule overstates it — flag that above the map.
+// A held reach is frozen (e.g. the origin copy was pulled back to Pending) — worth
+// calling out, since the outline then stops short of where the post is still listed.
 const reachHeld = computed(() => reach.value?.status === 'held')
 
-// How long the post has already been live: the EXPECTED point (where reach SHOULD be).
-// The map + scrubber open here; this is the "up to" marker.
+// How long the post has already been live. Seeds the explorer's time position so the
+// group tinting matches the post's age rather than a default slider value.
 const elapsedHours = computed(() => {
   if (!props.arrival) return 0
   const t = new Date(props.arrival).getTime()
   if (Number.isNaN(t)) return 0
   return Math.max(0, (Date.now() - t) / 3600000)
-})
-
-// The hazard schedule (wall-clock hours per reach tick) — mirrors config/freegle.php.
-const HAZARD_HOURS = [1, 3, 6, 12, 24, 48, 72, 120, 168]
-function tickForHours(hours) {
-  let t = 1
-  HAZARD_HOURS.forEach((h, i) => {
-    if (hours >= h) t = i + 1
-  })
-  return Math.min(t, HAZARD_HOURS.length)
-}
-
-// The ACTUAL point ("now"), as elapsed-hours, ONLY when the engine is behind where it
-// should be. Null = up to date (or not rippling / dark) -> the modal shows just "up to".
-const actualElapsedHours = computed(() => {
-  const r = reach.value
-  if (!r || !r.rippling || !r.tick) return null
-  const expectedTick = tickForHours(elapsedHours.value)
-  if (r.tick >= expectedTick) return null // caught up -> only "up to"
-  return HAZARD_HOURS[Math.min(r.tick, HAZARD_HOURS.length) - 1]
 })
 
 async function show() {

--- a/iznik-nuxt3/modtools/components/RipplingExplorer.vue
+++ b/iznik-nuxt3/modtools/components/RipplingExplorer.vue
@@ -494,9 +494,14 @@ const props = defineProps({
   // the engine is behind the expected point. Null = up to date -> show just "up to".
   actualElapsedHours: { type: Number, default: null },
   // The ACTUAL stored reach outline (GeoJSON Polygon string or object, from the mod-only
-  // /message/{id}/reach endpoint), drawn as an overlay so held/clipped/capped reaches are
-  // visible against the projection. Arrives after mount (fetched separately), so it's watched.
+  // /message/{id}/reach endpoint). Arrives after mount (fetched separately), so it's watched.
   actualReach: { type: [String, Object], default: null },
+  // Suppress the projected (schedule-modelled) reach polygons, leaving the actual stored
+  // reach as the only reach drawn. For the per-post reach modal: once we can show where a
+  // post really got to, a model of where it should have got to is just a second, contradictory
+  // outline on the same map. The standalone explorer - which has no actual reach to show -
+  // leaves this false and keeps the projection.
+  hideProjection: { type: Boolean, default: false },
 })
 
 let cleanup = null

--- a/iznik-nuxt3/modtools/components/RipplingExplorer.vue
+++ b/iznik-nuxt3/modtools/components/RipplingExplorer.vue
@@ -493,6 +493,10 @@ const props = defineProps({
   // The ACTUAL reach point (elapsed-hours equivalent), shown as a "now" marker ONLY when
   // the engine is behind the expected point. Null = up to date -> show just "up to".
   actualElapsedHours: { type: Number, default: null },
+  // The ACTUAL stored reach outline (GeoJSON Polygon string or object, from the mod-only
+  // /message/{id}/reach endpoint), drawn as an overlay so held/clipped/capped reaches are
+  // visible against the projection. Arrives after mount (fetched separately), so it's watched.
+  actualReach: { type: [String, Object], default: null },
 })
 
 let cleanup = null

--- a/iznik-nuxt3/modtools/composables/rippling/actualreach.js
+++ b/iznik-nuxt3/modtools/composables/rippling/actualreach.js
@@ -1,0 +1,35 @@
+// The ACTUAL stored reach overlay for the per-post reach modal: what the engine actually
+// holds, as opposed to what the schedule says it should - the two diverge when a reach is
+// held, clipped where members left a group, or capped by the poster's distance preference.
+// Takes L and the map as arguments (rather than closing over them) so the whole update is
+// unit-testable with stubs.
+import { geoJsonToLatLngs } from './polygon.js'
+
+// Replace `existing` (if any) with a layer drawn from `raw` (GeoJSON string or object, from
+// the mod-only /message/{id}/reach endpoint). Returns the new layer, or null when there is
+// nothing to draw. With the projection suppressed (`filled`) this is the only reach on the
+// map, so fill it and drop the dashes - it's the subject, not an annotation over something
+// else. Alongside a projection it stays a dashed outline so the filled red area still reads
+// through.
+export function updateActualReachLayer(L, map, existing, raw, filled) {
+  if (existing && map && map.hasLayer(existing)) {
+    map.removeLayer(existing)
+  }
+  if (!raw || !map) return null
+  const latlngs = geoJsonToLatLngs(raw)
+  if (!latlngs) return null
+  return L.polygon(
+    latlngs,
+    filled
+      ? {
+          color: '#0055cc',
+          weight: 2,
+          fill: true,
+          fillColor: '#0055cc',
+          fillOpacity: 0.18,
+        }
+      : { color: '#0055cc', weight: 2, dashArray: '6 4', fill: false }
+  )
+    .bindTooltip('Actual reach right now (from the engine)', { sticky: true })
+    .addTo(map)
+}

--- a/iznik-nuxt3/modtools/composables/rippling/polygon.js
+++ b/iznik-nuxt3/modtools/composables/rippling/polygon.js
@@ -157,3 +157,27 @@ export function ringsOverlap(ring1, ring2) {
   }
   return false
 }
+
+/**
+ * Convert a GeoJSON Polygon/MultiPolygon (object, or JSON string as returned by the mod-only
+ * /message/{id}/reach endpoint) into Leaflet latlngs: an array of polygons, each an array of
+ * rings, each an array of [lat, lng]. GeoJSON stores [lng, lat], so every pair is flipped.
+ * Returns null for anything unusable (bad JSON, missing coordinates) - the caller draws
+ * nothing rather than throwing mid-render.
+ */
+export function geoJsonToLatLngs(raw) {
+  let geom = raw
+  if (typeof geom === 'string') {
+    try {
+      geom = JSON.parse(geom)
+    } catch (e) {
+      return null
+    }
+  }
+  if (!geom || !Array.isArray(geom.coordinates)) return null
+  const polys =
+    geom.type === 'MultiPolygon' ? geom.coordinates : [geom.coordinates]
+  return polys.map((rings) =>
+    rings.map((ring) => ring.map(([lng, lat]) => [lat, lng]))
+  )
+}

--- a/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
+++ b/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
@@ -69,11 +69,11 @@ export async function setupRipplingExplorer({
     }
   ).addTo(map)
 
-  // The ACTUAL stored reach outline (per-post reach modal only). The projection animates what
-  // the schedule SAYS the reach should be; this overlay is what the engine actually holds -
-  // the two diverge when a reach is held, clipped where members left a group, or capped by
-  // the poster's distance preference. The host modal fetches it separately, so it arrives
-  // after mount: watch, and redraw on change.
+  // The ACTUAL stored reach outline (per-post reach modal only): what the engine actually
+  // holds, as opposed to what the schedule says it should - the two diverge when a reach is
+  // held, clipped where members left a group, or capped by the poster's distance preference,
+  // which is why the modal draws this instead of the projection. The host modal fetches it
+  // separately, so it arrives after mount: watch, and redraw on change.
   let actualReachLayer = null
   function drawActualReach(raw) {
     if (actualReachLayer) {
@@ -85,13 +85,21 @@ export async function setupRipplingExplorer({
     if (!raw || !map) return
     const latlngs = geoJsonToLatLngs(raw)
     if (!latlngs) return
-    // Dashed outline, no fill, so it reads against the filled red projection.
-    actualReachLayer = L.polygon(latlngs, {
-      color: '#0055cc',
-      weight: 2,
-      dashArray: '6 4',
-      fill: false,
-    })
+    // With the projection suppressed this is the only reach on the map, so fill it and
+    // drop the dashes - it's the subject, not an annotation over something else. Alongside
+    // a projection it stays a dashed outline so the filled red area still reads through.
+    actualReachLayer = L.polygon(
+      latlngs,
+      props.hideProjection
+        ? {
+            color: '#0055cc',
+            weight: 2,
+            fill: true,
+            fillColor: '#0055cc',
+            fillOpacity: 0.18,
+          }
+        : { color: '#0055cc', weight: 2, dashArray: '6 4', fill: false }
+    )
       .bindTooltip('Actual reach right now (from the engine)', { sticky: true })
       .addTo(map)
   }
@@ -1586,6 +1594,16 @@ export async function setupRipplingExplorer({
 
   function drawPolygons(data, transitionMs, skipStandard = false) {
     lastIsoData = data
+    // Projection suppressed (per-post reach modal): the actual stored reach is drawn
+    // instead, so don't put a modelled outline on the same map to argue with it. Clear
+    // anything already drawn - a pin move must not strand the previous projection.
+    if (props.hideProjection) {
+      Object.keys(layers).forEach((k) => {
+        if (map && map.hasLayer(layers[k])) map.removeLayer(layers[k])
+        delete layers[k]
+      })
+      return
+    }
     const dur = transitionMs || 0
     const outgoing = Object.assign({}, layers)
     const newLayers = {}

--- a/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
+++ b/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
@@ -11,6 +11,7 @@
 //   props        — { spatialUrl, jwt } from the host component
 //   digestModal  — ref to <RipplingDigestModal>; modal opening is delegated
 //   legendMode   — ref ('outbound' | 'inbound') flipped by view-toggle
+import { watch } from 'vue'
 import {
   chaikinSmooth,
   geoToLeaflet,
@@ -66,6 +67,49 @@ export async function setupRipplingExplorer({
       maxZoom: 19,
     }
   ).addTo(map)
+
+  // The ACTUAL stored reach outline (per-post reach modal only). The projection animates what
+  // the schedule SAYS the reach should be; this overlay is what the engine actually holds -
+  // the two diverge when a reach is held, clipped where members left a group, or capped by
+  // the poster's distance preference. The host modal fetches it separately, so it arrives
+  // after mount: watch, and redraw on change.
+  let actualReachLayer = null
+  function drawActualReach(raw) {
+    if (actualReachLayer) {
+      if (map && map.hasLayer(actualReachLayer)) {
+        map.removeLayer(actualReachLayer)
+      }
+      actualReachLayer = null
+    }
+    if (!raw || !map) return
+    let geom = raw
+    if (typeof geom === 'string') {
+      try {
+        geom = JSON.parse(geom)
+      } catch (e) {
+        return
+      }
+    }
+    if (!geom || !geom.coordinates) return
+    const polys =
+      geom.type === 'MultiPolygon' ? geom.coordinates : [geom.coordinates]
+    // GeoJSON rings are [lng, lat]; Leaflet wants [lat, lng].
+    const latlngs = polys.map((rings) =>
+      rings.map((ring) => ring.map(([lng, lat]) => [lat, lng]))
+    )
+    // Dashed outline, no fill, so it reads against the filled red projection.
+    actualReachLayer = L.polygon(latlngs, {
+      color: '#0055cc',
+      weight: 2,
+      dashArray: '6 4',
+      fill: false,
+    })
+      .bindTooltip('Actual reach right now (from the engine)', { sticky: true })
+      .addTo(map)
+  }
+  cleanupFns.push(
+    watch(() => props.actualReach, drawActualReach, { immediate: true })
+  )
 
   let currentLat = null
   let currentLng = null

--- a/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
+++ b/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
@@ -24,8 +24,8 @@ import {
   groupCentroid,
   distSq,
   homeGroupOverlapFraction,
-  geoJsonToLatLngs,
 } from './polygon.js'
+import { updateActualReachLayer } from './actualreach.js'
 import { partitionInboxData, swingometerDisplay } from './scoring.js'
 import { renderPie as renderPieSvg } from './pie.js'
 import { driveMinForAudience, clampAudienceMinutes } from './audience.js'
@@ -75,36 +75,20 @@ export async function setupRipplingExplorer({
   // which is why the modal draws this instead of the projection. The host modal fetches it
   // separately, so it arrives after mount: watch, and redraw on change.
   let actualReachLayer = null
-  function drawActualReach(raw) {
-    if (actualReachLayer) {
-      if (map && map.hasLayer(actualReachLayer)) {
-        map.removeLayer(actualReachLayer)
-      }
-      actualReachLayer = null
-    }
-    if (!raw || !map) return
-    const latlngs = geoJsonToLatLngs(raw)
-    if (!latlngs) return
-    // With the projection suppressed this is the only reach on the map, so fill it and
-    // drop the dashes - it's the subject, not an annotation over something else. Alongside
-    // a projection it stays a dashed outline so the filled red area still reads through.
-    actualReachLayer = L.polygon(
-      latlngs,
-      props.hideProjection
-        ? {
-            color: '#0055cc',
-            weight: 2,
-            fill: true,
-            fillColor: '#0055cc',
-            fillOpacity: 0.18,
-          }
-        : { color: '#0055cc', weight: 2, dashArray: '6 4', fill: false }
-    )
-      .bindTooltip('Actual reach right now (from the engine)', { sticky: true })
-      .addTo(map)
-  }
   cleanupFns.push(
-    watch(() => props.actualReach, drawActualReach, { immediate: true })
+    watch(
+      () => props.actualReach,
+      (raw) => {
+        actualReachLayer = updateActualReachLayer(
+          L,
+          map,
+          actualReachLayer,
+          raw,
+          props.hideProjection
+        )
+      },
+      { immediate: true }
+    )
   )
 
   let currentLat = null

--- a/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
+++ b/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
@@ -24,6 +24,7 @@ import {
   groupCentroid,
   distSq,
   homeGroupOverlapFraction,
+  geoJsonToLatLngs,
 } from './polygon.js'
 import { partitionInboxData, swingometerDisplay } from './scoring.js'
 import { renderPie as renderPieSvg } from './pie.js'
@@ -82,21 +83,8 @@ export async function setupRipplingExplorer({
       actualReachLayer = null
     }
     if (!raw || !map) return
-    let geom = raw
-    if (typeof geom === 'string') {
-      try {
-        geom = JSON.parse(geom)
-      } catch (e) {
-        return
-      }
-    }
-    if (!geom || !geom.coordinates) return
-    const polys =
-      geom.type === 'MultiPolygon' ? geom.coordinates : [geom.coordinates]
-    // GeoJSON rings are [lng, lat]; Leaflet wants [lat, lng].
-    const latlngs = polys.map((rings) =>
-      rings.map((ring) => ring.map(([lng, lat]) => [lat, lng]))
-    )
+    const latlngs = geoJsonToLatLngs(raw)
+    if (!latlngs) return
     // Dashed outline, no fill, so it reads against the filled red projection.
     actualReachLayer = L.polygon(latlngs, {
       color: '#0055cc',

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageReachMap.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageReachMap.spec.js
@@ -38,11 +38,12 @@ const ExplorerStub = {
     initialView: { default: null },
     initialElapsedHours: { default: null },
     actualElapsedHours: { default: null },
+    actualReach: { default: null },
     spatialUrl: { default: null },
     jwt: { default: null },
   },
   template:
-    '<div class="explorer-stub" :data-lat="initialLat" :data-lng="initialLng" :data-view="initialView" :data-minimal="minimal" :data-spatial="spatialUrl" :data-actual="actualElapsedHours" />',
+    '<div class="explorer-stub" :data-lat="initialLat" :data-lng="initialLng" :data-view="initialView" :data-minimal="minimal" :data-spatial="spatialUrl" :data-actual="actualElapsedHours" :data-reach="actualReach" />',
 }
 
 // arrival N hours ago, as an ISO string.
@@ -140,6 +141,52 @@ describe('ModMessageReachMap', () => {
     await flushPromises()
     const a = wrapper.find('.explorer-stub').attributes('data-actual')
     expect(a === undefined || a === '').toBe(true)
+  })
+
+  // The mod-only reach endpoint now returns the ACTUAL stored outline as GeoJSON; the modal
+  // hands it to the explorer to overlay against the projection, and explains the overlay.
+  it('passes the actual stored reach outline through to the explorer', async () => {
+    const POLY =
+      '{"type":"Polygon","coordinates":[[[-0.2,51.4],[0,51.4],[0,51.6],[-0.2,51.4]]]}'
+    mockFetchReach.mockResolvedValueOnce({
+      rippling: true,
+      tick: 4,
+      totalticks: 9,
+      status: 'expanding',
+      polygon: POLY,
+    })
+    const wrapper = mountComponent({
+      messageid: 42,
+      lat: 55.95,
+      lng: -3.19,
+      arrival: hoursAgo(14),
+    })
+    await wrapper.vm.show()
+    await flushPromises()
+    expect(wrapper.find('.explorer-stub').attributes('data-reach')).toBe(POLY)
+    expect(wrapper.text()).toContain('actual reach right now')
+  })
+
+  // A held reach is frozen, so the projection overstates it - the modal must say so
+  // rather than letting the animated schedule read as reality.
+  it('flags a held (frozen) reach above the map', async () => {
+    mockFetchReach.mockResolvedValueOnce({
+      rippling: true,
+      tick: 3,
+      totalticks: 9,
+      status: 'held',
+      polygon:
+        '{"type":"Polygon","coordinates":[[[-0.2,51.4],[0,51.4],[0,51.6],[-0.2,51.4]]]}',
+    })
+    const wrapper = mountComponent({
+      messageid: 42,
+      lat: 55.95,
+      lng: -3.19,
+      arrival: hoursAgo(14),
+    })
+    await wrapper.vm.show()
+    await flushPromises()
+    expect(wrapper.text()).toContain('frozen (held)')
   })
 
   it('shows a no-location message instead of the map when the post has no location', async () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageReachMap.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageReachMap.spec.js
@@ -33,17 +33,17 @@ const ExplorerStub = {
   name: 'RipplingExplorer',
   props: {
     minimal: { type: Boolean, default: false },
+    hideProjection: { type: Boolean, default: false },
     initialLat: { default: null },
     initialLng: { default: null },
     initialView: { default: null },
     initialElapsedHours: { default: null },
-    actualElapsedHours: { default: null },
     actualReach: { default: null },
     spatialUrl: { default: null },
     jwt: { default: null },
   },
   template:
-    '<div class="explorer-stub" :data-lat="initialLat" :data-lng="initialLng" :data-view="initialView" :data-minimal="minimal" :data-spatial="spatialUrl" :data-actual="actualElapsedHours" :data-reach="actualReach" />',
+    '<div class="explorer-stub" :data-lat="initialLat" :data-lng="initialLng" :data-view="initialView" :data-minimal="minimal" :data-spatial="spatialUrl" :data-hideprojection="hideProjection" :data-reach="actualReach" />',
 }
 
 // arrival N hours ago, as an ISO string.
@@ -98,9 +98,10 @@ describe('ModMessageReachMap', () => {
     expect(explorer.attributes('data-spatial')).toBe('http://spatial.test')
   })
 
-  it('passes a "now" (actual) point only when the engine is behind expected', async () => {
-    // Post ~14h old -> expected tick 4 (12h band). Actual tick 2 (3h) = behind.
-    mockFetchReach.mockResolvedValueOnce({ rippling: true, tick: 2, totalticks: 9 })
+  // Once the endpoint can tell us where a post REALLY got to, drawing a schedule-modelled
+  // projection beside it just puts two contradictory outlines on one map, so the modal
+  // suppresses the projection and the actual reach is the only thing drawn.
+  it('tells the explorer to suppress the projected reach', async () => {
     const wrapper = mountComponent({
       messageid: 42,
       lat: 55.95,
@@ -109,42 +110,13 @@ describe('ModMessageReachMap', () => {
     })
     await wrapper.vm.show()
     await flushPromises()
-    expect(mockFetchReach).toHaveBeenCalledWith(42, false)
-    // actual = HAZARD_HOURS[tick-1] = HAZARD_HOURS[1] = 3
-    expect(wrapper.find('.explorer-stub').attributes('data-actual')).toBe('3')
+    expect(
+      wrapper.find('.explorer-stub').attributes('data-hideprojection')
+    ).toBeTruthy()
   })
 
-  it('does NOT pass a "now" point when the engine is up to date', async () => {
-    // Post ~14h old -> expected tick 4. Actual tick 4 = caught up.
-    mockFetchReach.mockResolvedValueOnce({ rippling: true, tick: 4, totalticks: 9 })
-    const wrapper = mountComponent({
-      messageid: 42,
-      lat: 55.95,
-      lng: -3.19,
-      arrival: hoursAgo(14),
-    })
-    await wrapper.vm.show()
-    await flushPromises()
-    const a = wrapper.find('.explorer-stub').attributes('data-actual')
-    expect(a === undefined || a === '').toBe(true)
-  })
-
-  it('does NOT pass a "now" point when the post is not rippling (dark)', async () => {
-    mockFetchReach.mockResolvedValueOnce({ rippling: false, reason: 'disabled' })
-    const wrapper = mountComponent({
-      messageid: 42,
-      lat: 55.95,
-      lng: -3.19,
-      arrival: hoursAgo(14),
-    })
-    await wrapper.vm.show()
-    await flushPromises()
-    const a = wrapper.find('.explorer-stub').attributes('data-actual')
-    expect(a === undefined || a === '').toBe(true)
-  })
-
-  // The mod-only reach endpoint now returns the ACTUAL stored outline as GeoJSON; the modal
-  // hands it to the explorer to overlay against the projection, and explains the overlay.
+  // The mod-only reach endpoint returns the ACTUAL stored outline as GeoJSON; the modal
+  // hands it to the explorer to draw, and says what the shape means.
   it('passes the actual stored reach outline through to the explorer', async () => {
     const POLY =
       '{"type":"Polygon","coordinates":[[[-0.2,51.4],[0,51.4],[0,51.6],[-0.2,51.4]]]}'
@@ -163,12 +135,27 @@ describe('ModMessageReachMap', () => {
     })
     await wrapper.vm.show()
     await flushPromises()
+    expect(mockFetchReach).toHaveBeenCalledWith(42, false)
     expect(wrapper.find('.explorer-stub').attributes('data-reach')).toBe(POLY)
-    expect(wrapper.text()).toContain('actual reach right now')
+    expect(wrapper.text()).toContain('actually rippled out')
   })
 
-  // A held reach is frozen, so the projection overstates it - the modal must say so
-  // rather than letting the animated schedule read as reality.
+  // With no projection to fall back on, a post that hasn't rippled would otherwise show a
+  // bare map with no explanation of why nothing is drawn.
+  it('explains when the post has not rippled out', async () => {
+    mockFetchReach.mockResolvedValueOnce({ rippling: false, reason: 'pending' })
+    const wrapper = mountComponent({
+      messageid: 42,
+      lat: 55.95,
+      lng: -3.19,
+      arrival: hoursAgo(14),
+    })
+    await wrapper.vm.show()
+    await flushPromises()
+    expect(wrapper.text()).toContain("hasn't rippled out yet")
+  })
+
+  // A held reach is frozen short of where the post is still listed - the modal must say so.
   it('flags a held (frozen) reach above the map', async () => {
     mockFetchReach.mockResolvedValueOnce({
       rippling: true,

--- a/iznik-nuxt3/tests/unit/composables/rippling-actualreach.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/rippling-actualreach.spec.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest'
+import { updateActualReachLayer } from '~/modtools/composables/rippling/actualreach.js'
+
+const POLY = JSON.stringify({
+  type: 'Polygon',
+  coordinates: [
+    [
+      [-0.2, 51.4],
+      [0, 51.4],
+      [0, 51.6],
+      [-0.2, 51.4],
+    ],
+  ],
+})
+
+// A stub Leaflet: L.polygon(...).bindTooltip(...).addTo(map) returns a sentinel layer.
+function stubLeaflet() {
+  const layer = { addTo: vi.fn(() => layer), bindTooltip: vi.fn(() => layer) }
+  const L = { polygon: vi.fn(() => layer) }
+  return { L, layer }
+}
+
+function stubMap(hasExisting = false) {
+  return {
+    hasLayer: vi.fn(() => hasExisting),
+    removeLayer: vi.fn(),
+  }
+}
+
+describe('updateActualReachLayer', () => {
+  it('fills the reach when the projection is suppressed (it is the subject)', () => {
+    const { L, layer } = stubLeaflet()
+    const map = stubMap()
+    const out = updateActualReachLayer(L, map, null, POLY, true)
+    expect(out).toBe(layer)
+    const [latlngs, style] = L.polygon.mock.calls[0]
+    expect(style).toMatchObject({ fill: true, fillColor: '#0055cc' })
+    expect(style.dashArray).toBeUndefined()
+    // GeoJSON [lng, lat] flipped to Leaflet [lat, lng].
+    expect(latlngs[0][0][0]).toEqual([51.4, -0.2])
+    expect(layer.bindTooltip).toHaveBeenCalled()
+    expect(layer.addTo).toHaveBeenCalledWith(map)
+  })
+
+  it('stays a dashed outline alongside a projection (annotation, not subject)', () => {
+    const { L } = stubLeaflet()
+    updateActualReachLayer(L, stubMap(), null, POLY, false)
+    const [, style] = L.polygon.mock.calls[0]
+    expect(style).toMatchObject({ dashArray: '6 4', fill: false })
+  })
+
+  it('removes the previous layer before drawing the replacement', () => {
+    const { L } = stubLeaflet()
+    const map = stubMap(true)
+    const existing = { existing: true }
+    updateActualReachLayer(L, map, existing, POLY, true)
+    expect(map.removeLayer).toHaveBeenCalledWith(existing)
+  })
+
+  it('removes the previous layer and returns null when the reach clears', () => {
+    const { L } = stubLeaflet()
+    const map = stubMap(true)
+    const existing = { existing: true }
+    expect(updateActualReachLayer(L, map, existing, null, true)).toBeNull()
+    expect(map.removeLayer).toHaveBeenCalledWith(existing)
+    expect(L.polygon).not.toHaveBeenCalled()
+  })
+
+  it('draws nothing for unusable GeoJSON or a missing map', () => {
+    const { L } = stubLeaflet()
+    expect(
+      updateActualReachLayer(L, stubMap(), null, 'not json', true)
+    ).toBeNull()
+    expect(updateActualReachLayer(L, null, null, POLY, true)).toBeNull()
+    expect(L.polygon).not.toHaveBeenCalled()
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/rippling-polygon.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/rippling-polygon.spec.js
@@ -6,6 +6,7 @@ import {
   distSq,
   ringsOverlap,
   homeGroupOverlapFraction,
+  geoJsonToLatLngs,
 } from '~/modtools/composables/rippling/polygon.js'
 
 // A minimal GeoJSON-shaped polygon wrapper.
@@ -316,5 +317,61 @@ describe('rippling/polygon', () => {
       const frac = homeGroupOverlapFraction(nearlyAllIso, groupRing)
       expect(frac).toBeGreaterThanOrEqual(0.9)
     })
+  })
+})
+
+// geoJsonToLatLngs feeds the mod reach modal's ACTUAL-reach overlay: the /message/{id}/reach
+// endpoint returns the stored reach as a GeoJSON string, Leaflet wants [lat, lng] rings.
+describe('geoJsonToLatLngs', () => {
+  const RING = [
+    [-0.2, 51.4],
+    [0, 51.4],
+    [0, 51.6],
+    [-0.2, 51.4],
+  ]
+
+  it('parses a GeoJSON Polygon string and flips [lng, lat] to [lat, lng]', () => {
+    const out = geoJsonToLatLngs(
+      JSON.stringify({ type: 'Polygon', coordinates: [RING] })
+    )
+    expect(out).toEqual([[RING.map(([lng, lat]) => [lat, lng])]])
+    expect(out[0][0][0]).toEqual([51.4, -0.2])
+  })
+
+  it('accepts an already-parsed object', () => {
+    const out = geoJsonToLatLngs({ type: 'Polygon', coordinates: [RING] })
+    expect(out[0][0]).toHaveLength(RING.length)
+  })
+
+  it('wraps each MultiPolygon part as its own polygon', () => {
+    const out = geoJsonToLatLngs({
+      type: 'MultiPolygon',
+      coordinates: [[RING], [RING]],
+    })
+    expect(out).toHaveLength(2)
+    expect(out[1][0][0]).toEqual([51.4, -0.2])
+  })
+
+  it('keeps holes (inner rings) with their polygon', () => {
+    const hole = [
+      [-0.1, 51.45],
+      [-0.05, 51.45],
+      [-0.05, 51.5],
+      [-0.1, 51.45],
+    ]
+    const out = geoJsonToLatLngs({
+      type: 'Polygon',
+      coordinates: [RING, hole],
+    })
+    expect(out[0]).toHaveLength(2)
+    expect(out[0][1][0]).toEqual([51.45, -0.1])
+  })
+
+  it('returns null rather than throwing for unusable input', () => {
+    expect(geoJsonToLatLngs('not json')).toBeNull()
+    expect(geoJsonToLatLngs('')).toBeNull()
+    expect(geoJsonToLatLngs(null)).toBeNull()
+    expect(geoJsonToLatLngs({})).toBeNull()
+    expect(geoJsonToLatLngs({ type: 'Polygon' })).toBeNull()
   })
 })

--- a/iznik-server-go/message/reach.go
+++ b/iznik-server-go/message/reach.go
@@ -73,6 +73,15 @@ type ReachResponse struct {
 	Status          string  `json:"status"`
 	Arrival         *string `json:"arrival"`
 	NextExpansionAt *string `json:"nextexpansionat"`
+	// Polygon is the ACTUAL stored reach (rippling_reach.polygon) as GeoJSON, so the reach
+	// modal can overlay the real outline against its client-side projection - the two diverge
+	// when a reach is held, clipped where members left a group, or capped by the poster's
+	// distance preference, none of which the projection knows about. This is the ONE place the
+	// stored polygon crosses the API: mod-of-group-only, one post per request, so the payload
+	// (~300KB typical / ~850KB worst on prod at 5 decimal places, well-compressed on the wire
+	// - the grid-fill polygons are highly repetitive) is a deliberate exception to the "never
+	// ship reach polygons" rule that governs the member-facing feed.
+	Polygon string `json:"polygon,omitempty"`
 }
 
 type reachRow struct {
@@ -81,6 +90,7 @@ type reachRow struct {
 	Status          string
 	Arrival         *string
 	NextExpansionAt *string
+	Polygon         *string
 }
 
 // Reach returns a post's current ACTUAL rippling-out progress (the hazard-schedule tick it has
@@ -129,8 +139,13 @@ func Reach(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusForbidden, "Not a moderator of this post's group")
 	}
 
+	// 5 decimal places ≈ 1m - plenty for a map overlay, and it keeps the grid-fill polygons
+	// (~11k vertices) to a fraction of their full-precision WKT size. The stored geometry's
+	// coordinates are lng/lat degrees (the SRID label notwithstanding), which is exactly
+	// GeoJSON's [lng, lat] order, so no transform is needed.
 	var row reachRow
-	found := db.Raw("SELECT tick, total_ticks, status, arrival, next_expansion_at "+
+	found := db.Raw("SELECT tick, total_ticks, status, arrival, next_expansion_at, "+
+		"ST_AsGeoJSON(polygon, 5) AS polygon "+
 		"FROM rippling_reach WHERE msgid = ?", id).Scan(&row)
 
 	if found.RowsAffected == 0 {
@@ -149,6 +164,10 @@ func Reach(c *fiber.Ctx) error {
 		return c.JSON(ReachResponse{Rippling: false, Reason: reason, Msgid: id})
 	}
 
+	polygon := ""
+	if row.Polygon != nil {
+		polygon = *row.Polygon
+	}
 	return c.JSON(ReachResponse{
 		Rippling:        true,
 		Msgid:           id,
@@ -157,5 +176,6 @@ func Reach(c *fiber.Ctx) error {
 		Status:          row.Status,
 		Arrival:         row.Arrival,
 		NextExpansionAt: row.NextExpansionAt,
+		Polygon:         polygon,
 	})
 }

--- a/iznik-server-go/message/reach.go
+++ b/iznik-server-go/message/reach.go
@@ -73,11 +73,11 @@ type ReachResponse struct {
 	Status          string  `json:"status"`
 	Arrival         *string `json:"arrival"`
 	NextExpansionAt *string `json:"nextexpansionat"`
-	// Polygon is the ACTUAL stored reach (rippling_reach.polygon) as GeoJSON, so the reach
-	// modal can overlay the real outline against its client-side projection - the two diverge
-	// when a reach is held, clipped where members left a group, or capped by the poster's
-	// distance preference, none of which the projection knows about. This is the ONE place the
-	// stored polygon crosses the API: mod-of-group-only, one post per request, so the payload
+	// Polygon is the ACTUAL stored reach (rippling_reach.polygon) as GeoJSON, and is what the
+	// reach modal draws - a reach is held, clipped where members left a group, or capped by the
+	// poster's distance preference, none of which a client-side projection of the schedule
+	// knows about, so the projection was dropped in favour of this. This is the ONE place the
+	// stored polygon crosses the API: mod-only, one post per request, so the payload
 	// (~300KB typical / ~850KB worst on prod at 5 decimal places, well-compressed on the wire
 	// - the grid-fill polygons are highly repetitive) is a deliberate exception to the "never
 	// ship reach polygons" rule that governs the member-facing feed.
@@ -94,8 +94,8 @@ type reachRow struct {
 }
 
 // Reach returns a post's current ACTUAL rippling-out progress (the hazard-schedule tick it has
-// really reached), for moderators to compare with the expected progress on the reach map.
-// Mod-of-group (or Admin/Support) only; returns rippling:false (not 404) with a reason when the
+// really reached), which is what the moderation reach map draws.
+// Any moderator (or Admin/Support); returns rippling:false (not 404) with a reason when the
 // post has no reach row.
 //
 // @Router /message/{id}/reach [get]
@@ -105,7 +105,7 @@ type reachRow struct {
 // @Param id path int true "Message ID"
 // @Security BearerAuth
 // @Success 200 {object} message.ReachResponse
-// @Failure 403 {object} fiber.Error "Moderator of the post's group required"
+// @Failure 403 {object} fiber.Error "Moderator required"
 func Reach(c *fiber.Ctx) error {
 	db := database.DBConn
 
@@ -119,24 +119,20 @@ func Reach(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid message id")
 	}
 
-	// The groups the post is on, for the mod-of-group authorisation and to confirm it exists.
+	// Confirm the post exists (and is on a group at all).
 	var groupids []uint64
 	db.Raw("SELECT groupid FROM messages_groups WHERE msgid = ? AND deleted = 0", id).Scan(&groupids)
 	if len(groupids) == 0 {
 		return fiber.NewError(fiber.StatusNotFound, "Message not found")
 	}
 
-	allowed := user.IsAdminOrSupport(myid)
-	if !allowed {
-		for _, gid := range groupids {
-			if user.IsModOfGroup(myid, gid) {
-				allowed = true
-				break
-			}
-		}
-	}
-	if !allowed {
-		return fiber.NewError(fiber.StatusForbidden, "Not a moderator of this post's group")
+	// Any moderator may look at reach, not only mods of the groups this post is on.
+	// Rippling deliberately carries posts to OTHER groups, so the mods who most need
+	// to see how far one has travelled are usually not mods of its origin group -
+	// gating on mod-of-this-post's-group hid reach from exactly them. Reach exposes
+	// no member data, so there is nothing here to scope per group.
+	if !user.IsModOfAnyGroup(myid) {
+		return fiber.NewError(fiber.StatusForbidden, "Moderator required")
 	}
 
 	// 5 decimal places ≈ 1m - plenty for a map overlay, and it keeps the grid-fill polygons

--- a/iznik-server-go/test/message_reach_test.go
+++ b/iznik-server-go/test/message_reach_test.go
@@ -59,6 +59,21 @@ func TestMessageReachAsMod(t *testing.T) {
 	assert.Equal(t, true, result["rippling"], "post has a reach row")
 	assert.Equal(t, float64(3), result["tick"], "actual tick surfaced")
 	assert.Equal(t, float64(9), result["totalticks"], "total ticks surfaced")
+
+	// The ACTUAL stored reach outline crosses as GeoJSON, so the reach modal can overlay it
+	// against its client-side projection (held/clipped/capped reaches diverge from projected).
+	polyStr, ok := result["polygon"].(string)
+	assert.True(t, ok, "polygon returned as a GeoJSON string")
+	var geo struct {
+		Type        string         `json:"type"`
+		Coordinates [][][2]float64 `json:"coordinates"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(polyStr), &geo), "polygon parses as GeoJSON")
+	assert.Equal(t, "Polygon", geo.Type)
+	assert.NotEmpty(t, geo.Coordinates, "polygon has at least one ring")
+	// Coordinates are [lng, lat] in degrees, matching how the reach geometry is stored.
+	assert.InDelta(t, -0.2, geo.Coordinates[0][0][0], 0.001)
+	assert.InDelta(t, 51.4, geo.Coordinates[0][0][1], 0.001)
 }
 
 // A non-moderator is forbidden.

--- a/iznik-server-go/test/message_reach_test.go
+++ b/iznik-server-go/test/message_reach_test.go
@@ -60,8 +60,8 @@ func TestMessageReachAsMod(t *testing.T) {
 	assert.Equal(t, float64(3), result["tick"], "actual tick surfaced")
 	assert.Equal(t, float64(9), result["totalticks"], "total ticks surfaced")
 
-	// The ACTUAL stored reach outline crosses as GeoJSON, so the reach modal can overlay it
-	// against its client-side projection (held/clipped/capped reaches diverge from projected).
+	// The ACTUAL stored reach outline crosses as GeoJSON - it is what the reach modal draws,
+	// since held/clipped/capped reaches are invisible to a schedule-based projection.
 	polyStr, ok := result["polygon"].(string)
 	assert.True(t, ok, "polygon returned as a GeoJSON string")
 	var geo struct {
@@ -74,6 +74,37 @@ func TestMessageReachAsMod(t *testing.T) {
 	// Coordinates are [lng, lat] in degrees, matching how the reach geometry is stored.
 	assert.InDelta(t, -0.2, geo.Coordinates[0][0][0], 0.001)
 	assert.InDelta(t, 51.4, geo.Coordinates[0][0][1], 0.001)
+}
+
+// A moderator of some OTHER group can still see a post's reach. Rippling carries posts to
+// groups beyond the one they were posted on, so the mods asking "how far did this get?" are
+// usually not mods of its origin group - gating on mod-of-this-post's-group hid reach from
+// exactly the people it is for. Reach carries no member data, so there is nothing to scope.
+func TestMessageReachAsModOfDifferentGroup(t *testing.T) {
+	ensureRippleReachTable()
+	db := database.DBConn
+
+	prefix := uniquePrefix("reachothermod")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	group := CreateTestGroup(t, prefix)
+	mid := CreateTestMessage(t, posterID, group, "OFFER: reach other-group mod", 51.5, -0.1)
+
+	// A mod of an unrelated group, with no membership at all of the post's group.
+	otherGroup := CreateTestGroup(t, prefix+"_other")
+	modID := CreateTestUser(t, prefix+"_othermod", "User")
+	CreateTestMembership(t, modID, otherGroup, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	insertReach(mid, 3, 9)
+	defer db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", mid)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d/reach?jwt=%s", mid, token), nil))
+	assert.Equal(t, 200, resp.StatusCode, "any moderator may view reach, not just mods of the post's group")
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, true, result["rippling"], "post has a reach row")
+	assert.Equal(t, float64(3), result["tick"], "actual tick surfaced to an other-group mod")
 }
 
 // A non-moderator is forbidden.

--- a/iznik-server-go/user/authorization.go
+++ b/iznik-server-go/user/authorization.go
@@ -19,6 +19,13 @@ func IsModOfGroup(myid uint64, groupid uint64) bool {
 	return auth.IsModOfGroup(myid, groupid)
 }
 
+// IsModOfAnyGroup checks if the user is a Moderator or Owner of ANY group, or is Admin/Support.
+// For mod-only surfaces that expose no group-scoped member data.
+// Delegates to auth.IsModOfAnyGroup to avoid circular imports.
+func IsModOfAnyGroup(myid uint64) bool {
+	return auth.IsModOfAnyGroup(myid)
+}
+
 // IsModOfUser checks if myid is Admin/Support or a Moderator/Owner of any
 // group that targetid also belongs to (including groups the target is banned from).
 func IsModOfUser(myid, targetid uint64) bool {


### PR DESCRIPTION
## Problem

The moderation reach modal drew a client-side projection of where the hazard schedule says a post should have reached. The reach the engine actually holds diverges from that whenever it is frozen (`held`, when the origin copy goes back to Pending), clipped where members left a community, or capped by the poster's distance preference — none of which a projection knows about.

Reach was also limited to moderators of the communities the post is on. Rippling exists to carry posts to other communities, so the moderators asking how far a post travelled, and why it turned up on their patch, are typically not moderators of where it started.

## What this does

**Returns the stored reach.** `/message/{id}/reach` includes `rippling_reach.polygon` as GeoJSON (`ST_AsGeoJSON(polygon, 5)`; ~300KB typical, ~850KB worst on production, one post per on-demand request). This is the one place a reach polygon crosses the API — a deliberate exception to the rule that governs the member-facing feed.

**Draws the actual reach alone.** The projection is suppressed in the modal and the stored reach is filled rather than outlined, since it is the subject rather than an annotation over something else. A post that has not rippled says so, rather than showing a modelled shape. The standalone rippling explorer, which has no actual reach to draw, keeps its projection.

**Opens reach to any moderator.** Reach carries no member data, so there is nothing to scope per community. Non-moderators are refused.

## Tests

Go covers the polygon crossing as parseable GeoJSON in `[lng, lat]`, a moderator of an unrelated community getting a result, a non-moderator being refused, and a post with no reach row. Vitest covers the modal suppressing the projection, passing the stored outline through, and the messages for a frozen reach and a post that has not rippled.

## Docs

`docs/moderators/rippling-out.md` describes the blue area as the actual reach and states that any moderator can open it.

Discourse: https://discourse.ilovefreegle.org/t/9808
