### PR TITLE
fix(rippling): distinguish never-reviewed posting status from a moderator's decision

### DIFF
--- a/iznik-nuxt3/modtools/components/ModModeration.vue
+++ b/iznik-nuxt3/modtools/components/ModModeration.vue
@@ -1,11 +1,14 @@
 <template>
-  <div class="d-inline d-flex justify-content-start flex-wrap">
+  <div class="d-inline d-flex justify-content-start flex-wrap align-items-center">
     <b-form-select
       v-model="postingStatus"
       :options="options"
       class="sel"
       :size="size"
     />
+    <small v-if="!membership.ourpostingstatusreviewed" class="text-muted ms-1">
+      Not yet reviewed by a moderator - this is just the default
+    </small>
     <b-form-select v-model="trustlevel" class="sel" :size="size" readyonly>
       <option :value="null">Volunteering - not asked</option>
       <option value="Basic">Volunteering - basic</option>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModModeration.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModModeration.spec.js
@@ -223,6 +223,30 @@ describe('ModModeration', () => {
     })
   })
 
+  describe('unreviewed posting status notice', () => {
+    it('shows a notice when the membership has never been reviewed by a moderator', () => {
+      // e.g. a member auto-joined by rippling out: ourpostingstatus resolves
+      // to MODERATED server-side, but no moderator ever set it (Discourse 9890/9886).
+      const wrapper = mountComponent({
+        membership: createMembership({
+          ourpostingstatus: 'MODERATED',
+          ourpostingstatusreviewed: false,
+        }),
+      })
+      expect(wrapper.text()).toContain('Not yet reviewed by a moderator')
+    })
+
+    it('does not show the notice when a moderator has explicitly set the status', () => {
+      const wrapper = mountComponent({
+        membership: createMembership({
+          ourpostingstatus: 'MODERATED',
+          ourpostingstatusreviewed: true,
+        }),
+      })
+      expect(wrapper.text()).not.toContain('Not yet reviewed by a moderator')
+    })
+  })
+
   describe('options computed', () => {
     it('returns correct posting status options', () => {
       const wrapper = mountComponent()

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -315,6 +315,10 @@ type GetMembershipsMember struct {
 	Engagement          *string                 `json:"engagement"`
 	Lastmodmail         *string                 `json:"lastmodmail,omitempty"`
 	Bouncing            bool                    `json:"bouncing" gorm:"column:bouncing"`
+	// OurPostingStatusReviewed is true only when a moderator has actually stored a posting
+	// status for this membership - see the identical field on user.Membership for why this
+	// matters (Discourse 9890/9886).
+	OurPostingStatusReviewed bool `json:"ourpostingstatusreviewed" gorm:"-"`
 }
 
 // GetMemberships handles GET /memberships - list group members (moderator use).
@@ -592,6 +596,7 @@ func enrichMembers(members []GetMembershipsMember) {
 
 		// NULL ourPostingStatus defaults to MODERATED.
 		// DEFAULT stays as DEFAULT — it's an explicit status (Group.php line 967).
+		m.OurPostingStatusReviewed = m.OurPostingStatus != nil && *m.OurPostingStatus != ""
 		if m.OurPostingStatus == nil || *m.OurPostingStatus == "" {
 			moderated := utils.POSTING_STATUS_MODERATED
 			m.OurPostingStatus = &moderated

--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -3098,6 +3098,68 @@ func TestGetUserMembershipsPostingStatus(t *testing.T) {
 	}
 }
 
+// TestGetUserMembershipsPostingStatusReviewed verifies that a moderator can tell
+// apart a membership whose posting status was never explicitly reviewed (NULL,
+// resolved to MODERATED for display) from one where a moderator actually chose
+// MODERATED. Without this distinction, a member auto-joined by rippling out -
+// whose arriving post required no moderator review at all - looks in ModTools
+// exactly like a member a moderator deliberately flagged as needing review
+// (Discourse 9890/9886).
+func TestGetUserMembershipsPostingStatusReviewed(t *testing.T) {
+	prefix := uniquePrefix("fetchmt_psr")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Owner")
+	_, modToken := CreateTestSession(t, modID)
+
+	// A rippled-in membership: ExpandService::addPosterMembershipToRippledGroups
+	// inserts (role, collection, ...) but never sets ourPostingStatus, and marks
+	// rippled=1. NULL is the default - don't set ourPostingStatus.
+	rippledUser := CreateTestUser(t, prefix+"_rippled", "User")
+	CreateTestMembership(t, rippledUser, groupID, "Member")
+	db.Exec("UPDATE memberships SET rippled = 1 WHERE userid = ? AND groupid = ?", rippledUser, groupID)
+
+	// A membership a moderator has actually reviewed and explicitly set to MODERATED.
+	reviewedUser := CreateTestUser(t, prefix+"_reviewed", "User")
+	CreateTestMembership(t, reviewedUser, groupID, "Member")
+	db.Exec("UPDATE memberships SET ourPostingStatus = 'MODERATED' WHERE userid = ? AND groupid = ?", reviewedUser, groupID)
+
+	for _, tc := range []struct {
+		name             string
+		uid              uint64
+		expectedStatus   string
+		expectedReviewed bool
+	}{
+		{"rippled, never reviewed", rippledUser, "MODERATED", false},
+		{"explicitly reviewed by a moderator", reviewedUser, "MODERATED", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", tc.uid, modToken)
+			resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+			assert.NoError(t, err)
+			assert.Equal(t, 200, resp.StatusCode)
+
+			var result map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&result)
+			memberships := result["memberships"].([]interface{})
+
+			found := false
+			for _, m := range memberships {
+				mem := m.(map[string]interface{})
+				if uint64(mem["groupid"].(float64)) == groupID {
+					found = true
+					assert.Equal(t, tc.expectedStatus, mem["ourpostingstatus"], "ourpostingstatus should be %s", tc.expectedStatus)
+					assert.Equal(t, tc.expectedReviewed, mem["ourpostingstatusreviewed"], "ourpostingstatusreviewed should be %v", tc.expectedReviewed)
+					break
+				}
+			}
+			assert.True(t, found, "Should find group membership")
+		})
+	}
+}
+
 // TestFetchMTModmailsCount verifies that the modmails count is returned in fetchmt responses
 // and filters by the viewing mod's groups.
 func TestFetchMTModmailsCount(t *testing.T) {

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -155,6 +155,13 @@ type Membership struct {
 	Type                     string `json:"type"`
 	Bbox                     string `json:"bbox"`
 	Microvolunteeringallowed int    `json:"microvolunteeringallowed"`
+	// OurPostingStatusReviewed is true only when a moderator has actually stored a posting
+	// status for this membership. A NULL column (e.g. every rippling auto-join - see
+	// ExpandService::addPosterMembershipToRippledGroups) is resolved to MODERATED below for
+	// display, which is indistinguishable from an explicit moderator decision unless this flag
+	// is also sent - otherwise a member nobody has ever reviewed looks, in ModTools, exactly
+	// like one a moderator deliberately flagged (Discourse 9890/9886).
+	OurPostingStatusReviewed bool `json:"ourpostingstatusreviewed"`
 }
 
 type UserMessageHistory struct {
@@ -1356,6 +1363,7 @@ func enrichUserForModtools(u *User, id uint64, myid uint64, modtools bool) {
 	if modtools {
 		for i := range memberships {
 			m := &memberships[i]
+			m.OurPostingStatusReviewed = m.OurPostingStatus != nil && *m.OurPostingStatus != ""
 			if m.OurPostingStatus == nil || *m.OurPostingStatus == "" {
 				v := utils.POSTING_STATUS_MODERATED
 				m.OurPostingStatus = &v


### PR DESCRIPTION
## Problem

Rippling auto-joins a poster to every group their post reaches (`ExpandService::addPosterMembershipToRippledGroups`) without setting `ourPostingStatus`, so the membership row keeps it NULL.

The Go API resolves a NULL `ourPostingStatus` to the literal `MODERATED` for ModTools display. That is indistinguishable from a moderator having explicitly chosen "Moderated", so every rippled-in arrival shows as an actively moderated member — even though the post that just arrived went live with no moderator involvement at all, having already been vetted on its origin group.

That produces the contradiction reported: a member "not approved by anyone but has come through as a moderated member".

## Change

The membership API response gains `OurPostingStatusReviewed`, true only when a moderator has actually stored a status. `ModModeration.vue` shows a short note when it is false, so the dropdown no longer reads as an active decision nobody made.

The NULL → `MODERATED` resolution itself is unchanged, so nothing that depends on the effective status shifts; this only distinguishes "never reviewed" from "reviewed and set to Moderated" in what moderators see.

## Tests

`user_test.go` covers the new field being false for a membership with a NULL status and true once a status is stored. `ModModeration.spec.js` covers the note appearing only in the never-reviewed case.

Full Go and vitest suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi
