### PR TITLE
fix(moderation): explain each hold reason once, not four times

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -407,26 +407,6 @@
             >
               {{ contextGroup.spamreason }}
             </NoticeMessage>
-            <!-- Why the automated content check left this in the queue. The keyword
-                 that flagged it is recorded per post but was never shown, so a mod
-                 had to guess - a paint post flagged on the word "mineral" looked
-                 like it had been flagged as a medicine for no reason (Discourse
-                 #9988), and a post held purely by a moderation setting said nothing
-                 at all (#9987). The server only sends this to moderators. -->
-            <NoticeMessage
-              v-if="holdReasons.length"
-              variant="warning"
-              class="mb-2"
-            >
-              <p class="mb-1">
-                <strong>Why this is waiting for approval:</strong>
-              </p>
-              <ul class="mb-0 ps-3">
-                <li v-for="(reason, ix) in holdReasons" :key="ix">
-                  {{ reason }}
-                </li>
-              </ul>
-            </NoticeMessage>
             <NoticeMessage
               v-if="
                 pending &&
@@ -480,6 +460,7 @@
               "
               :messageid="message.id"
               :groupid="currentGroupid"
+              :covered="explainedElsewhere"
             />
             <div v-if="expanded">
               <!-- eslint-disable-next-line -->
@@ -1042,30 +1023,26 @@ const contextGroup = computed(() => {
   )
 })
 
-// What the automated content check found, in plain words. The API only sends
-// contentcheck_reasons to moderators, so this is empty for anyone else.
-const holdReasons = computed(() => {
-  const raw = contextGroup.value?.contentcheck_reasons
+// Hold reasons this component already explains with its own notices above, which
+// use live state - the location we resolved now, the member's current posting
+// status - rather than whatever the content check stored when it ran. Passing
+// them to ModMessageWorry stops the same cause being stated twice, once here and
+// once from the stored reason (Discourse #9989).
+const explainedElsewhere = computed(() => {
+  // Location is always better answered live than from the stored reason: either
+  // we still can't place the post, and the notice above says so in more helpful
+  // words, or a moderator has since added a postcode and the stored reason is
+  // stale - it would claim we don't know where a post with a visible postcode is.
+  const covered = ['NoLocation']
 
-  if (!raw) {
-    return []
+  // Only claim this one when the notice above is actually rendering. The member's
+  // memberships may simply not have loaded, and a post held purely by a setting
+  // with nothing saying so is what Discourse #9987 was about.
+  if (pending.value && membership.value?.ourpostingstatus === 'MODERATED') {
+    covered.push('MemberModerated')
   }
 
-  let parsed = raw
-
-  if (typeof raw === 'string') {
-    try {
-      parsed = JSON.parse(raw)
-    } catch (e) {
-      // Never let a malformed reason take the whole message card down.
-      console.error('Could not parse contentcheck_reasons', e)
-      return []
-    }
-  }
-
-  return Array.isArray(parsed)
-    ? parsed.map((reason) => reason?.detail).filter(Boolean)
-    : []
+  return covered
 })
 
 // The origin group: the earliest arrival across the post's groups (shown as "First

--- a/iznik-nuxt3/modtools/components/ModMessageWorry.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageWorry.vue
@@ -13,30 +13,17 @@
         }}</span
         >".
       </p>
-      <p v-if="match.worryword.type === 'Regulated'">
-        This post looks as though it might contain a regulated substance. These
-        are not legal on Freegle. If in doubt please check on
-        <ExternalLink href="https://discourse.ilovefreegle.org/"
-          >Central</ExternalLink
+      <p v-if="substanceCopy(WORRY_TYPE_CATEGORY[match.worryword.type])">
+        <strong
+          >{{
+            substanceCopy(WORRY_TYPE_CATEGORY[match.worryword.type]).label
+          }}:</strong
         >
-        first.
-      </p>
-      <p v-else-if="match.worryword.type === 'Reportable'">
-        This post looks as though it might contain a reportable substance. These
-        may need to be reported to the police. Please ask the member about it,
-        and if in doubt discuss on
-        <ExternalLink href="https://discourse.ilovefreegle.org/"
+        {{ substanceCopy(WORRY_TYPE_CATEGORY[match.worryword.type]).body }} If
+        you have questions, ask on
+        <ExternalLink href="https://discourse.ilovefreegle.org/c/central/9"
           >Central</ExternalLink
         >.
-      </p>
-      <p v-else-if="match.worryword.type === 'Medicine'">
-        This post looks as though it might contain a drug, medicine or
-        supplement. These are not legal on Freegle. Please do not approve this
-        without checking on
-        <ExternalLink href="https://discourse.ilovefreegle.org/"
-          >Central</ExternalLink
-        >
-        first.
       </p>
       <p v-else>
         This post contains a keyword which means it's flagged up for review. If
@@ -48,7 +35,7 @@
     <NoticeMessage
       v-for="(reason, i) in displayedReasons"
       :key="'contentcheck-' + message.id + '-' + i"
-      variant="warning"
+      :variant="reasonVariant(reason)"
       class="mb-1"
     >
       <span v-if="reason.check === 'Vague'">
@@ -68,31 +55,13 @@
         member to remove the link.
       </span>
       <span v-else-if="reason.check === 'ConcernKeyword'">
-        <span v-if="reason.category === 'substance_regulated'">
-          <strong>Regulated substance:</strong> This post might contain a
-          regulated substance. These are not legal on Freegle. If in doubt
-          please check on
-          <ExternalLink href="https://discourse.ilovefreegle.org/">
-            Central
-          </ExternalLink>
-          first.
-        </span>
-        <span v-else-if="reason.category === 'substance_reportable'">
-          <strong>Reportable substance:</strong> This post might contain a
-          reportable substance which may need to be reported to the police.
-          Please ask the member about it, and if in doubt discuss on
-          <ExternalLink href="https://discourse.ilovefreegle.org/">
-            Central </ExternalLink
+        <span v-if="substanceCopy(reason.category)">
+          <strong>{{ substanceCopy(reason.category).label }}:</strong>
+          {{ substanceCopy(reason.category).body }} If you have questions, ask
+          on
+          <ExternalLink href="https://discourse.ilovefreegle.org/c/central/9"
+            >Central</ExternalLink
           >.
-        </span>
-        <span v-else-if="reason.category === 'substance_medicine'">
-          <strong>Medicine or drug:</strong> This post might contain a drug,
-          medicine or supplement. These are not legal on Freegle. Please do not
-          approve this without checking on
-          <ExternalLink href="https://discourse.ilovefreegle.org/">
-            Central
-          </ExternalLink>
-          first.
         </span>
         <span v-else-if="reason.category === 'scam'">
           <strong>Possible scam:</strong> This post has been flagged as a
@@ -103,13 +72,44 @@
           <strong>Flagged for review:</strong> {{ reason.detail }}. If you can't
           see anything wrong, it's fine to approve.
         </span>
+        <!-- Name the word that did it. A paint post flagged as a Medicine gave
+             no clue it was "mineral", so the category looked arbitrary and the
+             answer had to be typed out by hand on Central (Discourse #9988).
+             Only for the categorised messages above - the generic one already
+             quotes the word in its detail text. -->
+        <span v-if="reason.category && flaggedWord(reason)" class="d-block">
+          Triggered by the word "<span class="text-danger fw-bold">{{
+            flaggedWord(reason)
+          }}</span
+          >".
+        </span>
       </span>
       <span v-else-if="reason.check === 'NotAnItem'">
         <strong>Possibly not an item:</strong> {{ reason.detail }}. This may be
         a service, rental, job, or help/advice request rather than a physical
         item — please check before approving.
       </span>
-      <span v-else> <strong>Flagged:</strong> {{ reason.detail }} </span>
+      <!-- Held by a setting rather than by anything in the post. Nothing is
+           wrong with these, so they must not read like a flag - a queue that
+           says nothing at all is what prompted Discourse #9987. -->
+      <span v-else-if="reason.check === 'GroupModerated'">
+        <strong>Group setting:</strong> This group moderates all posts, whatever
+        the member's setting, so this one needs approving.
+      </span>
+      <span v-else-if="reason.check === 'MemberModerated'">
+        <strong>Member setting:</strong> This member's posts are moderated, so
+        this one needs approving.
+      </span>
+      <span v-else-if="reason.check === 'NoLocation'">
+        <strong>No location:</strong> We couldn't work out where this post is.
+        Please click <strong>Edit</strong> and add a postcode so members can
+        find it.
+      </span>
+      <!-- Same lead-in as every other flag above. It used to say just "Flagged",
+           so one post could carry both wordings for the same kind of thing. -->
+      <span v-else>
+        <strong>Flagged for review:</strong> {{ reason.detail }}
+      </span>
     </NoticeMessage>
   </div>
 </template>
@@ -131,7 +131,56 @@ const props = defineProps({
     type: Number,
     default: 0,
   },
+  /* Check names the parent is already explaining with its own notices, which know
+     the live state (where the post resolved to now, the member's current posting
+     status) where a stored reason may be out of date. Their stored copies are
+     dropped here so a moderator isn't told the same thing twice - a post with two
+     flags was showing four notices (Discourse #9989). */
+  covered: {
+    type: Array,
+    default: () => [],
+  },
 })
+
+/* Guidance for the substance categories, in one place because the same three
+   cases arrive by two routes - a real-time worry word (typed Regulated /
+   Reportable / Medicine) and a stored content check (categorised) - and used to
+   be worded differently in each, so the same post read differently depending on
+   which pass caught it. Every one ends with the same "If you have questions, ask on
+   Central", added by the template. */
+const SUBSTANCE_COPY = {
+  substance_regulated: {
+    label: 'Regulated substance',
+    body: "This post might contain a regulated substance, which isn't allowed on Freegle.",
+  },
+  substance_reportable: {
+    label: 'Reportable substance',
+    body: 'This post might contain a reportable substance, which may need to be reported to the police. Please ask the member about it.',
+  },
+  substance_medicine: {
+    label: 'Medicine or drug',
+    body: "This post might contain a drug, medicine or supplement, which isn't allowed on Freegle.",
+  },
+}
+
+/* worrywords.type names the same three cases as the stored categories. */
+const WORRY_TYPE_CATEGORY = {
+  Regulated: 'substance_regulated',
+  Reportable: 'substance_reportable',
+  Medicine: 'substance_medicine',
+}
+
+function substanceCopy(category) {
+  return SUBSTANCE_COPY[category] || null
+}
+
+/* Checks that mean "held by a setting", not "something looks wrong with this
+   post" - so they show as information rather than as a warning. */
+const SETTING_CHECKS = ['GroupModerated', 'MemberModerated']
+
+function reasonVariant(reason) {
+  return SETTING_CHECKS.includes(reason?.check) ? 'info' : 'warning'
+}
 
 const messageStore = useMessageStore()
 const message = computed(() => messageStore.byId(props.messageid))
