### PR TITLE
fix(moderation): tell moderators why a post is waiting for approval

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -27,6 +27,12 @@ class ContentCheckService
     public const CHECK_LANGUAGE          = 'Language';
     public const CHECK_NOT_AN_ITEM       = 'NotAnItem';
 
+    // Not content problems - these explain a hold that the member's or group's
+    // moderation settings caused, so the mod queue says why (Discourse #9987).
+    public const CHECK_MEMBER_MODERATED  = 'MemberModerated';
+    public const CHECK_GROUP_MODERATED   = 'GroupModerated';
+    public const CHECK_NO_LOCATION       = 'NoLocation';
+
     /**
      * Candidate languages for the content-check language detector. Restricted to
      * languages realistically seen on UK Freegle — English/Welsh, the main UK
@@ -294,8 +300,9 @@ class ContentCheckService
                             continue;
                         }
 
-                        $isModerated = $this->isUserModerated((int) $row->msgid, (int) $row->groupid, (int) $row->fromuser)
-                                    || $this->isGroupModerated((int) $row->groupid);
+                        $userModerated  = $this->isUserModerated((int) $row->msgid, (int) $row->groupid, (int) $row->fromuser);
+                        $groupModerated = $this->isGroupModerated((int) $row->groupid);
+                        $isModerated    = $userModerated || $groupModerated;
                         // Never auto-promote an Offer/Wanted we couldn't locate (NULL lat -
                         // subject didn't geocode and no usable poster fallback): it would go
                         // live undiscoverable. Keep it in the mod queue so a moderator adds a
@@ -307,6 +314,18 @@ class ContentCheckService
                             $reasons,
                             fn($r) => ($r['action'] ?? 'flag') === 'block'
                         ));
+
+                        // A post held for a STATUS reason rather than a content reason used to
+                        // store no reasons at all, so it arrived in the mod queue with nothing
+                        // saying why - "there is no explanation of why the post needs Approval"
+                        // (Discourse #9987). Record the cause too. Appended after $hasBlock is
+                        // computed so it can never turn a flag into a block.
+                        if (!$promote && !$hasBlock) {
+                            $reasons = array_merge(
+                                $reasons,
+                                $this->holdReasons($userModerated, $groupModerated, $missingLocation)
+                            );
+                        }
 
                         if ($dryRun) {
                             if ($promote) {
@@ -498,6 +517,50 @@ class ContentCheckService
      * @param int      $groupid  Group ID.
      * @param int|null $fromuser Known fromuser value; skips the messages query when supplied.
      */
+    /**
+     * Why a post is being kept pending when the content itself was clean.
+     *
+     * Without these a moderator sees a post sitting in the queue with no
+     * indication of what put it there, which is what Discourse #9987 reported.
+     * These are 'flag', never 'block' - they explain a hold, they don't cause one.
+     *
+     * @return array<int, array{check:string, category:null, action:string, detail:string}>
+     */
+    private function holdReasons(bool $userModerated, bool $groupModerated, bool $missingLocation): array
+    {
+        $reasons = [];
+
+        if ($groupModerated) {
+            $reasons[] = [
+                'check'    => self::CHECK_GROUP_MODERATED,
+                'category' => null,
+                'action'   => 'flag',
+                'detail'   => 'This group moderates all posts, whatever the member\'s setting',
+            ];
+        }
+
+        // Only worth saying if the group isn't moderating everything anyway.
+        if ($userModerated && !$groupModerated) {
+            $reasons[] = [
+                'check'    => self::CHECK_MEMBER_MODERATED,
+                'category' => null,
+                'action'   => 'flag',
+                'detail'   => 'This member\'s posts are moderated',
+            ];
+        }
+
+        if ($missingLocation) {
+            $reasons[] = [
+                'check'    => self::CHECK_NO_LOCATION,
+                'category' => null,
+                'action'   => 'flag',
+                'detail'   => 'We could not work out where this post is - add a postcode before approving',
+            ];
+        }
+
+        return $reasons;
+    }
+
     public function isUserModerated(int $msgid, int $groupid, ?int $fromuser = null): bool
     {
         if ($fromuser === null) {

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature\Message;
 
+use App\Models\Group;
 use App\Models\Message;
 use App\Models\MessageGroup;
+use App\Models\User;
 use App\Services\ContentCheckService;
 use App\Services\ContentEmbeddingService;
 use Illuminate\Support\Facades\DB;
@@ -2901,5 +2903,120 @@ class ContentCheckTest extends TestCase
         $this->assertNotNull($row->contentcheck_checked_at, 'a clean held post is still checked');
         $this->assertEquals(MessageGroup::COLLECTION_PENDING, $row->collection,
             'a clean held post must NOT be auto-approved while a moderator holds it');
+    }
+
+    /**
+     * Discourse #9987: a post held because of a moderation SETTING rather than
+     * its content used to reach the mod queue with contentcheck_reasons NULL,
+     * so the moderator had nothing telling them why it needed approving.
+     */
+    private function pendingCleanPost(Group $group, User $user, array $messageOverrides = []): int
+    {
+        $msgid = DB::table('messages')->insertGetId(array_merge([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Solid oak table (SW1A)',
+            'textbody' => 'Beautiful table. Collection only.',
+            'message'  => 'Beautiful table. Collection only.',
+            'lat'      => 51.5,
+            'lng'      => -0.12,
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ], $messageOverrides));
+
+        DB::table('items')->insertOrIgnore(['name' => 'Solid oak table']);
+        $itemId = DB::table('items')->where('name', 'Solid oak table')->value('id');
+        DB::table('messages_items')->insert(['msgid' => $msgid, 'itemid' => $itemId]);
+
+        DB::table('messages_groups')->insert([
+            'msgid'      => $msgid,
+            'groupid'    => $group->id,
+            'collection' => 'Pending',
+            'arrival'    => now(),
+            'deleted'    => 0,
+        ]);
+
+        return $msgid;
+    }
+
+    private function reasonsFor(int $msgid, int $groupid): array
+    {
+        $json = DB::table('messages_groups')
+            ->where('msgid', $msgid)->where('groupid', $groupid)
+            ->value('contentcheck_reasons');
+
+        return $json ? json_decode($json, true) : [];
+    }
+
+    public function test_moderated_member_hold_records_why(): void
+    {
+        $group = $this->createTestGroup();
+        $user  = $this->createTestUser();
+        // NULL ourPostingStatus = MODERATED.
+        $this->createMembership($user, $group);
+
+        $msgid = $this->pendingCleanPost($group, $user);
+
+        $stats = $this->service->processUnprocessed();
+        $this->assertEquals(1, $stats['kept_pending']);
+
+        $checks = array_column($this->reasonsFor($msgid, $group->id), 'check');
+        $this->assertContains(ContentCheckService::CHECK_MEMBER_MODERATED, $checks,
+            'a post held because the member is moderated must say so');
+    }
+
+    public function test_fully_moderated_group_hold_records_why(): void
+    {
+        // Group::$casts has 'rules' => 'array', so pass an array - a pre-encoded
+        // string gets encoded a second time and isGroupModerated() cannot read it.
+        $group = $this->createTestGroup(['rules' => ['fullymoderated' => true]]);
+        $user  = $this->createTestUser();
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+
+        $msgid = $this->pendingCleanPost($group, $user);
+
+        $this->service->processUnprocessed();
+
+        $checks = array_column($this->reasonsFor($msgid, $group->id), 'check');
+        $this->assertContains(ContentCheckService::CHECK_GROUP_MODERATED, $checks,
+            'a post held because the group moderates everything must say so');
+        $this->assertNotContains(ContentCheckService::CHECK_MEMBER_MODERATED, $checks,
+            'the member is on Group Settings, so do not also blame the member');
+    }
+
+    public function test_missing_location_hold_records_why(): void
+    {
+        $group = $this->createTestGroup();
+        $user  = $this->createTestUser();
+        // Not moderated, so the only thing keeping this pending is the location.
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+
+        $msgid = $this->pendingCleanPost($group, $user, ['lat' => null, 'lng' => null]);
+
+        $this->service->processUnprocessed();
+
+        $checks = array_column($this->reasonsFor($msgid, $group->id), 'check');
+        $this->assertContains(ContentCheckService::CHECK_NO_LOCATION, $checks,
+            'a post held because we could not locate it must say so');
+    }
+
+    public function test_clean_unmoderated_post_is_approved_with_no_reasons(): void
+    {
+        $group = $this->createTestGroup();
+        $user  = $this->createTestUser();
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+
+        $msgid = $this->pendingCleanPost($group, $user);
+
+        $this->service->processUnprocessed();
+
+        $row = DB::table('messages_groups')
+            ->where('msgid', $msgid)->where('groupid', $group->id)->first();
+
+        $this->assertEquals(MessageGroup::COLLECTION_APPROVED, $row->collection,
+            'nothing is holding this post, so it should go live');
+        $this->assertNull($row->contentcheck_reasons,
+            'an approved post carries no hold reasons');
     }
 }

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -372,8 +372,8 @@
               </NoticeMessage>
             </div>
             <NoticeMessage v-if="noLocation" variant="warning" class="mb-2">
-              We couldn't work out where this post is (often an emailed post whose
-              subject has no recognised place name). Please click
+              We couldn't work out where this post is (often an emailed post
+              whose subject has no recognised place name). Please click
               <strong>Edit</strong> and add a postcode (it doesn't have to be
               exactly right - do your best) so members can find it.
             </NoticeMessage>
@@ -406,6 +406,26 @@
               class="mb-2"
             >
               {{ contextGroup.spamreason }}
+            </NoticeMessage>
+            <!-- Why the automated content check left this in the queue. The keyword
+                 that flagged it is recorded per post but was never shown, so a mod
+                 had to guess - a paint post flagged on the word "mineral" looked
+                 like it had been flagged as a medicine for no reason (Discourse
+                 #9988), and a post held purely by a moderation setting said nothing
+                 at all (#9987). The server only sends this to moderators. -->
+            <NoticeMessage
+              v-if="holdReasons.length"
+              variant="warning"
+              class="mb-2"
+            >
+              <p class="mb-1">
+                <strong>Why this is waiting for approval:</strong>
+              </p>
+              <ul class="mb-0 ps-3">
+                <li v-for="(reason, ix) in holdReasons" :key="ix">
+                  {{ reason }}
+                </li>
+              </ul>
             </NoticeMessage>
             <NoticeMessage
               v-if="
@@ -740,7 +760,9 @@
           This message needs editing so that we know where it is.
         </NoticeMessage>
         <div
-          v-if="pending && (!contextGroup?.heldby || heldbyId === myid) && !editing"
+          v-if="
+            pending && (!contextGroup?.heldby || heldbyId === myid) && !editing
+          "
           class="text-end mb-1"
         >
           <b-button variant="danger" @click="spamReport">
@@ -1020,6 +1042,32 @@ const contextGroup = computed(() => {
   )
 })
 
+// What the automated content check found, in plain words. The API only sends
+// contentcheck_reasons to moderators, so this is empty for anyone else.
+const holdReasons = computed(() => {
+  const raw = contextGroup.value?.contentcheck_reasons
+
+  if (!raw) {
+    return []
+  }
+
+  let parsed = raw
+
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw)
+    } catch (e) {
+      // Never let a malformed reason take the whole message card down.
+      console.error('Could not parse contentcheck_reasons', e)
+      return []
+    }
+  }
+
+  return Array.isArray(parsed)
+    ? parsed.map((reason) => reason?.detail).filter(Boolean)
+    : []
+})
+
 // The origin group: the earliest arrival across the post's groups (shown as "First
 // posted on ..."). Excluded from the "may also be shown" list so it isn't listed twice.
 const originGroupid = computed(() => {
@@ -1112,7 +1160,9 @@ const isRippledInToContextGroup = computed(() =>
 // (both fields non-null) when the routing server said quicker=true at ripple-in time.
 const rippleProximity = computed(() => {
   const gid = currentGroupid.value
-  const g = (message.value?.groups || []).find((row) => parseInt(row.groupid) === gid)
+  const g = (message.value?.groups || []).find(
+    (row) => parseInt(row.groupid) === gid
+  )
   if (g?.ripple_proximity_p && g?.ripple_proximity_q) {
     return { p: g.ripple_proximity_p, q: g.ripple_proximity_q }
   }

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -462,6 +462,114 @@ describe('ModMessage', () => {
     })
   })
 
+  // The automated content check records WHY it left a post in the queue, but nothing
+  // ever showed it. A paint post flagged on the word "mineral" looked to the moderator
+  // like it had been called a medicine for no reason (Discourse 9988), and a post held
+  // purely by a moderation setting said nothing at all (9987).
+  describe('Content check hold reasons', () => {
+    it('shows the word that flagged the post', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          groups: [
+            {
+              groupid: 789,
+              collection: 'Pending',
+              contentcheck_reasons: JSON.stringify([
+                {
+                  check: 'ConcernKeyword',
+                  category: 'substance_medicine',
+                  action: 'flag',
+                  keyword: 'mineral',
+                  detail: "Matched concern keyword 'mineral'",
+                },
+              ]),
+            },
+          ],
+        }
+      )
+      await flushPromises()
+      expect(wrapper.text()).toContain('Why this is waiting for approval')
+      expect(wrapper.text()).toContain("Matched concern keyword 'mineral'")
+    })
+
+    it('explains a hold caused by a moderation setting', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          groups: [
+            {
+              groupid: 789,
+              collection: 'Pending',
+              contentcheck_reasons: JSON.stringify([
+                {
+                  check: 'GroupModerated',
+                  category: null,
+                  action: 'flag',
+                  detail:
+                    'This group moderates all posts, whatever the member’s setting',
+                },
+              ]),
+            },
+          ],
+        }
+      )
+      await flushPromises()
+      expect(wrapper.text()).toContain('This group moderates all posts')
+    })
+
+    it('accepts reasons already parsed into an array', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          groups: [
+            {
+              groupid: 789,
+              collection: 'Pending',
+              contentcheck_reasons: [
+                { check: 'PhoneNumber', detail: 'Post contains a phone number' },
+              ],
+            },
+          ],
+        }
+      )
+      await flushPromises()
+      expect(wrapper.text()).toContain('Post contains a phone number')
+    })
+
+    it('shows nothing when there are no reasons', async () => {
+      const wrapper = mountComponent(
+        {},
+        { groups: [{ groupid: 789, collection: 'Pending' }] }
+      )
+      await flushPromises()
+      expect(wrapper.vm.holdReasons).toEqual([])
+      expect(wrapper.text()).not.toContain('Why this is waiting for approval')
+    })
+
+    it('survives malformed reasons rather than breaking the card', async () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+      const wrapper = mountComponent(
+        {},
+        {
+          groups: [
+            {
+              groupid: 789,
+              collection: 'Pending',
+              contentcheck_reasons: 'not json at all',
+            },
+          ],
+        }
+      )
+      await flushPromises()
+      expect(wrapper.vm.holdReasons).toEqual([])
+      expect(wrapper.text()).not.toContain('Why this is waiting for approval')
+      consoleError.mockRestore()
+    })
+  })
+
   describe('Computed: alreadyOnHomeGroup', () => {
     // Regression: a post must not be told it "Possibly should be on" a group it is ALREADY
     // on (its origin, or a group it has rippled onto). The hint previously fired whenever the

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -706,6 +706,15 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 					message.Fromaddr = nil
 					message.Fromip = nil
 					message.Fromcountry = nil
+
+					// Why a post was held is moderator information: it names the
+					// keyword that flagged it, which tells a spammer exactly what
+					// to avoid next time. The row is selected for everyone because
+					// collection/arrival are public, so strip the check fields here.
+					for i := range message.MessageGroups {
+						message.MessageGroups[i].ContentcheckReasons = nil
+						message.MessageGroups[i].ContentcheckCheckedAt = nil
+					}
 				}
 
 				// Convert 2-letter country code to full name for frontend display.

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -1257,6 +1257,64 @@ func TestMessageModOnlyFields(t *testing.T) {
 	assert.Nil(t, anonMsg.Fromcountry, "Anonymous user should NOT see fromcountry")
 }
 
+// Why a post was held names the keyword that flagged it, which tells a spammer
+// exactly what to avoid next time. It is moderator information (Discourse #9988).
+func TestMessageContentCheckReasonsAreModOnly(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("msg_ccreasons")
+
+	groupID := CreateTestGroup(t, prefix)
+	regularUserID := CreateTestUser(t, prefix+"_reg", "User")
+	modUserID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	CreateTestMembership(t, regularUserID, groupID, "Member")
+	CreateTestMembership(t, modUserID, groupID, "Moderator")
+	_, regularToken := CreateTestSession(t, regularUserID)
+	_, modToken := CreateTestSession(t, modUserID)
+
+	msgID := CreateTestMessage(t, regularUserID, groupID, "Test ContentCheck Reasons Item", 55.9533, -3.1883)
+	db.Exec("UPDATE messages_groups SET contentcheck_checked_at = NOW(), contentcheck_reasons = ? WHERE msgid = ?",
+		`[{"check":"ConcernKeyword","category":"substance_medicine","action":"flag","keyword":"mineral","detail":"Matched concern keyword 'mineral'"}]`,
+		msgID)
+
+	resp, err := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d?jwt=%s", msgID, modToken), nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var modMsg message.Message
+	json2.Unmarshal(rsp(resp), &modMsg)
+	assert.NotEmpty(t, modMsg.MessageGroups, "mod should get the groups block")
+	foundReasons := false
+	for _, mg := range modMsg.MessageGroups {
+		if mg.ContentcheckReasons != nil {
+			foundReasons = true
+			assert.Contains(t, string(*mg.ContentcheckReasons), "mineral",
+				"a mod needs the word that flagged the post")
+		}
+	}
+	assert.True(t, foundReasons, "mod should see contentcheck_reasons")
+
+	resp, err = getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d?jwt=%s", msgID, regularToken), nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var regMsg message.Message
+	json2.Unmarshal(rsp(resp), &regMsg)
+	for _, mg := range regMsg.MessageGroups {
+		assert.Nil(t, mg.ContentcheckReasons, "a member must NOT see why their post was held")
+		assert.Nil(t, mg.ContentcheckCheckedAt, "nor when it was checked")
+	}
+
+	resp, err = getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d", msgID), nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var anonMsg2 message.Message
+	json2.Unmarshal(rsp(resp), &anonMsg2)
+	for _, mg := range anonMsg2.MessageGroups {
+		assert.Nil(t, mg.ContentcheckReasons, "logged out must NOT see why a post was held")
+	}
+}
+
 // --- Mod action helpers ---
 
 // createPendingMessage creates a message in Pending collection for mod tests.


### PR DESCRIPTION
## Summary

Two Discourse reports, one cause: the mod queue never explains itself.

- [#9987](https://discourse.ilovefreegle.org/t/approving-posts-that-are-in-group-settings/9987) — posts needing approval "and there is no explanation of why".
- [#9988](https://discourse.ilovefreegle.org/t/paint-pots-flagged/9988) — a paint post flagged as a Medicine or Drug with nothing saying which word did it. The answer, typed by hand in the thread, was "Mineral".

The system already knew both answers. `ContentCheckService` computes structured reasons and stores them in `messages_groups.contentcheck_reasons` — `concern_keywords` row 44 is `keyword='mineral', category='substance_medicine'` — but two things stopped a moderator ever seeing them.

**Nothing was recorded for setting-based holds.** A post kept pending because of a moderation *setting* rather than its *content* stored `contentcheck_reasons = NULL`. On live that is **163 of the 170** pending checked posts. `isModerated` was a single boolean OR'd over member-and-group so it could not say which applied; it is now split, and each cause records a reason: `GroupModerated`, `MemberModerated` (suppressed when the group moderates everything anyway, so the queue doesn't blame the member for the group's setting) and `NoLocation`. Appended after `$hasBlock` is computed, so an explanation can never turn a flag into a block.

**Nothing read the column.** The Go API selects `contentcheck_reasons` into the groups block (`message.go:503`) and serialises it with no mod gate, so it was already being sent to every member's browser while no UI rendered it — handing a spammer the exact word to avoid next time. It is now stripped for non-mods alongside the existing `Source`/`Fromip` stripping, server-side rather than in the template. ModTools then renders the details in a "Why this is waiting for approval" notice, beside the existing back-to-pending reason whose comment already complains about mods "clicking Approve with no explanation".

For Emma's paint pots this now reads: *Matched concern keyword 'mineral'*.

## Code Quality Review

- The gate is server-side, so a member's browser never receives the data — a template `v-if` would still have shipped it in the payload.
- `MemberModerated` is suppressed when the group moderates everything, so a mod isn't told two competing things.
- The ModTools computed tolerates both a JSON string and an already-parsed array, and swallows malformed JSON rather than letting one bad row take down the whole message card.
- Four `prettier/prettier` errors already present in `ModMessage.vue` on master (lines 375/376, 743, 1115 — verified by linting `HEAD:` via stdin) were fixed, since CI lints changed files.

## Future Improvements

- `spamtype`/`spamreason` are selected on the same row and may deserve the same look, though they are less specific than a keyword.
- Worth considering whether `NoLocation` should prompt the "add a postcode" flow directly from the notice.

## Test Plan

- **Laravel: 5090 tests**, with 4 new hold-reason tests covering member-moderated, fully-moderated group, missing location, and the clean case that approves with no reasons.
- **Go: 3741 tests**, including a new `TestMessageContentCheckReasonsAreModOnly` asserting a mod sees the reasons and a member and a logged-out caller do not.
- **ModTools: 5 new unit tests** — the flagged keyword, a setting-based hold, pre-parsed reasons, the empty case, and malformed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi