### PR TITLE
fix(notifications): stop doubling the site in Exhort notification links

### DIFF
--- a/iznik-batch/app/Mail/Notification/ChaseUpMail.php
+++ b/iznik-batch/app/Mail/Notification/ChaseUpMail.php
@@ -77,6 +77,31 @@ class ChaseUpMail extends MjmlMailable
         );
     }
 
+    /**
+     * Work out where a notification's button should point.
+     *
+     * Exhort notifications carry their own URL in users_notifications.url. That
+     * column holds a site-relative path for some senders (microvolunteering
+     * writes /microvolunteering/message/123) and a full URL for others (the
+     * stories nudge is scheduled with https://www.ilovefreegle.org/stories), so
+     * only prepend the site when it is relative. Prepending unconditionally
+     * produced links to https://www.ilovefreegle.orghttps://www.ilovefreegle.org/stories.
+     */
+    public function resolveNotificationUrl(array $notif): string
+    {
+        $url = $notif['url'] ?? null;
+
+        if (($notif['type'] ?? '') === 'Exhort' && $url) {
+            return preg_match('#^https?://#i', $url)
+                ? $url
+                : rtrim($this->userSite, '/') . '/' . ltrim($url, '/');
+        }
+
+        return ($notif['newsfeed'] ?? null)
+            ? $this->userSite . '/chitchat/' . $notif['newsfeed']['id']
+            : $this->chitchatUrl;
+    }
+
     public function build(): static
     {
         $count       = count($this->notifications);
@@ -85,9 +110,7 @@ class ChaseUpMail extends MjmlMailable
 
         // Build tracked URLs per notification — mutate public property so text view sees them too.
         $this->notifications = array_map(function ($notif) {
-            $url = ($notif['type'] === 'Exhort' && $notif['url'])
-                ? $this->userSite . $notif['url']
-                : ($notif['newsfeed'] ? $this->userSite . '/chitchat/' . $notif['newsfeed']['id'] : $this->chitchatUrl);
+            $url = $this->resolveNotificationUrl($notif);
 
             $notif['trackedUrl'] = $this->trackedUrl($url, 'notification_' . $notif['id'], 'view');
 

--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -350,7 +350,7 @@ class PushNotificationService
 
             $title = ($latest->title ?? '') ?: 'You have a new notification';
             $message = $latest->text ?? '';
-            $route = ($latest->url ?? '') ?: '/';
+            $route = $this->notificationRoute($latest->url ?? '');
 
             if (($latest->type ?? '') === 'Exhort') {
                 $category = self::CATEGORY_EXHORT;
@@ -380,6 +380,31 @@ class PushNotificationService
             'threadId' => $threadId,
             'notId' => (string) $userId,
         ];
+    }
+
+    /**
+     * Turn a users_notifications.url into an in-app route.
+     *
+     * The app feeds this straight to vue-router, which needs a path. Some
+     * notifications store a full URL rather than a path (the stories exhort is
+     * scheduled with https://www.ilovefreegle.org/stories), so strip our own
+     * site off the front.
+     */
+    private function notificationRoute(?string $url): string
+    {
+        $url = trim((string) $url);
+
+        if ($url === '') {
+            return '/';
+        }
+
+        $userSite = rtrim((string) config('freegle.sites.user'), '/');
+
+        if ($userSite !== '' && str_starts_with($url, $userSite)) {
+            $url = substr($url, strlen($userSite));
+        }
+
+        return $url === '' ? '/' : $url;
     }
 
     /**

--- a/iznik-batch/tests/Unit/Mail/Notification/ChaseUpMailUrlTest.php
+++ b/iznik-batch/tests/Unit/Mail/Notification/ChaseUpMailUrlTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit\Mail\Notification;
+
+use App\Mail\Notification\ChaseUpMail;
+use Tests\TestCase;
+
+/**
+ * Link targets for the notification chaseup email.
+ *
+ * Regression: the stories exhort is scheduled with a full URL
+ * (https://www.ilovefreegle.org/stories) in users_notifications.url, but the
+ * mail prefixed the site unconditionally, producing tracked links to
+ * https://www.ilovefreegle.orghttps://www.ilovefreegle.org/stories which 404.
+ */
+class ChaseUpMailUrlTest extends TestCase
+{
+    private function makeMail(): ChaseUpMail
+    {
+        $user = $this->createTestUser();
+
+        return new ChaseUpMail($user, [], 'You have a notification');
+    }
+
+    public function test_absolute_exhort_url_is_not_prefixed_with_the_site(): void
+    {
+        $site = rtrim(config('freegle.sites.user'), '/');
+
+        $url = $this->makeMail()->resolveNotificationUrl([
+            'type' => 'Exhort',
+            'url' => $site . '/stories',
+            'newsfeed' => null,
+        ]);
+
+        $this->assertSame($site . '/stories', $url,
+            'An absolute Exhort URL must be used as-is, not concatenated onto the site');
+    }
+
+    public function test_relative_exhort_url_is_prefixed_with_the_site(): void
+    {
+        $site = rtrim(config('freegle.sites.user'), '/');
+
+        $url = $this->makeMail()->resolveNotificationUrl([
+            'type' => 'Exhort',
+            'url' => '/microvolunteering/message/123',
+            'newsfeed' => null,
+        ]);
+
+        $this->assertSame($site . '/microvolunteering/message/123', $url,
+            'A relative Exhort URL must be resolved against the user site');
+    }
+
+    public function test_exhort_url_without_leading_slash_is_still_joined_correctly(): void
+    {
+        $site = rtrim(config('freegle.sites.user'), '/');
+
+        $url = $this->makeMail()->resolveNotificationUrl([
+            'type' => 'Exhort',
+            'url' => 'stories',
+            'newsfeed' => null,
+        ]);
+
+        $this->assertSame($site . '/stories', $url,
+            'A path without a leading slash must not be glued onto the hostname');
+    }
+
+    public function test_newsfeed_notification_links_to_the_thread(): void
+    {
+        $site = rtrim(config('freegle.sites.user'), '/');
+
+        $url = $this->makeMail()->resolveNotificationUrl([
+            'type' => 'CommentOnYourPost',
+            'url' => null,
+            'newsfeed' => ['id' => 42],
+        ]);
+
+        $this->assertSame($site . '/chitchat/42', $url);
+    }
+
+    public function test_notification_without_newsfeed_falls_back_to_chitchat(): void
+    {
+        $site = rtrim(config('freegle.sites.user'), '/');
+
+        $url = $this->makeMail()->resolveNotificationUrl([
+            'type' => 'LovedPost',
+            'url' => null,
+            'newsfeed' => null,
+        ]);
+
+        $this->assertSame($site . '/chitchat', $url);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -1225,4 +1225,49 @@ class PushNotificationServiceTest extends TestCase
         $this->assertStringNotContainsString('ModBob', $payload['title'],
             'Individual mod name must NOT leak to the member in push title');
     }
+
+    /**
+     * The app pushes the payload route into vue-router, so it must be a path.
+     * The stories exhort is scheduled with a full URL in users_notifications.url,
+     * which would otherwise be routed to verbatim and land on a 404.
+     */
+    public function test_buildUserNotificationPayload_strips_site_from_absolute_notification_url(): void
+    {
+        $user = $this->createTestUser();
+
+        DB::table('users_notifications')->insert([
+            'touser' => $user->id,
+            'type' => 'Exhort',
+            'url' => rtrim(config('freegle.sites.user'), '/') . '/stories',
+            'title' => 'Tell us your Freegle story!',
+            'text' => 'We love to hear why people Freegle.',
+            'seen' => 0,
+            'timestamp' => now(),
+        ]);
+
+        $payload = $this->service->buildUserNotificationPayload($user->id);
+
+        $this->assertSame('/stories', $payload['route'],
+            'Absolute notification URLs on our own site must become a router path');
+    }
+
+    public function test_buildUserNotificationPayload_keeps_relative_notification_url(): void
+    {
+        $user = $this->createTestUser();
+
+        DB::table('users_notifications')->insert([
+            'touser' => $user->id,
+            'type' => 'Exhort',
+            'url' => '/microvolunteering/message/123',
+            'title' => 'Can you help?',
+            'text' => 'Check this post.',
+            'seen' => 0,
+            'timestamp' => now(),
+        ]);
+
+        $payload = $this->service->buildUserNotificationPayload($user->id);
+
+        $this->assertSame('/microvolunteering/message/123', $payload['route'],
+            'Relative notification URLs must be passed through unchanged');
+    }
 }


### PR DESCRIPTION
## Problem

The "Tell us your Freegle story!" notification chaseup mail links to a tracking redirect whose `url=` payload base64-decodes to:

```
https://www.ilovefreegle.orghttps://www.ilovefreegle.org/stories
```

The site appears twice, so the redirect lands on a 404.

## Cause

`users_notifications.url` is not consistently relative:

- microvolunteering (`iznik-server-go/microvolunteering/microvolunteering.go`) writes a path, `/microvolunteering/message/123`
- the stories nudge is scheduled with a full URL, `https://www.ilovefreegle.org/stories` (the documented crontab arg on `NotificationExhortService`, and the default in `ExhortUsersCommand`)

`ChaseUpMail::build()` prefixed `config('freegle.sites.user')` unconditionally, which is correct for the first and produces the doubled URL for the second.

The same column feeds the app push payload's `route` (`PushNotificationService::buildUserNotificationPayload()`), which the app hands straight to vue-router (`iznik-nuxt3/stores/mobile.js`). A full URL is not a route, so app taps on the stories nudge were also going nowhere useful.

## Fix

Both consumers now accept either form:

- `ChaseUpMail::resolveNotificationUrl()` only prepends the site when the stored URL is relative (and joins the slash properly if the path has no leading one).
- `PushNotificationService::notificationRoute()` strips our own site off the front so the app gets a path.

Fixing it at the point of use rather than at the point of insert means the rows already in `users_notifications` are repaired too, not just future ones.

## Second commit: the unit runner was checking stale sources

Running the unit suite locally against this branch surfaced 18 failures and 2 suites that would not load. The cause was in `file-sync.sh`: unit spec files are synced to `modtools-dev-local`, which is where vitest runs, but most of the source those specs import was not. Only `plugins/`, `composables/`, `stores/`, `utils/`, `components/` and `assets/` were routed there; everything else under `iznik-nuxt3/` fell through to the generic branch, which targets `dev-local` and `dev-live` only.

The runner was therefore exercising current specs against page and server sources baked into the image months earlier:

| Failure | Missing from the runner |
| --- | --- |
| `tests/unit/server/sitemap.spec.js` | `server/utils/` absent entirely |
| `MessageSummaryRowSize.spec.js` | `assets/css/_feed-card.scss` absent |
| `pages/message/id.spec.js` (17 cases) | stale `[id].vue` |
| `pages/stats.spec.js` | stale `[[groupname]].vue` |

CI never saw this because it builds the image from a full checkout. With `pages/` and `server/` routed to the runner as well, the suite goes from 14560 passed / 18 failed to **14611 passed / 0 failed**.

`scripts/test-file-sync-routing.sh` pins the contract: every source tree a unit spec imports must reach the vitest runner. It fails against the previous routing and passes against this one.

## Checks

- New `ChaseUpMailUrlTest`: absolute, relative and no-leading-slash Exhort URLs, plus the newsfeed and chitchat fallbacks.
- Two new cases in `PushNotificationServiceTest` for the push route.
- Full Laravel suite locally: 5048 cases, 14139 assertions, all green.
- Full unit suite locally: 14611 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113siHRAJPUxhHgVx3Cogif
