### PR TITLE
fix(tests): stop the two remaining coverage flippers

### DIFF
--- a/iznik-batch/tests/Unit/Services/AutoRepostServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AutoRepostServiceTest.php
@@ -654,6 +654,65 @@ class AutoRepostServiceTest extends TestCase
     }
 
     /**
+     * A rippled-in row that reaches the WARNING window is skipped, not warned.
+     *
+     * The test above exercises the same branch only by luck: it gives the home group a row
+     * in the window too, and process() iterates groups with inRandomOrder() (V1 ORDER BY
+     * RAND()). When home happens to go first it stamps lastautopostwarning on every row of
+     * the message, so the rippled rows arrive with lastwarnago ~0, fail the outer window
+     * condition and never reach the rippled_in skip at all — one ordering in three. That
+     * makes coverage of that line a dice roll, and it has repeatedly failed Coveralls on
+     * branches that touch no PHP whatsoever.
+     *
+     * Here only the rippled row is in the window: the home row is fresh, so nothing can
+     * stamp it first and no ordering can dodge the branch.
+     */
+    public function test_rippled_in_row_in_warning_window_is_skipped_not_warned(): void
+    {
+        $domain = config('freegle.mail.user_domain', 'users.ilovefreegle.org');
+        $user = $this->createTestUser();
+        $home = $this->createTestGroup();
+        $rippled = $this->createTestGroup();
+
+        DB::table('users')->where('id', $user->id)->update(['lastaccess' => now()->subHours(1)]);
+        $this->createMembership($user, $home, ['added' => now()->subDays(30)]);
+        $this->createMembership($user, $rippled, ['added' => now()->subDays(30)]);
+
+        $message = $this->createTestMessage($user, $home, [
+            'type' => 'Offer',
+            'fromaddr' => 'test-' . $user->id . '@' . $domain,
+            'source' => Message::SOURCE_PLATFORM,
+        ]);
+
+        // Home posting fresh: outside both the warning and repost windows, so it cannot
+        // stamp lastautopostwarning regardless of the order groups are processed in.
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $home->id)
+            ->update(['arrival' => now()->subHours(1), 'autoreposts' => 0, 'rippled_in' => 0]);
+
+        // Rippled-in posting inside the warning window (offer interval 3d => 48-72h).
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id,
+            'groupid' => $rippled->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subHours(50),
+            'autoreposts' => 0,
+            'rippled_in' => 1,
+        ]);
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(0, $stats['warned'], 'a rippled-in row must never warn on its own');
+        $this->assertEquals(0, $stats['reposted'], 'still mid-window, nothing to repost yet');
+        $this->assertGreaterThan(0, $stats['skipped'], 'the rippled-in row must be counted as skipped');
+
+        // Nothing stamped, because no reminder was sent for it.
+        $mgRippled = DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $rippled->id)->first();
+        $this->assertNull($mgRippled->lastautopostwarning);
+    }
+
+    /**
      * Rippling-out: a rippled-in posting (rippled_in=1) is still reposted on its group to
      * keep the item fresh there, but it never generates its own repost reminder email.
      */

--- a/iznik-nuxt3/components/LoginModal.vue
+++ b/iznik-nuxt3/components/LoginModal.vue
@@ -478,6 +478,16 @@ function loginNative(e) {
       })
       .then(() => {
         // We are now logged in. Prompt the browser to remember the credentials.
+        //
+        // This arm is a race: it runs only when a login is submitted before the
+        // async email validation has come back, so whether an end-to-end run
+        // reaches it depends on which of the two wins on the day. Per-line
+        // coverage confirms it - these lines read 0 in one Playwright job and 2
+        // in another, which is the whole 33-vs-38 swing on this file and enough
+        // to fail Coveralls on branches that change nothing here. The 0 also
+        // proves the unit tests never reach it, so excluding it costs nothing
+        // there. Same treatment as SpinButton.vue's timer line (PR #910).
+        /* v8 ignore start */
         if (window.PasswordCredential) {
           try {
             // We used to pass in the DOM element, but in Chrome 92 that causes a crash.
@@ -501,6 +511,7 @@ function loginNative(e) {
         } else {
           pleaseShowModal.value = false
         }
+        /* v8 ignore stop */
       })
       .catch((e) => {
         console.log('Login error', e)


### PR DESCRIPTION
## Summary

`AutoRepostService.php` flips between **171/180 and 172/180** run to run, which fails `Coveralls - laravel` on branches that touch no PHP at all - most recently on one whose only changes were a Node backend and a CI config.

The line is `$stats['skipped']++` in the `if ($msg->rippled_in)` arm of the warning window (`AutoRepostService.php:207`).

The existing test that reaches it (`test_rippled_item_warns_once_across_groups`) gives the **home** group a row in the window as well, and `process()` iterates groups with `inRandomOrder()` (V1 `ORDER BY RAND()`):

- home processed **first** - it stamps `lastautopostwarning` on every row of the message, so the rippled rows then arrive with `lastwarnago ~0`, fail the outer window condition, and never reach the `rippled_in` branch at all;
- a rippled group processed **first** - its row is unstamped, `lastwarnago` is null, the branch is reached.

With three groups that is roughly one ordering in three, so the line is a dice roll. A previous fix (#1011) added a second `process()` pass, which made the `lastwarnago` computation deterministic but not this branch.

This adds a test where **only** the rippled-in row is in the window and the home row is fresh, so nothing can stamp it first and no ordering can dodge the branch.

It also states the behaviour the old test only implied: a rippled-in row inside the warning window is skipped and never warns on its own, and nothing is stamped because no reminder went out.

## Code Quality Review

- No production change - this is a test-only fix for a test-only defect.
- The new test is not a duplicate: the existing rippled-in test puts the rippled row at 80h (past the repost window), so it exercises the `elseif` repost path, not the warning-window skip.
- It asserts the behaviour, not just the line: `warned` is 0, `reposted` is 0, `skipped` is non-zero, and `lastautopostwarning` is left null.

## Future Improvements

- `inRandomOrder()` faithfully mirrors V1, so it is worth keeping, but it makes every per-group branch's coverage order-dependent. Tests that care about a specific branch should isolate it to one group rather than relying on the draw, which is what this one does.
- `components/ProxyImage.vue` moved once (6/10 vs 8/10) but not between the two master runs, so it may be a smaller third flipper. Left alone rather than excluded on a single observation.

## Also here: the LoginModal race (`027a8a8b3`)

`LoginModal.vue` swings between **33/135 and 38/135** between Playwright jobs - the largest single contributor left after `GeneratedAvatar`, and enough on its own to fail Coveralls on a branch that changes nothing it measures.

The lines are pinned, not guessed. The job-level `source.json` endpoint 404s and CircleCI keeps no Playwright lcov (only Go and Laravel), but the **build-level** `source.json` does return per-line hits, so diffing a low build against a high one for this file names them exactly: **481, 482, 484, 488, 494** read `0` in one and `2` in the other - the whole 5-line delta.

They are the `PasswordCredential` block inside the `!emailValid` arm: the path taken only when a login is submitted *before* the async email validation has come back. Whether a run gets there is a race between the two.

Worth recording what it is **not**. My first guess was the three `setTimeout` bodies (3s `timerElapsed`, recursive 500ms `bumpIt`, 1s Facebook SDK loader). Per-line data shows those read `0` in **both** builds - permanently uncovered, so they cannot be what moves. Guessing would have excluded the wrong lines and left the flip in place.

The `0` in the low build is across all jobs, so the unit tests never reach this arm either and excluding it costs nothing there - unlike the `GeneratedAvatar` attempt on the previous branch, where the lines were fully unit-covered and ignoring them cost real coverage.

## Test Plan

- `AutoRepostServiceTest` via the status API: **33 tests, 69 assertions, all pass**.
- The new test reaches the branch regardless of ordering: with the home row fresh there is no ordering in which the rippled row arrives stamped.
- Frontend unit suite via the status API after the LoginModal change: **14639 pass, 0 fail** - the same count as before it, since the change is a coverage comment only.
