### PR TITLE
fix(push): decode emoji in chat push notifications

### DIFF
--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -6,6 +6,7 @@ use App\Models\ChatRoom;
 use App\Models\User;
 use App\Services\LokiService;
 use App\Services\Ripple\RippleReplyService;
+use App\Support\EmojiUtils;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Kreait\Firebase\Factory;
@@ -1116,7 +1117,14 @@ class PushNotificationService
 
         $title = $this->resolveChatPushTitle($row);
 
-        $message = $row->message ?? '';
+        // Emoji are stored in the twem encoding the front end writes - a smile is
+        // the literal text \\u1f642\\u - so an undecoded body reaches the phone as
+        // "I'll delete it for you \\u1f642\\u". The email path for this very same
+        // column already decodes (ChatNotification), push did not. Decode BEFORE
+        // truncating: cutting at 256 could otherwise slice an escape in half and
+        // leave a fragment like \\u1f6 on screen, and the decoded text is what the
+        // member actually sees, so it is what the limit should apply to.
+        $message = EmojiUtils::decodeEmojis($row->message ?? '');
         if (mb_strlen($message) > 256) {
             $message = mb_substr($message, 0, 253) . '...';
         }

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -1043,6 +1043,74 @@ class PushNotificationServiceTest extends TestCase
         $this->assertEquals('1', (string) $payload['modtools']);
     }
 
+    /**
+     * Emoji reached the phone as raw twem escapes: a member saw
+     * "No worries, I'll delete it for you \\u1f642\\u" in a push. The front end
+     * stores emoji that way (untwem in useTwem.js) and the email path for this
+     * same column already decodes it; only push did not.
+     */
+    public function test_chat_payload_decodes_emoji(): void
+    {
+        $sender = $this->createTestUser(['fullname' => 'Alice']);
+        $recipient = $this->createTestUser();
+        $room = $this->createTestChatRoom($sender, $recipient);
+        $msg = $this->createTestChatMessage($room, $sender, [
+            'message' => "No worries, I'll delete it for you \\\\u1f642\\\\u",
+        ]);
+
+        $payload = $this->service->buildChatMessagePayload($msg->id, $recipient->id, FALSE);
+
+        $this->assertStringContainsString("\u{1F642}", $payload['message'],
+            'the emoji itself must reach the phone');
+        $this->assertStringNotContainsString('1f642', $payload['message'],
+            'no raw codepoint may survive');
+        $this->assertStringNotContainsString('\\u', $payload['message'],
+            'no twem escape markers may survive');
+    }
+
+    public function test_chat_payload_decodes_multi_codepoint_emoji(): void
+    {
+        // Flags and ZWJ sequences encode as several codepoints joined by '-'.
+        $sender = $this->createTestUser(['fullname' => 'Alice']);
+        $recipient = $this->createTestUser();
+        $room = $this->createTestChatRoom($sender, $recipient);
+        $msg = $this->createTestChatMessage($room, $sender, [
+            'message' => "Flag \\\\u1f1ec-1f1e7\\\\u",
+        ]);
+
+        $payload = $this->service->buildChatMessagePayload($msg->id, $recipient->id, FALSE);
+
+        $this->assertStringContainsString("\u{1F1EC}\u{1F1E7}", $payload['message']);
+        $this->assertStringNotContainsString('1f1ec', $payload['message']);
+    }
+
+    /**
+     * Decoding must happen BEFORE the 256-char truncation. Truncating the encoded
+     * form could cut an escape in half and leave a fragment like "\\u1f6" on screen,
+     * and the limit should apply to what the member actually sees.
+     */
+    public function test_chat_payload_truncates_after_decoding_so_no_escape_is_severed(): void
+    {
+        $sender = $this->createTestUser(['fullname' => 'Alice']);
+        $recipient = $this->createTestUser();
+        $room = $this->createTestChatRoom($sender, $recipient);
+
+        // Pad so that an emoji sits right around the 256-char boundary of the
+        // ENCODED string but well inside it once decoded.
+        $padding = str_repeat('a', 250);
+        $msg = $this->createTestChatMessage($room, $sender, [
+            'message' => $padding . "\\\\u1f642\\\\u tail",
+        ]);
+
+        $payload = $this->service->buildChatMessagePayload($msg->id, $recipient->id, FALSE);
+
+        $this->assertStringNotContainsString('\\u', $payload['message'],
+            'a severed escape must never appear');
+        $this->assertStringContainsString("\u{1F642}", $payload['message'],
+            'the emoji survives because decoding happens first');
+        $this->assertLessThanOrEqual(256, mb_strlen($payload['message']));
+    }
+
     public function test_chat_payload_uses_chatid_as_notid(): void
     {
         // V1: notId = chatid so a second message in the same chat REPLACES


### PR DESCRIPTION
## Summary

A member's phone showed:

> No worries, I'll delete it for you `\\u1f642\\u`

The front end stores emoji in its own encoding (`untwem` in `iznik-nuxt3/composables/useTwem.js`): 🙂 becomes the literal text `\\u1f642\\u` in `chat_messages.message`, and `twem()` turns it back for display.

`PushNotificationService::buildChatMessagePayload()` read that column straight into the FCM body without decoding, so the escape travelled all the way to the notification shade.

The decoder already exists and is already applied to the **same column** on the email path - `EmojiUtils::decodeEmojis()`, called from `ChatNotification.php:876` and `UnifiedDigest.php:956`. Push was simply never wired to it. One import, one call.

**Decoding happens before the 256-character truncation, not after.** Truncating the encoded form can slice an escape in half and leave a fragment like `\\u1f6` on screen, and the limit should apply to the text the member actually sees - an emoji costs 11 characters encoded and 1 decoded.

Covers both apps: the same builder serves the Freegle and ModTools chat pushes (`buildChatMessagePayload($msg, $recipient, $modtools)`).

## Code Quality Review

- Reuses the existing shared helper rather than adding a second decoder; the encoding grammar (including multi-codepoint sequences joined by `-`) is defined in exactly one place in PHP.
- Ordering with respect to truncation is deliberate and has its own test, so a later refactor that moves the decode after the cut will fail rather than silently regress.
- No change to the payload shape - `message` is still always present.

## Future Improvements

- The aggregate badge push (`buildUserNotificationPayload`) reads `users_notifications.text` at line 353 without decoding. Nothing currently writes emoji-bearing text to that column - the Go inserts never set `title`/`text` - so it cannot misfire today, but it is the same shape of latent bug and would be worth decoding defensively if that column ever carries member-authored text.
- Go has no decoder, only a stripper (`chat/chatroom.go:1353` `splitEmoji`, which removes non-emoji text for the chat-list snippet and relies on the client running `twem()`). If push text ever moves to Go, it will need a port of `EmojiUtils::decodeEmojis`.

## Test Plan

- `PushNotificationServiceTest` via the status API: **50 tests, 97 assertions, all pass**.
- Three new tests, each **verified to fail without the fix and pass with it** (I reverted the one-line change and re-ran to confirm - all three failed, `Tests: 50, Failures: 3`):
  - a single emoji decodes, with no raw `1f642` and no `\\u` markers surviving;
  - a multi-codepoint sequence decodes (flags and ZWJ encode as `hex-hex`);
  - padding to the truncation boundary proves no severed escape can appear and the emoji still survives.
