### PR TITLE
fix(chat): give the mobile profile card a close button

### DIFF
--- a/iznik-nuxt3/components/ChatMobileNavbar.vue
+++ b/iznik-nuxt3/components/ChatMobileNavbar.vue
@@ -57,6 +57,22 @@
       manual
     >
       <div v-if="otheruser && otheruser.info" class="profile-card-content">
+        <!-- Until this was here the card could only be dismissed by tapping the
+             avatar again, taking one of the actions, or scrolling the thread -
+             none of which look like a way out, so it read as stuck open.
+             Hidden while the first-visit hint is up: "Got it" already closes the
+             whole card (dismissHint), so a second control there would only
+             overlap it. -->
+        <button
+          v-if="!showProfileHint"
+          class="profile-card-close"
+          type="button"
+          aria-label="Close profile info"
+          title="Close"
+          @click="profileCardExpanded = false"
+        >
+          <v-icon icon="times" />
+        </button>
         <!-- Hint tip for first-time visitors -->
         <div v-if="showProfileHint" class="profile-hint-tip">
           <span>Tap here to show profile info.</span>
@@ -612,12 +628,44 @@ onBeforeUnmount(() => {
 }
 
 .profile-card-content {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 12px;
   padding-bottom: 12px;
   border-bottom: 1px solid $color-gray--lighter;
   margin-bottom: 10px;
+}
+
+/* Top-right of the card. 44px is the minimum comfortable touch target, which
+   matters more here than on desktop - this popover only exists below md. Given
+   a solid background and a border so it reads as a control rather than as a
+   stray glyph, and stacked above the first-visit hint tip, which it would
+   otherwise sit on top of unnoticed. */
+.profile-card-close {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid $color-gray--light;
+  border-radius: 50%;
+  background-color: white;
+  color: $color-gray--darker;
+  font-size: 1.1rem;
+  line-height: 1;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+.profile-card-close:hover,
+.profile-card-close:focus {
+  background-color: $color-gray--lighter;
+  color: black;
 }
 
 .profile-card-main {

--- a/iznik-nuxt3/tests/unit/components/ChatMobileNavbar.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMobileNavbar.spec.js
@@ -30,6 +30,43 @@ describe('profile popover hidden for User2Mod (Discourse 9918)', () => {
   })
 })
 
+// The profile card could only be dismissed by tapping the avatar again, taking
+// one of its actions, or scrolling the thread. None of those look like a way
+// out, so the card read as stuck open on a phone - and this navbar is the only
+// chat header below md, so there was no other affordance.
+describe('profile card close button', () => {
+  it('has a close control that collapses the card', () => {
+    expect(navbarSource).toMatch(/class="profile-card-close"/)
+    expect(navbarSource).toMatch(
+      /class="profile-card-close"[\s\S]*?@click="profileCardExpanded = false"/
+    )
+  })
+
+  it('gives the close control an accessible name', () => {
+    expect(navbarSource).toMatch(
+      /class="profile-card-close"[\s\S]*?aria-label="Close profile info"/
+    )
+  })
+
+  it('hides the close control while the first-visit hint is showing', () => {
+    // dismissHint() already sets profileCardExpanded = false, so "Got it"
+    // closes the whole card; a second control there would only overlap it.
+    expect(navbarSource).toMatch(
+      /<button\s+v-if="!showProfileHint"\s+class="profile-card-close"/
+    )
+    expect(navbarSource).toMatch(
+      /function dismissHint\(\)[\s\S]*?profileCardExpanded\.value = false/
+    )
+  })
+
+  it('sizes the close control as a comfortable touch target', () => {
+    // This popover only exists below md, so it is always touched, never clicked.
+    expect(navbarSource).toMatch(
+      /\.profile-card-close\s*\{[\s\S]*?width:\s*44px[\s\S]*?height:\s*44px/
+    )
+  })
+})
+
 describe('ChatMobileNavbar', () => {
   describe('component structure', () => {
     it('is a mobile navbar for chat pages', () => {


### PR DESCRIPTION
## Summary

Tapping the avatar in a chat drops down a profile card - ratings, last seen, and the Profile / Hide / Block / Report row. There was no way out of it that looked like a way out. It closed only by:

- tapping the avatar again,
- taking one of its actions, or
- scrolling the thread past 50px.

None of those read as "close", so the card looked stuck open. Below `md` this navbar **is** the chat header - `ChatPane.vue` renders `ChatHeader` for md+ only - so there was no other affordance either.

Adds a close button in the top-right of the card:

- **44px**, because this popover only exists below `md`, so it is always touched and never clicked;
- white background, border and shadow, so it reads as a control rather than as a stray glyph sitting on the card;
- `aria-label="Close profile info"`.

**Hidden while the first-visit hint is showing.** `dismissHint()` already sets `profileCardExpanded = false`, so "Got it" closes the whole card - a second control there is redundant, and it landed directly on top of the "Got it" button, which is how it looked before I gated it.

## Code Quality Review

- Sets `profileCardExpanded = false` directly, the same thing every other dismissal path in this component does; no new state.
- `position: relative` added to `.profile-card-content` so the absolute positioning is anchored to the card rather than to whatever ancestor happened to be positioned.
- Colours come from the existing palette. Worth noting: my first draft used `$colour-info-fg`, which does not exist - the variable is `$color-info-fg`. An undefined SCSS variable breaks the page build, so I checked `_color-vars.scss` and switched to `$color-gray--darker`, then confirmed the container compiled the style with no error.

## Future Improvements

- The card also closes on a 50px scroll (`profileCardExpanded = false` in the scroll handler). That is reasonable, but combined with the close button it now has four dismissal routes; the scroll one could arguably go.
- `ChatHeader.vue` has the mirror-image problem on desktop: its collapse control sits inside a `d-none d-md-flex` row and contains a `d-block d-md-none` icon that can therefore never render. It is dead markup rather than a user-visible bug, since ChatHeader is desktop-only, but it is misleading and worth tidying.

## Test Plan

- Full unit suite via the status API: **14701 pass, 0 fail**.
- Four new tests, each **verified to fail against the current component and pass with this one** (reverted the component in the runner and re-ran: `53 passed, 4 failed`): the close control exists and collapses the card, it has an accessible name, it is absent while the hint is up, and it is sized as a touch target.
- Verified against the running app at a 375px viewport, not only in units: the card opens, the button is **44x44** with the expected `aria-label`, and clicking it collapses the card. With the first-visit hint up the button is correctly absent, and clicking "Got it" closes the card as before.
