### PR TITLE
fix(chat): a ban should stop a reply only where the two people actually share a community

### DIFF
--- a/iznik-batch/app/Models/ChatMessage.php
+++ b/iznik-batch/app/Models/ChatMessage.php
@@ -86,6 +86,14 @@ class ChatMessage extends Model implements Auditable
     protected $guarded = ['id'];
     public $timestamps = FALSE;
 
+    /**
+     * Reasons a message was dropped during processing (chat_messages.processingfailreason).
+     * A dropped message is never notified to the recipient, so support needs to be able to
+     * say why rather than leave it looking like the sender never wrote.
+     */
+    public const PROCESSFAIL_SPAMMER = 'Spammer';
+    public const PROCESSFAIL_BANNED_IN_COMMON = 'BannedInCommonGroups';
+
     public const TYPE_DEFAULT = 'Default';
     public const TYPE_SYSTEM = 'System';
     public const TYPE_MODMAIL = 'ModMail';

--- a/iznik-batch/app/Services/ChatProcessService.php
+++ b/iznik-batch/app/Services/ChatProcessService.php
@@ -106,21 +106,14 @@ class ChatProcessService
         $chattype = $message->chattype;
         $platform = (bool) $message->platform;
 
-        // --- Ban check for messages with a refmsgid ---
-        if (!empty($message->refmsgid)) {
-            $banned = DB::table('messages_groups')
-                ->join('users_banned', function ($join) use ($userid) {
-                    $join->on('messages_groups.groupid', '=', 'users_banned.groupid')
-                        ->where('users_banned.userid', '=', $userid);
-                })
-                ->where('messages_groups.msgid', $message->refmsgid)
-                ->exists();
-
-            if ($banned) {
-                $this->processFailed($id);
-                return true;
-            }
-        }
+        // A ban is a fact about the sender's standing with the communities they share with
+        // the person they are writing to - see isBannedInCommonGroups below, which is the
+        // check that applies. It deliberately does NOT look at which communities the post
+        // reached: rippling puts a post on communities the poster never chose, so asking
+        // "is the sender banned anywhere this post landed?" threw away replies from members
+        // in good standing wherever they and the poster actually talk (one live example was
+        // 410m away, on the poster's own community, banned only on a community the post had
+        // rippled into and that neither of them was conversing on).
 
         // --- User2User spam and review checks ---
         $review = 0;
@@ -135,7 +128,7 @@ class ChatProcessService
                 ->exists();
 
             if ($isSpammer) {
-                $this->processFailed($id);
+                $this->processFailed($id, ChatMessage::PROCESSFAIL_SPAMMER);
                 return true;
             }
 
@@ -145,7 +138,7 @@ class ChatProcessService
             $bannedInCommon = $this->isBannedInCommonGroups($userid, $otherId);
 
             if ($bannedInCommon) {
-                $this->processFailed($id);
+                $this->processFailed($id, ChatMessage::PROCESSFAIL_BANNED_IN_COMMON);
                 return true;
             }
 
@@ -265,15 +258,26 @@ class ChatProcessService
 
     /**
      * Mark a message as failed processing.
+     *
+     * A failed message is never notified to the recipient (ChatNotificationService only
+     * takes processingsuccessful = 1), so record WHY. Without this a suppressed reply is
+     * indistinguishable from one that was never sent, which is how a batch of dropped
+     * replies got misdiagnosed as a rippling delay.
      */
-    private function processFailed(int $messageId): void
+    private function processFailed(int $messageId, ?string $reason = null): void
     {
         DB::table('chat_messages')
             ->where('id', $messageId)
             ->update([
                 'processingrequired' => 0,
                 'processingsuccessful' => 0,
+                'processingfailreason' => $reason,
             ]);
+
+        Log::info('ChatProcess: message suppressed', [
+            'chatmsgid' => $messageId,
+            'reason' => $reason,
+        ]);
     }
 
     /**

--- a/iznik-batch/database/migrations/2026_07_30_000001_add_chat_messages_processingfailreason.php
+++ b/iznik-batch/database/migrations/2026_07_30_000001_add_chat_messages_processingfailreason.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Record WHY a chat message was dropped during processing.
+ *
+ * A message that fails processing is set processingsuccessful = 0, which permanently
+ * excludes it from chat notifications - the recipient is never told it exists, and the
+ * sender believes they were ignored. Until now nothing recorded the reason, so a
+ * suppressed reply was indistinguishable from one that was never written, and support
+ * had no way to answer "why didn't I see this reply?" except by guessing.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('chat_messages', function (Blueprint $table) {
+            $table->string('processingfailreason', 32)->nullable()->after('processingsuccessful');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('chat_messages', function (Blueprint $table) {
+            $table->dropColumn('processingfailreason');
+        });
+    }
+};

--- a/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
@@ -19,6 +19,113 @@ class ChatProcessServiceTest extends TestCase
         $this->service = new ChatProcessService();
     }
 
+
+    // --- Ban handling (Discourse: replies silently destroyed) ---
+
+    /**
+     * A ban belongs to the relationship between the two people, not to every community a
+     * post happens to be on. Rippling puts a post on communities the poster never chose,
+     * so asking "is the sender banned on ANY group this post is on?" silently destroyed
+     * replies from members in good standing wherever they were talking.
+     *
+     * Live example: a Battersea member 410m from the poster, a member of her own community
+     * and never banned there, had his reply thrown away because the post had rippled into a
+     * community he happened to be banned on. The offerer was never told, and he had no idea
+     * he had been ignored.
+     */
+    public function test_reply_delivered_when_sender_banned_only_on_an_unrelated_group_the_post_reached(): void
+    {
+        $poster = $this->createTestUser();
+        $replier = $this->createTestUser();
+        $room = $this->createTestChatRoom($poster, $replier);
+
+        $shared = $this->createTestGroup();      // both belong here, replier in good standing
+        $elsewhere = $this->createTestGroup();   // replier banned here; poster has no part in it
+        $this->createMembership($poster, $shared);
+        $this->createMembership($replier, $shared);
+
+        // The post is on both: its own community, plus one it rippled into.
+        $message = $this->createTestMessage($poster, $shared);
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id, 'groupid' => $elsewhere->id,
+            'collection' => 'Approved', 'arrival' => now(), 'deleted' => 0, 'rippled_in' => 1,
+        ]);
+
+        DB::table('users_banned')->insert([
+            'userid' => $replier->id, 'groupid' => $elsewhere->id, 'byuser' => $poster->id,
+        ]);
+
+        $msg = $this->createTestChatMessage($room, $replier, [
+            'processingrequired' => 1, 'processingsuccessful' => 0,
+            'platform' => 1, 'refmsgid' => $message->id,
+        ]);
+
+        $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(1, $updated->processingsuccessful,
+            'a reply from someone in good standing where they are both members must be delivered');
+    }
+
+    /**
+     * The protection that must survive: someone banned everywhere the two of them share is
+     * blocked. That is a fact about the two people, so it holds regardless of which
+     * communities the post reached or how it got there.
+     */
+    public function test_reply_suppressed_when_sender_banned_on_every_group_they_share(): void
+    {
+        $poster = $this->createTestUser();
+        $replier = $this->createTestUser();
+        $room = $this->createTestChatRoom($poster, $replier);
+
+        $shared = $this->createTestGroup();
+        $this->createMembership($poster, $shared);
+        $this->createMembership($replier, $shared);
+
+        $message = $this->createTestMessage($poster, $shared);
+
+        DB::table('users_banned')->insert([
+            'userid' => $replier->id, 'groupid' => $shared->id, 'byuser' => $poster->id,
+        ]);
+
+        $msg = $this->createTestChatMessage($room, $replier, [
+            'processingrequired' => 1, 'processingsuccessful' => 0,
+            'platform' => 1, 'refmsgid' => $message->id,
+        ]);
+
+        $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(0, $updated->processingsuccessful,
+            'someone banned everywhere they share a community with the poster stays blocked');
+        $this->assertEquals(ChatMessage::PROCESSFAIL_BANNED_IN_COMMON, $updated->processingfailreason,
+            'support tools must be able to see WHY the reply never arrived');
+    }
+
+    /**
+     * The silence was the worst part: a suppressed reply looked identical to one that was
+     * never written, so it got misdiagnosed. Record why on the message itself.
+     */
+    public function test_spam_suppression_records_a_reason_for_support(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        DB::table('spam_users')->insert([
+            'userid' => $user1->id, 'collection' => 'Spammer', 'added' => now(),
+        ]);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 1, 'processingsuccessful' => 0, 'platform' => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(ChatMessage::PROCESSFAIL_SPAMMER, $updated->processingfailreason);
+    }
+
     // --- Basic processing ---
 
     public function test_message_with_processingrequired_gets_marked_processed(): void

--- a/iznik-nuxt3/modtools/components/ModChatReview.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReview.vue
@@ -80,9 +80,29 @@
           data-testid="rippling-held-notice"
         >
           <v-icon icon="pause-circle" class="me-1" />
-          Held: rippling out - this reply arrived before the post's reach grew to
-          cover the sender's location. It will be delivered automatically once the
-          reach expands far enough.
+          Held: rippling out - this reply arrived before the post's reach grew
+          to cover the sender's location. It will be delivered automatically
+          once the reach expands far enough.
+        </NoticeMessage>
+        <NoticeMessage
+          v-if="message.processingfailreason"
+          class="mb-2"
+          variant="danger"
+          data-testid="processing-suppressed-notice"
+        >
+          <v-icon icon="ban" class="me-1" />
+          <span v-if="message.processingfailreason === 'BannedInCommonGroups'">
+            Not delivered: the sender is banned on every community they and the
+            recipient share, so this never reached them and never will.
+          </span>
+          <span v-else-if="message.processingfailreason === 'Spammer'">
+            Not delivered: the sender was flagged as a spammer when this was
+            processed, so it never reached the recipient.
+          </span>
+          <span v-else>
+            Not delivered ({{ message.processingfailreason }}) - this never
+            reached the recipient.
+          </span>
         </NoticeMessage>
         <div class="rounded bg-white p-2 fw-bold border border-warning mb-2">
           <ChatMessage

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -46,6 +46,17 @@ type ChatMessage struct {
 	Reviewrejected       bool            `json:"reviewrejected"`
 	Processingrequired   bool            `json:"processingrequired"`
 	Processingsuccessful bool            `json:"processingsuccessful"`
+	// Processingfailreason says WHY a message was dropped during processing
+	// (processingsuccessful = 0). A dropped message is never notified to the recipient and
+	// is filtered out of their chat fetch, so without this a support volunteer sees a
+	// message the recipient swears never arrived and has no way to explain it - which is
+	// how a run of suppressed replies got put down to a rippling delay. Values come from
+	// ChatMessage::PROCESSFAIL_* in the batch app.
+	//
+	// Read-only here (`gorm:"->"`): only the batch processor ever sets it, and without
+	// this GORM adds it to every chat_messages INSERT, which fails outright on a database
+	// that has the code but not yet the migration.
+	Processingfailreason *string `json:"processingfailreason,omitempty" gorm:"->"`
 	// HeldByRippling is true when this message is held by the rippling reply-hold engine
 	// (a non-released row exists in rippling_held_replies). Populated for moderators (any
 	// message) and for a normal caller on their OWN held reply, so the sender can show a


### PR DESCRIPTION
## Problem

Chat processing suppresses a reply when the sender is banned on **any** community the referenced post is on. Rippling puts a post on communities the poster never chose, so that spans every community a post reaches, not the one the two people are talking on.

A member replying from her own community, in good standing there, has her reply destroyed because the post rippled into a community she happens to be banned on and where neither party is conversing. On production over 30 days, 396 replies are suppressed this way, 319 of them from senders banned only on a community the post had rippled into.

The suppression is invisible from every side. A suppressed message is set `processingsuccessful = 0`, which removes it from chat notifications and from the recipient's chat fetch (`chat/chatmessage.go`), while the sender still sees it as sent. Nothing records a reason, so a destroyed reply cannot be told apart from one nobody wrote, and support has no way to answer "why did I never see this reply?".

## What this does

**Scopes the ban to the two people.** `isBannedInCommonGroups()` — banned on every community the sender and recipient share — is the check. It reads memberships, so it is indifferent to which communities a post reached or how. The wider check is gone. A sender banned everywhere they share a community with the recipient is still blocked, as are senders flagged as spammers.

**Records why a message was dropped.** `chat_messages.processingfailreason` is written by `processFailed()` with a log line, using `ChatMessage::PROCESSFAIL_BANNED_IN_COMMON` / `PROCESSFAIL_SPAMMER`.

**Surfaces it to support.** The reason is on the chat API and rendered in ModTools chat review in words a volunteer can repeat to a member: "Not delivered: the sender is banned on every community they and the recipient share, so this never reached them and never will." Moderators already see suppressed messages; this tells them why.

The Go field is read-only (`gorm:"->"`). Only the batch processor writes the column, and without the tag GORM includes it in every `chat_messages` INSERT, which fails against a database carrying the code but not the migration.

## Tests

Laravel covers a reply delivered when the sender is banned only on a community the post reached, a reply suppressed when the sender is banned on every community the two share, and the reason being recorded for both ban and spam suppression.

## Rollout

The migration must land before the Go code. The read-only tag means the API degrades to an absent reason rather than failing if it does not.

Discourse: https://discourse.ilovefreegle.org/t/9481
