### PR TITLE
fix(jobs): make the job-ads block read as distinct from the nav bar

### DIFF
--- a/iznik-nuxt3/components/JobsDaSlot.vue
+++ b/iznik-nuxt3/components/JobsDaSlot.vue
@@ -186,11 +186,26 @@ function onJobClicked(clickedId) {
 
 .jobs-slot {
   width: 100%;
-  /* Muted (not pure white) so the job-ads block reads as distinct sponsored content and
-     separates from the white nav bar that can sit directly above it on Browse. */
-  background: $color-gray--lighter;
-  border: 1px solid $gray-200;
+  /* Muted so the job-ads block reads as distinct sponsored content and separates
+     from the mobile nav bar, which is pure white and sits directly above it.
+     $color-gray--lighter (#F5F5F5) was too close to white to do that - against
+     the white bar the two ran together into one surface. */
+  background: $gray-200;
+  border: 1px solid $gray-300;
   overflow-y: auto;
+}
+
+/* JobOne paints its rows white, which covered the muted background above and
+   left the block looking white again. Inside this slot the rows sit ON the
+   muted background instead; elsewhere (the /jobs page, the sidebar) they keep
+   their own white. */
+.jobs-slot :deep(.job-summary) {
+  background: transparent;
+
+  &:hover,
+  &:focus-visible {
+    background: $gray-300;
+  }
 }
 
 .jobs-slot-header {
@@ -198,11 +213,13 @@ function onJobClicked(clickedId) {
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 0.75rem;
-  background: $gray-100;
+  /* Sits a step darker than the body so the block reads as a labelled panel
+     rather than a lighter strip inside a darker one. */
+  background: $gray-300;
   color: $gray-700;
   font-weight: 600;
   font-size: 0.85rem;
-  border-bottom: 1px solid $gray-200;
+  border-bottom: 1px solid $gray-400;
 }
 
 .jobs-slot-icon {

--- a/iznik-nuxt3/tests/unit/components/JobsDaSlotBackground.spec.js
+++ b/iznik-nuxt3/tests/unit/components/JobsDaSlotBackground.spec.js
@@ -1,0 +1,59 @@
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+import { describe, it, expect } from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// The mobile nav bar is pure white (NavbarMobile.vue `background: white`) and the
+// job-ads slot sits directly beneath it. When the slot is also white the two run
+// together and the nav bar stops reading as a separate bar.
+//
+// This was fixed once before by tinting `.jobs-slot`, but JobOne paints each
+// `.job-summary` row white, which covered the tint and left the block looking
+// white again. Both halves are needed, so both are asserted here.
+describe('Jobs ad slot background', () => {
+  const source = readFileSync(
+    resolve(__dirname, '../../../components/JobsDaSlot.vue'),
+    'utf-8'
+  )
+
+  // Comments inside these rules explain the colour choice and name the old one,
+  // so strip them: we are asserting on what the CSS DOES, not what it says.
+  function block(selector) {
+    const idx = source.indexOf(selector)
+    expect(idx, `${selector} should exist in JobsDaSlot`).toBeGreaterThan(-1)
+    return source
+      .substring(idx, source.indexOf('}', idx))
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+  }
+
+  function backgroundOf(selector) {
+    const declaration = block(selector).match(/background:\s*([^;]+);/)
+    expect(declaration, `${selector} must set a background`).not.toBeNull()
+    return declaration[1].trim()
+  }
+
+  it('tints the slot so it is not white like the nav bar above it', () => {
+    const background = backgroundOf('.jobs-slot {')
+
+    expect(background, '.jobs-slot must not be white').not.toMatch(
+      /^(\$white|#fff|#ffffff|white)$/i
+    )
+    // #F5F5F5 is only 4% off white and did not separate from the bar in practice.
+    expect(
+      background,
+      'the tint must be stronger than $color-gray--lighter'
+    ).not.toBe('$color-gray--lighter')
+  })
+
+  it('stops the job rows painting white over that tint', () => {
+    const rows = block('.jobs-slot :deep(.job-summary) {')
+
+    expect(
+      rows,
+      'rows inside the slot must let the slot background show through'
+    ).toContain('background: transparent')
+  })
+})


### PR DESCRIPTION
## Problem

On mobile the bottom nav bar is pure white (`NavbarMobile.vue` — `background: white`) and the job-ads slot sits directly beneath it. Both surfaces were white, so they ran together into one block and the bar stopped reading as a bar.

This was tinted once before — the comment on `.jobs-slot` says exactly that intent — but the fix never showed, for two independent reasons, and either one alone was enough to defeat it:

- **`JobOne` paints every `.job-summary` row `background: $white`**, which covered the tint. The slot was tinted; the surface you actually see was not.
- **`$color-gray--lighter` is `#F5F5F5`** — 4% off white. Even with nothing painted over it, that would not have separated from a white bar.


## Before / after

Same page, same viewport (390px), same seeded jobs — captured in Chrome against the dev container.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/job-ads-background/before.png) | ![after](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/job-ads-background/after.png) |

Computed styles read out of the live page confirm it:

| | Before | After |
|---|---|---|
| `.jobs-slot` | `rgb(245, 245, 245)` | `rgb(233, 236, 239)` |
| `.job-summary` rows | `rgb(255, 255, 255)` | `rgba(0, 0, 0, 0)` |

The rows going transparent is the half that was missing: before, they painted white over the tint, so the block matched the white nav bar however the slot was coloured.


## Change

- `.jobs-slot` tinted with `$gray-200` (`#e9ecef`).
- `.jobs-slot-header` stepped to `$gray-300` so the block reads as a labelled panel rather than a lighter strip inside a darker one.
- Rows made transparent **inside this slot only**, via `:deep(.job-summary)`. The `/jobs` page and the sidebar keep their white rows — there they sit on a page background, not under the nav bar, so white is right.
- Row hover moves to `$gray-300`, since the previous `$gray-100` hover would now be *lighter* than the background and read as no change at all.

## Code Quality Review

- Scoped to `.jobs-slot` rather than changing `JobOne` globally, so the other two placements are untouched.
- `$gray-200/300/400` are Bootstrap variables, confirmed defined in `node_modules/bootstrap/scss/_variables.scss` — an undefined SCSS variable breaks page load in this codebase, so that was checked rather than assumed.
- Verified the stylesheet compiles in the dev container; the only output is Bootstrap's own Dart Sass deprecation warnings, which predate this change.

## Test Plan

- New `JobsDaSlotBackground.spec.js` asserts **both** halves, because either one alone leaves the block white: the slot background is neither white nor the old too-pale `$color-gray--lighter`, and the rows inside the slot let it show through.
- The assertions strip SCSS comments first — the comment explaining the choice names the old colour, and a naive text match hits the comment instead of the declaration. (It did, on the first run.)
- Both tests pass.

Confirmed in a browser (see above). The chrome-devtools MCP dropped out mid-session, so this was driven over CDP against an isolated headless Chrome instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi

