### PR TITLE
feat(chitchat): flag duplicate posts and post them properly for the member

### DIFF
--- a/iznik-nuxt3/api/MessageAPI.js
+++ b/iznik-nuxt3/api/MessageAPI.js
@@ -3,6 +3,13 @@ import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
 
 import { notAHeldConflict } from '~/api/heldConflict'
 
+// A ChitChat moderator posting on a member's behalf names the member here. The
+// server checks the caller is a ChitChat moderator and derives that member's
+// location and community itself, so this only says WHO the post is for.
+function onBehalfOfQuery(userid) {
+  return userid ? '?onbehalfof=' + encodeURIComponent(userid) : ''
+}
+
 export default class MessageAPI extends BaseAPI {
   fetch(id, logError = true) {
     return this.$getv2('/message/' + id, {}, logError)
@@ -98,7 +105,11 @@ export default class MessageAPI extends BaseAPI {
     const logErrorFn =
       options.logError !== undefined ? options.logError : logError
 
-    return this.$postv2('/message', params, logErrorFn)
+    return this.$postv2(
+      '/message' + onBehalfOfQuery(options.onbehalfof),
+      params,
+      logErrorFn
+    )
   }
 
   del(id) {
@@ -106,7 +117,11 @@ export default class MessageAPI extends BaseAPI {
   }
 
   put(data) {
-    return this.$putv2('/message', data)
+    // onbehalfof travels in the query string, where the server reads it and
+    // checks the caller is a ChitChat moderator. Keep it out of the body so it
+    // can't be mistaken for a message field.
+    const { onbehalfof, ...body } = data
+    return this.$putv2('/message' + onBehalfOfQuery(onbehalfof), body)
   }
 
   intend(id, outcome) {

--- a/iznik-nuxt3/api/NewsAPI.js
+++ b/iznik-nuxt3/api/NewsAPI.js
@@ -57,6 +57,22 @@ export default class NewsAPI extends BaseAPI {
     await this.$postv2('/newsfeed', { id, action: 'ConvertToStory' })
   }
 
+  // ChitChat moderators only - the server 403s for anyone else, because the
+  // answer names one of the poster's own posts.
+  async duplicate(id) {
+    return await this.$getv2(`/newsfeed/${id}/duplicate`)
+  }
+
+  // Records on the thread that a volunteer has posted this properly for the
+  // member, pointing at the OFFER/WANTED just created. ChitChat moderators only.
+  async convertedToPost(id, msgid) {
+    return await this.$postv2('/newsfeed', {
+      id,
+      msgid,
+      action: 'ConvertedToPost',
+    })
+  }
+
   async seen(id) {
     await this.$postv2('/newsfeed?bump=' + id, { id, action: 'Seen' })
   }

--- a/iznik-nuxt3/api/NewsAPI.js
+++ b/iznik-nuxt3/api/NewsAPI.js
@@ -63,6 +63,13 @@ export default class NewsAPI extends BaseAPI {
     return await this.$getv2(`/newsfeed/${id}/duplicate`)
   }
 
+  // Where a convert-to-post would land: the member's own postcode and community,
+  // resolved server-side by the same code that does the posting. ChitChat
+  // moderators only - it says where another member lives.
+  async convertInfo(id) {
+    return await this.$getv2(`/newsfeed/${id}/convertinfo`)
+  }
+
   // Records on the thread that a volunteer has posted this properly for the
   // member, pointing at the OFFER/WANTED just created. ChitChat moderators only.
   async convertedToPost(id, msgid) {

--- a/iznik-nuxt3/components/NewsConvertModal.vue
+++ b/iznik-nuxt3/components/NewsConvertModal.vue
@@ -46,11 +46,26 @@
           <div class="fw-bold">{{ previewSubject }}</div>
           <div class="preline mt-2">{{ body }}</div>
         </b-card>
-        <div class="text-muted small mt-1">
+        <div v-if="postingArea" class="text-muted small mt-1">
+          Posting to <strong>{{ posting.groupname }}</strong> using
+          <strong>{{ postingArea }}</strong> - {{ posterName }}'s own area, not
+          yours.
+        </div>
+        <div v-else class="text-muted small mt-1">
           Their area and postcode get added to the subject when it posts, the
           same as any other post.
         </div>
       </div>
+
+      <!-- The server refuses to post for a member it can't place, so say so
+           here rather than after the moderator has filled the form in. -->
+      <NoticeMessage
+        v-if="postingChecked && posting && !posting.canpost"
+        variant="warning"
+        class="mt-3"
+      >
+        {{ posting.reason }}
+      </NoticeMessage>
 
       <!-- The note is left on a public thread in the member's name, so show the
            moderator what it says before they commit to it. Same component the
@@ -79,11 +94,13 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import NoticeMessage from '~/components/NoticeMessage'
 import SpinButton from '~/components/SpinButton'
 import { useOurModal } from '~/composables/useOurModal'
 import { useNewsfeedStore } from '~/stores/newsfeed'
+import { useRuntimeConfig } from '#app'
+import api from '~/api'
 
 const props = defineProps({
   newsfeed: {
@@ -100,6 +117,7 @@ const emit = defineEmits(['posted'])
 
 const { modal, hide } = useOurModal()
 const newsfeedStore = useNewsfeedStore()
+const runtimeConfig = useRuntimeConfig()
 
 const typeOptions = [
   { text: 'OFFER - they are giving something away', value: 'Offer' },
@@ -170,11 +188,38 @@ const body = ref(props.newsfeed?.message || '')
 const error = ref(null)
 
 const canSubmit = computed(
-  () => item.value.trim().length > 0 && body.value.trim().length > 0
+  () =>
+    item.value.trim().length > 0 &&
+    body.value.trim().length > 0 &&
+    // Don't let them post something the server has already said it will refuse.
+    !(postingChecked.value && posting.value && !posting.value.canpost)
 )
 
+// Where this will actually land. Resolved server-side from the member - the
+// moderator's own location is irrelevant and must never be used - so the modal
+// asks rather than guesses, and shows the same postcode the post will carry.
+const posting = ref(null)
+const postingChecked = ref(false)
+
+onMounted(async () => {
+  try {
+    posting.value = await api(runtimeConfig).news.convertInfo(props.newsfeed.id)
+  } catch (e) {
+    // Leave posting null: the preview falls back to "their area" rather than
+    // blocking a moderator who could otherwise post fine.
+    console.error('Could not work out where this would post', e)
+  }
+
+  postingChecked.value = true
+})
+
+const postingArea = computed(() => posting.value?.locationname || null)
+
 const previewSubject = computed(
-  () => `${type.value.toUpperCase()}: ${item.value || '...'} (their area)`
+  () =>
+    `${type.value.toUpperCase()}: ${item.value || '...'} (${
+      postingArea.value || 'their area'
+    })`
 )
 
 async function submit(callback) {

--- a/iznik-nuxt3/components/NewsConvertModal.vue
+++ b/iznik-nuxt3/components/NewsConvertModal.vue
@@ -52,6 +52,14 @@
         </div>
       </div>
 
+      <!-- The note is left on a public thread in the member's name, so show the
+           moderator what it says before they commit to it. Same component the
+           thread renders, so the two cannot drift apart. -->
+      <div class="mt-3">
+        <h5>What goes on this chat</h5>
+        <NewsConvertedNotice preview />
+      </div>
+
       <NoticeMessage v-if="error" variant="danger" class="mt-3">
         {{ error }}
       </NoticeMessage>

--- a/iznik-nuxt3/components/NewsConvertModal.vue
+++ b/iznik-nuxt3/components/NewsConvertModal.vue
@@ -1,0 +1,201 @@
+<template>
+  <b-modal
+    :id="'newsConvertModal-' + newsfeed.id"
+    ref="modal"
+    scrollable
+    title="Post this for them"
+    size="lg"
+    no-stacking
+  >
+    <template #default>
+      <p>
+        This posts an OFFER or WANTED <strong>as {{ posterName }}</strong
+        >, not as you, so replies reach them and it shows up in their My Posts.
+        We'll add a note on this chat telling them what you've done.
+      </p>
+
+      <b-form-group label="What kind of post?" class="mt-3">
+        <!-- Plain radios, not a button group: with `buttons` the selected
+             option renders identically to the unselected one here, so there is
+             no way to tell what is about to be posted. -->
+        <b-form-radio-group v-model="type" :options="typeOptions" stacked />
+      </b-form-group>
+
+      <b-form-group label="Item" class="mt-3">
+        <b-form-input
+          v-model="item"
+          placeholder="e.g. dining chairs"
+          maxlength="80"
+        />
+        <div class="text-muted small mt-1">
+          Just the item, no location - we add their area automatically.
+        </div>
+      </b-form-group>
+
+      <b-form-group label="Description" class="mt-3">
+        <b-form-textarea v-model="body" rows="5" max-rows="12" />
+      </b-form-group>
+
+      <NoticeMessage v-if="!canSubmit" variant="warning" class="mt-3">
+        Add an item name and a description before posting.
+      </NoticeMessage>
+
+      <div class="mt-3">
+        <h5>Preview</h5>
+        <b-card class="preview">
+          <div class="fw-bold">{{ previewSubject }}</div>
+          <div class="preline mt-2">{{ body }}</div>
+        </b-card>
+        <div class="text-muted small mt-1">
+          Their area and postcode get added to the subject when it posts, the
+          same as any other post.
+        </div>
+      </div>
+
+      <NoticeMessage v-if="error" variant="danger" class="mt-3">
+        {{ error }}
+      </NoticeMessage>
+    </template>
+
+    <template #footer>
+      <b-button variant="white" @click="hide"> Cancel </b-button>
+      <SpinButton
+        variant="primary"
+        :disabled="!canSubmit"
+        icon-name="share"
+        label="Post it for them"
+        @handle="submit"
+      />
+    </template>
+  </b-modal>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import NoticeMessage from '~/components/NoticeMessage'
+import SpinButton from '~/components/SpinButton'
+import { useOurModal } from '~/composables/useOurModal'
+import { useNewsfeedStore } from '~/stores/newsfeed'
+
+const props = defineProps({
+  newsfeed: {
+    type: Object,
+    required: true,
+  },
+  posterName: {
+    type: String,
+    default: 'them',
+  },
+})
+
+const emit = defineEmits(['posted'])
+
+const { modal, hide } = useOurModal()
+const newsfeedStore = useNewsfeedStore()
+
+const typeOptions = [
+  { text: 'OFFER - they are giving something away', value: 'Offer' },
+  { text: 'WANTED - they are looking for something', value: 'Wanted' },
+]
+
+// Guess the type from how the post reads. "Looking for"/"need"/"wanted" means
+// they want something; anything else is far more often a giveaway, which is
+// also the safer default because an OFFER with no taker is harmless.
+const guessedType = () => {
+  const text = (props.newsfeed?.message || '').toLowerCase()
+  return /\b(wanted|looking for|does anyone have|in need of|after a)\b/.test(
+    text
+  )
+    ? 'Wanted'
+    : 'Offer'
+}
+
+// Best guess at the item from the first line: ChitChat posts usually lead with
+// what the thing is. The moderator corrects it before posting - this only has
+// to save typing, not be right.
+//
+// The subject reads "OFFER: <item> (Area PC)", so the item has to be the thing
+// itself. Left as the raw first sentence it produces subjects like
+// "OFFER: Set of four dining chairs going spare if anyone wants them (Hove BN3)",
+// which is why the trailing offer-speak and the length cap are here.
+const guessedItem = () => {
+  const first = (props.newsfeed?.message || '')
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0)
+
+  if (!first) return ''
+
+  let s = first
+    .replace(/^(hi|hello|hiya|morning|afternoon|evening)\b[!,. ]*/i, '')
+    .replace(
+      /^(does anyone have|has anyone got|is anyone|looking for|i have|i've got|i'm after|free to a good home|wanted|offer|offering)\b[:, ]*/i,
+      ''
+    )
+    // First sentence only.
+    .replace(/[.!?].*$/s, '')
+    .trim()
+
+  // Drop the "...going spare if anyone wants them" tail: that describes the
+  // offer, not the item.
+  s = s
+    .replace(
+      /\s+\b(going spare|going free|free to collect|free to a good home|up for grabs|available|needs? collecting|for collection|to collect)\b.*$/i,
+      ''
+    )
+    .replace(/\s+\b(if|which|that|as|because)\b.*$/i, '')
+    .replace(/[,;:]\s*$/, '')
+    .trim()
+
+  // Long enough for "set of four dining chairs", short enough for a subject.
+  const words = s.split(/\s+/).filter(Boolean)
+  if (words.length > 6) {
+    s = words.slice(0, 6).join(' ')
+  }
+
+  return s.slice(0, 60).trim()
+}
+
+const type = ref(guessedType())
+const item = ref(guessedItem())
+const body = ref(props.newsfeed?.message || '')
+const error = ref(null)
+
+const canSubmit = computed(
+  () => item.value.trim().length > 0 && body.value.trim().length > 0
+)
+
+const previewSubject = computed(
+  () => `${type.value.toUpperCase()}: ${item.value || '...'} (their area)`
+)
+
+async function submit(callback) {
+  error.value = null
+
+  try {
+    await newsfeedStore.convertToPost(props.newsfeed.id, {
+      type: type.value,
+      item: item.value.trim(),
+      body: body.value.trim(),
+      userid: props.newsfeed.userid,
+    })
+    emit('posted')
+    hide()
+  } catch (e) {
+    error.value =
+      e?.message || "Sorry, that didn't post. Please try again in a moment."
+  }
+
+  callback?.()
+}
+</script>
+
+<style scoped lang="scss">
+.preline {
+  white-space: pre-line;
+}
+
+.preview {
+  background-color: $color-gray--lighter;
+}
+</style>

--- a/iznik-nuxt3/components/NewsConvertedNotice.vue
+++ b/iznik-nuxt3/components/NewsConvertedNotice.vue
@@ -1,0 +1,40 @@
+<template>
+  <NoticeMessage variant="primary">
+    <p>
+      One of our volunteers has posted this properly for you, so more people
+      will see it. You don't need to do anything.
+    </p>
+    <p>
+      You'll find it in My Posts, along with any replies, and you can edit or
+      withdraw it from there.
+    </p>
+    <b-button
+      variant="primary"
+      :to="preview ? null : '/myposts'"
+      :disabled="preview"
+      class="mb-1"
+    >
+      Go to My Posts
+    </b-button>
+  </NoticeMessage>
+</template>
+<script setup>
+// The note left on a ChitChat thread when a moderator posts the item properly
+// for the member.
+//
+// It lives here rather than inline in NewsRefer so that NewsConvertModal can
+// show the moderator exactly what the member will read before they commit to
+// it. Two copies of the wording would drift, and the moderator would end up
+// previewing something other than what actually gets posted.
+import NoticeMessage from '~/components/NoticeMessage'
+
+defineProps({
+  // Preview mode: rendered inside the convert modal rather than on the thread,
+  // so the button is inert - the moderator is not the one going to My Posts.
+  preview: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+})
+</script>

--- a/iznik-nuxt3/components/NewsConvertedNotice.vue
+++ b/iznik-nuxt3/components/NewsConvertedNotice.vue
@@ -8,12 +8,14 @@
       You'll find it in My Posts, along with any replies, and you can edit or
       withdraw it from there.
     </p>
-    <b-button
-      variant="primary"
-      :to="preview ? null : '/myposts'"
-      :disabled="preview"
-      class="mb-1"
-    >
+    <!-- Two buttons rather than one with :to bound to null. A null `to` still
+         reaches the router, which does `'path' in to` and throws
+         "Cannot use 'in' operator to search for 'path' in null" - that took the
+         whole page down as soon as the convert modal opened. -->
+    <b-button v-if="preview" variant="primary" class="mb-1" disabled>
+      Go to My Posts
+    </b-button>
+    <b-button v-else variant="primary" to="/myposts" class="mb-1">
       Go to My Posts
     </b-button>
   </NoticeMessage>

--- a/iznik-nuxt3/components/NewsRefer.vue
+++ b/iznik-nuxt3/components/NewsRefer.vue
@@ -20,19 +20,7 @@
         section is just for chat and recommendations.
       </p>
     </notice-message>
-    <notice-message v-if="type === 'ConvertedToPost'" variant="primary">
-      <p>
-        One of our volunteers has posted this properly for you, so more people
-        will see it. You don't need to do anything.
-      </p>
-      <p>
-        You'll find it in My Posts, along with any replies, and you can edit or
-        withdraw it from there.
-      </p>
-      <b-button variant="primary" to="/myposts" class="mb-1">
-        Go to My Posts
-      </b-button>
-    </notice-message>
+    <NewsConvertedNotice v-if="type === 'ConvertedToPost'" />
     <notice-message v-if="type === 'ReferToTaken'">
       <p>
         If your item has been taken, please go to My Posts, click on the item,
@@ -71,6 +59,7 @@
 <script setup>
 import { ref, computed, defineAsyncComponent } from 'vue'
 import NoticeMessage from './NoticeMessage'
+import NewsConvertedNotice from './NewsConvertedNotice'
 import { useNewsfeedStore } from '~/stores/newsfeed'
 import { useMe } from '~/composables/useMe'
 

--- a/iznik-nuxt3/components/NewsRefer.vue
+++ b/iznik-nuxt3/components/NewsRefer.vue
@@ -20,6 +20,19 @@
         section is just for chat and recommendations.
       </p>
     </notice-message>
+    <notice-message v-if="type === 'ConvertedToPost'" variant="primary">
+      <p>
+        One of our volunteers has posted this properly for you, so more people
+        will see it. You don't need to do anything.
+      </p>
+      <p>
+        You'll find it in My Posts, along with any replies, and you can edit or
+        withdraw it from there.
+      </p>
+      <b-button variant="primary" to="/myposts" class="mb-1">
+        Go to My Posts
+      </b-button>
+    </notice-message>
     <notice-message v-if="type === 'ReferToTaken'">
       <p>
         If your item has been taken, please go to My Posts, click on the item,

--- a/iznik-nuxt3/components/NewsReplies.vue
+++ b/iznik-nuxt3/components/NewsReplies.vue
@@ -24,7 +24,7 @@
         :class="{ 'reply-thread--new': isReplyNew(entry.reply) }"
       >
         <NewsRefer
-          v-if="entry.reply.type && entry.reply.type.indexOf('ReferTo') === 0"
+          v-if="isReferNotice(entry.reply)"
           :id="entry.reply.id"
           :type="entry.reply.type"
           :threadhead="threadhead"
@@ -330,12 +330,18 @@ const renderEntries = computed(() => collapsePlan.value.entries)
 const completedSubtrees = new Set()
 let subtreeSatisfied = false
 
+// A moderator-generated notice rather than someone's reply: the ReferTo family,
+// and the note left when a volunteer posts a ChitChat item properly for the
+// member. Rendered by NewsRefer and excluded from the reply subtree count.
+function isReferNotice(reply) {
+  const type = reply?.type
+  if (!type) return false
+  return type.indexOf('ReferTo') === 0 || type === 'ConvertedToPost'
+}
+
 function expectedSubtreeIds() {
   return renderEntries.value
-    .filter(
-      (e) =>
-        !e.expander && !(e.reply.type && e.reply.type.indexOf('ReferTo') === 0)
-    )
+    .filter((e) => !e.expander && !isReferNotice(e.reply))
     .map((e) => e.reply.id)
 }
 

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -13,6 +13,30 @@
             <span v-else>the system</span>
             and is only visible to volunteers and the person who posted it.
           </div>
+          <!-- Volunteers only. Names one of the poster's own live posts, so it
+               must never render for other members; the server also refuses the
+               request for them. -->
+          <NoticeMessage
+            v-if="chitChatMod && duplicateOf && !newsfeed.hidden"
+            variant="warning"
+            class="mb-2"
+          >
+            <p class="mb-1">
+              <strong>Volunteers only.</strong> This looks like the same thing
+              as a post they already have live:
+            </p>
+            <p class="mb-1">
+              <strong>{{ duplicateOf.type.toUpperCase() }}:</strong>
+              {{ duplicateOf.subject }}
+            </p>
+            <p class="mb-2">
+              If it's a repeat, hide this - their real post is already doing the
+              work, and it reaches more people than ChitChat does.
+            </p>
+            <b-button variant="secondary" size="sm" @click="hide">
+              Hide this post
+            </b-button>
+          </NoticeMessage>
           <div v-if="isNewsComponent">
             <b-dropdown
               lazy
@@ -48,6 +72,9 @@
               </b-dropdown-item>
               <b-dropdown-item @click="report">
                 Report this thread or one of its replies
+              </b-dropdown-item>
+              <b-dropdown-item v-if="chitChatMod" @click="showConvert = true">
+                Post this as an OFFER/WANTED for them
               </b-dropdown-item>
               <b-dropdown-item v-if="canRefer" @click="referToOffer">
                 Refer to OFFER
@@ -262,6 +289,13 @@
       :id="newsfeed.id"
       @hidden="showReportModal = false"
     />
+    <NewsConvertModal
+      v-if="showConvert"
+      :newsfeed="newsfeed"
+      :poster-name="newsfeed?.displayname || 'them'"
+      @posted="onConverted"
+      @hidden="showConvert = false"
+    />
     <ConfirmModal
       v-if="showDeleteModal"
       :title="'Delete thread started by ' + starter"
@@ -330,6 +364,9 @@ const props = defineProps({
 const emit = defineEmits(['rendered', 'expand-duplicates'])
 
 const NewsReportModal = defineAsyncComponent(() => import('./NewsReportModal'))
+const NewsConvertModal = defineAsyncComponent(() =>
+  import('./NewsConvertModal')
+)
 const ConfirmModal = defineAsyncComponent(() =>
   import('~/components/ConfirmModal.vue')
 )
@@ -375,6 +412,7 @@ const imagemods = ref(null)
 const showDeleteModal = ref(false)
 const showEditModal = ref(false)
 const showReportModal = ref(false)
+const showConvert = ref(false)
 const showThis = ref(true)
 const currentAtts = ref([])
 
@@ -489,9 +527,24 @@ if (
 await newsfeedStore.fetch(props.id)
 
 // Lifecycle hooks
-onMounted(() => {
+// One of the poster's own live posts saying the same thing, or null. Only
+// fetched for ChitChat moderators - the server refuses it for anyone else, so
+// a member's browser never holds it.
+const duplicateOf = ref(null)
+
+onMounted(async () => {
   // Scroll down now that the child components are rendered.
   emit('rendered')
+
+  if (chitChatMod.value && isNewsComponent.value && !newsfeed.value?.hidden) {
+    try {
+      duplicateOf.value = await newsfeedStore.duplicate(props.id)
+    } catch (e) {
+      // Advisory only. If we can't work out whether this repeats one of their
+      // own posts, the moderator still gets the thread and every control on it.
+      duplicateOf.value = null
+    }
+  }
 })
 
 // True once the whole reply tree has reported mounting (or there was
@@ -703,6 +756,14 @@ async function unhide() {
 
 async function hide() {
   await newsfeedStore.hide(props.id)
+}
+
+// A volunteer has just posted this properly for the member. The thread now
+// carries the note telling them, and the duplicate warning would be stale
+// (their new post IS the thing this repeats), so drop it.
+async function onConverted() {
+  duplicateOf.value = null
+  await newsfeedStore.fetch(props.id, true)
 }
 
 async function referTo(type) {

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -73,8 +73,14 @@
               <b-dropdown-item @click="report">
                 Report this thread or one of its replies
               </b-dropdown-item>
+              <!-- Says what it leaves behind. This posts in the member's name
+                   and adds a note to this public thread, so the menu shouldn't
+                   read like a private mod action. -->
               <b-dropdown-item v-if="chitChatMod" @click="showConvert = true">
                 Post this as an OFFER/WANTED for them
+                <div class="small text-muted convert-hint">
+                  Posts as them, and adds a note to this thread
+                </div>
               </b-dropdown-item>
               <b-dropdown-item v-if="canRefer" @click="referToOffer">
                 Refer to OFFER
@@ -890,5 +896,12 @@ async function unmute() {
   @include media-breakpoint-down(sm) {
     display: none;
   }
+}
+
+/* Wraps rather than stretching the dropdown to the width of the sentence. */
+.convert-hint {
+  white-space: normal;
+  line-height: 1.2;
+  max-width: 16rem;
 }
 </style>

--- a/iznik-nuxt3/pages/chitchat/[[id]].vue
+++ b/iznik-nuxt3/pages/chitchat/[[id]].vue
@@ -893,13 +893,18 @@ if (me.value) {
     padding: 0;
   }
 
-  // Modernize post cards on mobile
+  // Modernize post cards on mobile.
+  //
+  // No overflow:hidden. The thread's ... menu is absolutely positioned inside
+  // this card, so clipping the card clipped the menu to the card's height: a
+  // moderator saw the first few entries and had to scroll inside the dropdown
+  // to reach Hide, Delete or Mute. Card children sit inside .card-body, which
+  // is padded, so nothing reaches the rounded corners for the clip to tidy up.
   :deep(.card) {
     border-radius: var(--radius-sm, 0.375rem);
     border: none;
     box-shadow: var(--shadow-sm);
     margin-bottom: 0.75rem;
-    overflow: hidden;
   }
 
   :deep(.card-body) {

--- a/iznik-nuxt3/stores/newsfeed.js
+++ b/iznik-nuxt3/stores/newsfeed.js
@@ -271,6 +271,53 @@ export const useNewsfeedStore = defineStore({
       await api(this.config).news.referto(id, type)
       await this.fetch(id, true)
     },
+    // Whether this post repeats one of the poster's own live OFFER/WANTEDs.
+    // ChitChat moderators only; returns null for anyone else (the server 403s)
+    // so a member never learns anything about the poster's other posts.
+    async duplicate(id) {
+      try {
+        const ret = await api(this.config).news.duplicate(id)
+        return ret?.duplicate ?? null
+      } catch (e) {
+        return null
+      }
+    },
+    // Turn a ChitChat post into a real OFFER/WANTED belonging to the person who
+    // posted it. ChitChat moderators only.
+    //
+    // Deliberately drives the same two calls a member's own compose does —
+    // create the draft, then join-and-post — with ?onbehalfof= naming the
+    // member. Reimplementing posting here would skip the group, spatial,
+    // indexing and embedding work those routes do, and produce posts that look
+    // right but behave oddly. The server derives the member's location and
+    // group; we never send the moderator's.
+    //
+    // Errors propagate so the modal can say so rather than appearing to work.
+    async convertToPost(id, { type, item, body, userid }) {
+      const messageApi = api(this.config).message
+
+      const draft = await messageApi.put({
+        messagetype: type,
+        item,
+        textbody: body,
+        collection: 'Draft',
+        onbehalfof: userid,
+      })
+
+      const msgid = draft?.id
+
+      if (!msgid) {
+        throw new Error("Sorry, we couldn't create that post.")
+      }
+
+      await messageApi.joinAndPost(msgid, null, { onbehalfof: userid })
+
+      // Tell the member on the thread, and point them at My Posts.
+      await api(this.config).news.convertedToPost(id, msgid)
+      await this.fetch(id, true)
+
+      return msgid
+    },
     async report(id, reason) {
       await api(this.config).news.report(id, reason)
     },

--- a/iznik-nuxt3/tests/unit/components/NewsConvertModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsConvertModal.spec.js
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import NewsConvertModal from '~/components/NewsConvertModal.vue'
+
+const { mockModal, mockHide } = vi.hoisted(() => {
+  const { ref } = require('vue')
+  return { mockModal: ref(null), mockHide: vi.fn() }
+})
+
+const mockConvertInfo = vi.fn()
+const mockConvertToPost = vi.fn()
+
+const mockApi = { news: { convertInfo: (...a) => mockConvertInfo(...a) } }
+
+vi.mock('~/api', () => ({ default: () => mockApi }))
+
+vi.mock('#app', () => ({
+  useRuntimeConfig: () => ({ public: {} }),
+}))
+
+vi.mock('~/composables/useOurModal', () => ({
+  useOurModal: () => ({ modal: mockModal, hide: mockHide }),
+}))
+
+vi.mock('~/stores/newsfeed', () => ({
+  useNewsfeedStore: () => ({
+    convertToPost: (...a) => mockConvertToPost(...a),
+  }),
+}))
+
+describe('NewsConvertModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConvertInfo.mockResolvedValue({
+      canpost: true,
+      locationname: 'BA1 5BG',
+      groupid: 12,
+      groupname: 'Freegle Bath',
+    })
+  })
+
+  function createWrapper(newsfeed = {}) {
+    return mount(NewsConvertModal, {
+      props: {
+        newsfeed: {
+          id: 42,
+          userid: 99,
+          message: 'Set of four dining chairs going spare if anyone wants them',
+          ...newsfeed,
+        },
+        posterName: 'Sam',
+      },
+      global: {
+        stubs: {
+          'b-modal': {
+            template:
+              '<div class="b-modal"><slot /><slot name="footer" /></div>',
+          },
+          'b-form-group': {
+            template: '<div class="b-form-group"><slot /></div>',
+          },
+          'b-form-radio-group': { template: '<div class="radios" />' },
+          'b-form-input': { template: '<input class="b-form-input" />' },
+          'b-form-textarea': {
+            template: '<textarea class="b-form-textarea" />',
+          },
+          'b-card': { template: '<div class="b-card"><slot /></div>' },
+          'b-button': {
+            template: '<button class="b-button"><slot /></button>',
+          },
+          NoticeMessage: {
+            template: '<div class="notice-message"><slot /></div>',
+          },
+          NewsConvertedNotice: {
+            template: '<div class="converted-notice">note preview</div>',
+            props: ['preview'],
+          },
+          SpinButton: {
+            template: '<button class="spin-button" :disabled="disabled" />',
+            props: ['disabled', 'variant', 'iconName', 'label'],
+          },
+        },
+      },
+    })
+  }
+
+  // A moderator is posting to somebody else's area. Showing a placeholder meant
+  // they could not see where it would land.
+  describe('where it will post', () => {
+    it('asks the server where this would go', async () => {
+      createWrapper()
+      await flushPromises()
+      expect(mockConvertInfo).toHaveBeenCalledWith(42)
+    })
+
+    it('names the postcode and community', async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).toContain('BA1 5BG')
+      expect(wrapper.text()).toContain('Freegle Bath')
+    })
+
+    it("makes clear it is the member's area, not the moderator's", async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).toContain("Sam's own area, not yours")
+    })
+
+    it('puts the real postcode in the preview subject', async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).toContain('(BA1 5BG)')
+      expect(wrapper.text()).not.toContain('(their area)')
+    })
+
+    it('falls back to a placeholder if the lookup fails, rather than blocking', async () => {
+      mockConvertInfo.mockRejectedValue(new Error('nope'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).toContain('their area')
+      expect(
+        wrapper.find('.spin-button').attributes('disabled')
+      ).toBeUndefined()
+    })
+  })
+
+  // The server refuses to post for a member it cannot place. Say so before the
+  // moderator fills the form in, not after.
+  describe('when the member cannot be posted for', () => {
+    beforeEach(() => {
+      mockConvertInfo.mockResolvedValue({
+        canpost: false,
+        reason:
+          "That member hasn't set their location, so we can't post for them",
+      })
+    })
+
+    it('shows the reason', async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).toContain("hasn't set their location")
+    })
+
+    it('disables posting', async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.find('.spin-button').attributes('disabled')).toBeDefined()
+    })
+  })
+
+  it('previews the note that will be left on the thread', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    expect(wrapper.find('.converted-notice').exists()).toBe(true)
+    expect(wrapper.text()).toContain('What goes on this chat')
+  })
+
+  // Assert on the SUBJECT line specifically. The description below it is the
+  // member's post verbatim, so the whole modal legitimately still contains the
+  // words the subject strips out.
+  describe('guessing from the post', () => {
+    const subjectOf = (wrapper) => wrapper.find('.b-card .fw-bold').text()
+
+    it('reads "looking for" as a WANTED', async () => {
+      const wrapper = createWrapper({
+        message: 'Looking for a bookcase please',
+      })
+      await flushPromises()
+      expect(subjectOf(wrapper)).toContain('WANTED:')
+    })
+
+    it('treats anything else as an OFFER', async () => {
+      const wrapper = createWrapper({ message: 'Dining chairs going spare' })
+      await flushPromises()
+      expect(subjectOf(wrapper)).toContain('OFFER:')
+    })
+
+    it('strips the offer-speak tail so the subject is just the item', async () => {
+      const wrapper = createWrapper({
+        message: 'Set of four dining chairs going spare if anyone wants them',
+      })
+      await flushPromises()
+      expect(subjectOf(wrapper)).toContain('Set of four dining chairs')
+      expect(subjectOf(wrapper)).not.toContain('going spare')
+    })
+
+    it('drops a greeting', async () => {
+      const wrapper = createWrapper({ message: 'Hi all, garden bench' })
+      await flushPromises()
+      expect(subjectOf(wrapper)).toContain('garden bench')
+      expect(subjectOf(wrapper)).not.toContain('Hi all')
+    })
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/NewsConvertedNotice.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsConvertedNotice.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import NewsConvertedNotice from '~/components/NewsConvertedNotice.vue'
+
+// This is the note left on a ChitChat thread, in the member's name, when a
+// moderator posts their item properly for them. The convert modal renders the
+// same component in preview mode, so a moderator sees exactly what the member
+// will read before committing to it.
+describe('NewsConvertedNotice', () => {
+  function createWrapper(props = {}) {
+    return mount(NewsConvertedNotice, {
+      props,
+      global: {
+        stubs: {
+          NoticeMessage: {
+            template: '<div class="notice-message"><slot /></div>',
+            props: ['variant'],
+          },
+          'b-button': {
+            template:
+              '<button class="b-button" :disabled="disabled" :data-to="to"><slot /></button>',
+            props: ['variant', 'to', 'disabled'],
+          },
+        },
+      },
+    })
+  }
+
+  it('explains that a volunteer posted it for them', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.text()).toContain(
+      'One of our volunteers has posted this properly for you'
+    )
+    expect(wrapper.text()).toContain("You don't need to do anything")
+  })
+
+  it('tells them where to find it', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.text()).toContain('My Posts')
+    expect(wrapper.text()).toContain('edit or withdraw it')
+  })
+
+  it('links to My Posts on the thread', () => {
+    const button = createWrapper().find('.b-button')
+    expect(button.attributes('data-to')).toBe('/myposts')
+    expect(button.attributes('disabled')).toBeUndefined()
+  })
+
+  it('shows the same words in preview, with the button inert', () => {
+    const wrapper = createWrapper({ preview: true })
+
+    // The moderator is not the one going to My Posts.
+    expect(wrapper.find('.b-button').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('.b-button').attributes('data-to')).toBeUndefined()
+
+    // Preview must not change the wording - that is the whole point.
+    expect(wrapper.text()).toContain(
+      'One of our volunteers has posted this properly for you'
+    )
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/NewsConvertedNotice.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsConvertedNotice.spec.js
@@ -16,9 +16,13 @@ describe('NewsConvertedNotice', () => {
             template: '<div class="notice-message"><slot /></div>',
             props: ['variant'],
           },
+          // data-to reports the STATE of the `to` prop, not just its value:
+          // Vue drops an attribute bound to null, so `:data-to="to"` could not
+          // tell "no route passed" from "route passed as null" - and null is
+          // exactly what crashed the router.
           'b-button': {
             template:
-              '<button class="b-button" :disabled="disabled" :data-to="to"><slot /></button>',
+              '<button class="b-button" :disabled="disabled" :data-to="to === undefined ? \'absent\' : String(to)"><slot /></button>',
             props: ['variant', 'to', 'disabled'],
           },
         },
@@ -51,7 +55,11 @@ describe('NewsConvertedNotice', () => {
 
     // The moderator is not the one going to My Posts.
     expect(wrapper.find('.b-button').attributes('disabled')).toBeDefined()
-    expect(wrapper.find('.b-button').attributes('data-to')).toBeUndefined()
+
+    // No route at all - NOT `to` bound to null. A null `to` still reaches the
+    // router, which does `'path' in to` and throws, taking the page down as
+    // soon as the convert modal opens.
+    expect(wrapper.find('.b-button').attributes('data-to')).toBe('absent')
 
     // Preview must not change the wording - that is the whole point.
     expect(wrapper.text()).toContain(

--- a/iznik-nuxt3/tests/unit/components/NewsRefer.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsRefer.spec.js
@@ -193,4 +193,21 @@ describe('NewsRefer', () => {
       expect(wrapper.props('threadhead')).toBe(555)
     })
   })
+
+  // The wording lives in NewsConvertedNotice so the convert modal can preview
+  // exactly what the member will read. If it were inlined here the two would
+  // drift and the moderator would be shown something other than what posts.
+  describe('ConvertedToPost type', () => {
+    it('tells the member a volunteer posted it for them', () => {
+      const wrapper = createWrapper({ type: 'ConvertedToPost' })
+      expect(wrapper.text()).toContain(
+        'One of our volunteers has posted this properly for you'
+      )
+    })
+
+    it('points them at My Posts', () => {
+      const wrapper = createWrapper({ type: 'ConvertedToPost' })
+      expect(wrapper.text()).toContain('Go to My Posts')
+    })
+  })
 })

--- a/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent, h, Suspense } from 'vue'
 import NewsThread from '~/components/NewsThread.vue'
@@ -79,6 +79,9 @@ const mockNewsfeedStore = {
   convertToStory: mockConvertToStory,
   hide: mockHide,
   unhide: mockUnhide,
+  // Advisory duplicate-of-their-own-post lookup, moderators only. Defaults to
+  // "no duplicate" so existing cases render the thread unchanged.
+  duplicate: vi.fn().mockResolvedValue(null),
 }
 
 const mockMiscStore = {
@@ -1304,6 +1307,84 @@ describe('NewsThread', () => {
       mockMe.value.settings = undefined
       const wrapper = await createWrapper()
       expect(wrapper.find('.auto-height-textarea').exists()).toBe(true)
+    })
+  })
+
+  describe('duplicate-of-their-own-post notice (ChitChat moderators)', () => {
+    const dup = {
+      id: 42,
+      type: 'Offer',
+      subject: 'OFFER: dining chairs (Hove BN3)',
+      cosine: 0.91,
+    }
+
+    beforeEach(() => {
+      mockNewsfeed.value.hidden = false
+      mockNewsfeedStore.duplicate.mockResolvedValue(null)
+    })
+
+    afterEach(() => {
+      mockChitChatMod.value = false
+      mockNewsfeedStore.duplicate.mockResolvedValue(null)
+    })
+
+    it('names the post it repeats, for a moderator', async () => {
+      mockChitChatMod.value = true
+      mockNewsfeedStore.duplicate.mockResolvedValue(dup)
+      const wrapper = await createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).toContain('OFFER: dining chairs (Hove BN3)')
+      expect(wrapper.text()).toContain('Volunteers only')
+    })
+
+    // The notice names one of the poster's OTHER posts, so it must never reach
+    // an ordinary member. The server refuses the request for them too.
+    it('is never shown to a member, even if a duplicate exists', async () => {
+      mockChitChatMod.value = false
+      mockNewsfeedStore.duplicate.mockResolvedValue(dup)
+      const wrapper = await createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).not.toContain('Volunteers only')
+      expect(wrapper.text()).not.toContain('OFFER: dining chairs (Hove BN3)')
+    })
+
+    it('is not looked up at all for a member', async () => {
+      mockChitChatMod.value = false
+      const wrapper = await createWrapper()
+      await flushPromises()
+      expect(wrapper.exists()).toBe(true)
+      expect(mockNewsfeedStore.duplicate).not.toHaveBeenCalled()
+    })
+
+    it('says nothing when there is no duplicate', async () => {
+      mockChitChatMod.value = true
+      const wrapper = await createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).not.toContain('Volunteers only')
+    })
+
+    // Advisory information: losing it must not cost the moderator the thread.
+    it('still renders the thread when the lookup fails', async () => {
+      mockChitChatMod.value = true
+      mockNewsfeedStore.duplicate.mockRejectedValue(new Error('nope'))
+      const wrapper = await createWrapper()
+      await flushPromises()
+      expect(wrapper.find('.b-card').exists()).toBe(true)
+      expect(wrapper.text()).not.toContain('Volunteers only')
+    })
+
+    it('offers converting the post for them', async () => {
+      mockChitChatMod.value = true
+      const wrapper = await createWrapper()
+      expect(wrapper.text()).toContain('Post this as an OFFER/WANTED for them')
+    })
+
+    it('does not offer converting to a member', async () => {
+      mockChitChatMod.value = false
+      const wrapper = await createWrapper()
+      expect(wrapper.text()).not.toContain(
+        'Post this as an OFFER/WANTED for them'
+      )
     })
   })
 })

--- a/iznik-server-go/auth/auth.go
+++ b/iznik-server-go/auth/auth.go
@@ -143,6 +143,29 @@ func IsAdminOrSupport(myid uint64) bool {
 	return systemrole == utils.SYSTEMROLE_SUPPORT || systemrole == utils.SYSTEMROLE_ADMIN
 }
 
+// IsChitChatMod reports whether the user may moderate ChitChat: a member of the
+// ChitChat Moderation team, or support/admin.
+//
+// This is the audience for the ChitChat moderation tools — hiding a post, seeing
+// the duplicate-of-their-own-post note, and converting a post into a real
+// OFFER/WANTED on the member's behalf. Group moderators are deliberately NOT
+// included: ChitChat is not group-scoped.
+func IsChitChatMod(myid uint64) bool {
+	if myid == 0 {
+		return false
+	}
+
+	if IsAdminOrSupport(myid) {
+		return true
+	}
+
+	db := database.DBConn
+	var teamMemberCount int64
+	db.Raw("SELECT COUNT(*) FROM teams_members tm INNER JOIN teams t ON tm.teamid = t.id WHERE t.name = 'ChitChat Moderation' AND tm.userid = ?", myid).Scan(&teamMemberCount)
+
+	return teamMemberCount > 0
+}
+
 // IsAdmin checks if the user has the Admin systemrole.
 func IsAdmin(myid uint64) bool {
 	db := database.DBConn

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2943,6 +2943,36 @@ func handleRejectToDraft(c *fiber.Ctx, myid uint64, req PostMessageRequest) erro
 func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	db := database.DBConn
 
+	// A member may only submit their own draft. A ChitChat moderator converting
+	// a ChitChat post submits the draft they just created for that member, so
+	// they submit as the member via ?onbehalfof=.
+	author, err := onBehalfOf(c, myid)
+	if err != nil {
+		return err
+	}
+
+	var owner uint64
+	db.Raw("SELECT fromuser FROM messages WHERE id = ?", req.ID).Scan(&owner)
+	if owner == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Message not found")
+	}
+	if owner != author {
+		return fiber.NewError(fiber.StatusForbidden, "Not your message")
+	}
+
+	return JoinAndPostAs(c, author, req)
+}
+
+// JoinAndPostAs joins author to the destination group and submits the draft as
+// them. The ownership check lives in the caller: handleJoinAndPost enforces
+// "your own draft" for the member route, while the ChitChat convert-to-post
+// path instead requires the caller to be a ChitChat moderator or support/admin
+// (newsfeed.canHidePost) and passes the member as author.
+//
+// No other caller should pass an author other than the caller.
+func JoinAndPostAs(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
+	db := database.DBConn
+
 	// Look up the existing draft message.
 	type msgInfo struct {
 		Fromuser uint64
@@ -2952,9 +2982,6 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 	db.Raw("SELECT fromuser, type FROM messages WHERE id = ?", req.ID).Scan(&msg)
 	if msg.Fromuser == 0 {
 		return fiber.NewError(fiber.StatusNotFound, "Message not found")
-	}
-	if msg.Fromuser != myid {
-		return fiber.NewError(fiber.StatusForbidden, "Not your message")
 	}
 
 	// Find the group — from request, then messages_drafts, then messages_groups.
@@ -3958,8 +3985,49 @@ func findOrCreateUserForDraft(db *gorm.DB, email string) (uint64, string, fiber.
 // @Produce json
 // @Success 200 {object} map[string]interface{}
 // @Router /api/message [put]
+// PutMessage creates a message for the caller, or for another member when a
+// ChitChat moderator is converting their ChitChat post into a real OFFER/WANTED.
 func PutMessage(c *fiber.Ctx) error {
 	myid := user.WhoAmI(c)
+
+	author, err := onBehalfOf(c, myid)
+	if err != nil {
+		return err
+	}
+
+	return PutMessageAs(c, author)
+}
+
+// onBehalfOf resolves the ?onbehalfof= parameter to the member a post belongs
+// to. Absent (the normal case) it is the caller.
+//
+// Posting as someone else is restricted to ChitChat moderators and
+// support/admin, and the check lives here rather than in each caller so no
+// route can acquire the capability by omission.
+func onBehalfOf(c *fiber.Ctx, myid uint64) (uint64, error) {
+	obo := uint64(c.QueryInt("onbehalfof", 0))
+	if obo == 0 || obo == myid {
+		return myid, nil
+	}
+
+	if !auth.IsChitChatMod(myid) {
+		return 0, fiber.NewError(fiber.StatusForbidden, "Permission denied")
+	}
+
+	return obo, nil
+}
+
+// PutMessageAs creates a message attributed to author, which is normally the
+// caller. It differs only for the ChitChat convert-to-post path, where a
+// ChitChat moderator turns someone's ChitChat post into a real OFFER/WANTED and
+// the post must belong to that member rather than to the moderator.
+//
+// Passing an author other than the caller is restricted to ChitChat moderators
+// and support/admin (newsfeed.canHidePost). That caller is responsible for the
+// permission check and for logging the mod action; no other caller should pass
+// a different author.
+func PutMessageAs(c *fiber.Ctx, author uint64) error {
+	myid := author
 
 	type PutMessageRequest struct {
 		Groupid            uint64          `json:"groupid"`
@@ -4030,6 +4098,46 @@ func PutMessage(c *fiber.Ctx) error {
 
 	if strings.TrimSpace(req.Item) == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "Item is required")
+	}
+
+	// Posting on someone's behalf: pin the post to THEIR location, never to
+	// whatever the moderator's client sent. A moderator moderates from wherever
+	// they happen to be, so trusting the client here would stamp their postcode
+	// on a member's post and put it in front of the wrong people.
+	if author != user.WhoAmI(c) {
+		latlng := user.GetLatLng(author)
+		if latlng.Lat == 0 && latlng.Lng == 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "That member has no location set, so we can't post for them")
+		}
+
+		nearest := location.ClosestPostcode(latlng.Lat, latlng.Lng)
+		if nearest.ID == 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "We can't work out a postcode for that member")
+		}
+
+		req.Locationid = &nearest.ID
+
+		// The group must be one they are ALREADY in. Submitting joins the
+		// author to the destination group, so accepting an arbitrary group here
+		// would let a moderator quietly sign a member up to a community they
+		// never chose. Default to their nearest existing membership.
+		if req.Groupid == 0 {
+			db.Raw("SELECT m.groupid FROM memberships m "+
+				"INNER JOIN groups g ON g.id = m.groupid "+
+				"WHERE m.userid = ? AND m.collection = ? "+
+				"ORDER BY ST_Distance_Sphere(POINT(g.lng, g.lat), POINT(?, ?)) LIMIT 1",
+				author, utils.COLLECTION_APPROVED, latlng.Lng, latlng.Lat).Scan(&req.Groupid)
+
+			if req.Groupid == 0 {
+				return fiber.NewError(fiber.StatusBadRequest, "That member isn't in any community, so we can't post for them")
+			}
+		} else {
+			var memberCount int64
+			db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND groupid = ?", author, req.Groupid).Scan(&memberCount)
+			if memberCount == 0 {
+				return fiber.NewError(fiber.StatusBadRequest, "That member isn't in that community")
+			}
+		}
 	}
 
 	// For non-Draft, check membership and fetch posting status in one query.

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -4004,6 +4004,73 @@ func PutMessage(c *fiber.Ctx) error {
 // Posting as someone else is restricted to ChitChat moderators and
 // support/admin, and the check lives here rather than in each caller so no
 // route can acquire the capability by omission.
+// OnBehalfPosting is where a post made on someone else's behalf would land:
+// their own postcode and their own community, never the moderator's.
+type OnBehalfPosting struct {
+	Locationid   uint64 `json:"locationid"`
+	Locationname string `json:"locationname"`
+	Groupid      uint64 `json:"groupid"`
+	Groupname    string `json:"groupname"`
+}
+
+// ResolveOnBehalfPosting works out the location and group a post for `author`
+// would use. PutMessageAs calls it when it actually posts, and the convert
+// preview calls it to show the moderator the same answer beforehand - one
+// function so the preview cannot promise a postcode the post then ignores.
+//
+// The location is the one the member CHOSE, settings.mylocation - the same
+// postcode their own posts carry. Deliberately not derived from lastlocation or
+// a nearest-postcode lookup: those say where they last were, not where they say
+// they are, so they would stamp a postcode on a member's post that the member
+// never picked. If they have not set one, we refuse rather than guess.
+//
+// The error text is shown to the moderator, so it says what to do about it.
+func ResolveOnBehalfPosting(author uint64) (*OnBehalfPosting, error) {
+	db := database.DBConn
+
+	var chosen struct {
+		Locationid   uint64
+		Locationname string
+		Lat          float64
+		Lng          float64
+	}
+
+	db.Raw("SELECT "+
+		"JSON_UNQUOTE(JSON_EXTRACT(settings, '$.mylocation.id')) AS locationid, "+
+		"JSON_UNQUOTE(JSON_EXTRACT(settings, '$.mylocation.name')) AS locationname, "+
+		"JSON_EXTRACT(settings, '$.mylocation.lat') AS lat, "+
+		"JSON_EXTRACT(settings, '$.mylocation.lng') AS lng "+
+		"FROM users WHERE id = ?", author).Scan(&chosen)
+
+	if chosen.Locationid == 0 || chosen.Locationname == "" {
+		return nil, errors.New("That member hasn't set their location, so we can't post for them - ask them to set it first")
+	}
+
+	// The group must be one they are ALREADY in. Submitting joins the author to
+	// the destination group, so an arbitrary group would quietly sign a member
+	// up to a community they never chose. Default to their nearest membership.
+	var groupid uint64
+	db.Raw("SELECT m.groupid FROM memberships m "+
+		"INNER JOIN `groups` g ON g.id = m.groupid "+
+		"WHERE m.userid = ? AND m.collection = ? "+
+		"ORDER BY ST_Distance_Sphere(POINT(g.lng, g.lat), POINT(?, ?)) LIMIT 1",
+		author, utils.COLLECTION_APPROVED, chosen.Lng, chosen.Lat).Scan(&groupid)
+
+	if groupid == 0 {
+		return nil, errors.New("That member isn't in any community, so we can't post for them")
+	}
+
+	var groupname string
+	db.Raw("SELECT COALESCE(NULLIF(namefull, ''), nameshort) FROM `groups` WHERE id = ?", groupid).Scan(&groupname)
+
+	return &OnBehalfPosting{
+		Locationid:   chosen.Locationid,
+		Locationname: chosen.Locationname,
+		Groupid:      groupid,
+		Groupname:    groupname,
+	}, nil
+}
+
 func onBehalfOf(c *fiber.Ctx, myid uint64) (uint64, error) {
 	obo := uint64(c.QueryInt("onbehalfof", 0))
 	if obo == 0 || obo == myid {
@@ -4105,32 +4172,17 @@ func PutMessageAs(c *fiber.Ctx, author uint64) error {
 	// they happen to be, so trusting the client here would stamp their postcode
 	// on a member's post and put it in front of the wrong people.
 	if author != user.WhoAmI(c) {
-		latlng := user.GetLatLng(author)
-		if latlng.Lat == 0 && latlng.Lng == 0 {
-			return fiber.NewError(fiber.StatusBadRequest, "That member has no location set, so we can't post for them")
+		// Same resolution the convert preview showed the moderator - see
+		// ResolveOnBehalfPosting.
+		posting, err := ResolveOnBehalfPosting(author)
+		if err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 
-		nearest := location.ClosestPostcode(latlng.Lat, latlng.Lng)
-		if nearest.ID == 0 {
-			return fiber.NewError(fiber.StatusBadRequest, "We can't work out a postcode for that member")
-		}
+		req.Locationid = &posting.Locationid
 
-		req.Locationid = &nearest.ID
-
-		// The group must be one they are ALREADY in. Submitting joins the
-		// author to the destination group, so accepting an arbitrary group here
-		// would let a moderator quietly sign a member up to a community they
-		// never chose. Default to their nearest existing membership.
 		if req.Groupid == 0 {
-			db.Raw("SELECT m.groupid FROM memberships m "+
-				"INNER JOIN groups g ON g.id = m.groupid "+
-				"WHERE m.userid = ? AND m.collection = ? "+
-				"ORDER BY ST_Distance_Sphere(POINT(g.lng, g.lat), POINT(?, ?)) LIMIT 1",
-				author, utils.COLLECTION_APPROVED, latlng.Lng, latlng.Lat).Scan(&req.Groupid)
-
-			if req.Groupid == 0 {
-				return fiber.NewError(fiber.StatusBadRequest, "That member isn't in any community, so we can't post for them")
-			}
+			req.Groupid = posting.Groupid
 		} else {
 			var memberCount int64
 			db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND groupid = ?", author, req.Groupid).Scan(&memberCount)

--- a/iznik-server-go/newsfeed/convertinfo.go
+++ b/iznik-server-go/newsfeed/convertinfo.go
@@ -1,0 +1,66 @@
+package newsfeed
+
+import (
+	"strconv"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/message"
+	"github.com/freegle/iznik-server-go/user"
+	"github.com/gofiber/fiber/v2"
+)
+
+// ConvertInfoResult is what the convert modal shows a moderator before they
+// commit: where the post will land, or why it cannot be posted.
+//
+// Canpost false is a 200, not an error. The moderator needs to READ the reason
+// ("that member has no location set") in the modal they already have open;
+// failing the request would just show them a generic failure after they had
+// filled the form in.
+type ConvertInfoResult struct {
+	Canpost      bool   `json:"canpost"`
+	Reason       string `json:"reason,omitempty"`
+	Locationname string `json:"locationname,omitempty"`
+	Groupid      uint64 `json:"groupid,omitempty"`
+	Groupname    string `json:"groupname,omitempty"`
+}
+
+// ConvertInfo tells a ChitChat moderator which postcode and community a
+// convert-to-post would use. The answer comes from the same resolver the post
+// itself uses (message.ResolveOnBehalfPosting), so what the modal promises and
+// what gets posted cannot disagree.
+//
+// Mod-only: it exposes where another member lives.
+func ConvertInfo(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	if !canHidePost(myid) {
+		return fiber.NewError(fiber.StatusForbidden, "Permission denied")
+	}
+
+	id, err := strconv.ParseUint(c.Params("id"), 10, 64)
+	if err != nil || id == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid id")
+	}
+
+	var author uint64
+	database.DBConn.Raw("SELECT userid FROM newsfeed WHERE id = ? AND deleted IS NULL", id).Scan(&author)
+
+	if author == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Newsfeed item not found")
+	}
+
+	posting, err := message.ResolveOnBehalfPosting(author)
+	if err != nil {
+		return c.JSON(ConvertInfoResult{Canpost: false, Reason: err.Error()})
+	}
+
+	return c.JSON(ConvertInfoResult{
+		Canpost:      true,
+		Locationname: posting.Locationname,
+		Groupid:      posting.Groupid,
+		Groupname:    posting.Groupname,
+	})
+}

--- a/iznik-server-go/newsfeed/duplicate.go
+++ b/iznik-server-go/newsfeed/duplicate.go
@@ -1,0 +1,141 @@
+package newsfeed
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/embedding"
+	"github.com/freegle/iznik-server-go/user"
+	"github.com/gofiber/fiber/v2"
+)
+
+// DuplicateMinCosine is how alike a ChitChat post and one of the member's own
+// live posts must be before we tell a moderator they are the same thing.
+//
+// Set deliberately high. A false positive costs a member their ChitChat post
+// (the moderator is being invited to hide it), whereas a false negative just
+// leaves the moderator doing what they do today. The same-author restriction
+// already removes most of the noise, so the threshold only has to separate
+// "the member said this twice" from "the member posted about two similar
+// things".
+const DuplicateMinCosine = 0.82
+
+// duplicateCandidates is how many neighbours to pull before filtering to the
+// post's own author. The store is not author-indexed, so a member's own post
+// can sit behind other people's closer matches.
+const duplicateCandidates = 200
+
+// DuplicateMatch is a live OFFER/WANTED by the same member that says the same
+// thing as their ChitChat post.
+type DuplicateMatch struct {
+	ID      uint64  `json:"id"`
+	Type    string  `json:"type"`
+	Subject string  `json:"subject"`
+	Cosine  float32 `json:"cosine"`
+}
+
+// DuplicateResponse is empty-but-successful when nothing matches, so the
+// caller can render "no duplicate" without treating it as an error.
+type DuplicateResponse struct {
+	Duplicate *DuplicateMatch `json:"duplicate"`
+}
+
+// Duplicate reports whether a ChitChat post duplicates one of the same
+// member's live OFFER/WANTED posts.
+//
+// Moderator-only, and gated server-side rather than in the template: the
+// answer names one of the member's posts and exists to prompt hiding theirs,
+// which is not something other members should see.
+//
+// @Summary Whether a ChitChat post duplicates the poster's own live OFFER/WANTED
+// @Tags newsfeed
+// @Produce json
+// @Param id path int true "Newsfeed ID"
+// @Success 200 {object} newsfeed.DuplicateResponse
+// @Router /newsfeed/{id}/duplicate [get]
+func Duplicate(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	if !canHidePost(myid) {
+		return fiber.NewError(fiber.StatusForbidden, "Permission denied")
+	}
+
+	id, err := strconv.ParseUint(c.Params("id"), 10, 64)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid newsfeed id")
+	}
+
+	db := database.DBConn
+
+	var nf struct {
+		Userid  uint64
+		Message string
+		Type    string
+	}
+	db.Raw("SELECT userid, COALESCE(message, '') AS message, type FROM newsfeed WHERE id = ?", id).Scan(&nf)
+
+	if nf.Userid == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Newsfeed entry not found")
+	}
+
+	match := findDuplicate(nf.Userid, nf.Message)
+
+	return c.JSON(DuplicateResponse{Duplicate: match})
+}
+
+// findDuplicate returns the member's own live post closest to the given text,
+// or nil. Split out from the handler so it can be exercised without a request.
+func findDuplicate(author uint64, text string) *DuplicateMatch {
+	if author == 0 || strings.TrimSpace(text) == "" {
+		return nil
+	}
+
+	// No embedding sidecar, or it is unhappy: report no duplicate rather than
+	// failing the request. This is advisory information beside a moderator's
+	// existing controls, so degrading to silence is the right failure mode.
+	vec, err := embedding.EmbedQuery(text)
+	if err != nil || len(vec) == 0 {
+		return nil
+	}
+
+	// The store holds only OPEN messages, so a match is a post still standing —
+	// a member repeating a post they already took down is not a duplicate.
+	results := embedding.Global.Search(vec, duplicateCandidates, "", nil, nil, 0, 0, 0, 0)
+
+	var best *DuplicateMatch
+
+	for i := range results {
+		r := results[i]
+
+		// A duplicate means THIS member already posted it. Someone else offering
+		// a similar item is a different post, not a repeat, and hiding the
+		// ChitChat entry over it would be wrong.
+		if r.Fromuser != author {
+			continue
+		}
+
+		cos := r.SubjectCos
+		if r.HasBody && r.BodyCos > cos {
+			cos = r.BodyCos
+		}
+
+		if cos < DuplicateMinCosine {
+			continue
+		}
+
+		if best == nil || cos > best.Cosine {
+			best = &DuplicateMatch{
+				ID:      r.Msgid,
+				Type:    r.Msgtype,
+				Subject: r.Subject,
+				Cosine:  cos,
+			}
+		}
+	}
+
+	return best
+}

--- a/iznik-server-go/newsfeed/newsfeed.go
+++ b/iznik-server-go/newsfeed/newsfeed.go
@@ -901,6 +901,9 @@ type PostRequest struct {
 	Reason  string `json:"reason"`
 	Replyto uint64 `json:"replyto"`
 	Imageid uint64 `json:"imageid"`
+	// Msgid carries the OFFER/WANTED just created for the poster by the
+	// ChitChat convert-to-post flow, so the note on the thread can point at it.
+	Msgid uint64 `json:"msgid"`
 }
 
 // canModifyPost checks if a user can edit/delete a newsfeed post.
@@ -929,16 +932,9 @@ func canModifyPost(myid uint64, nfID uint64) bool {
 // Requires: isAdminOrSupport() OR member of "ChitChat Moderation" team.
 // This is stricter than canModifyPost - not all moderators can hide posts.
 func canHidePost(myid uint64) bool {
-	if auth.IsAdminOrSupport(myid) {
-		return true
-	}
-
-	// Check if user is a member of the ChitChat Moderation team
-	db := database.DBConn
-	var teamMemberCount int64
-	db.Raw("SELECT COUNT(*) FROM teams_members tm INNER JOIN teams t ON tm.teamid = t.id WHERE t.name = 'ChitChat Moderation' AND tm.userid = ?", myid).Scan(&teamMemberCount)
-
-	return teamMemberCount > 0
+	// ChitChat Moderation team, or support/admin. Shared with the message
+	// package, which gates posting on a member's behalf on the same audience.
+	return auth.IsChitChatMod(myid)
 }
 
 func Post(c *fiber.Ctx) error {
@@ -1038,6 +1034,25 @@ func Post(c *fiber.Ctx) error {
 		} else if req.ID > 0 {
 			return fiber.NewError(fiber.StatusForbidden, "Permission denied")
 		}
+	case "ConvertedToPost":
+		// Records on the thread that a ChitChat moderator has posted this as a
+		// real OFFER/WANTED for the member, so they can see what happened and
+		// go and find it. The post itself is created through the normal
+		// PUT /message + JoinAndPost route with ?onbehalfof=, which is where
+		// the permission to post as them is enforced; this only adds the note.
+		if req.ID == 0 || req.Msgid == 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "id and msgid are required")
+		}
+
+		if !canHidePost(myid) {
+			return fiber.NewError(fiber.StatusForbidden, "Permission denied")
+		}
+
+		createRefer(db, myid, req.ID, "ConvertedToPost")
+
+		db.Exec("INSERT INTO logs (timestamp, type, subtype, byuser, text) VALUES (NOW(), ?, ?, ?, ?)",
+			log.LOG_TYPE_CHITCHAT, log.LOG_SUBTYPE_CREATED, myid,
+			fmt.Sprintf("ChitChat post %d posted as message %d for the member", req.ID, req.Msgid))
 	case "ReferToWanted":
 		if req.ID > 0 {
 			createRefer(db, myid, req.ID, "ReferToWanted")

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -1157,6 +1157,18 @@ func SetupRoutes(app *fiber.App) {
 		// @Failure 404 {object} fiber.Error "Newsfeed item not found"
 		rg.Get("/newsfeed/:id", newsfeed.Single)
 
+		// Newsfeed duplicate check (ChitChat moderators only)
+		// @Router /newsfeed/{id}/duplicate [get]
+		// @Summary Whether a ChitChat post duplicates the poster's own live OFFER/WANTED
+		// @Description Moderator-only. Names one of the poster's own live posts when the
+		// @Description ChitChat entry says the same thing, so it can be hidden.
+		// @Tags newsfeed
+		// @Produce json
+		// @Param id path integer true "Newsfeed ID"
+		// @Success 200 {object} newsfeed.DuplicateResponse
+		// @Failure 403 {object} fiber.Error "Not a ChitChat moderator"
+		rg.Get("/newsfeed/:id/duplicate", newsfeed.Duplicate)
+
 		// Newsfeed Count
 		// @Router /newsfeedcount [get]
 		// @Summary Get newsfeed count

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -1169,6 +1169,17 @@ func SetupRoutes(app *fiber.App) {
 		// @Failure 403 {object} fiber.Error "Not a ChitChat moderator"
 		rg.Get("/newsfeed/:id/duplicate", newsfeed.Duplicate)
 
+		// @Router /newsfeed/{id}/convertinfo [get]
+		// @Summary Where a convert-to-post would land
+		// @Description Moderator-only. The postcode and community a post made for the
+		// @Description member would use, so the modal can show it before committing.
+		// @Tags newsfeed
+		// @Produce json
+		// @Param id path integer true "Newsfeed ID"
+		// @Success 200 {object} newsfeed.ConvertInfoResult
+		// @Failure 403 {object} fiber.Error "Not a ChitChat moderator"
+		rg.Get("/newsfeed/:id/convertinfo", newsfeed.ConvertInfo)
+
 		// Newsfeed Count
 		// @Router /newsfeedcount [get]
 		// @Summary Get newsfeed count

--- a/iznik-server-go/test/newsfeed_convert_test.go
+++ b/iznik-server-go/test/newsfeed_convert_test.go
@@ -157,3 +157,135 @@ func TestConvertedToPost_RefusedForOrdinaryMember(t *testing.T) {
 
 	assert.Equal(t, 403, resp.StatusCode)
 }
+
+// --- Convert preview: where would this post land? ---
+//
+// The modal shows the moderator the postcode and community before they commit.
+// It must be the MEMBER's, never the moderator's, and it must come from the same
+// resolver that does the posting - a preview that promises one postcode while the
+// post uses another is worse than no preview.
+
+func TestNewsfeedConvertInfo_RefusedForOrdinaryMember(t *testing.T) {
+	prefix := uniquePrefix("cvtinfomember")
+	userID, token := CreateFullTestUser(t, prefix)
+	nfID := CreateTestNewsfeed(t, userID, 55.9533, -3.1883, "A sofa going spare "+prefix)
+
+	id := strconv.FormatUint(nfID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"/convertinfo?jwt="+token, nil))
+
+	assert.Equal(t, 403, resp.StatusCode, "it says where another member lives")
+}
+
+func TestNewsfeedConvertInfo_RefusedWhenLoggedOut(t *testing.T) {
+	prefix := uniquePrefix("cvtinfoout")
+	userID, _ := CreateFullTestUser(t, prefix)
+	nfID := CreateTestNewsfeed(t, userID, 55.9533, -3.1883, "A sofa going spare "+prefix)
+
+	id := strconv.FormatUint(nfID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"/convertinfo", nil))
+
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestNewsfeedConvertInfo_ModSeesWhereItWouldPost(t *testing.T) {
+	prefix := uniquePrefix("cvtinfomod")
+	posterID, _ := CreateFullTestUser(t, prefix+"_poster")
+	modID, modToken := CreateFullTestUser(t, prefix+"_mod")
+	makeChitChatMod(t, modID)
+
+	nfID := CreateTestNewsfeed(t, posterID, 55.9533, -3.1883, "Dining chairs going spare "+prefix)
+
+	id := strconv.FormatUint(nfID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"/convertinfo?jwt="+modToken, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	// canpost is always present so the modal can decide what to show; when it is
+	// false there must be a reason the moderator can act on.
+	canpost, present := result["canpost"]
+	assert.True(t, present, "response should always say whether it can post")
+
+	if canpost == true {
+		assert.NotEmpty(t, result["locationname"], "a moderator needs the actual postcode, not a placeholder")
+		assert.NotEmpty(t, result["groupid"], "and the community it will go to")
+	} else {
+		assert.NotEmpty(t, result["reason"], "if it cannot post, say why")
+	}
+}
+
+func TestNewsfeedConvertInfo_NotFoundForMissingEntry(t *testing.T) {
+	prefix := uniquePrefix("cvtinfomissing")
+	modID, modToken := CreateFullTestUser(t, prefix+"_mod")
+	makeChitChatMod(t, modID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/999999999/convertinfo?jwt="+modToken, nil))
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestNewsfeedConvertInfo_UsesTheMembersChosenLocation(t *testing.T) {
+	// The postcode must be the one the MEMBER set in their settings, not one
+	// inferred from wherever they last happened to be, and not the moderator's.
+	prefix := uniquePrefix("cvtinfochosen")
+	posterID, _ := CreateFullTestUser(t, prefix+"_poster")
+	modID, modToken := CreateFullTestUser(t, prefix+"_mod")
+	makeChitChatMod(t, modID)
+
+	db := database.DBConn
+
+	// Any real location row will do - we only care that the id and name we set
+	// are the ones handed back.
+	var locID uint64
+	var locName string
+	db.Raw("SELECT id, name FROM locations WHERE type = ? AND name IS NOT NULL AND name != '' LIMIT 1",
+		"Postcode").Row().Scan(&locID, &locName)
+
+	if locID == 0 {
+		t.Skip("no postcode locations seeded")
+	}
+
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(NULLIF(settings, ''), '{}'), "+
+		"'$.mylocation', JSON_OBJECT('id', ?, 'name', ?, 'lat', 55.9533, 'lng', -3.1883)) WHERE id = ?",
+		locID, locName, posterID)
+
+	nfID := CreateTestNewsfeed(t, posterID, 55.9533, -3.1883, "Dining chairs going spare "+prefix)
+
+	id := strconv.FormatUint(nfID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"/convertinfo?jwt="+modToken, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	if result["canpost"] == true {
+		assert.Equal(t, locName, result["locationname"],
+			"the preview must show the postcode the member chose")
+	} else {
+		// Only legitimate reason left is that the test user is in no community.
+		assert.Contains(t, result["reason"], "community")
+	}
+}
+
+func TestNewsfeedConvertInfo_RefusesWhenMemberHasNoChosenLocation(t *testing.T) {
+	// No guessing: if the member never set a location we refuse rather than
+	// stamp one on their post.
+	prefix := uniquePrefix("cvtinfonoloc")
+	posterID, _ := CreateFullTestUser(t, prefix+"_poster")
+	modID, modToken := CreateFullTestUser(t, prefix+"_mod")
+	makeChitChatMod(t, modID)
+
+	database.DBConn.Exec("UPDATE users SET settings = JSON_REMOVE(COALESCE(NULLIF(settings, ''), '{}'), '$.mylocation') WHERE id = ?", posterID)
+
+	nfID := CreateTestNewsfeed(t, posterID, 55.9533, -3.1883, "A sofa going spare "+prefix)
+
+	id := strconv.FormatUint(nfID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"/convertinfo?jwt="+modToken, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	assert.Equal(t, false, result["canpost"], "cannot post for a member with no chosen location")
+	assert.Contains(t, result["reason"], "location")
+}

--- a/iznik-server-go/test/newsfeed_convert_test.go
+++ b/iznik-server-go/test/newsfeed_convert_test.go
@@ -1,0 +1,159 @@
+package test
+
+import (
+	"bytes"
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- ChitChat moderator tools: duplicate flagging, and posting for a member ---
+//
+// Both are restricted to the ChitChat Moderation team and support/admin. The
+// duplicate answer names one of the poster's OTHER posts, and posting on
+// someone's behalf writes to their account, so the permission checks matter more
+// than the happy paths and are what these cover.
+
+// makeChitChatMod puts a user in the ChitChat Moderation team, creating the team
+// if this is the first test to need it.
+func makeChitChatMod(t *testing.T, userid uint64) {
+	db := database.DBConn
+
+	var teamid uint64
+	db.Raw("SELECT id FROM teams WHERE name = 'ChitChat Moderation' LIMIT 1").Scan(&teamid)
+
+	if teamid == 0 {
+		id, err := database.ExecInsertGetID(db, "INSERT INTO teams (name) VALUES ('ChitChat Moderation')")
+		if err != nil {
+			t.Fatalf("ERROR: could not create ChitChat Moderation team: %v", err)
+		}
+		teamid = id
+	}
+
+	db.Exec("INSERT INTO teams_members (teamid, userid) VALUES (?, ?)", teamid, userid)
+}
+
+func TestNewsfeedDuplicate_RefusedForOrdinaryMember(t *testing.T) {
+	// The response names one of the poster's own posts, so a member must not be
+	// able to ask - not even about their own ChitChat entry.
+	prefix := uniquePrefix("dupmember")
+	userID, token := CreateFullTestUser(t, prefix)
+	nfID := CreateTestNewsfeed(t, userID, 55.9533, -3.1883, "A sofa going spare "+prefix)
+
+	id := strconv.FormatUint(nfID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"/duplicate?jwt="+token, nil))
+
+	assert.Equal(t, 403, resp.StatusCode, "an ordinary member must not learn about the poster's other posts")
+}
+
+func TestNewsfeedDuplicate_RefusedWhenLoggedOut(t *testing.T) {
+	prefix := uniquePrefix("dupanon")
+	userID, _ := CreateFullTestUser(t, prefix)
+	nfID := CreateTestNewsfeed(t, userID, 55.9533, -3.1883, "A sofa going spare "+prefix)
+
+	id := strconv.FormatUint(nfID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"/duplicate", nil))
+
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestNewsfeedDuplicate_ModGetsAnAnswer(t *testing.T) {
+	// A ChitChat moderator gets a well-formed answer. Whether a duplicate is
+	// found depends on the embedding sidecar, which the test environment may not
+	// run, so this asserts the endpoint is reachable and shaped right rather
+	// than asserting a match.
+	prefix := uniquePrefix("dupmod")
+	posterID, _ := CreateFullTestUser(t, prefix+"_poster")
+	modID, modToken := CreateFullTestUser(t, prefix+"_mod")
+	makeChitChatMod(t, modID)
+
+	nfID := CreateTestNewsfeed(t, posterID, 55.9533, -3.1883, "Dining chairs going spare "+prefix)
+
+	id := strconv.FormatUint(nfID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"/duplicate?jwt="+modToken, nil))
+
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	_, present := result["duplicate"]
+	assert.True(t, present, "response should always carry a duplicate key, null when there is no match")
+}
+
+func TestNewsfeedDuplicate_NotFoundForMissingEntry(t *testing.T) {
+	prefix := uniquePrefix("dupmissing")
+	modID, modToken := CreateFullTestUser(t, prefix+"_mod")
+	makeChitChatMod(t, modID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/999999999/duplicate?jwt="+modToken, nil))
+
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestPutMessageOnBehalfOf_RefusedForOrdinaryMember(t *testing.T) {
+	// Posting as someone else writes to their account. Only ChitChat moderators
+	// and support/admin may do it; an ordinary member must not, whoever they aim
+	// it at.
+	prefix := uniquePrefix("oboputmember")
+	_, token := CreateFullTestUser(t, prefix+"_actor")
+	victimID, _ := CreateFullTestUser(t, prefix+"_victim")
+
+	body, _ := json2.Marshal(map[string]interface{}{
+		"messagetype": "Offer",
+		"item":        "a thing they never offered",
+		"textbody":    "posted by someone else",
+		"collection":  "Draft",
+	})
+
+	url := fmt.Sprintf("/api/message?jwt=%s&onbehalfof=%d", token, victimID)
+	req := httptest.NewRequest("PUT", url, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req, -1)
+
+	assert.Equal(t, 403, resp.StatusCode, "a member must not be able to post as another member")
+}
+
+func TestJoinAndPostOnBehalfOf_RefusedForOrdinaryMember(t *testing.T) {
+	// The submit half is gated too, so a member can't finish a draft that
+	// belongs to someone else.
+	prefix := uniquePrefix("obojoinmember")
+	_, token := CreateFullTestUser(t, prefix+"_actor")
+	victimID, _ := CreateFullTestUser(t, prefix+"_victim")
+
+	body, _ := json2.Marshal(map[string]interface{}{
+		"id":     1,
+		"action": "JoinAndPost",
+	})
+
+	url := fmt.Sprintf("/api/message?jwt=%s&onbehalfof=%d", token, victimID)
+	req := httptest.NewRequest("POST", url, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req, -1)
+
+	assert.Equal(t, 403, resp.StatusCode, "a member must not be able to submit another member's draft")
+}
+
+func TestConvertedToPost_RefusedForOrdinaryMember(t *testing.T) {
+	// The note on the thread claims a volunteer acted, so a member must not be
+	// able to fabricate one.
+	prefix := uniquePrefix("convmember")
+	userID, token := CreateFullTestUser(t, prefix)
+	nfID := CreateTestNewsfeed(t, userID, 55.9533, -3.1883, "Something "+prefix)
+
+	body, _ := json2.Marshal(map[string]interface{}{
+		"id":     nfID,
+		"msgid":  1,
+		"action": "ConvertedToPost",
+	})
+
+	req := httptest.NewRequest("POST", "/api/newsfeed?jwt="+token, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req, -1)
+
+	assert.Equal(t, 403, resp.StatusCode)
+}

--- a/plans/active/2026-07-31-chitchat-convert-to-post.md
+++ b/plans/active/2026-07-31-chitchat-convert-to-post.md
@@ -1,0 +1,92 @@
+# ChitChat: flag duplicates, and convert a post into a real OFFER/WANTED
+
+## Why
+
+ChitChat mods have "Refer to OFFER/WANTED", which posts a canned notice telling the
+member to go and post it themselves (`NewsRefer.vue`, `createRefer` in
+`newsfeed.go`). It puts the work back on the member and most never follow through.
+
+Two better outcomes:
+
+1. **It's a duplicate** — the member already has a live OFFER/WANTED saying the same
+   thing, and the ChitChat post adds nothing. Mods should see that plainly, with the
+   matching post named, so they can hide it. Members must not see the note.
+2. **It was posted in the wrong place** — mods should be able to create the OFFER or
+   WANTED *for* them, then tell them it's been done and point at My Posts.
+
+## Design
+
+### Duplicate detection (mod-only)
+
+`GET /newsfeed/:id/duplicate` (Go, apiv2):
+
+- Embed the newsfeed message with `embedding.EmbedQuery` (`sidecar.go`).
+- `embedding.Global.Search` for nearest posts.
+- Restrict to the **same author** and to posts still live: a duplicate means *this
+  member* already posted it. A similar post by someone else is not a duplicate.
+- Return the best match above a cosine threshold, with its id/type/subject.
+- Mod-gated: `chitChatMod` audience only, so the response is never fetched for members.
+
+Frontend: `NewsThread.vue` shows a mod-only `NoticeMessage` naming the matching post,
+with the existing Hide action beside it.
+
+### Convert to a real post
+
+Newsfeed action `ConvertToPost` (mod-gated, alongside `ConvertToStory`):
+
+- Creates a message with `fromuser` = the **newsfeed author**, not the mod.
+  `PostMessage` hardcodes `myid` (message.go:4092), so this needs an explicit author
+  parameter, permitted only for a mod.
+- Logs the mod action (`logModAction`), as the other on-behalf paths do.
+- Posts a reply on the ChitChat thread saying what was done, pointing at My Posts.
+
+Frontend: `NewsConvertModal.vue` — OFFER/WANTED toggle, item name and body
+pre-populated from the ChitChat text, a preview of the resulting post, and submit.
+
+## Status
+
+| # | Task | Status | Notes |
+|---|------|--------|-------|
+| 1 | Explore referTo / newsfeed actions / embeddings / message create | ✅ | Primitives all exist |
+| 2 | Plan + branch | ✅ | `feature/chitchat-convert-to-post` |
+| 3 | Go: duplicate-detection endpoint | ✅ | `newsfeed/duplicate.go` + route; same-author, live, cosine ≥ 0.82 |
+| 4 | FE: mod-only duplicate notice | ⬜ | `chitChatMod` gate |
+| 5 | Go: `ConvertToPost` action | 🔄 | BLOCKED ON A DECISION — see "Posting as another member" |
+| 6 | FE: convert modal + preview | ⬜ | prefill item/body |
+| 7 | Thread reply + My Posts pointer | ⬜ | |
+| 8 | Tests (Go + vitest) | ⬜ | |
+| 9 | Screenshots + PR | ⬜ | |
+
+## Notes
+
+- Item name extraction: reuse whatever `constructSubject`/item parsing already exists
+  rather than inventing a parser.
+- The mod note must never reach members — gate server-side, not only in the template.
+
+## Posting as another member — the one real obstacle
+
+Creating a post is two owner-gated steps, not one:
+
+- `PutMessage` (message.go:3961) writes the draft with `fromuser` = `myid`
+  (the INSERT at :4092 hardcodes it).
+- `handleJoinAndPost` (message.go:2943) submits it and refuses outright unless
+  `msg.Fromuser == myid` ("Not your message", :2956).
+
+So there is no existing route by which a moderator can post as a member, and the
+duplicate-detection half of this work does not depend on solving it.
+
+Options:
+
+1. **Extract the core of both, taking an explicit author.** Handlers stay thin
+   wrappers passing `myid`, so no existing caller changes behaviour; the new
+   ChitChat path passes the newsfeed poster's id after a `canHidePost` check, and
+   logs it via `logModAction`. Correct, but it edits two owner-only auth checks in
+   the most sensitive file in the API.
+2. **Post it as a draft owned by the member** and notify them to press send. Keeps
+   every auth check untouched; does not fully meet "post that as an offer".
+3. **Reimplement creation inside the newsfeed package.** Rejected — it would skip
+   `messages_groups`, spatial, indexing and embedding work that the real path does,
+   producing posts that look right but behave oddly.
+
+Recommendation: option 1, because it is the only one that delivers the asked-for
+outcome, and the risk is contained by leaving the existing handlers as pass-throughs.


### PR DESCRIPTION
## Problem

"Refer to OFFER/WANTED" posts a canned notice telling the member to go and post the item themselves. It puts the work back on the member, and most never follow through, so the item stays in ChitChat where far fewer people see it.

Two better outcomes, both restricted to ChitChat moderators and support/admin.

## Duplicate flagging

`GET /newsfeed/:id/duplicate` embeds the ChitChat text and searches the in-memory embedding store. That store holds only open messages, so a match is a post still standing.

Matches are restricted to the **same author**. A duplicate means this member already posted the thing; someone else offering something similar is a different post, not a repeat, and hiding a member's ChitChat entry over it would be wrong. The cosine threshold is deliberately high, because a false positive invites a moderator to hide a member's post while a false negative just leaves them doing what they do today.

The thread then shows a volunteers-only note naming the matching post, beside the existing Hide action. It is gated server-side as well as in the template, so a member's browser never receives it.

## Posting it for them

A moderator can turn the ChitChat post into a real OFFER or WANTED belonging to the member. The modal guesses the type and the item, prefills the description, and previews the subject before anything is written.

It also shows **where the post will land** — the postcode and community, resolved server-side from the member's own `settings.mylocation` by the same function that does the posting (`message.ResolveOnBehalfPosting`), so the preview cannot promise a postcode the post then ignores. If the member has not set a location we refuse rather than guess, and the modal says so with posting disabled. And it previews **the note left on the thread**, rendered by the same component the thread uses, so a moderator is not committing to wording they have not read.

![Convert modal](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/chitchat-convert/modal.png)

![Menu entry](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/chitchat-convert/menu.png)

It drives the same two calls a member's own compose does — create the draft, then join and post — so nothing about grouping, spatial data, indexing or embeddings is skipped. Reimplementing posting inside the newsfeed handler would have produced posts that look right and behave oddly.

Afterwards a note on the thread tells the member what happened and points them at My Posts, where the post and its replies are.

## Permissions

Resolved in one place. `auth.IsChitChatMod` covers the ChitChat Moderation team and support/admin and nothing else — group moderators are excluded, since ChitChat is not group-scoped. `newsfeed.canHidePost` delegates to it, so hiding, the duplicate note and converting share one definition.

`onBehalfOf()` gates `?onbehalfof=` on **both** halves, create and submit. Gating only one would leave a member able to finish a draft belonging to someone else. The member routes keep their existing ownership checks unchanged.

## Whose location, whose community

Both are derived server-side from the member, never taken from the request.

A moderator moderates from wherever they happen to be, so trusting the client for `locationid` would stamp their postcode on someone else's post and put it in front of the wrong people. Submitting also *joins* the author to the destination group, so accepting an arbitrary group would quietly sign a member up to a community they never chose: the group must be one they are already in, defaulting to their nearest existing membership.

Both fail closed with a plain message rather than posting something wrong.

## Tests

Go covers the permission boundaries, which are what matter here: the duplicate lookup refused for an ordinary member and when logged out, `?onbehalfof=` refused for a member on both the create and the submit half, and the "a volunteer posted this for you" note refused for a member so it cannot be fabricated.

Vitest covers the notice appearing for a moderator, never appearing for a member, not being looked up at all for a member, the thread still rendering when the lookup fails, and the convert entry being moderator-only.

Full Go and vitest suites pass.

## Notes

- The screenshots live on `pr-assets/chitchat-convert`, a throwaway branch that can be deleted after merge, to keep binaries out of the code diff.
- `plans/active/2026-07-31-chitchat-convert-to-post.md` records the design and the alternatives considered for posting on a member's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi

