### PR TITLE
fix(mail): don't geolocate private or reserved sender IPs

### DIFF
--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -2850,7 +2850,13 @@ class IncomingMailService
                 // Geolocate the sender IP so ModTools can flag posts from
                 // outside the UK (MessageHistory.vue). V1 (Message.php/Spam.php)
                 // stored the ISO code here; store NULL when it can't be resolved.
-                'fromcountry' => $email->senderIp ? $this->spamCheck->lookupIPCountryCode($email->senderIp) : null,
+                // Private/reserved IPs (e.g. an internal relay hop picked up
+                // from a Received: header) are never geolocated - see
+                // Discourse topic 9865, where 172.20.0.1 (RFC1918) was the
+                // only IP in the headers of a legitimate email post.
+                'fromcountry' => ($email->senderIp && ! SpamCheckService::isPrivateOrReservedIp($email->senderIp))
+                    ? $this->spamCheck->lookupIPCountryCode($email->senderIp)
+                    : null,
                 'subject' => $email->subject,
                 'suggestedsubject' => $email->subject, // TODO: implement subject suggestion
                 'messageid' => $messageId,

--- a/iznik-batch/app/Services/Mail/Incoming/SpamCheckService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/SpamCheckService.php
@@ -144,8 +144,12 @@ class SpamCheckService
         $fromTN = $email->isFromTrashNothing();
 
         if ($ip && ! $fromTN) {
-            // Skip internal IPs
-            if (str_starts_with($ip, '10.')) {
+            // Skip private/reserved IPs (RFC1918 10.0.0.0/8, 172.16.0.0/12,
+            // 192.168.0.0/16, loopback, link-local, etc.) - these are internal
+            // relay hops (e.g. a mail server's own Docker gateway address
+            // appearing in a Received: header), never the sender's real
+            // location, so they must never reach the country-block/GeoIP check.
+            if (self::isPrivateOrReservedIp($ip)) {
                 $ip = null;
             } else {
                 // Check IP whitelist
@@ -376,6 +380,24 @@ class SpamCheckService
         return DB::table('spam_whitelist_ips')
             ->where('ip', $ip)
             ->exists();
+    }
+
+    /**
+     * True if $ip is a private (RFC1918/RFC4193) or otherwise reserved
+     * (loopback, link-local, documentation ranges, etc.) address.
+     *
+     * These addresses can never be a genuine sender location - they show up
+     * here as internal relay hops (e.g. a mail server's own Docker gateway
+     * address leaking into a Received: header), so they must never be used
+     * for country/GeoIP-based decisions. See Discourse topic 9865.
+     */
+    public static function isPrivateOrReservedIp(string $ip): bool
+    {
+        return filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        ) === false;
     }
 
     /**

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -1652,6 +1652,53 @@ class IncomingMailServiceTest extends TestCase
         $this->assertStringContainsString('score', $message->spamreason);
     }
 
+    public function test_fromcountry_not_populated_for_private_ip_sender(): void
+    {
+        // Regression test for Discourse topic 9865 post 11: a post submitted by
+        // email whose only header IP is 172.20.0.1 (RFC1918, an internal relay
+        // hop - e.g. docker.local in a Received: header) must never end up with
+        // a geolocated fromcountry, since that field drives the ModTools
+        // "different country" warning in MessageHistory.vue. The mock below
+        // simulates a GeoIP backend that (incorrectly) resolves a country for
+        // the private IP, so the test proves an explicit guard - not incidental
+        // GeoIP failure - is what keeps fromcountry null.
+        $spamCheckMock = \Mockery::mock(\App\Services\Mail\Incoming\SpamCheckService::class)->makePartial();
+        $spamCheckMock->shouldReceive('checkMessage')->andReturn(null);
+        $spamCheckMock->shouldReceive('checkSpamAssassin')->andReturn([0, false]);
+        $spamCheckMock->shouldReceive('lookupIPCountryCode')->andReturn('US');
+
+        $this->service = new IncomingMailService(spamCheck: $spamCheckMock);
+
+        [$user, $group, $userEmail] = $this->createPostableUser();
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'X-Originating-IP' => '[172.20.0.1]',
+            'Subject' => 'OFFER: Test item (London)',
+        ], 'Test body');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $this->service->route($parsed);
+
+        $message = DB::table('messages')
+            ->where('fromuser', $user->id)
+            ->orderBy('id', 'desc')
+            ->first();
+
+        $this->assertNotNull($message, 'Message should be created in database');
+        $this->assertEquals('172.20.0.1', $message->fromip);
+        $this->assertNull(
+            $message->fromcountry,
+            'A private/reserved sender IP must never populate fromcountry'
+        );
+    }
+
     public function test_routing_context_includes_spam_info(): void
     {
         $group = $this->createTestGroup();

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/SpamCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/SpamCheckServiceTest.php
@@ -611,6 +611,52 @@ class SpamCheckServiceTest extends TestCase
         $this->assertNull($service->checkMessage($email));
     }
 
+    /**
+     * Regression test for Discourse topic 9865: an email post whose only
+     * header IP was 172.20.0.1 (RFC1918, 172.16.0.0/12 - an internal relay
+     * hop, e.g. a mail server's own Docker gateway address in a Received:
+     * header) was treated as a real sender IP because the old "internal IP"
+     * check only recognised the 10.0.0.0/8 range.
+     *
+     * @dataProvider privateAndReservedIpProvider
+     */
+    public function test_check_message_skips_ip_checks_for_private_and_reserved_ips(string $ip): void
+    {
+        DB::table('spam_countries')->insert(['country' => 'TestCountry']);
+
+        $service = $this->createServiceWithMockedGeoIP('TestCountry');
+
+        $email = $this->createParsedEmailForSpamTest([
+            'senderIp' => $ip,
+        ]);
+
+        $this->assertNull($service->checkMessage($email), "Expected IP {$ip} to be skipped as private/reserved");
+    }
+
+    public static function privateAndReservedIpProvider(): array
+    {
+        return [
+            '172.16.0.0/12 (reported IP, Discourse 9865)' => ['172.20.0.1'],
+            '192.168.0.0/16' => ['192.168.1.1'],
+            'loopback 127.0.0.0/8' => ['127.0.0.1'],
+        ];
+    }
+
+    /**
+     * @dataProvider privateAndReservedIpProvider
+     */
+    public function test_is_private_or_reserved_ip_true_for_private_ranges(string $ip): void
+    {
+        $this->assertTrue(SpamCheckService::isPrivateOrReservedIp($ip), "Expected {$ip} to be private/reserved");
+    }
+
+    public function test_is_private_or_reserved_ip_false_for_public_ips(): void
+    {
+        foreach (['8.8.8.8', '1.2.3.4', '81.158.135.133'] as $ip) {
+            $this->assertFalse(SpamCheckService::isPrivateOrReservedIp($ip), "Expected {$ip} to be a public IP");
+        }
+    }
+
     public function test_check_message_for_chat_reply_skips_subject_reuse(): void
     {
         // A common post subject like "Washing Machine" legitimately appears on many


### PR DESCRIPTION
## Problem

The incoming-mail spam check decided whether a sender IP was "internal" with a single prefix test:

```php
// Skip internal IPs
if (str_starts_with($ip, '10.')) {
```

That recognises only `10.0.0.0/8`. A mail server's own internal relay hop arriving in a `Received:` header — `172.20.0.1`, which is RFC1918 but sits in `172.16.0.0/12` — was therefore treated as the sender's real address and fed to the country blocklist and the GeoIP lookup. A legitimate email post could be judged by an address that was never the sender's.

The same address also reached `messages.fromcountry` through `createGroupPostMessage`, so ModTools' "posted from outside the UK" flag could be derived from a Docker gateway.

Reported as Discourse topic 9865.

## Change

`SpamCheckService::isPrivateOrReservedIp()` replaces the prefix test, using `filter_var` with `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE`. That covers RFC1918 in full (`10/8`, `172.16/12`, `192.168/16`) plus loopback, link-local, and the other reserved blocks, rather than enumerating ranges by hand.

`createGroupPostMessage` applies the same check before calling `lookupIPCountryCode`, storing `NULL` when the only available address is private or reserved.

## Tests

`SpamCheckServiceTest` gains a data-provider regression test asserting such addresses skip the IP checks entirely, covering `172.20.0.1` (the reported address), `192.168.1.1` and `127.0.0.1`, with a country blocklist loaded so the assertion would fail if the address still reached the GeoIP path. `IncomingMailServiceTest` covers `fromcountry` being left NULL for a private sender IP.

The `Incoming` Laravel suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi
