### PR TITLE
fix(modtools): stop the location prompt appearing on unrelated pages

### DIFF
--- a/iznik-nuxt3/modtools/composables/rippling/geometry.js
+++ b/iznik-nuxt3/modtools/composables/rippling/geometry.js
@@ -65,3 +65,32 @@ export function reachedIdSet(frameIds, gateIds) {
   if (Array.isArray(frameIds)) return new Set(frameIds)
   return new Set(gateIds || [])
 }
+
+// Whether the explorer should ask the browser for the moderator's location to
+// centre the map.
+//
+// This is deliberately a separate, testable rule because getting it wrong is
+// user-visible and alarming rather than merely broken. ModTools is a
+// single-page app, and the explorer defers this decision past an await (a URL
+// geocode lookup), so by the time it runs the moderator may have navigated on.
+// Firing then pops "Allow <site> to access your location?" over an unrelated
+// page - reported from /settings, where a location request has no business
+// appearing and reads as the site misbehaving.
+//
+//   destroyed       - the explorer has been torn down (navigated away)
+//   urlSetLocation  - a location already came from props or the URL
+//   hasGeolocation  - the browser offers navigator.geolocation
+//   currentLat      - the map already has a location (null when it does not)
+export function shouldAutoLocate({
+  destroyed,
+  urlSetLocation,
+  hasGeolocation,
+  currentLat,
+}) {
+  return (
+    !destroyed &&
+    !urlSetLocation &&
+    Boolean(hasGeolocation) &&
+    currentLat === null
+  )
+}

--- a/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
+++ b/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
@@ -17,6 +17,7 @@ import {
   geoToLeaflet,
   pointInRing,
   reachedIdSet,
+  shouldAutoLocate,
 } from './geometry.js'
 import {
   hasRing,
@@ -41,6 +42,11 @@ export async function setupRipplingExplorer({
 
   let map = null
   const cleanupFns = []
+
+  // Set by cleanup() when the explorer is torn down. Work that resumes after an
+  // await must check this: ModTools is a single-page app, so anything deferred
+  // can otherwise land on whatever page the moderator has since navigated to.
+  let destroyed = false
 
   function apiUrl(path) {
     const sep = path.includes('?') ? '&' : '?'
@@ -1242,14 +1248,28 @@ export async function setupRipplingExplorer({
   // Defer until after onMounted's synchronous setup completes (so all the
   // let-bindings further down are reached) — setTimeout(0) is enough.
   setTimeout(async () => {
+    if (destroyed) return
     // Reflect the default view (catchment) in the DOM before URL/props may switch it —
     // applyViewMode is otherwise only called on a tab click, and the markup default view
     // is catchment (its panel starts hidden until applyViewMode shows it).
     if (!pendingView) applyViewMode()
     const urlSetLocation = await applyUrlInit()
-    if (!urlSetLocation && navigator.geolocation && currentLat === null) {
+    // applyUrlInit can await an external geocode lookup, so re-check: the
+    // moderator may have left the explorer while it was in flight. Asking the
+    // browser for their location at that point pops "Allow modtools.org to
+    // access your location?" over an unrelated page — reported on /settings,
+    // where it reads as a site doing something it has no business doing.
+    if (
+      shouldAutoLocate({
+        destroyed,
+        urlSetLocation,
+        hasGeolocation: navigator.geolocation,
+        currentLat,
+      })
+    ) {
       navigator.geolocation.getCurrentPosition(
         (pos) => {
+          if (destroyed) return
           if (currentLat === null)
             setLocation(pos.coords.latitude, pos.coords.longitude, true)
         },
@@ -3222,6 +3242,7 @@ export async function setupRipplingExplorer({
   }
 
   return function cleanup() {
+    destroyed = true
     cleanupFns.forEach((fn) => fn())
     if (map) {
       map.remove()

--- a/iznik-nuxt3/tests/unit/composables/rippling-geometry.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/rippling-geometry.spec.js
@@ -6,6 +6,7 @@ import {
   pointInRing,
   reachedIdSet,
   segmentsIntersect,
+  shouldAutoLocate,
 } from '~/modtools/composables/rippling/geometry.js'
 
 // Closed [lng,lat] ring for a 2-unit square centred on origin.
@@ -36,7 +37,9 @@ describe('rippling/geometry', () => {
 
   describe('reachedIdSet', () => {
     it("prefers a frame's per-tick ids when present", () => {
-      expect([...reachedIdSet([1, 2], [9])].sort((a, b) => a - b)).toEqual([1, 2])
+      expect([...reachedIdSet([1, 2], [9])].sort((a, b) => a - b)).toEqual([
+        1, 2,
+      ])
     })
 
     it('treats an empty frame array as an answer (tick reached nothing yet)', () => {
@@ -44,7 +47,9 @@ describe('rippling/geometry', () => {
     })
 
     it('falls back to the max-extent gate ids when no frame ids', () => {
-      expect([...reachedIdSet(undefined, [9, 10])].sort((a, b) => a - b)).toEqual([9, 10])
+      expect(
+        [...reachedIdSet(undefined, [9, 10])].sort((a, b) => a - b)
+      ).toEqual([9, 10])
     })
 
     it('tints nothing when neither source has answered - never geometry', () => {
@@ -137,5 +142,38 @@ describe('rippling/geometry', () => {
       // (0,0)→(2,0) and (1,0)→(3,0) are collinear — cross product is 0.
       expect(segmentsIntersect(0, 0, 2, 0, 1, 0, 3, 0)).toBe(false)
     })
+  })
+})
+
+describe('shouldAutoLocate', () => {
+  const base = {
+    destroyed: false,
+    urlSetLocation: false,
+    hasGeolocation: {},
+    currentLat: null,
+  }
+
+  it('asks for the location when the explorer is live and has none', () => {
+    expect(shouldAutoLocate(base)).toBe(true)
+  })
+
+  // The reported bug: ModTools is a single-page app and this decision is taken
+  // after an await, so a moderator who has moved on to another page would
+  // otherwise get "Allow modtools.org to access your location?" on a page with
+  // nothing to do with maps (seen on /settings).
+  it('does not ask once the explorer has been torn down', () => {
+    expect(shouldAutoLocate({ ...base, destroyed: true })).toBe(false)
+  })
+
+  it('does not ask when props or the URL already supplied a location', () => {
+    expect(shouldAutoLocate({ ...base, urlSetLocation: true })).toBe(false)
+  })
+
+  it('does not ask when the map already has a location', () => {
+    expect(shouldAutoLocate({ ...base, currentLat: 53.8 })).toBe(false)
+  })
+
+  it('does not ask when the browser offers no geolocation', () => {
+    expect(shouldAutoLocate({ ...base, hasGeolocation: undefined })).toBe(false)
   })
 })


### PR DESCRIPTION
## Problem

A moderator on `modtools.org/settings`, looking for the newsletter control, got a Firefox prompt asking `Allow modtools.org to access your location?`. A settings page has no reason to want a location, so it reads as the site misbehaving.

Reported at https://discourse.ilovefreegle.org/t/notice-from-firefox/9984

## Cause

The Rippling Explorer asks the browser for the moderator's location to centre its map when no location arrives from props or the URL (`setupRipplingExplorer.js`). The request is deferred behind `setTimeout(..., 0)` — needed because `onMounted`'s later let-bindings are in the temporal dead zone — and the callback then awaits `applyUrlInit()`, which for a `?postcode=` / `?q=` URL performs an external geocode lookup that can take seconds.

Nothing checked that the explorer was still on screen. ModTools is a single-page app, so opening Rippling and navigating on before that work resumed produced a location prompt anchored to whatever page the moderator had reached, with no visible cause.

## Change

`RipplingExplorer.vue` already calls the composable's `cleanup()` on unmount. `cleanup()` now sets a `destroyed` flag, checked at each point the deferred work resumes: before the setup runs, after the awaited lookup, and inside the `getCurrentPosition` success handler.

The decision moves into `shouldAutoLocate()` in `geometry.js`, next to the other pure helpers, so a rule whose failure is user-visible and alarming is covered by tests rather than buried in a 3,000-line closure.

The per-post reach modal (`ModMessageReachMap`) is unaffected: it is gated on `hasLocation` and seeds `initialLat`/`initialLng`, so `applyUrlInit()` returns a location and the geolocation branch is never reached.

## Tests

`rippling-geometry.spec.js` covers `shouldAutoLocate`: it asks when the explorer is live and has no location, and declines once torn down (the reported case), when props or the URL already supplied one, when the map already has one, and when the browser offers no geolocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi
