### PR TITLE
fix(chats): stop the chat list jumping when you click a chat you can see

### DIFF
--- a/iznik-nuxt3/pages/chats/[[id]].vue
+++ b/iznik-nuxt3/pages/chats/[[id]].vue
@@ -300,6 +300,14 @@ const loggedIn = computed(() => authStore.user !== null)
 
 definePageMeta({
   layout: 'login',
+  // Constant key so selecting a chat does NOT remount this page. Nuxt's default key
+  // interpolates the route params (generateRouteKey -> interpolatePath), so it changed
+  // from /chats/1 to /chats/2 on every selection and tore the whole page down and back
+  // up. That re-ran onMounted, whose deep-link "scroll the selected chat to the top of
+  // the panel" jumped the list under someone who had just clicked a chat they could
+  // already see - and re-ran the fetchOlder() below it too. gotoChat() already assumed
+  // this was the case ("quicker than navigating and re-rendering this page"); now it is.
+  key: 'chats',
 })
 
 let title = 'Chats'
@@ -316,9 +324,13 @@ const showChats = ref(20)
 const showContactDetailsAskModal =
   storeToRefs(chatStore).showContactDetailsAskModal
 
-const id = route.params.id ? parseInt(route.params.id) : 0
+// The chat we arrived on, used for the initial fetch and the page title. The template
+// must NOT use these: they are read once during setup, and the page no longer remounts
+// when you pick a different chat, so they would stay pinned to the chat you arrived on.
+// `id` and `chat` below are the reactive versions the template uses.
+const initialId = route.params.id ? parseInt(route.params.id) : 0
 
-let chat = null
+let initialChat = null
 
 const search = ref(null)
 
