### PR TITLE
fix(ai-support): split SET TRANSACTION and max_execution_time into two statements

### DIFF
--- a/claude-agent-sdk/tools.js
+++ b/claude-agent-sdk/tools.js
@@ -58,7 +58,10 @@ async function dbSelect(sql, maxRows = 500) {
   // BEFORE running the query; if that can't be set, abort rather than run writable.
   const conn = await getPool().getConnection()
   try {
-    await conn.query('SET SESSION TRANSACTION READ ONLY, SESSION max_execution_time = 15000')
+    // Two statements: SET TRANSACTION and SET <variable> are different SET
+    // forms and cannot be comma-combined (syntax error on MySQL/Percona).
+    await conn.query('SET SESSION TRANSACTION READ ONLY')
+    await conn.query('SET SESSION max_execution_time = 15000')
     const [rows] = await conn.query(guarded)
     return rows
   } finally {


### PR DESCRIPTION
The support helper's guarded `dbSelect` ran `SET SESSION TRANSACTION READ ONLY, SESSION max_execution_time = 15000` as one statement. `SET TRANSACTION` and `SET <variable>` are different SET statement forms and cannot be comma-combined — MySQL/Percona rejects it with a syntax error, so **every** DB query through the helper's guarded path failed.

This went unnoticed because the prod helper never had a working DB connection until the `iznik_ro` read-only grant was wired up today (SUPPORT_DB_* in .env); the first real query surfaced the error.

Fix: run the two statements separately. Verified in the rebuilt prod container: guarded SELECT works against the read host as `iznik_ro`, writes are still refused both by the SQL guard (SELECT-only) and by the grant itself. Helper unit tests (guard/auth/device-summary, 37) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbiCj4MqfgBgqD5gpmmEaP