### PR TITLE
fix(support): no dollar figure when the AI helper runs on a subscription

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.362
+  freegle: freegle/tests@1.1.364
 
 jobs:
   mark-ci-passed:

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -1484,6 +1484,45 @@ commands:
               exit $VITEST_EXIT_CODE
             fi
 
+  run-agent-sdk-tests:
+    description: "Run the claude-agent-sdk unit tests (node:test). Fast, no containers."
+    steps:
+      - run:
+          name: Run claude-agent-sdk unit tests
+          command: |
+            set -e
+            # These specs (guard.js SQL guard, auth.js role gate + billing mode,
+            # device-summary.js) had no CI at all - nothing under .circleci
+            # referenced claude-agent-sdk, so they only ever ran on a developer's
+            # machine. They cover the SELECT-only guard and the Support/Admin
+            # gate, which are the security controls on de-anonymised member data,
+            # so they are worth failing the build over.
+            SDK_DIR=""
+            for d in ./claude-agent-sdk "$HOME/FreegleDocker/claude-agent-sdk" "$HOME/project/claude-agent-sdk"; do
+              if [ -d "$d" ]; then SDK_DIR="$d"; break; fi
+            done
+            if [ -z "$SDK_DIR" ]; then
+              echo "Could not find claude-agent-sdk (cwd: $(pwd))"
+              exit 1
+            fi
+            SDK_DIR=$(cd "$SDK_DIR" && pwd)
+            echo "Using $SDK_DIR"
+
+            # The tested modules require nothing outside Node's stdlib, so there is
+            # no npm install here - verified by running with node_modules removed.
+            # Prefer the runner's own Node; Katapult VMs may not have one, so fall
+            # back to a container rather than installing a toolchain.
+            if command -v node >/dev/null 2>&1 && \
+               node -e 'process.exit(Number(process.versions.node.split(".")[0]) >= 20 ? 0 : 1)' 2>/dev/null; then
+              echo "Running with host node $(node --version)"
+              cd "$SDK_DIR"
+              node --test
+            else
+              echo "No suitable host Node (need >= 20) - running in node:22-alpine"
+              docker run --rm -v "$SDK_DIR":/app -w /app node:22-alpine node --test
+            fi
+            echo "claude-agent-sdk unit tests passed"
+
   run-playwright-tests:
     description: "Run Playwright tests via the status service API and upload coverage"
     parameters:
@@ -2297,6 +2336,10 @@ jobs:
             # ModTools is now built from iznik-nuxt3/modtools (same repo, different build)
             echo "=== Verifying modtools directory ==="
             ls -la iznik-nuxt3/modtools/Dockerfile* || echo "WARNING: modtools/Dockerfile files not found"
+
+      # Cheap, container-free, and covers the SQL guard and role gate on the AI
+      # support helper - run before anything expensive starts.
+      - run-agent-sdk-tests
 
       - run:
           name: Determine changed paths

--- a/claude-agent-sdk/auth.js
+++ b/claude-agent-sdk/auth.js
@@ -103,6 +103,27 @@ function driverMode() {
 }
 
 /**
+ * What this query actually costs, given how the SDK is authenticated.
+ *
+ * The SDK always reports a `total_cost_usd`, but that is a notional token price
+ * worked out from the model's list rates - it is only what anyone is charged in
+ * 'api' mode. Both 'subscription' (a `claude setup-token` OAuth token) and
+ * 'session' (a mounted ~/.claude login) run against a Claude subscription that
+ * is paid for monthly, so nothing is billed per query and showing a dollar
+ * figure is meaningless, and alarming to whoever is reading it.
+ *
+ * This used to test for 'session' alone, so the helper reported a cost on a
+ * subscription - the one case the comment was trying to exclude.
+ *
+ * @param {'api'|'subscription'|'session'} mode from driverMode()
+ * @param {number} sdkCostUsd the SDK's total_cost_usd
+ * @returns {number} dollars actually billed for this query
+ */
+function billableCostUsd(mode, sdkCostUsd) {
+  return mode === 'api' ? sdkCostUsd || 0 : 0
+}
+
+/**
  * Make the subscription token win. When a `claude setup-token` OAuth token is present,
  * remove ANTHROPIC_API_KEY from the environment so the Claude Agent SDK / CLI authenticates
  * with the subscription instead of silently billing the metered API (which it does whenever
@@ -117,4 +138,12 @@ function preferSubscriptionToken() {
   return false
 }
 
-module.exports = { verifyModerator, extractJWT, driverMode, preferSubscriptionToken, FREEGLE_API_URL, SUPPORT_ROLES }
+module.exports = {
+  verifyModerator,
+  extractJWT,
+  driverMode,
+  preferSubscriptionToken,
+  billableCostUsd,
+  FREEGLE_API_URL,
+  SUPPORT_ROLES,
+}

--- a/claude-agent-sdk/cost.test.js
+++ b/claude-agent-sdk/cost.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { billableCostUsd } = require('./auth')
+
+// The SDK reports a notional total_cost_usd on every query, worked out from the
+// model's list rates. Only 'api' mode is actually metered - 'subscription' (a
+// `claude setup-token` OAuth token) and 'session' (a mounted ~/.claude login)
+// both run against a monthly Claude subscription where no per-query charge
+// exists. Reporting one there is meaningless and alarming.
+//
+// The check used to be `mode === 'session' ? 0 : cost`, which reported a cost on
+// a subscription - the very case it meant to exclude.
+
+test('a metered API key is billed the SDK cost', () => {
+  assert.strictEqual(billableCostUsd('api', 0.0123), 0.0123)
+})
+
+test('a subscription is never billed per query', () => {
+  assert.strictEqual(billableCostUsd('subscription', 0.0123), 0)
+})
+
+test('a mounted login session is never billed per query', () => {
+  assert.strictEqual(billableCostUsd('session', 0.0123), 0)
+})
+
+test('a missing or zero SDK cost reports 0 rather than undefined or NaN', () => {
+  for (const mode of ['api', 'subscription', 'session']) {
+    assert.strictEqual(billableCostUsd(mode, undefined), 0, mode)
+    assert.strictEqual(billableCostUsd(mode, null), 0, mode)
+    assert.strictEqual(billableCostUsd(mode, 0), 0, mode)
+  }
+})
+
+test('an unrecognised mode is treated as not billable, not as metered', () => {
+  // Fail safe: a new driver mode should not start showing dollar figures until
+  // someone decides it genuinely is metered.
+  assert.strictEqual(billableCostUsd('something-new', 0.5), 0)
+  assert.strictEqual(billableCostUsd(undefined, 0.5), 0)
+})

--- a/claude-agent-sdk/support-agent.js
+++ b/claude-agent-sdk/support-agent.js
@@ -10,13 +10,14 @@
 
 const { query, createSdkMcpServer } = require('@anthropic-ai/claude-agent-sdk')
 const { buildTools, audit } = require('./tools')
-const { driverMode } = require('./auth')
+const { driverMode, billableCostUsd } = require('./auth')
 
 // Use an unpinned alias, not a dated snapshot: snapshots get retired and then
 // the SDK 404s on the model. On the Claude subscription (session mode) we can
 // use Opus. Override with SUPPORT_AI_MODEL if needed.
 const MODEL = process.env.SUPPORT_AI_MODEL || 'opus'
 const CODEBASE = process.env.CODEBASE_DIR || '/app/codebase'
+
 
 
 function systemPrompt(userId) {
@@ -195,10 +196,7 @@ async function runSupportQuery({ query: userQuery, userId, jwt, agentSessionId, 
       } else if (message.type === 'result') {
         if (message.subtype === 'success') {
           analysis = message.result || ''
-          // Session mode runs on the Claude subscription — there is no per-query
-          // API charge, so report $0 rather than the SDK's notional token cost.
-          costUsd =
-            driverMode() === 'session' ? 0 : message.total_cost_usd || 0
+          costUsd = billableCostUsd(driverMode(), message.total_cost_usd)
           usage = {
             inputTokens: message.usage?.input_tokens || 0,
             outputTokens: message.usage?.output_tokens || 0,

--- a/iznik-nuxt3/modtools/components/ModSupportAIAssistant.vue
+++ b/iznik-nuxt3/modtools/components/ModSupportAIAssistant.vue
@@ -39,12 +39,26 @@
       >
         <div class="d-flex align-items-center flex-wrap">
           <strong>AI Support Helper</strong>
-          <span v-if="totalCost > 0" class="session-cost ms-2">
-            Session: ${{ totalCost.toFixed(4) }}
+          <!-- On a Claude subscription nothing is billed per query, so the
+               server reports a cost of 0 and no money is shown. The token
+               counts are still worth having, so they no longer hang off the
+               cost being non-zero. -->
+          <span
+            v-if="
+              totalCost > 0 ||
+              totalTokens.inputTokens ||
+              totalTokens.outputTokens
+            "
+            class="session-cost ms-2"
+          >
+            <template v-if="totalCost > 0">
+              Session: ${{ totalCost.toFixed(4) }}
+            </template>
             <template
               v-if="totalTokens.inputTokens || totalTokens.outputTokens"
             >
-              &middot; {{ formatTokenCounts(totalTokens) }}
+              <template v-if="totalCost > 0">&middot; </template>
+              {{ formatTokenCounts(totalTokens) }}
             </template>
           </span>
           <div
@@ -196,10 +210,11 @@
           class="text-muted small"
         >
           <template v-if="deviceSummary?.lastApiActivity">
-            Active on the server side {{ formatLastSeen(deviceSummary.lastApiActivity) }},
-            but their device sends no telemetry &mdash; usually an ad/tracker
-            blocker, or an app from before client logging. Device details
-            aren't available for this member.
+            Active on the server side
+            {{ formatLastSeen(deviceSummary.lastApiActivity) }}, but their
+            device sends no telemetry &mdash; usually an ad/tracker blocker, or
+            an app from before client logging. Device details aren't available
+            for this member.
           </template>
           <template v-else>
             No device sessions found in the last 7 days.

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSupportAIAssistant.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSupportAIAssistant.spec.js
@@ -716,6 +716,43 @@ describe('ModSupportAIAssistant', () => {
 
       expect(wrapper.text()).toContain('100 in / 50 out tokens')
     })
+
+    // On a Claude subscription nothing is billed per query, so the server sends
+    // a cost of 0. Showing "$0.0000" - or a dollar figure at all - is meaningless
+    // and alarming, but the token counts are still useful.
+    it('shows no money at all when the cost is zero', async () => {
+      const wrapper = mountComponent()
+
+      wrapper.vm.messages = [
+        {
+          role: 'assistant',
+          content: 'test',
+          costUsd: 0,
+          usage: { inputTokens: 100, outputTokens: 50 },
+        },
+      ]
+      await nextTick()
+
+      expect(wrapper.text()).not.toContain('Session: $')
+      expect(wrapper.text()).not.toContain('$0.0000')
+      expect(wrapper.text()).toContain('100 in / 50 out tokens')
+    })
+
+    it('still shows token totals when no cost is reported at all', async () => {
+      const wrapper = mountComponent()
+
+      wrapper.vm.messages = [
+        {
+          role: 'assistant',
+          content: 'test',
+          usage: { inputTokens: 20, outputTokens: 7 },
+        },
+      ]
+      await nextTick()
+
+      expect(wrapper.text()).not.toContain('Session: $')
+      expect(wrapper.text()).toContain('20 in / 7 out tokens')
+    })
   })
 
   describe('follow-up input', () => {


### PR DESCRIPTION
## Summary

The AI Support Helper showed a dollar figure per query and a running session total even when it was authenticated against a Claude subscription, where nothing is billed per query. The number is the SDK's notional token price, so it was both meaningless and alarming.

The code meant to handle this and got the condition wrong:

```js
// Session mode runs on the Claude subscription - there is no per-query
// API charge, so report $0 rather than the SDK's notional token cost.
costUsd = driverMode() === 'session' ? 0 : message.total_cost_usd || 0
```

`driverMode()` returns three values (`auth.js`): `'api'` when only `ANTHROPIC_API_KEY` is set (metered), `'subscription'` when a `claude setup-token` OAuth token is set (Max/Pro subscription billing), and `'session'` for a mounted `~/.claude` login. Only `'session'` was zeroed, so the one mode actually named "subscription" still displayed a price - the case the comment was trying to exclude.

- Inverted the test: only `'api'` is metered, so only `'api'` reports a cost. Extracted as `billableCostUsd(mode, sdkCostUsd)` in `auth.js`, next to `driverMode()` which it depends on, so the decision is one named, tested function rather than an inline ternary.
- An unrecognised mode now reports 0 rather than a price, so a future driver mode cannot start showing dollar figures until someone decides it genuinely is metered.
- The header badge previously hid the session token totals along with the cost, because both sat behind `v-if="totalCost > 0"`. Tokens are still useful on a subscription, so they now show on their own and only the money disappears.

## Code Quality Review

- `billableCostUsd` lives in `auth.js` because that module already owns `driverMode()` and the subscription-vs-metered distinction. It also has no heavy dependencies, so it is unit-testable outside the container - `support-agent.js` pulls in `tools.js`, which requires `mysql2`, and cannot be loaded in a bare checkout.
- The per-message cost line already handled a zero cost correctly (`v-if="msg.costUsd"`), so only the session badge needed changing.
- No change to what the server returns beyond the value itself: `costUsd` is still always present in the response shape.

## Future Improvements

- `support-agent.js` still has no tests of its own for the same dependency reason. Extracting the remaining pure decisions the way this PR did for the cost would make them reachable.

## Test Plan

- `claude-agent-sdk`: `node --test` - **42 pass, 0 fail**, including 5 new cases in `cost.test.js` covering a metered key (billed), a subscription (never billed), a mounted session (never billed), missing/zero/null SDK costs (0, never `undefined` or `NaN`), and an unrecognised mode (not billable).
- Frontend unit suite via the status API: **full suite pass**, including two new cases - no money shown at all when the cost is zero (asserting neither `Session: $` nor `$0.0000` appears) while the token counts still render, and token totals still shown when no cost is reported at all.

---

## CI: these tests now actually run (`2361f7498`)

`claude-agent-sdk` had no CI at all, so `auth.test.js`, `guard.test.js` and `device-summary.test.js` had never run in CI - and neither would the cost test added here. Between them they cover `guard.js` (SELECT-only enforcement, comment-stripping, the DANGEROUS-keyword and auth-secret denylists, the LIMIT cap) and `auth.js` (the Support/Admin gate that keeps plain Moderators out of de-anonymised member data), which are the security controls on this tool.

- New `run-agent-sdk-tests` orb command, wired into `build-and-test` straight after the subtree check and before `setup-dependencies`, so it fails fast without waiting on a container.
- No `npm install`. The tested modules require nothing outside Node's stdlib - verified by running the suite with `node_modules` moved away (37 pass). It uses the runner's Node when that is 20+, else `node:22-alpine`, since a Katapult VM may not have Node on the host.
- Published as `freegle/tests@1.1.364` and pinned in `continue-config.yml`, which was still on `1.1.362`.

Verified before publishing:
- `circleci orb validate` passes.
- The step's script, extracted from the YAML and run from a repo root exactly as CI would, passes 37 tests.
- With a deliberately failing test dropped in, it exits **1** - so a red suite really does fail the build, rather than the step only being able to go green.