@@ -329,29 +341,29 @@ if (route.query.search) {
 if (myid && process.client) {
   // Fetch the list of chats. Only on client — SSR has no auth token
   // and the template uses <client-only> anyway.
-  await chatStore.fetchChats(search.value, true, id)
+  await chatStore.fetchChats(search.value, true, initialId)
 
   // Is this chat in the list?
-  chat = chatStore.byChatId(id)
+  initialChat = chatStore.byChatId(initialId)
 
-  if (!chat) {
+  if (!initialChat) {
     // Might be old.  Try fetching it specifically.
     try {
-      chat = await chatStore.fetchChat(id)
+      initialChat = await chatStore.fetchChat(initialId)
     } catch (e) {
-      console.log("Couldn't fetch chat", id, e)
+      console.log("Couldn't fetch chat", initialId, e)
     }
   } else {
     // We have the chat, but maybe it's not quite up to date (e.g. a new message).  So fetch, but don't wait.
-    title = chat.name
-    description = 'Chat with ' + chat.name
+    title = initialChat.name
+    description = 'Chat with ' + initialChat.name
 
-    chatStore.fetchChat(id)
+    chatStore.fetchChat(initialId)
   }
 
-  if (id) {
+  if (initialId) {
     // Find id in the list of chats.
-    const index = chatStore.list.findIndex((c) => c.id === id)
+    const index = chatStore.list.findIndex((c) => c.id === initialId)
     showChats.value = Math.max(showChats.value, index + 1)
   }
 }
@@ -368,6 +380,13 @@ const bump = ref(1)
 let searchGeneration = 0
 const distance = ref(1000)
 const selectedChatId = ref(null)
+
+// The chat currently being viewed, for the mobile navbar. These used to be plain setup
+// constants, refreshed only because picking a chat remounted the whole page; now that it
+// does not, they have to track the selection or the navbar would keep showing the chat
+// you first arrived on (and would never appear at all if you arrived at /chats).
+const id = computed(() => selectedChatId.value || 0)
+const chat = computed(() => (id.value ? chatStore.byChatId(id.value) : null))
 
 // If no chats were found initially, mark as complete so "Show older chats" button appears.
 if (chatStore.list.length === 0) {
@@ -457,53 +476,69 @@ watch(search, (newVal, oldVal) => {
   }
 })
 
+// Bring a chat we have ARRIVED at into view: render enough of the list to reach it,
+// fetching older chats if it isn't loaded yet, then put it at the top of the panel.
+//
+// This is for deep links - opening /chats/123 from an email, a push notification or a
+// bookmark, where the chat can be a long way down the list, or not loaded at all. It is
+// deliberately NOT run when someone picks a chat out of the list they are already looking
+// at: they can see where it is, so moving it under their cursor (and pulling the entire
+// chat history to make room below it) is disruptive rather than helpful.
+async function revealChat(chatId) {
+  // Ensure enough chats are rendered so the target chat can be scrolled
+  // to the top of the panel (needs entries below it too).
+  const SCROLL_SLACK = 50
+  let idx = filteredChats.value.findIndex((c) => c.id === chatId)
+
+  if (idx < 0 && !chatStore.searchSince) {
+    // Selected chat is not in the current list.  This happens for brand-new
+    // User2Mod chats (latestmessage=0) which the API excludes by default.
+    // Fetch with keepChat so the API force-includes it regardless of the
+    // latestmessage filter.
+    await fetchOlder()
+    idx = filteredChats.value.findIndex((c) => c.id === chatId)
+  }
+
+  if (idx >= 0) {
+    const below = filteredChats.value.length - 1 - idx
+    if (below < SCROLL_SLACK && !chatStore.searchSince) {
+      // Not enough chats below the target to scroll it to the top of the
+      // panel. Fetch all historical chats to populate entries below it.
+      await fetchOlder()
+      idx = filteredChats.value.findIndex((c) => c.id === chatId)
+    }
+
+    if (idx >= 0) {
+      showChats.value = Math.max(showChats.value, idx + 1 + SCROLL_SLACK)
+    }
+  }
+
+  await nextTick()
+  const activeEl = chatlistRef.value?.querySelector('.chat.active')
+  if (activeEl) {
+    activeEl.scrollIntoView({ block: 'start' })
+  }
+}
+
+// The page no longer remounts when the chat changes (see the key in definePageMeta), so
+// the selection has to follow the route rather than being read once on mount. This covers
+// in-list clicks, Back, and any other navigation; it must NOT reveal/scroll, which is for
+// arrivals only.
+watch(
+  () => route.params.id,
+  (newId) => {
+    selectedChatId.value = newId ? parseInt(newId) : 0
+  }
+)
+
 onMounted(async () => {
   selectedChatId.value = null
 
   if (authStore.user) {
-    const route = useRoute()
     selectedChatId.value = route.params.id ? parseInt(route.params.id) : 0
 
     if (selectedChatId.value) {
-      // Ensure enough chats are rendered so the target chat can be scrolled
-      // to the top of the panel (needs entries below it too).
-      const SCROLL_SLACK = 50
-      let idx = filteredChats.value.findIndex(
-        (c) => c.id === selectedChatId.value
-      )
-
-      if (idx < 0 && !chatStore.searchSince) {
-        // Selected chat is not in the current list.  This happens for brand-new
-        // User2Mod chats (latestmessage=0) which the API excludes by default.
-        // Fetch with keepChat so the API force-includes it regardless of the
-        // latestmessage filter.
-        await fetchOlder()
-        idx = filteredChats.value.findIndex(
-          (c) => c.id === selectedChatId.value
-        )
-      }
-
-      if (idx >= 0) {
-        const below = filteredChats.value.length - 1 - idx
-        if (below < SCROLL_SLACK && !chatStore.searchSince) {
-          // Not enough chats below the target to scroll it to the top of the
-          // panel. Fetch all historical chats to populate entries below it.
-          await fetchOlder()
-          idx = filteredChats.value.findIndex(
-            (c) => c.id === selectedChatId.value
-          )
-        }
-
-        if (idx >= 0) {
-          showChats.value = Math.max(showChats.value, idx + 1 + SCROLL_SLACK)
-        }
-      }
-
-      await nextTick()
-      const activeEl = chatlistRef.value?.querySelector('.chat.active')
-      if (activeEl) {
-        activeEl.scrollIntoView({ block: 'start' })
-      }
+      await revealChat(selectedChatId.value)
     }
   }
 })
@@ -567,7 +602,7 @@ function scanChats(closed, chats) {
   }
 
   chats = chats.filter((chat) => {
-    if (id && !closed && chat.id === id) {
+    if (id.value && !closed && chat.id === id.value) {
       return true
     }
 
@@ -625,24 +660,25 @@ async function markAllRead() {
   chatStore.fetchChats()
 }
 
-function gotoChat(id) {
+function gotoChat(chatId) {
   const router = useRouter()
+  const wasSelected = Boolean(selectedChatId.value)
 
-  if (selectedChatId.value) {
-    // We just replace the route, which is quicker than navigating and re-rendering this page.
-    //
-    // This means that history won't get updated, which means that Back will go to the top-level /chats page.
-    // That is nice behaviour otherwise you have to hit Back a lot if you've viewed several chats.
-    selectedChatId.value = id
-    let url = id ? '/chats/' + id : '/chats'
+  // Selecting a chat no longer re-renders the page either way (see the key in
+  // definePageMeta) - the route watcher moves the selection. push vs replace is now
+  // purely about history: once a chat is open we replace, so Back goes to the top-level
+  // /chats page rather than walking back through every chat viewed.
+  selectedChatId.value = chatId
+  let url = chatId ? '/chats/' + chatId : '/chats'
 
-    if (search.value) {
-      url += '?search=' + search.value
-    }
+  if (search.value) {
+    url += '?search=' + search.value
+  }
 
+  if (wasSelected) {
     router.replace(url)
   } else {
-    router.push(id ? '/chats/' + id : '/chats')
+    router.push(url)
   }
 }
 

--- a/iznik-nuxt3/tests/unit/pages/chats/chat-list-scroll-on-select.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/chats/chat-list-scroll-on-select.spec.js
@@ -1,0 +1,266 @@
+/**
+ * The chat list jumped when you clicked a chat you could already see: the clicked chat
+ * was yanked to the very top of the panel.
+ *
+ * That scroll is `revealChat()` — `scrollIntoView({ block: 'start' })` plus, above it, a
+ * `fetchOlder()` that pulls the ENTIRE chat history to make room below the target. It is
+ * meant for deep links (opening /chats/123 from an email or push notification, where the
+ * chat may be far down the list or not loaded at all), and it lived in onMounted.
+ *
+ * It ran on ordinary clicks because Nuxt's default page key interpolates the route params
+ * (generateRouteKey -> interpolatePath, nuxt/dist/pages/runtime/utils.js), so the key went
+ * /chats/1 -> /chats/2 on every selection and the page remounted.
+ *
+ * The fix pins a constant `key: 'chats'` in definePageMeta and moves the selection onto a
+ * route watcher, so ARRIVING reveals but SELECTING does not. Anything that was previously
+ * refreshed only by the remount (`id`, `chat` for the mobile navbar) has to track the
+ * selection instead.
+ *
+ * The harness mirrors id.spec.js, except route params are reactive — the watcher under
+ * test cannot fire against a snapshot.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref, computed, defineComponent, h, Suspense, nextTick } from 'vue'
+
+import ChatsPage from '~/pages/chats/[[id]].vue'
+
+vi.mock('dayjs', () => {
+  const mockDayjs = () => ({
+    diff: vi.fn().mockReturnValue(0),
+    format: vi.fn().mockReturnValue(''),
+    isSameOrBefore: vi.fn().mockReturnValue(false),
+    isToday: vi.fn().mockReturnValue(false),
+    fromNow: vi.fn().mockReturnValue('just now'),
+  })
+  mockDayjs.extend = vi.fn()
+  return { default: mockDayjs }
+})
+
+vi.mock('dayjs/plugin/advancedFormat', () => ({ default: {} }))
+vi.mock('dayjs/plugin/relativeTime', () => ({ default: {} }))
+vi.mock('dayjs/plugin/isToday', () => ({ default: {} }))
+vi.mock('dayjs/plugin/isSameOrBefore', () => ({ default: {} }))
+
+vi.mock('~/components/VisibleWhen', () => ({
+  default: { template: '<div><slot /></div>', props: ['at'] },
+}))
+vi.mock('~/components/InfiniteLoading', () => ({
+  default: {
+    template: '<div class="infinite-loading" />',
+    props: ['identifier', 'forceUseInfiniteWrapper', 'distance'],
+    emits: ['infinite'],
+  },
+}))
+vi.mock('~/components/SidebarRight', () => ({
+  default: { template: '<div />' },
+}))
+vi.mock('~/components/ChatMobileNavbar.vue', () => ({
+  default: { template: '<div />' },
+}))
+vi.mock('~/components/ExternalDa.vue', () => ({
+  default: { template: '<div />' },
+}))
+vi.mock('~/components/ChatListEntry.vue', () => ({
+  default: { template: '<div />', props: ['id'] },
+}))
+
+const mockChatStore = {
+  list: [],
+  listMT: [],
+  listByChatId: {},
+  showContactDetailsAskModal: ref(false),
+  fetchChats: vi.fn().mockResolvedValue([]),
+  fetchChat: vi.fn().mockResolvedValue({}),
+  markRead: vi.fn().mockResolvedValue({}),
+  markAllRead: vi.fn().mockResolvedValue(),
+  byChatId: vi.fn().mockReturnValue(null),
+  clear: vi.fn(),
+  unseenCount: 0,
+  showClosed: false,
+  searchSince: null,
+}
+
+vi.mock('~/stores/chat', () => ({
+  useChatStore: () => mockChatStore,
+}))
+
+vi.mock('~/stores/misc', () => ({
+  useMiscStore: () => ({
+    get: vi.fn(),
+    set: vi.fn(),
+    breakpoint: 'lg',
+    stickyAdRendered: false,
+  }),
+}))
+
+const mockMe = ref({ id: 1, displayname: 'Test User', settings: {} })
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({
+    me: mockMe,
+    myid: computed(() => mockMe.value?.id || null),
+    myGroups: ref([]),
+  }),
+}))
+
+vi.mock('~/composables/useBuildHead', () => ({
+  buildHead: () => ({}),
+}))
+
+// The page gates its setup fetch and its onMounted body on authStore.user, so it has to
+// be logged in for any of this to run.
+const mockAuthUser = { id: 1, displayname: 'Test User', settings: {} }
+
+vi.mock('~/stores/auth', () => ({
+  useAuthStore: () => ({
+    user: mockAuthUser,
+    groups: [],
+  }),
+}))
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: (store) => ({
+      showContactDetailsAskModal: mockChatStore.showContactDetailsAskModal,
+      list: ref(store?.list || []),
+    }),
+  }
+})
+
+// Route params are REACTIVE here (id.spec.js snapshots them). The page now watches
+// route.params.id, and a snapshot would never trigger that watcher.
+// NB no vi.resetModules() here (id.spec.js has one): it splits the test file's `vue` from
+// the component's, so a ref written here would not wake a watcher over there — which is
+// exactly what these tests exercise.
+const mockRouteParams = ref({})
+
+const routeStub = {
+  get params() {
+    return mockRouteParams.value
+  },
+  query: {},
+  path: '/chats',
+  name: 'chats',
+  fullPath: '/chats',
+  matched: [],
+  redirectedFrom: undefined,
+  meta: {},
+}
+
+const mockPush = vi.fn()
+const mockReplace = vi.fn()
+const routerStub = {
+  push: mockPush,
+  replace: mockReplace,
+  currentRoute: { value: { path: '/chats' } },
+}
+
+vi.mock('#imports', async () => {
+  const actual = await vi.importActual('#imports')
+  return {
+    ...actual,
+    useRoute: () => routeStub,
+    useRouter: () => routerStub,
+  }
+})
+
+globalThis.__testUseRoute = () => routeStub
+globalThis.__testUseRouter = () => routerStub
+
+globalThis.definePageMeta = vi.fn()
+globalThis.useHead = vi.fn()
+globalThis.useRuntimeConfig = () => ({ public: { BUILD_DATE: '2026-01-01' } })
+globalThis.defineAsyncComponent = () => ({ template: '<div />' })
+
+describe('chats/[[id]].vue - selecting a chat must not scroll the list', () => {
+  function mountComponent() {
+    const Wrapper = defineComponent({
+      setup() {
+        return () => h(Suspense, null, { default: () => h(ChatsPage) })
+      },
+    })
+    return mount(Wrapper, {
+      global: {
+        plugins: [createPinia()],
+        stubs: {
+          'client-only': { template: '<div><slot /></div>' },
+          'b-container': { template: '<div><slot /></div>' },
+          'b-row': { template: '<div><slot /></div>' },
+          'b-col': { template: '<div><slot /></div>' },
+          'b-card': { template: '<div><slot /></div>' },
+          'b-card-body': { template: '<div><slot /></div>' },
+          'b-form-input': { template: '<input />' },
+          'b-button': { template: '<button><slot /></button>' },
+          'b-badge': { template: '<span><slot /></span>' },
+          'v-icon': { template: '<i />' },
+          ChatPane: { template: '<div />' },
+          GlobalMessage: { template: '<div />' },
+          ExpectedRepliesWarning: { template: '<div />' },
+        },
+      },
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    mockMe.value = { id: 1, displayname: 'Test User', settings: {} }
+    mockChatStore.list = []
+    mockChatStore.searchSince = null
+    mockChatStore.fetchChats = vi.fn().mockResolvedValue([])
+    mockChatStore.fetchChat = vi.fn().mockResolvedValue({})
+    mockChatStore.byChatId = vi.fn().mockReturnValue(null)
+    mockRouteParams.value = {}
+  })
+
+  // The constant `key: 'chats'` in definePageMeta is what stops the remount, but
+  // definePageMeta is a compiler macro that is stripped at build time, so there is
+  // nothing here to assert against. What IS observable is the behaviour it enables, and
+  // that is what the rest of this file covers: the page keeping its state and tracking
+  // the route itself instead of being rebuilt.
+
+  // These drive gotoChat() — the click handler on every row of the list — rather than
+  // pushing a new route param, because that is the path the report is about and it does
+  // not depend on the harness faking router reactivity. Arrival via the route is covered
+  // by the deep-link test at the end.
+
+  it('does not pull the whole chat history when a chat is picked from the list', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+    const page = wrapper.findComponent(ChatsPage)
+
+    mockChatStore.fetchChats.mockClear()
+    mockChatStore.searchSince = null
+
+    page.vm.gotoChat(123)
+    await nextTick()
+    await flushPromises()
+
+    // revealChat() calls fetchOlder(), which sets searchSince and refetches every chat
+    // ever, purely so there are entries below the target to scroll past — and then
+    // scrollIntoView({ block: 'start' }) yanks it to the top. Doing either on a click is
+    // the disruption being fixed. Asserting the fetch is how the scroll is observed:
+    // jsdom has no layout, so scrollIntoView itself proves nothing.
+    expect(mockChatStore.searchSince).toBeNull()
+    expect(mockChatStore.fetchChats).not.toHaveBeenCalled()
+    expect(mockPush).toHaveBeenCalledWith('/chats/123')
+  })
+
+  it('still reveals a deep-linked chat on arrival', async () => {
+    // Arriving directly at /chats/123 - the chat may be far down the list or not loaded
+    // at all, so this path must still fetch and scroll.
+    mockRouteParams.value = { id: '123' }
+
+    const wrapper = mountComponent()
+    await flushPromises()
+    const page = wrapper.findComponent(ChatsPage)
+
+    expect(page.vm.selectedChatId).toBe(123)
+    expect(mockChatStore.fetchChats).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## The report

Clicking a chat already visible in the list sometimes scrolls the list so that chat sits at the very top.

## Why

The scroll is deliberate, but only for **arriving** at a chat. Opening `/chats/123` from an email or push notification can target a chat far down the list, or one not loaded at all, so the page fetches enough history to reach it and pins it to the top of the panel. That is `revealChat()`, and it lived in `onMounted`.

It ran on ordinary clicks because **Nuxt's default page key interpolates the route params**:

```js
// nuxt/dist/pages/runtime/utils.js
const interpolatePath = (route, match) =>
  match.path.replace(..., (r) => route.params[r.slice(1)]?.toString() || '')
const source = override ?? matchedRoute?.meta.key ?? interpolatePath(route, matchedRoute)
```

So the key went `/chats/1` to `/chats/2` on every selection and the page was torn down and rebuilt, re-running `onMounted`. `gotoChat()` already assumed otherwise - its comment says `router.replace` is *"quicker than navigating and re-rendering this page"* - but the key changes regardless of push vs replace.

The **"sometimes"** is geometry: `scrollIntoView({ block: 'start' })` only moves the list when there is enough content below the clicked chat. Click near the top, or near the end, and nothing visibly happens.

The remount was also costing more than the scroll: `revealChat()` calls `fetchOlder()`, which pulls the **entire** chat history purely to have entries below the target to scroll past - on every click.

## The fix

- Constant `key: 'chats'` in `definePageMeta`, so selecting a chat no longer remounts the page.
- Selection moves onto a route watcher (previously only `onMounted` set `selectedChatId`, which is why it depended on the remount).
- `revealChat()` is called only for the chat we arrive on.
- `gotoChat()` keeps push-vs-replace, now purely so Back returns to `/chats` rather than walking back through every chat viewed.

### Regression this would otherwise have introduced

`id` and `chat` feed `ChatMobileNavbar` and were plain setup constants, refreshed *only* because the page remounted. Without changing them the mobile navbar would stick on the chat you arrived at, and never appear at all if you arrived at `/chats`. They are now computeds, and the setup-time values are renamed `initialId` / `initialChat` so they cannot be used by mistake.

## Tests

New `tests/unit/pages/chats/chat-list-scroll-on-select.spec.js`:

- picking a chat from the list does not trigger `fetchOlder()` / the reveal
- arriving at a deep link still does

Asserting the fetch is how the scroll is observed - jsdom has no layout, so `scrollIntoView` itself proves nothing. The constant page key is a compiler macro stripped at build time, so the tests cover the behaviour it enables rather than the macro.

Full unit suite: **14613 passing, 0 failing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113siHRAJPUxhHgVx3Cogif