@@ -144,10 +193,18 @@ watch(
   { immediate: true }
 )
 
+/* The word that triggered a keyword flag, as a moderator should see it. New
+   reasons carry an explicit `keyword`; older stored ones only have it quoted
+   inside the detail text. */
+function flaggedWord(reason) {
+  if (reason?.keyword) return String(reason.keyword)
+  const m = /'([^']+)'/.exec(reason?.detail || '')
+  return m ? m[1] : null
+}
+
 /* The keyword a flag is about, for de-duplication. Only the keyword-based
    checks carry one; other checks (Vague, PhoneNumber, …) return null and are
-   never de-duplicated. New reasons carry an explicit `keyword`; older stored
-   reasons are parsed from the quoted word in the detail text. */
+   never de-duplicated. */
 function reasonKeyword(reason) {
   if (
     !reason ||
@@ -155,9 +212,8 @@ function reasonKeyword(reason) {
   ) {
     return null
   }
-  if (reason.keyword) return String(reason.keyword).toLowerCase()
-  const m = /'([^']+)'/.exec(reason.detail || '')
-  return m ? m[1].toLowerCase() : null
+  const word = flaggedWord(reason)
+  return word ? word.toLowerCase() : null
 }
 
 /* Collapse reasons that name the same keyword, preferring the richer
@@ -187,17 +243,35 @@ function dedupeByKeyword(reasons) {
   return out
 }
 
+/* The API sends contentcheck_reasons as a JSON array, but tolerate a string in
+   case a caller passes the column through unparsed - and never let a malformed
+   value take the whole message card down. */
+function parseReasons(raw) {
+  if (!raw) return []
+
+  let parsed = raw
+
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw)
+    } catch (e) {
+      console.error('Could not parse contentcheck_reasons', e)
+      return []
+    }
+  }
+
+  return Array.isArray(parsed) ? parsed : []
+}
+
 /* Keywords flagged by the stored content checks on ANY group the post is on.
    Used to suppress the redundant real-time worry box once the batch has stored
    a richer reason for that keyword somewhere. */
 const allStoredKeywords = computed(() => {
   const set = new Set()
   for (const mg of message.value?.groups ?? []) {
-    if (Array.isArray(mg.contentcheck_reasons)) {
-      for (const reason of mg.contentcheck_reasons) {
-        const kw = reasonKeyword(reason)
-        if (kw) set.add(kw)
-      }
+    for (const reason of parseReasons(mg.contentcheck_reasons)) {
+      const kw = reasonKeyword(reason)
+      if (kw) set.add(kw)
     }
   }
   return set
@@ -213,24 +287,30 @@ const displayedReasons = computed(() => {
     const row = groups.find(
       (mg) => parseInt(mg.groupid) === parseInt(props.groupid)
     )
-    reasons =
-      row && Array.isArray(row.contentcheck_reasons)
-        ? row.contentcheck_reasons
-        : []
+    reasons = row ? parseReasons(row.contentcheck_reasons) : []
   } else {
     /* No group context: fall back to the first group that has reasons. */
     for (const mg of groups) {
-      if (
-        Array.isArray(mg.contentcheck_reasons) &&
-        mg.contentcheck_reasons.length
-      ) {
-        reasons = mg.contentcheck_reasons
+      const parsed = parseReasons(mg.contentcheck_reasons)
+      if (parsed.length) {
+        reasons = parsed
         break
       }
     }
   }
-  return dedupeByKeyword(reasons)
+  return dedupeByKeyword(reasons).filter(
+    (reason) => !props.covered.includes(reason?.check)
+  )
 })
+
+/* A "£" or "$" worry word and the stored Money check are the same symbol found
+   by two different passes. dedupeByKeyword can't see the overlap because the
+   Money reason names no keyword, so it needs matching on the symbol itself. */
+const MONEY_KEYWORDS = new Set(['£', '$'])
+
+const showingMoneyCheck = computed(() =>
+  displayedReasons.value.some((reason) => reason?.check === 'Money')
+)
 
 /* Real-time worry words from the Go API (message.worry), minus any keyword the
    stored content check has already flagged (shown via displayedReasons). */
@@ -240,7 +320,9 @@ const displayedWorry = computed(() => {
     const kw = match?.worryword?.keyword
       ? String(match.worryword.keyword).toLowerCase()
       : null
-    return !kw || !stored.has(kw)
+    if (!kw) return true
+    if (MONEY_KEYWORDS.has(kw) && showingMoneyCheck.value) return false
+    return !stored.has(kw)
   })
 })
 </script>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import ModMessage from '~/modtools/components/ModMessage.vue'
+// The real child, so tests can assert on what a moderator actually sees rather
+// than on the stub that hid duplicate hold reasons (Discourse 9989).
+import ModMessageWorry from '~/modtools/components/ModMessageWorry.vue'
 
 // Hoisted mocks
 const {
@@ -198,8 +201,14 @@ describe('ModMessage', () => {
     ...overrides,
   })
 
-  // Mount helper with common stubs
-  function mountComponent(props = {}, messageOverrides = {}) {
+  // Mount helper with common stubs. Pass stubOverrides to change or disable one
+  // of them - `{ ModMessageWorry: false }` mounts the real child, which is how
+  // duplicate hold-reason rendering becomes visible (Discourse 9989).
+  function mountComponent(
+    props = {},
+    messageOverrides = {},
+    stubOverrides = {}
+  ) {
     const testMessage = createTestMessage(messageOverrides)
     mockMessageStore.byId.mockReturnValue(testMessage)
     return mount(ModMessage, {
@@ -372,6 +381,11 @@ describe('ModMessage', () => {
             ],
           },
           'client-only': { template: '<div><slot /></div>' },
+          ExternalLink: {
+            template: '<a :href="href"><slot /></a>',
+            props: ['href'],
+          },
+          ...stubOverrides,
         },
         mocks: {
           datetimeshort: (val) => `formatted:${val}`,
@@ -452,7 +466,11 @@ describe('ModMessage', () => {
         {
           spamreason: 'Flagged as spam',
           groups: [
-            { groupid: 789, collection: 'Pending', spamreason: 'Flagged as spam' },
+            {
+              groupid: 789,
+              collection: 'Pending',
+              spamreason: 'Flagged as spam',
+            },
           ],
         }
       )
@@ -465,8 +483,11 @@ describe('ModMessage', () => {
   // The automated content check records WHY it left a post in the queue, but nothing
   // ever showed it. A paint post flagged on the word "mineral" looked to the moderator
   // like it had been called a medicine for no reason (Discourse 9988), and a post held
-  // purely by a moderation setting said nothing at all (9987).
+  // purely by a moderation setting said nothing at all (9987). ModMessageWorry renders
+  // these, so mount the real one rather than the stub used elsewhere in this file.
   describe('Content check hold reasons', () => {
+    const REAL_WORRY = { ModMessageWorry }
+
     it('shows the word that flagged the post', async () => {
       const wrapper = mountComponent(
         {},
@@ -486,11 +507,15 @@ describe('ModMessage', () => {
               ]),
             },
           ],
-        }
+        },
+        REAL_WORRY
       )
       await flushPromises()
-      expect(wrapper.text()).toContain('Why this is waiting for approval')
-      expect(wrapper.text()).toContain("Matched concern keyword 'mineral'")
+      const text = wrapper.text()
+      expect(text).toContain('Medicine or drug')
+      // Named once - the category alone told Emma nothing (9988), but saying it
+      // twice is what 9989 was about.
+      expect(text.split('mineral').length - 1).toBe(1)
     })
 
     it('explains a hold caused by a moderation setting', async () => {
@@ -512,7 +537,8 @@ describe('ModMessage', () => {
               ]),
             },
           ],
-        }
+        },
+        REAL_WORRY
       )
       await flushPromises()
       expect(wrapper.text()).toContain('This group moderates all posts')
@@ -527,24 +553,29 @@ describe('ModMessage', () => {
               groupid: 789,
               collection: 'Pending',
               contentcheck_reasons: [
-                { check: 'PhoneNumber', detail: 'Post contains a phone number' },
+                {
+                  check: 'PhoneNumber',
+                  detail: 'Post contains a phone number',
+                },
               ],
             },
           ],
-        }
+        },
+        REAL_WORRY
       )
       await flushPromises()
-      expect(wrapper.text()).toContain('Post contains a phone number')
+      expect(wrapper.text()).toContain('Phone number')
     })
 
     it('shows nothing when there are no reasons', async () => {
       const wrapper = mountComponent(
         {},
-        { groups: [{ groupid: 789, collection: 'Pending' }] }
+        { groups: [{ groupid: 789, collection: 'Pending' }] },
+        REAL_WORRY
       )
       await flushPromises()
-      expect(wrapper.vm.holdReasons).toEqual([])
-      expect(wrapper.text()).not.toContain('Why this is waiting for approval')
+      expect(wrapper.find('.mod-message-worry').exists()).toBe(false)
+      expect(wrapper.text()).not.toContain('Flagged')
     })
 
     it('survives malformed reasons rather than breaking the card', async () => {
@@ -561,12 +592,136 @@ describe('ModMessage', () => {
               contentcheck_reasons: 'not json at all',
             },
           ],
-        }
+        },
+        REAL_WORRY
       )
       await flushPromises()
-      expect(wrapper.vm.holdReasons).toEqual([])
-      expect(wrapper.text()).not.toContain('Why this is waiting for approval')
+      expect(wrapper.text()).toContain('OFFER: Test Item')
+      expect(wrapper.text()).not.toContain('Flagged')
       consoleError.mockRestore()
+    })
+  })
+
+  // Discourse 9989 ("All flags waving"): a post with two flags showed four notices.
+  // ModMessageWorry has rendered contentcheck_reasons since June; a second renderer
+  // was added here for the same array, plus hold-reason kinds that repeat notices
+  // this component already shows. Every test below mounts the REAL ModMessageWorry -
+  // the stub used elsewhere in this file is what hid the duplication.
+  describe('Hold reasons are explained exactly once (Discourse 9989)', () => {
+    const REAL_WORRY = { ModMessageWorry }
+
+    function occurrences(text, needle) {
+      return text.split(needle).length - 1
+    }
+
+    function mountWithReasons(reasons, extraMessage = {}, props = {}) {
+      return mountComponent(
+        props,
+        {
+          groups: [
+            {
+              groupid: 789,
+              collection: 'Pending',
+              contentcheck_reasons: reasons,
+            },
+          ],
+          ...extraMessage,
+        },
+        REAL_WORRY
+      )
+    }
+
+    it('states a flagged keyword once, not twice', async () => {
+      const wrapper = mountWithReasons([
+        {
+          check: 'ConcernKeyword',
+          category: null,
+          action: 'flag',
+          keyword: 'jewellery',
+          detail: "Matched concern keyword 'jewellery'",
+        },
+      ])
+      await flushPromises()
+      expect(occurrences(wrapper.text(), 'jewellery')).toBe(1)
+    })
+
+    it('states a money-symbol flag once across both of its sources', async () => {
+      // The stored Money check and the real-time worry word are the same "£".
+      const wrapper = mountWithReasons(
+        [{ check: 'Money', detail: 'Post contains a money symbol' }],
+        { worry: [{ worryword: { keyword: '£', type: 'Other' } }] }
+      )
+      await flushPromises()
+      const text = wrapper.text()
+      expect(occurrences(text, 'Post contains a money symbol')).toBe(1)
+      expect(text).not.toContain('Flagged for review: "£"')
+    })
+
+    it('explains a group moderation setting once, and not as a flag', async () => {
+      const wrapper = mountWithReasons([
+        {
+          check: 'GroupModerated',
+          detail:
+            "This group moderates all posts, whatever the member's setting",
+        },
+      ])
+      await flushPromises()
+      const text = wrapper.text()
+      expect(occurrences(text, 'This group moderates all posts')).toBe(1)
+      expect(text).not.toContain('Flagged: This group moderates all posts')
+    })
+
+    it('leaves the missing-location advice to the notice that already gives it', async () => {
+      const wrapper = mountWithReasons(
+        [
+          {
+            check: 'NoLocation',
+            detail:
+              'We could not work out where this post is - add a postcode before approving',
+          },
+        ],
+        { location: null, lat: 0, lng: 0 },
+        { summary: false }
+      )
+      await flushPromises()
+      const text = wrapper.text()
+      expect(text).toContain("We couldn't work out where this post is")
+      expect(text).not.toContain('add a postcode before approving')
+    })
+
+    it('drops a stale no-location reason once the post has a location', async () => {
+      // A moderator added a postcode after the check ran. Saying we don't know
+      // where a post with a visible postcode is would be worse than saying nothing.
+      const wrapper = mountWithReasons(
+        [
+          {
+            check: 'NoLocation',
+            detail:
+              'We could not work out where this post is - add a postcode before approving',
+          },
+        ],
+        { location: { lat: 54.97, lng: -1.61 } },
+        { summary: false }
+      )
+      await flushPromises()
+      const text = wrapper.text()
+      expect(text).not.toContain('add a postcode before approving')
+      expect(text).not.toContain("We couldn't work out where this post is")
+    })
+
+    it('still explains a member moderation setting when no membership is loaded', async () => {
+      // The "This member is Moderated" notice needs fromUser.memberships. Without
+      // it the stored reason is the only explanation, so it must survive (9987).
+      const wrapper = mountWithReasons([
+        {
+          check: 'MemberModerated',
+          detail: "This member's posts are moderated",
+        },
+      ])
+      await flushPromises()
+      expect(
+        occurrences(wrapper.text(), "This member's posts are moderated")
+      ).toBe(1)
     })
   })
 
