### PR TITLE
fix(modtools): stop the alert history showing "Invalid Date" while a mailing is still going out

### DIFF
--- a/iznik-nuxt3/modtools/components/ModAlertHistory.vue
+++ b/iznik-nuxt3/modtools/components/ModAlertHistory.vue
@@ -4,7 +4,8 @@
       {{ datetimeshort(alert.created) }}
     </b-col>
     <b-col cols="6" lg="2">
-      {{ datetimeshort(alert.complete) }}
+      <span v-if="completed">{{ completed }}</span>
+      <span v-else class="text-muted fst-italic">In progress</span>
     </b-col>
     <b-col cols="6" lg="2">
       <div v-if="alert.group">
@@ -36,6 +37,7 @@
 </template>
 <script setup>
 import { ref, computed } from 'vue'
+import { datetimeshort } from '~/composables/useTimeFormat'
 import { useAlertStore } from '~/stores/alert'
 
 const alertStore = useAlertStore()
@@ -48,6 +50,22 @@ const props = defineProps({
 })
 
 const alert = computed(() => alertStore.get(props.alertid))
+
+// An alert stays incomplete until the batch job has fanned it out to every group, and the API
+// serialises that NULL `complete` timestamp as an empty string. Feeding that to datetimeshort()
+// renders the literal "Invalid Date" in the history table, which reads like a bug rather than
+// "this mailing is still going out" - so only format a value we actually have.
+const completed = computed(() => {
+  const val = alert.value?.complete
+
+  if (!val) {
+    return null
+  }
+
+  const formatted = datetimeshort(val)
+
+  return formatted === 'Invalid Date' ? null : formatted
+})
 
 const showDetails = ref(false)
 const showStats = ref(false)

--- a/iznik-nuxt3/tests/unit/components/modtools/ModAlertHistory.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModAlertHistory.spec.js
@@ -2,19 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import ModAlertHistory from '~/modtools/components/ModAlertHistory.vue'
 
-// Mock datetimeshort helper
-vi.hoisted(() => {
-  vi.resetModules()
-})
-
-vi.mock('#imports', async () => {
-  const actual = await vi.importActual('#imports')
-  return {
-    ...actual,
-    datetimeshort: vi.fn().mockReturnValue('2024-01-01 12:00'),
-  }
-})
-
+// datetimeshort is deliberately NOT mocked: the "Invalid Date" bug lived in how the real
+// formatter handles a missing complete timestamp, so the tests below need the real thing.
 const defaultAlert = {
   id: 1,
   created: '2024-01-01T10:00:00',
@@ -34,7 +23,11 @@ vi.mock('~/stores/alert', () => ({
 }))
 
 describe('ModAlertHistory', () => {
-  function mountComponent(props = {}) {
+  function mountComponent(props = {}, alert = null) {
+    if (alert) {
+      mockAlertStore.get.mockImplementation((id) => (id === 1 ? alert : null))
+    }
+
     return mount(ModAlertHistory, {
       props: { alertid: 1, ...props },
       global: {
@@ -52,9 +45,6 @@ describe('ModAlertHistory', () => {
             template: '<div class="stats-modal" />',
             methods: { show: vi.fn() },
           },
-        },
-        mocks: {
-          datetimeshort: vi.fn().mockReturnValue('2024-01-01 12:00'),
         },
       },
     })
@@ -82,6 +72,28 @@ describe('ModAlertHistory', () => {
       const wrapper = mountComponent()
       expect(wrapper.text()).toContain('Show Stats')
       expect(wrapper.text()).toContain('Show Details')
+    })
+
+    it('shows the completion time for a finished alert', () => {
+      const wrapper = mountComponent(
+        {},
+        { ...defaultAlert, complete: '2024-01-01T12:00:00' }
+      )
+      expect(wrapper.text()).toContain('1st Jan, 2024 12:00')
+      expect(wrapper.text()).not.toContain('In progress')
+    })
+
+    // The API serialises a NULL complete timestamp as an empty string, which used to reach
+    // dayjs and render the literal "Invalid Date" in the history table.
+    it.each([
+      ['an empty string', ''],
+      ['null', null],
+      ['undefined', undefined],
+      ['an unparseable value', 'not a date'],
+    ])('shows In progress when complete is %s', (_label, complete) => {
+      const wrapper = mountComponent({}, { ...defaultAlert, complete })
+      expect(wrapper.text()).toContain('In progress')
+      expect(wrapper.text()).not.toContain('Invalid Date')
     })
   })
 


### PR DESCRIPTION
## Problem

On ModTools **Support → Contact group**, the mailing history table showed **"Invalid Date"** in the *Complete* column:

| Created | Complete |
|---|---|
| 29th Jul, 2026 11:56 | Invalid Date |
| 29th Jul, 2026 11:52 | Invalid Date |

## Cause

An alert's `alerts.complete` timestamp stays `NULL` until the batch job (`AlertService::processAlert`) has fanned it out to every group. The Go API scans that NULL into a plain `string` field, so it reaches the client as `""`. `datetimeshort('')` hands dayjs an unparseable value, which formats as the literal string `"Invalid Date"`.

So every mailing that was still going out displayed "Invalid Date" - which reads like a bug rather than "this is still sending". The two rows above were genuinely mid-send at the time of the screenshot; they completed a few minutes later.

## Fix

`ModAlertHistory.vue` now formats the completion time only when there actually is one, and shows a muted **"In progress"** otherwise. The guard also catches an unparseable value defensively, so nothing can put "Invalid Date" back on the page.

## Tests

`tests/unit/components/modtools/ModAlertHistory.spec.js` gains cases for a completed alert plus empty-string / null / undefined / unparseable `complete`, each asserting "In progress" and no "Invalid Date". The spec previously mocked `datetimeshort` to a fixed string, which would have hidden this entirely - that mock is removed so the tests exercise the real formatter.

Full unit suite run locally: **14618 passed, 0 failed**.

## Not fixed here

The *To* column in the same table is always blank: the header says "To" but the component renders `alert.group.nameshort`, and the API returns `groupid` with no `group` object. Flagged separately rather than widened into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi