### PR TITLE
fix(push): use the display name, not raw fullname, in chat push titles

### DIFF
--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\ChatRoom;
+use App\Models\User;
 use App\Services\LokiService;
 use App\Services\Ripple\RippleReplyService;
 use Illuminate\Support\Facades\DB;
@@ -1154,8 +1155,6 @@ class PushNotificationService
      */
     private function resolveChatPushTitle(object $row): string
     {
-        $senderName = $row->sender_name ?: 'Someone';
-
         if ($row->chattype === ChatRoom::TYPE_USER2MOD
             && (int) $row->sender_id !== (int) $row->user1
             && $row->groupid) {
@@ -1168,7 +1167,15 @@ class PushNotificationService
             return 'Freegle Volunteers';
         }
 
-        return $senderName;
+        // Use the display name the rest of the site uses rather than the raw
+        // users.fullname: it strips the TrashNothing "-gNNN" suffix from imported
+        // names (which was showing up in the push banner as "alice-g3486") and
+        // rewrites misleading brand/authority names. See
+        // User::getDisplayNameAttribute, which the chat notification email
+        // already goes through.
+        $sender = $row->sender_id ? User::find((int) $row->sender_id) : null;
+
+        return $sender?->display_name ?: ($row->sender_name ?: 'Someone');
     }
 
     // -------------------------------------------------------------------------

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -1119,6 +1119,28 @@ class PushNotificationServiceTest extends TestCase
     }
 
     /**
+     * TrashNothing-imported members have fullnames like "alice-g3486", taken from
+     * their -gNNN@user.trashnothing.com address. Every other surface hides that
+     * suffix via User::getDisplayNameAttribute (the chat notification email uses
+     * it), so the push banner must not show the raw users.fullname.
+     */
+    public function test_chat_payload_title_strips_trashnothing_group_suffix(): void
+    {
+        $sender = $this->createTestUser(['fullname' => 'alice-g3486']);
+        $recipient = $this->createTestUser();
+        $room = $this->createTestChatRoom($sender, $recipient);
+        $msg = $this->createTestChatMessage($room, $sender, [
+            'type'    => \App\Models\ChatMessage::TYPE_DEFAULT,
+            'message' => 'Still available?',
+        ]);
+
+        $payload = $this->service->buildChatMessagePayload($msg->id, $recipient->id, FALSE);
+
+        $this->assertSame('alice', $payload['title'],
+            'Push title must use the display name, which drops the TrashNothing -gNNN suffix');
+    }
+
+    /**
      * Image messages have no text — the push body must fall back to a
      * descriptive label ("Sent an image"), not repeat the sender name.
      *


### PR DESCRIPTION
Push notification banners were showing TrashNothing members' names with the `-gNNNN` suffix, for example `alice-g3486`.

## Root cause

`PushNotificationService::buildChatMessagePayload` selects the raw column:

```php
'cm.userid as sender_id', 'su.fullname as sender_name',
```

and `resolveChatPushTitle` used it directly. TN-imported members have `users.fullname` set from their `-gNNNN@user.trashnothing.com` address, so the suffix went straight into the title.

Every other surface hides it via `User::getDisplayNameAttribute()`, which runs `removeTNGroup()` and the impersonation sanitiser (Discourse #9587). The chat notification *email* already uses it (`app/Mail/Chat/ChatNotification.php:169`); the push did not.

## Fix

Resolve the title through `display_name`, falling back to the raw name and then `'Someone'`. The `{Group} Volunteers` branch for user-to-mod chats returns before the lookup, so it costs nothing there. As a side effect the push banner now also gets the impersonation rewrite the rest of the site has.

## Scope

Checked the other push paths: ModTools titles are counts, the daily new-posts title is an item name, and notification-derived titles come from `users_notifications.title`, which no writer populates with a member name. The chat title was the only place a raw name reached a notification.

## Testing

New regression test `test_chat_payload_title_strips_trashnothing_group_suffix`: a sender called `alice-g3486` must produce the title `alice`.

Full Laravel suite run locally via the status API: **5042 passed**.