@@ -677,7 +832,11 @@ describe('ModMessage', () => {
       // (0,0) and its blurred form are unresolved locations, not foreign ones -
       // they must NOT trip the scam warning (Discourse #9865).
       ['null island (0,0) is not outside UK', { lat: 0, lng: 0 }, false],
-      ['blurred null island (0.004,0) is not outside UK', { lat: 0.004, lng: 0 }, false],
+      [
+        'blurred null island (0.004,0) is not outside UK',
+        { lat: 0.004, lng: 0 },
+        false,
+      ],
     ])('%s returns %s', (_desc, location, expected) => {
       const wrapper = mountComponent({}, { location })
       expect(wrapper.vm.outsideUK).toBe(expected)
@@ -687,7 +846,11 @@ describe('ModMessage', () => {
   describe('Computed: noLocation', () => {
     it.each([
       ['real UK location', { lat: 51.5, lng: -0.1 }, false],
-      ['genuinely foreign location (New York)', { lat: 40.7, lng: -74.0 }, false],
+      [
+        'genuinely foreign location (New York)',
+        { lat: 40.7, lng: -74.0 },
+        false,
+      ],
       ['null island (0,0)', { lat: 0, lng: 0 }, true],
       ['blurred null island (0.004,0)', { lat: 0.004, lng: 0 }, true],
     ])('%s -> %s', (_desc, location, expected) => {
@@ -696,7 +859,10 @@ describe('ModMessage', () => {
     })
 
     it('is true when there is no position at all', () => {
-      const wrapper = mountComponent({}, { location: null, lat: null, lng: null })
+      const wrapper = mountComponent(
+        {},
+        { location: null, lat: null, lng: null }
+      )
       expect(wrapper.vm.noLocation).toBe(true)
     })
   })
@@ -1623,7 +1789,12 @@ describe('ModMessage', () => {
         { contextGroupid: 789 },
         {
           groups: [
-            { groupid: 999, namedisplay: 'Origin', collection: 'Approved', arrival: rippleEarlier },
+            {
+              groupid: 999,
+              namedisplay: 'Origin',
+              collection: 'Approved',
+              arrival: rippleEarlier,
+            },
             {
               groupid: 789,
               namedisplay: 'Context',
@@ -1648,7 +1819,12 @@ describe('ModMessage', () => {
         { contextGroupid: 789 },
         {
           groups: [
-            { groupid: 999, namedisplay: 'Origin', collection: 'Approved', arrival: rippleEarlier },
+            {
+              groupid: 999,
+              namedisplay: 'Origin',
+              collection: 'Approved',
+              arrival: rippleEarlier,
+            },
             {
               groupid: 789,
               namedisplay: 'Context',
@@ -1661,9 +1837,9 @@ describe('ModMessage', () => {
         }
       )
       expect(wrapper.vm.isRippledInToContextGroup).toBe(true)
-      expect(
-        wrapper.find('[data-test="ripple-proximity-note"]').exists()
-      ).toBe(false)
+      expect(wrapper.find('[data-test="ripple-proximity-note"]').exists()).toBe(
+        false
+      )
     })
 
     it('does not warn when the post has not rippled in', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
@@ -325,7 +325,7 @@ describe('ModMessageWorry', () => {
       expect(wrapper.text()).toContain('Regulated substance')
     })
 
-    it('substance_regulated: mentions not legal on Freegle', () => {
+    it('substance_regulated: says it is not allowed on Freegle', () => {
       const wrapper = mountWithReasons([
         {
           check: 'ConcernKeyword',
@@ -333,7 +333,7 @@ describe('ModMessageWorry', () => {
           detail: "Matched concern keyword 'cocaine'",
         },
       ])
-      expect(wrapper.text()).toContain('not legal on Freegle')
+      expect(wrapper.text()).toContain("isn't allowed on Freegle")
     })
 
     it('substance_regulated: links to Central', () => {
@@ -384,7 +384,7 @@ describe('ModMessageWorry', () => {
       expect(wrapper.text()).toContain('Medicine or drug')
     })
 
-    it('substance_medicine: mentions not legal on Freegle', () => {
+    it('substance_medicine: says it is not allowed on Freegle', () => {
       const wrapper = mountWithReasons([
         {
           check: 'ConcernKeyword',
@@ -392,7 +392,7 @@ describe('ModMessageWorry', () => {
           detail: "Matched concern keyword 'aspirin'",
         },
       ])
-      expect(wrapper.text()).toContain('not legal on Freegle')
+      expect(wrapper.text()).toContain("isn't allowed on Freegle")
     })
 
     it('scam: shows Possible scam heading', () => {
@@ -762,6 +762,256 @@ describe('ModMessageWorry', () => {
       }
       const wrapper = mountMessage(message, { groupid: 10 })
       expect(wrapper.findAll('.notice-message').length).toBe(1)
+    })
+  })
+
+  // This component is the only place stored hold reasons are rendered. A second
+  // renderer in ModMessage meant a post with two flags showed four notices
+  // (Discourse 9989); ModMessage now says which causes its own notices cover.
+  describe('single owner of hold reasons (Discourse 9989)', () => {
+    function mountMessage(message, props = {}) {
+      mockMessageStore.byId.mockImplementation((id) =>
+        id === message.id ? message : null
+      )
+      return mount(ModMessageWorry, {
+        props: { messageid: message.id, ...props },
+        global: { stubs: STUBS },
+      })
+    }
+
+    it('drops a reason the parent says it is already explaining', () => {
+      const wrapper = mountMessage(
+        {
+          id: 1,
+          worry: [],
+          groups: [
+            {
+              groupid: 10,
+              contentcheck_reasons: [
+                { check: 'NoLocation', detail: 'We could not work out where' },
+                { check: 'Vague', detail: 'too generic' },
+              ],
+            },
+          ],
+        },
+        { groupid: 10, covered: ['NoLocation'] }
+      )
+      const boxes = wrapper.findAll('.notice-message')
+      expect(boxes.length).toBe(1)
+      expect(wrapper.text()).toContain('Vague post')
+      expect(wrapper.text()).not.toContain('We could not work out where')
+    })
+
+    it('keeps a reason when the parent is not covering it', () => {
+      const wrapper = mountMessage(
+        {
+          id: 2,
+          worry: [],
+          groups: [
+            {
+              groupid: 10,
+              contentcheck_reasons: [
+                { check: 'MemberModerated', detail: 'moderated member' },
+              ],
+            },
+          ],
+        },
+        { groupid: 10, covered: [] }
+      )
+      expect(wrapper.text()).toContain("This member's posts are moderated")
+    })
+
+    it('shows a moderation setting as information, not as a warning', () => {
+      const wrapper = mountMessage(
+        {
+          id: 3,
+          worry: [],
+          groups: [
+            {
+              groupid: 10,
+              contentcheck_reasons: [
+                { check: 'GroupModerated', detail: 'group moderates' },
+              ],
+            },
+          ],
+        },
+        { groupid: 10 }
+      )
+      expect(wrapper.find('.notice-message.info').exists()).toBe(true)
+      expect(wrapper.find('.notice-message.warning').exists()).toBe(false)
+      expect(wrapper.text()).not.toContain('Flagged')
+    })
+
+    it('hides a money worry word when the stored Money check says the same thing', () => {
+      const wrapper = mountMessage(
+        {
+          id: 4,
+          worry: [{ worryword: { keyword: '£', type: 'Other' } }],
+          groups: [
+            {
+              groupid: 10,
+              contentcheck_reasons: [
+                { check: 'Money', detail: 'Post contains a money symbol' },
+              ],
+            },
+          ],
+        },
+        { groupid: 10 }
+      )
+      expect(wrapper.findAll('.notice-message').length).toBe(1)
+      expect(wrapper.text()).toContain('Post contains a money symbol')
+    })
+
+    it('still shows a money worry word when no stored Money check is displayed', () => {
+      const wrapper = mountMessage(
+        {
+          id: 5,
+          worry: [{ worryword: { keyword: '£', type: 'Other' } }],
+          groups: [{ groupid: 10, contentcheck_reasons: [] }],
+        },
+        { groupid: 10 }
+      )
+      expect(wrapper.text()).toContain('Flagged for review:')
+      expect(wrapper.text()).toContain('£')
+    })
+
+    it('names the word behind a categorised keyword flag (Discourse 9988)', () => {
+      const wrapper = mountMessage(
+        {
+          id: 6,
+          worry: [],
+          groups: [
+            {
+              groupid: 10,
+              contentcheck_reasons: [
+                {
+                  check: 'ConcernKeyword',
+                  category: 'substance_medicine',
+                  keyword: 'mineral',
+                  detail: "Matched concern keyword 'mineral'",
+                },
+              ],
+            },
+          ],
+        },
+        { groupid: 10 }
+      )
+      const text = wrapper.text()
+      expect(text).toContain('Medicine or drug')
+      expect(text).toContain('Triggered by the word')
+      expect(text.split('mineral').length - 1).toBe(1)
+    })
+
+    it('reads reasons that arrive as a JSON string', () => {
+      const wrapper = mountMessage(
+        {
+          id: 7,
+          worry: [],
+          groups: [
+            {
+              groupid: 10,
+              contentcheck_reasons: JSON.stringify([
+                { check: 'Vague', detail: 'too generic' },
+              ]),
+            },
+          ],
+        },
+        { groupid: 10 }
+      )
+      expect(wrapper.text()).toContain('Vague post')
+    })
+
+    it('uses one lead-in for every flag, never "Flagged" and "Flagged for review" together', () => {
+      const wrapper = mountMessage(
+        {
+          id: 9,
+          worry: [],
+          groups: [
+            {
+              groupid: 10,
+              contentcheck_reasons: [
+                {
+                  check: 'ConcernKeyword',
+                  category: null,
+                  keyword: 'jewellery',
+                  detail: "Matched concern keyword 'jewellery'",
+                },
+                {
+                  check: 'ConcernKeyword',
+                  category: 'substance_medicine',
+                  keyword: 'codeine',
+                  detail: "Matched concern keyword 'codeine'",
+                },
+                { check: 'Money', detail: 'Post contains a money symbol' },
+                { check: 'SomeFutureCheck', detail: 'something else' },
+              ],
+            },
+          ],
+        },
+        { groupid: 10 }
+      )
+      const text = wrapper.text()
+      expect(text).toContain('Flagged for review')
+      // Every "Flagged" must be part of "Flagged for review".
+      expect(text.split('Flagged').length - 1).toBe(
+        text.split('Flagged for review').length - 1
+      )
+    })
+
+    it('words the substance guidance the same whichever pass found it', () => {
+      // The stored check and the real-time worry word describe the same three
+      // substance cases and must not read differently.
+      const stored = mountMessage(
+        {
+          id: 10,
+          worry: [],
+          groups: [
+            {
+              groupid: 10,
+              contentcheck_reasons: [
+                {
+                  check: 'ConcernKeyword',
+                  category: 'substance_medicine',
+                  keyword: 'codeine',
+                  detail: "Matched concern keyword 'codeine'",
+                },
+              ],
+            },
+          ],
+        },
+        { groupid: 10 }
+      )
+      const live = mountMessage(
+        {
+          id: 11,
+          worry: [{ worryword: { keyword: 'codeine', type: 'Medicine' } }],
+          groups: [{ groupid: 10, contentcheck_reasons: [] }],
+        },
+        { groupid: 10 }
+      )
+      // Both routes must carry the identical guidance sentence. They differ only
+      // in how they name the word, which each does in its own lead-in.
+      const GUIDANCE =
+        "Medicine or drug: This post might contain a drug, medicine or supplement, which isn't allowed on Freegle. If you have questions, ask on Central."
+      const flat = (w) => w.text().replace(/\s+/g, ' ')
+      expect(flat(stored)).toContain(GUIDANCE)
+      expect(flat(live)).toContain(GUIDANCE)
+    })
+
+    it('survives a malformed reasons value rather than breaking the card', () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+      const wrapper = mountMessage(
+        {
+          id: 8,
+          worry: [],
+          groups: [{ groupid: 10, contentcheck_reasons: 'not json at all' }],
+        },
+        { groupid: 10 }
+      )
+      expect(wrapper.findAll('.notice-message').length).toBe(0)
+      consoleError.mockRestore()
     })
   })
 })


### PR DESCRIPTION
Reported on Central: https://discourse.ilovefreegle.org/t/all-flags-waving/9989

## Summary

- One pending post with two flags showed **four** notices. A `jewellery` keyword and a money symbol were each stated twice, in two different wordings.
- Regression from #1219, whose commit message says "nothing read the column". That was wrong: `ModMessageWorry` has rendered `messages_groups.contentcheck_reasons` since `783769dd6` (24 June), so #1219 added a **second renderer** of the same array.
- #1219 also added reason kinds that repeat notices `ModMessage` already shows - `MemberModerated` against "This member is Moderated", `NoLocation` against "couldn't work out where this post is". A moderated member's post with no postcode was showing **six** boxes for two causes.
- `ModMessageWorry` is now the only place a stored reason is rendered:
  - the "Why this is waiting for approval" box and its computed are gone;
  - `ModMessage` passes `covered` for what its own notices explain. `NoLocation` always - the live notice either says it better, or the stored reason is stale because a moderator has since added a postcode and it would deny knowing where a post with a visible postcode is. `MemberModerated` only when that notice really is rendering, since memberships may simply not have loaded and losing the explanation is #9987 again;
  - `GroupModerated`/`MemberModerated` render as `info`, not `warning` - a moderation setting is not something wrong with the post;
  - a stored `Money` check suppresses a `£`/`$` worry word. Same symbol, two passes; `dedupeByKeyword` can't see it because a `Money` reason names no keyword;
  - `parseReasons` keeps the JSON-string tolerance that lived in the deleted computed.
- Removing the box exposed what it was papering over: the categorised keyword branches never named the word that flagged the post - exactly Emma's #9988 report, a paint post called a Medicine with nothing saying it was "mineral". They now end with `Triggered by the word "mineral"`.

### Wording

- Everything leads with **"Flagged for review"**. A post could previously carry both that and a bare "Flagged" for the same kind of thing.
- "Please do not approve this without checking on Central first" is now "If you have questions, ask on Central", matching `ModSettingsGroup.vue` and linking the Central category rather than the Discourse root.
- The three substance messages moved into one `SUBSTANCE_COPY` map. The real-time worry word and the stored check describe the same cases and were worded differently in each, so a post read differently depending on which pass caught it.

## Code Quality Review

- One owner per explanation, rather than two components racing to describe the same row.
- The duplicated substance copy is gone, so the two routes cannot drift apart again.
- `flaggedWord` is shared by the display path and `reasonKeyword`, so parsing the word out of legacy details happens in one place.
- `covered` is a deliberately narrow contract: the parent names checks it is currently rendering, and it only ever suppresses, never adds.

## Future Improvements

- The `v-if` gating `ModMessageWorry` still tests `contentcheck_reasons` across every group while `displayedReasons` is scoped to the moderated one, so an all-covered post renders an empty wrapper div. Harmless, but the two conditions should agree.
- `ContentCheckService` stores `detail` strings that the UI mostly no longer renders. Once nothing reads them, they could become purely diagnostic.

## Test Plan

- Full unit suite via the status API: **14655 pass, 0 fail**.
- New tests mount the **real** `ModMessageWorry` inside `ModMessage` and count occurrences. `ModMessage.spec` had stubbed it with an empty template, which is why the duplication was invisible. Note VTU2 treats `{ ModMessageWorry: false }` as a component with no template - it renders nothing and passes silently, so the component itself must be passed.
- Covered: keyword stated once; money symbol once across both sources; setting shown as info and not as a flag; stale `NoLocation` dropped once the post has a location; `MemberModerated` still explained when no membership is loaded; one lead-in for every flag; identical substance wording via both routes.
- Verified in ModTools against the local database: the post from the report goes from four notices to two. Control - removing the `Money` reason brings the `£` box back, so the suppression is doing the work rather than the worry word never firing.
