### PR TITLE
fix(chitchat): shrink the comment box after sending, and space it off the reply above

### DIFF
--- a/iznik-nuxt3/components/AutoHeightTextarea.vue
+++ b/iznik-nuxt3/components/AutoHeightTextarea.vue
@@ -100,10 +100,18 @@ watch(currentValue, (newVal) => {
   if (newVal && !timer.value) {
     // Starting the timer here avoids having the timer run for empty textareas, which happen a lot in ChitChat.
     checkRows()
-  } else if (!newVal && timer.value) {
-    // No longer need to check.
-    clearTimeout(timer.value)
-    timer.value = null
+  } else if (!newVal) {
+    // Emptied - usually because the comment was just sent. Shrink back to the
+    // starting height: currentRows only ever grew, so after posting a long
+    // comment the box stayed at its grown height with nothing in it, which on
+    // mobile left an empty 8-row box filling the screen.
+    currentRows.value = props.rows
+
+    if (timer.value) {
+      // No longer need to check.
+      clearTimeout(timer.value)
+      timer.value = null
+    }
   }
 
   emit('update:modelValue', newVal)

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -128,7 +128,7 @@
           @rendered="rendered"
           @subtree-rendered="repliesRendered = true"
         />
-        <span v-if="!newsfeed?.closed">
+        <span v-if="!newsfeed?.closed" class="comment-box">
           <div v-if="enterNewLine">
             <OurAtTa
               v-if="!newsfeed.deleted"
@@ -753,6 +753,13 @@ async function unmute() {
 .card__volunteer-opportunity {
   background-color: $color-gray-2;
   border-radius: var(--radius-md, 0.375rem);
+}
+
+/* The comment box sat flush against the last reply, so the two ran together.
+   A span is inline by default, hence display: block for the margin to apply. */
+.comment-box {
+  display: block;
+  margin-top: 0.75rem;
 }
 
 .card__default {

--- a/iznik-nuxt3/tests/unit/components/AutoHeightTextarea.spec.js
+++ b/iznik-nuxt3/tests/unit/components/AutoHeightTextarea.spec.js
@@ -176,5 +176,46 @@ describe('AutoHeightTextarea', () => {
       const textarea = wrapper.find('textarea')
       expect(textarea.attributes('rows')).toBe('3')
     })
+
+    // The box grows as you type but only ever grew. Sending a comment clears
+    // the text, so an empty box kept the height it had reached - on mobile that
+    // left an 8-row box with nothing in it, pushed up against the last reply.
+    it('shrinks back to its starting height when emptied', async () => {
+      // modelValue must start as '' rather than be omitted: the prop declares
+      // `default: null`, so setting it to null later would be no change at all
+      // and the watcher would never fire.
+      const wrapper = createWrapper({ rows: 1, maxRows: 8, modelValue: '' })
+      const textarea = wrapper.find('textarea')
+
+      // Grow it: the component checks on a timer while there is content, and
+      // the stub reports a scrollHeight taller than its clientHeight.
+      const el = textarea.element
+      Object.defineProperty(el, 'scrollHeight', {
+        value: 500,
+        configurable: true,
+      })
+      Object.defineProperty(el, 'clientHeight', {
+        value: 20,
+        configurable: true,
+      })
+
+      await textarea.setValue('a long comment that wraps over several lines')
+      await flushPromises()
+      vi.advanceTimersByTime(400)
+      await flushPromises()
+
+      expect(
+        Number(wrapper.find('textarea').attributes('rows'))
+      ).toBeGreaterThan(1)
+
+      // Now send it - the parent sets the model to null. Two flushes: the
+      // modelValue watcher assigns currentValue, and the currentValue watcher
+      // (which does the shrinking) runs on the tick after that.
+      await wrapper.setProps({ modelValue: null })
+      await flushPromises()
+      await flushPromises()
+
+      expect(wrapper.find('textarea').attributes('rows')).toBe('1')
+    })
   })
 })


### PR DESCRIPTION
## Problem

Reported from mobile: the ChitChat comment box sat flush against the last reply, and filled most of the screen while empty.

Two separate causes.

**It never shrank.** `AutoHeightTextarea` grows on a timer while there is content, and only ever grew — its own comment said *"We don't shrink. If you're reading this, why not code it?"*. `sendComment` sets `threadcomment` to `null`, so after posting a long comment the box kept the height it had reached with nothing in it: up to 8 rows of empty box on a phone.

**Nothing separated it from the replies.** The box is a bare `<span>` directly after `NewsReplies` with no margin, so it butted against the last reply.

## Change

- `AutoHeightTextarea` returns to its starting `rows` when the value is emptied, and still clears its timer.
- The comment wrapper gets `display: block` and a `0.75rem` top margin. A span is inline, so the margin needs the display change to apply.

## Verification

Measured in Chrome at 390px, driving a real send (type a long comment, click Send):

| | rows | height | gap above |
|---|---|---|---|
| Before typing | 1 | 32px | 12px |
| While typing | 4 | 92px | 12px |
| **After sending** | **1** | **32px** | 12px |

Previously the last row stayed at 4 rows / 92px, and the gap was 0.

## Code Quality Review

- The shrink is in the existing `currentValue` watcher rather than a new one, and keeps the timer teardown that was already there.
- Growth behaviour while typing is unchanged — this only affects the emptied case.
- `AutoHeightTextarea` is shared with chat, so the full unit suite was run: **14638 pass**.

## Test Plan

- New unit test asserting the box grows and then returns to its starting rows when the model is emptied.
- That test needed `modelValue` to start as `''` rather than be omitted: the prop declares `default: null`, so setting it to `null` later is no change at all and the watcher never fires. My first version of the test failed for exactly that reason, and the component was right — worth knowing if this area is touched again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi
