### PR TITLE
fix(chat): stop the chat maps zooming out when you scroll past them

### DIFF
--- a/iznik-nuxt3/components/ChatMessageAddress.vue
+++ b/iznik-nuxt3/components/ChatMessageAddress.vue
@@ -30,6 +30,7 @@
                     :zoom="16"
                     :max-zoom="maxZoom"
                     :center="[address.lat, address.lng]"
+                    :options="mapOptions"
                     :style="'width: 100%; height: 200px'"
                   >
                     <l-tile-layer
@@ -99,6 +100,7 @@
                     :zoom="14"
                     :max-zoom="maxZoom"
                     :center="[address.lat, address.lng]"
+                    :options="mapOptions"
                     :style="'width: 100%; height: 200px'"
                   >
                     <l-tile-layer
@@ -145,7 +147,7 @@ import { useAddressStore } from '~/stores/address'
 import { useChatStore } from '~/stores/chat'
 import { useChatMessageBase } from '~/composables/useChat'
 import { constructMultiLine } from '~/composables/usePAF'
-import { attribution, osmtile } from '~/composables/useMap'
+import { attribution, osmtile, INLINE_MAP_OPTIONS } from '~/composables/useMap'
 import { MAX_MAP_ZOOM } from '~/constants'
 import { ref, computed, onMounted } from '#imports'
 
@@ -182,6 +184,7 @@ const address = ref(null)
 
 // Computed properties
 const maxZoom = computed(() => MAX_MAP_ZOOM)
+const mapOptions = INLINE_MAP_OPTIONS
 const multiline = computed(() => constructMultiLine(address.value))
 
 // Methods

--- a/iznik-nuxt3/components/ChatMessageText.vue
+++ b/iznik-nuxt3/components/ChatMessageText.vue
@@ -102,6 +102,7 @@
           :zoom="16"
           :max-zoom="maxZoom"
           :center="[lat, lng]"
+          :options="mapOptions"
           :style="'width: 100%; height: 200px'"
         >
           <l-tile-layer :url="osmtile()" :attribution="attribution()" />
@@ -124,7 +125,7 @@ import {
 import { ref, computed, onMounted } from '#imports'
 import ProfileImage from '~/components/ProfileImage'
 import { MAX_MAP_ZOOM, POSTCODE_REGEX } from '~/constants'
-import { attribution, osmtile } from '~/composables/useMap'
+import { attribution, osmtile, INLINE_MAP_OPTIONS } from '~/composables/useMap'
 import { useLocationStore } from '~/stores/location'
 import { useMiscStore } from '~/stores/misc'
 
@@ -169,6 +170,7 @@ const lng = ref(null)
 
 // Computed properties
 const maxZoom = computed(() => MAX_MAP_ZOOM)
+const mapOptions = INLINE_MAP_OPTIONS
 
 const messageIsNew = computed(() => {
   return (

--- a/iznik-nuxt3/composables/useMap.js
+++ b/iznik-nuxt3/composables/useMap.js
@@ -3,6 +3,15 @@ export function osmtile() {
   return runtimeConfig.public.OSM_TILE
 }
 
+// Options for the small maps we embed inside a scrolling list, e.g. the address
+// and postcode maps in chat. Leaflet grabs the wheel event by default, so
+// scrolling the conversation with the pointer over a map zooms the map out
+// instead of scrolling, one level per notch, until it's showing the whole world.
+export const INLINE_MAP_OPTIONS = {
+  scrollWheelZoom: false,
+  bounceAtZoomLimits: true,
+}
+
 export function attribution() {
   return 'Map data &copy; <a href="https://www.openstreetmap.org/" rel="noopener noreferrer">OpenStreetMap</a> contributors'
 }

--- a/iznik-nuxt3/tests/unit/components/ChatMessageAddress.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMessageAddress.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import ChatMessageAddress from '~/components/ChatMessageAddress.vue'
 
 const { mockOtheruser, mockChatmessage, mockMe } = vi.hoisted(() => {
@@ -52,6 +52,7 @@ vi.mock('~/composables/usePAF', () => ({
 vi.mock('~/composables/useMap', () => ({
   attribution: () => '© OpenStreetMap',
   osmtile: () => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+  INLINE_MAP_OPTIONS: { scrollWheelZoom: false, bounceAtZoomLimits: true },
 }))
 
 vi.mock('~/constants', () => ({
@@ -113,8 +114,9 @@ describe('ChatMessageAddress', () => {
             props: ['variant'],
           },
           'l-map': {
-            template: '<div class="l-map" :data-zoom="zoom"><slot /></div>',
-            props: ['zoom', 'maxZoom', 'center', 'style'],
+            template:
+              '<div class="l-map" :data-zoom="zoom" :data-scrollwheelzoom="String(options && options.scrollWheelZoom)"><slot /></div>',
+            props: ['zoom', 'maxZoom', 'center', 'style', 'options'],
           },
           'l-tile-layer': {
             template: '<div class="l-tile-layer" />',
@@ -208,6 +210,31 @@ describe('ChatMessageAddress', () => {
       const wrapper = createWrapper()
       expect(wrapper.text()).toContain(
         'Your address book lets you easily send addresses'
+      )
+    })
+  })
+
+  describe('map', () => {
+    // Leaflet grabs the wheel event by default, so without scrollWheelZoom
+    // disabled, scrolling the conversation with the pointer over the map zooms
+    // the map out instead of scrolling it, leaving it stuck at world view.
+    it('disables wheel zoom on a received address', async () => {
+      mockChatmessage.value.userid = 2
+      mockMe.value = { id: 1 }
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.find('.l-map').attributes('data-scrollwheelzoom')).toBe(
+        'false'
+      )
+    })
+
+    it('disables wheel zoom on a sent address', async () => {
+      mockChatmessage.value.userid = 1
+      mockMe.value = { id: 1 }
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.find('.l-map').attributes('data-scrollwheelzoom')).toBe(
+        'false'
       )
     })
   })

--- a/iznik-nuxt3/tests/unit/components/ChatMessageText.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMessageText.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, nextTick } from 'vue'
 import ChatMessageText from '~/components/ChatMessageText.vue'
 
 // Mock vue-highlight-words external component
@@ -68,6 +68,7 @@ vi.mock('~/composables/useLinkify', () => ({
 vi.mock('~/composables/useMap', () => ({
   attribution: () => '© OpenStreetMap',
   osmtile: () => 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+  INLINE_MAP_OPTIONS: { scrollWheelZoom: false, bounceAtZoomLimits: true },
 }))
 
 // Mock constants
@@ -100,8 +101,9 @@ describe('ChatMessageText', () => {
             props: ['fluid', 'src', 'lazy', 'rounded'],
           },
           'l-map': {
-            template: '<div class="l-map"><slot /></div>',
-            props: ['zoom', 'maxZoom', 'center', 'style'],
+            template:
+              '<div class="l-map" :data-scrollwheelzoom="String(options && options.scrollWheelZoom)"><slot /></div>',
+            props: ['zoom', 'maxZoom', 'center', 'style', 'options'],
           },
           'l-tile-layer': {
             template: '<div class="l-tile-layer"></div>',
@@ -130,6 +132,22 @@ describe('ChatMessageText', () => {
     })
     const wrapperMine = createWrapper()
     expect(wrapperMine.find('.myChatMessage').exists()).toBe(true)
+  })
+
+  it('disables wheel zoom on the postcode map', async () => {
+    // Leaflet grabs the wheel event by default, so without scrollWheelZoom
+    // disabled, scrolling the conversation with the pointer over the map zooms
+    // the map out instead of scrolling it, leaving it stuck at world view.
+    const wrapper = createWrapper()
+    expect(wrapper.find('.l-map').exists()).toBe(false)
+
+    wrapper.vm.lat = 53.8321
+    wrapper.vm.lng = -2.6191
+    await nextTick()
+
+    expect(wrapper.find('.l-map').attributes('data-scrollwheelzoom')).toBe(
+      'false'
+    )
   })
 
   it('highlights emails only when highlightEmails prop is true', () => {

--- a/iznik-nuxt3/tests/unit/composables/useMap.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMap.spec.js
@@ -7,6 +7,7 @@ import {
   osmtile,
   loadLeaflet,
   nearbyGroups,
+  INLINE_MAP_OPTIONS,
 } from '~/composables/useMap'
 
 // ============================================================
@@ -150,6 +151,19 @@ describe('attribution', () => {
 
   it('returns the same value on repeated calls (idempotent)', () => {
     expect(attribution()).toBe(attribution())
+  })
+})
+
+// ============================================================
+// INLINE_MAP_OPTIONS
+// ============================================================
+describe('INLINE_MAP_OPTIONS', () => {
+  it('disables wheel zoom so maps in a scrolling list do not steal the wheel', () => {
+    expect(INLINE_MAP_OPTIONS.scrollWheelZoom).toBe(false)
+  })
+
+  it('bounces at the zoom limits', () => {
+    expect(INLINE_MAP_OPTIONS.bounceAtZoomLimits).toBe(true)
   })
 })
 


### PR DESCRIPTION
## What

The address map in chat can end up showing the whole UK instead of the street. Reported with a screenshot of a "You sent an address" bubble zoomed out to United Kingdom / Eire level.

## Why

`ChatMessageAddress.vue` creates its map at `:zoom="14"` (and `MAX_MAP_ZOOM` is 14), so it opens at street level. It never passed `scrollWheelZoom: false`, so Leaflet's default wheel-zoom was live. Scrolling the conversation with the pointer over the map makes Leaflet swallow the wheel event (it calls `preventDefault`), so the chat does not scroll and the map drops one zoom level per notch instead. There is no `min-zoom` either, so it bottoms out at world view, and it stays there because the component is not remounted while the chat is open.

`ChatMessageText.vue`'s approximate-postcode map had exactly the same problem.

Every other embedded map in the app already guards against this: `MessageMap.vue` and `VisualiseMap.vue` both set `scrollWheelZoom: false`. The two chat maps were the ones that were missed.

## Change

Share the embedded-map options as `INLINE_MAP_OPTIONS` in `composables/useMap.js` and bind them on all three chat maps.

## Verification

Browser check against `freegle-dev-local`, dispatching six wheel notches over the map:

| | tile zoom before | tile zoom after | wheel events swallowed by map |
|---|---|---|---|
| Before fix | 14 | 2 | 6 |
| After fix | 14 | 14 | 0 |

Both the address map and the postcode map hold their zoom, and the wheel now reaches the conversation.

Full vitest suite green (14618 passing), including new coverage asserting the option reaches both branches of `ChatMessageAddress` and the `ChatMessageText` map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi
