### PR TITLE
fix(app): stop a shared photo being attached twice on Android

### DIFF
--- a/iznik-nuxt3/android/app/src/main/java/org/ilovefreegle/direct/MainActivity.java
+++ b/iznik-nuxt3/android/app/src/main/java/org/ilovefreegle/direct/MainActivity.java
@@ -26,6 +26,15 @@ public class MainActivity extends BridgeActivity implements ModifiedMainActivity
   // startup and on every resume, then starts an OFFER with them pre-attached.
   private final ArrayList<String> pendingSharedImages = new ArrayList<>();
 
+  // Marks an intent whose images we have already copied. On a cold-start share the
+  // same intent arrives twice: Capacitor's BridgeActivity.load() (reached from
+  // super.onCreate) hands the launch intent to onNewIntent() itself, and then our
+  // own onCreate calls handleSendIntent(getIntent()) as well. Without this flag the
+  // image was copied twice and the Offer opened with two identical photos. We keep
+  // both call sites - a future Capacitor may stop re-delivering the launch intent -
+  // and make the handling idempotent instead.
+  private static final String EXTRA_SHARE_HANDLED = "org.ilovefreegle.direct.SHARE_HANDLED";
+
   public void onCreate(Bundle savedInstanceState) {
     //Log.e("PHDCC","org.ilovefreegle.direct onCreate A");
     super.onCreate(savedInstanceState);
@@ -63,6 +72,11 @@ public class MainActivity extends BridgeActivity implements ModifiedMainActivity
     String action = intent.getAction();
     String type = intent.getType();
     if (action == null || type == null || !type.startsWith("image/")) return;
+
+    // Copy each shared intent's images exactly once, however many times the intent
+    // is delivered to us (see EXTRA_SHARE_HANDLED).
+    if (intent.getBooleanExtra(EXTRA_SHARE_HANDLED, false)) return;
+    intent.putExtra(EXTRA_SHARE_HANDLED, true);
 
     try {
       if (Intent.ACTION_SEND.equals(action)) {


### PR DESCRIPTION
Sharing an image into Freegle from another app opened the Offer with **two identical photos** when the app was not already running.

## Root cause

Capacitor's `BridgeActivity.load()`, reached from `super.onCreate()`, delivers the launch intent to `onNewIntent()` itself:

```java
// node_modules/@capacitor/android/.../BridgeActivity.java:45-52
protected void load() {
    bridge = bridgeBuilder...create();
    this.keepRunning = bridge.shouldKeepRunning();
    this.onNewIntent(getIntent());
}
```

`MainActivity` overrides `onNewIntent` to copy shared images, and `onCreate` then called `handleSendIntent(getIntent())` as well. So a cold-start share was copied twice into `pendingSharedImages`, and the give flow attached both.

A warm share (app already running) only goes through `onNewIntent`, which is why it worked when the app was already open.

## Fix

Mark an intent once its images have been copied, so however many times the same intent is delivered it is only handled once. Both call sites are kept deliberately: a future Capacitor may stop re-delivering the launch intent from `load()`.

## Testing

There is no JVM/instrumentation test harness under `iznik-nuxt3/android` (no `src/test` or `androidTest`), so this has no automated test. Verified by tracing the Capacitor source above. Worth a manual check on a device: force-stop the app, share a photo in, and confirm the Offer opens with one photo.