### PR TITLE
fix(volunteering): show national opportunities, at the top of the list

### DIFF
--- a/iznik-server-go/test/volunteering_test.go
+++ b/iznik-server-go/test/volunteering_test.go
@@ -757,3 +757,75 @@ func TestVolunteeringNullUserid(t *testing.T) {
 	resp, _ = getApp().Test(req)
 	assert.Equal(t, 200, resp.StatusCode)
 }
+
+// A national opportunity has no volunteering_groups row at all, so a group-only query
+// can never find it. It must still appear in a member's list - and ahead of the
+// group-specific ones, since it is relevant whoever is looking.
+func TestVolunteering_NationalOpsListedFirst(t *testing.T) {
+	prefix := uniquePrefix("volnatlist")
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+
+	creatorID := CreateTestUser(t, prefix+"_creator", "User")
+	CreateTestMembership(t, creatorID, groupID, "Member")
+
+	// The live NATIONAL op is created FIRST so it gets the LOWER id. That matters: a plain
+	// "ORDER BY id DESC" would then put it BELOW the group op, so this test fails unless the
+	// handler really does hoist national ops to the top.
+	db.Exec("INSERT INTO volunteering (userid, title, description, location, pending, deleted, expired) VALUES (?, 'National Live Vol', 'national desc', '', 0, 0, 0)", creatorID)
+	var nationalOpID uint64
+	db.Raw("SELECT id FROM volunteering WHERE userid = ? AND title = 'National Live Vol' ORDER BY id DESC LIMIT 1", creatorID).Scan(&nationalOpID)
+	assert.Greater(t, nationalOpID, uint64(0))
+	// No INSERT INTO volunteering_groups - that is what makes it national.
+
+	// A live per-group op, created second so it has the HIGHER id.
+	db.Exec("INSERT INTO volunteering (userid, title, description, location, pending, deleted, expired) VALUES (?, 'Group Live Vol', 'group desc', '', 0, 0, 0)", creatorID)
+	var groupOpID uint64
+	db.Raw("SELECT id FROM volunteering WHERE userid = ? AND title = 'Group Live Vol' ORDER BY id DESC LIMIT 1", creatorID).Scan(&groupOpID)
+	assert.Greater(t, groupOpID, nationalOpID, "group op must have the higher id for this test to mean anything")
+	db.Exec("INSERT INTO volunteering_groups (volunteeringid, groupid) VALUES (?, ?)", groupOpID, groupID)
+
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+	CreateTestMembership(t, memberID, groupID, "Member")
+	_, memberToken := CreateTestSession(t, memberID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/volunteering?jwt="+memberToken, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var ids []uint64
+	json2.Unmarshal(rsp(resp), &ids)
+
+	assert.Contains(t, ids, nationalOpID, "national op must be listed for a member")
+	assert.Contains(t, ids, groupOpID, "group op must still be listed")
+
+	natPos, grpPos := -1, -1
+	for i, id := range ids {
+		if id == nationalOpID {
+			natPos = i
+		}
+		if id == groupOpID {
+			grpPos = i
+		}
+	}
+	assert.Less(t, natPos, grpPos, "national op must be listed ahead of the group op")
+}
+
+// A member of no communities at all should still be shown national opportunities.
+func TestVolunteering_NationalOpsListedWithNoGroups(t *testing.T) {
+	prefix := uniquePrefix("volnatnogrp")
+	db := database.DBConn
+
+	creatorID := CreateTestUser(t, prefix+"_creator", "User")
+	db.Exec("INSERT INTO volunteering (userid, title, description, location, pending, deleted, expired) VALUES (?, 'National Only Vol', 'national desc', '', 0, 0, 0)", creatorID)
+	var nationalOpID uint64
+	db.Raw("SELECT id FROM volunteering WHERE userid = ? AND title = 'National Only Vol' ORDER BY id DESC LIMIT 1", creatorID).Scan(&nationalOpID)
+	assert.Greater(t, nationalOpID, uint64(0))
+
+	loneID := CreateTestUser(t, prefix+"_lone", "User")
+	_, loneToken := CreateTestSession(t, loneID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/volunteering?jwt="+loneToken, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var ids []uint64
+	json2.Unmarshal(rsp(resp), &ids)
+	assert.Contains(t, ids, nationalOpID, "member of no communities must still see national ops")
+}

--- a/iznik-server-go/volunteering/volunteering.go
+++ b/iznik-server-go/volunteering/volunteering.go
@@ -44,6 +44,11 @@ type Volunteering struct {
 	Canmodify      bool               `json:"canmodify" gorm:"-"`
 }
 
+// listLimit caps how many opportunities a member's list returns. National ops are taken
+// first, so a very large number of them could in principle crowd out local ones - there
+// are none live today, and any that appear are central Freegle asks worth seeing.
+const listLimit = 20
+
 func List(c *fiber.Ctx) error {
 	myid := user.WhoAmI(c)
 
@@ -99,17 +104,53 @@ func List(c *fiber.Ctx) error {
 				}
 			}
 		}
-	} else if len(groupids) > 0 {
+	} else {
 		start := time.Now().Format("2006-01-02")
+		seen := make(map[uint64]bool)
 
+		// National opportunities have NO volunteering_groups row (that absence is what makes
+		// them national), so the group query below can never find them - they were missing
+		// from the list entirely. Fetch them separately and put them FIRST: they apply
+		// whoever is looking, whereas ordering everything by id DESC would bury them under
+		// whatever local ops happen to be newer.
+		var nationalIds []uint64
 		db.Raw("SELECT DISTINCT volunteering.id FROM volunteering "+
-			"INNER JOIN volunteering_groups ON volunteering.id = volunteering_groups.volunteeringid "+
+			"LEFT JOIN volunteering_groups ON volunteering.id = volunteering_groups.volunteeringid "+
 			"LEFT JOIN volunteering_dates ON volunteering.id = volunteering_dates.volunteeringid "+
 			"LEFT JOIN users ON volunteering.userid = users.id "+
-			"WHERE groupid IN (?) AND "+
+			"WHERE volunteering_groups.groupid IS NULL AND "+
 			"(applyby IS NULL OR applyby >= ?) AND (end IS NULL OR end >= ?) AND volunteering.deleted = 0 AND expired = 0 AND (pending = 0 OR volunteering.userid = ?) "+
 			"AND users.deleted IS NULL "+
-			"ORDER BY id DESC LIMIT 20", groupids, start, start, myid).Pluck("id", &ids)
+			"ORDER BY volunteering.id DESC LIMIT ?", start, start, myid, listLimit).Pluck("id", &nationalIds)
+
+		for _, id := range nationalIds {
+			if !seen[id] {
+				seen[id] = true
+				ids = append(ids, id)
+			}
+		}
+
+		if len(groupids) > 0 && len(ids) < listLimit {
+			var groupOpIds []uint64
+			db.Raw("SELECT DISTINCT volunteering.id FROM volunteering "+
+				"INNER JOIN volunteering_groups ON volunteering.id = volunteering_groups.volunteeringid "+
+				"LEFT JOIN volunteering_dates ON volunteering.id = volunteering_dates.volunteeringid "+
+				"LEFT JOIN users ON volunteering.userid = users.id "+
+				"WHERE groupid IN (?) AND "+
+				"(applyby IS NULL OR applyby >= ?) AND (end IS NULL OR end >= ?) AND volunteering.deleted = 0 AND expired = 0 AND (pending = 0 OR volunteering.userid = ?) "+
+				"AND users.deleted IS NULL "+
+				"ORDER BY id DESC LIMIT ?", groupids, start, start, myid, listLimit).Pluck("id", &groupOpIds)
+
+			for _, id := range groupOpIds {
+				if len(ids) >= listLimit {
+					break
+				}
+				if !seen[id] {
+					seen[id] = true
+					ids = append(ids, id)
+				}
+			}
+		}
 	}
 
 	if len(ids) > 0 {


### PR DESCRIPTION
## Problem

A **national** volunteer opportunity is one with no row in `volunteering_groups` - that absence is the definition. The member-facing list built its query as:

```sql
INNER JOIN volunteering_groups ON ... WHERE groupid IN (?)
```

so a national op could never match it. They were not mis-ordered, they were **absent from `/volunteerings` entirely**.

The pending branch already handled this case for moderators with `PERM_NATIONAL_VOLUNTEERS` (`volunteering.go:87`), so only the live member list was affected.

## Change

`List` now runs a separate anti-join for nationals and puts them **first**, then appends group ops beneath, deduped, capped at 20 in total - the limit the group query already used, now a named constant.

Nationals go first rather than being merged into one `id DESC` ordering because they apply whoever is looking, and would otherwise sit below whatever local ops happen to be newer.

The branch is also no longer gated on the member having groups, so someone who belongs to no community still sees national asks.

## Verification

Live data: **0 active national ops** (245 historic, all expired or deleted), so nothing can crowd out local ops today.

The anti-join is index-driven - `EXPLAIN` on production shows a backward `PRIMARY` scan with `Not exists` on `volunteering_groups.eventid_2` - and the query returns in well under the 0.25s that a connect-and-run takes against prod.

The frontend needed no change: `allOfEm` returns `volunteeringStore.forUser` unmodified, so API order is what renders.

## Code Quality Review

- The group query is unchanged apart from the limit becoming a constant.
- Dedupe uses the same `seen` map pattern the pending branch already uses.
- Only two callers of this endpoint exist (`stores/volunteering.js:29` pending, `:67` member list); the pending path is untouched.

## Test Plan

Two new Go tests:

- A member of a community sees a national op **ahead of** a group op.
- A member of **no** communities still sees national ops.

The national op is deliberately created **first** in the ordering test so it has the **lower** id. Without that, a plain `id DESC` sort would put it top anyway and the test would prove nothing - my first draft had it the other way round and was worthless.

Full Go suite: **3745 pass, 0 fail**.
