### PR TITLE
fix(reply): auto-join the closest group, not an arbitrary one

### DIFF
--- a/iznik-nuxt3/composables/useReplyStateMachine.js
+++ b/iznik-nuxt3/composables/useReplyStateMachine.js
@@ -111,10 +111,12 @@ import { ref, computed, getCurrentInstance, watch, onScopeDispose } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '~/stores/auth'
 import { useMessageStore } from '~/stores/message'
+import { useGroupStore } from '~/stores/group'
 import { useReplyStore } from '~/stores/reply'
 import { useMe } from '~/composables/useMe'
 import { useReplyToPost } from '~/composables/useReplyToPost'
 import { action } from '~/composables/useClientLog'
+import { milesAway } from '~/composables/useDistance'
 
 // State enum
 export const ReplyState = {
@@ -226,6 +228,55 @@ function logError(message, err, state, messageId = null) {
   })
 }
 
+// When a reply-triggered auto-join has no group in common with the replier, pick
+// the group CLOSEST to the replier - not the post's origin/home group, and not
+// whichever group happens to be first or last in msg.groups (API ordering is
+// arbitrary, and messages_groups doesn't carry lat/lng so we look each candidate
+// up via the group store). Distance is to the group's centre point, which is
+// simple and available client-side; nearest-polygon-edge would be more accurate
+// for large/oddly-shaped areas but is a possible future refinement, not built here.
+//
+// If we don't know the replier's own location, there's nothing to compare
+// distances against - fall back to the previous (arbitrary) behaviour of the
+// last group in the list, rather than inventing a cleverer rule.
+async function closestGroupToReplier(
+  messageGroups,
+  replierLat,
+  replierLng,
+  groupStore
+) {
+  const fallbackId = messageGroups[messageGroups.length - 1]?.groupid ?? null
+
+  // A single-group post has a forced answer regardless of distance - skip the
+  // location check and the group-store fetch entirely rather than doing a
+  // pointless lookup on the critical path of the most common reply case.
+  if (messageGroups.length <= 1) {
+    return fallbackId
+  }
+
+  if (!replierLat && !replierLng) {
+    return fallbackId
+  }
+
+  const groups = await Promise.all(
+    messageGroups.map((messageGroup) => groupStore.fetch(messageGroup.groupid))
+  )
+
+  let closestId = null
+  let closestMiles = null
+  for (const group of groups) {
+    if (!group) continue
+    const miles = milesAway(replierLat, replierLng, group.lat, group.lng)
+    if (miles === null) continue
+    if (closestMiles === null || miles < closestMiles) {
+      closestId = group.id
+      closestMiles = miles
+    }
+  }
+
+  return closestId ?? fallbackId
+}
+
 export function useReplyStateMachine(messageId, options = {}) {
   // When stayOnPage is set, completing the reply creates and sends the chat but
   // does NOT navigate to it — used when replying from a list page (browse /
@@ -234,6 +285,7 @@ export function useReplyStateMachine(messageId, options = {}) {
   const instance = getCurrentInstance()
   const authStore = useAuthStore()
   const messageStore = useMessageStore()
+  const groupStore = useGroupStore()
   const replyStore = useReplyStore()
   const { me, myid, myGroups, fetchMe } = useMe()
   const { forceLogin, loggedInEver } = storeToRefs(authStore)
@@ -965,12 +1017,12 @@ export function useReplyStateMachine(messageId, options = {}) {
         return
       }
 
-      // Check if already a member
+      // Check if already a member of any group the message is on - if so, we
+      // never join anything (see closestGroupToReplier for the "which group"
+      // decision when there's no overlap).
       let isMember = false
-      let groupToJoin = null
 
       for (const messageGroup of msg.groups) {
-        groupToJoin = messageGroup.groupid
         for (const key of Object.keys(myGroups.value || {})) {
           const group = myGroups.value[key]
           if (messageGroup.groupid === group.id) {
@@ -980,6 +1032,15 @@ export function useReplyStateMachine(messageId, options = {}) {
         }
         if (isMember) break
       }
+
+      const groupToJoin = isMember
+        ? null
+        : await closestGroupToReplier(
+            msg.groups,
+            me.value?.lat,
+            me.value?.lng,
+            groupStore
+          )
 
       log('Group membership check:', { isMember, groupToJoin })
 

--- a/iznik-nuxt3/tests/unit/composables/useReplyStateMachine.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useReplyStateMachine.spec.js
@@ -19,6 +19,7 @@ const {
   mockReplyToPostFn,
   mockSaveDraft,
   mockClearDraft,
+  mockGroupFetch,
 } = vi.hoisted(() => ({
   mockClearReply: vi.fn(),
   mockMessageFetch: vi.fn(),
@@ -27,6 +28,7 @@ const {
   mockReplyToPostFn: vi.fn(),
   mockSaveDraft: vi.fn(),
   mockClearDraft: vi.fn(),
+  mockGroupFetch: vi.fn(),
 }))
 
 // ============================================================
@@ -105,6 +107,16 @@ vi.mock('~/stores/message', () => ({
   useMessageStore: () => ({
     fetch: mockMessageFetch,
     byId: mockMessageById,
+  }),
+}))
+
+// ============================================================
+// GROUP STORE MOCK — used to look up lat/lng for the "closest group" join pick
+// ============================================================
+
+vi.mock('~/stores/group', () => ({
+  useGroupStore: () => ({
+    fetch: mockGroupFetch,
   }),
 }))
 
@@ -260,6 +272,8 @@ beforeEach(() => {
     id: MSG_ID,
     groups: [{ groupid: 100 }],
   })
+  // Default: no group data (tests that care about distance configure this themselves).
+  mockGroupFetch.mockResolvedValue(null)
   // Default: the post is reply-eligible (no reach block) unless a test overrides byId.
   mockMessageById.mockReturnValue(null)
   mockReplyToPostFn.mockResolvedValue(MSG_ID)
@@ -1228,6 +1242,150 @@ describe('handleJoinGroup (via submit with logged-in user)', () => {
 
     expect(mockForceLogin.value).toBe(true)
     expect(result.state.value).toBe(ReplyState.AUTHENTICATING)
+  })
+})
+
+// ============================================================
+// Multi-group posts: which group do we auto-join?
+//
+// Requirement (Edward, 2026-08-02): only join when the replier has no group in
+// common with the post, and when we do join, pick the group CLOSEST to the
+// replier - not the post's origin/home group, and not whichever group happens to
+// be first or last in msg.groups (API ordering is arbitrary). Regression case:
+// Glen replied to a post on Runcton-area Portsmouth_Freegle and was auto-joined
+// to Portsmouth, nowhere near him. See
+// plans/2026-08-02-reply-join-closest-group.md.
+// ============================================================
+describe('handleJoinGroup: closest-group selection for multi-group posts', () => {
+  async function doLoggedInSubmit(result) {
+    result.startTyping()
+    result.replyText.value = 'My reply'
+    await result.submit()
+    await flushPromises()
+  }
+
+  // Replier is in central London. GROUP_FAR (Edinburgh) is ~330 miles away,
+  // GROUP_MEDIUM (Birmingham) ~100 miles, GROUP_CLOSEST ~1 mile. The message lists
+  // them far/closest/medium - so the closest group sits in the MIDDLE of the
+  // array, not first (would pass under a naive "first wins" bug) and not last
+  // (today's actual bug - groupToJoin is overwritten on every loop iteration and
+  // ends up as the last entry).
+  const REPLIER_LAT = 51.5074
+  const REPLIER_LNG = -0.1278
+  const GROUP_FAR = { id: 301, lat: 55.9533, lng: -3.1883 } // Edinburgh
+  const GROUP_CLOSEST = { id: 302, lat: 51.51, lng: -0.13 } // Central London
+  const GROUP_MEDIUM = { id: 303, lat: 52.4862, lng: -1.8904 } // Birmingham
+
+  function mockGroupFixtures() {
+    mockGroupFetch.mockImplementation((id) =>
+      Promise.resolve(
+        {
+          [GROUP_FAR.id]: GROUP_FAR,
+          [GROUP_CLOSEST.id]: GROUP_CLOSEST,
+          [GROUP_MEDIUM.id]: GROUP_MEDIUM,
+        }[id] || null
+      )
+    )
+  }
+
+  it('no join at all when the replier is already a member of one of the groups', async () => {
+    mockMeValue = { id: 10, lat: REPLIER_LAT, lng: REPLIER_LNG }
+    mockMyidValue = 10
+    mockMyGroupsValue = { 0: { id: GROUP_MEDIUM.id } } // member of one of the three
+    mockGroupFixtures()
+    mockMessageFetch.mockResolvedValue({
+      id: MSG_ID,
+      groups: [
+        { groupid: GROUP_FAR.id },
+        { groupid: GROUP_CLOSEST.id },
+        { groupid: GROUP_MEDIUM.id },
+      ],
+    })
+
+    const { result } = mountComposable()
+    result.setRefs({ form: makeFormRef(true), chatButton: makeChatButtonRef() })
+    await doLoggedInSubmit(result)
+
+    expect(mockAuthStore.joinGroup).not.toHaveBeenCalled()
+    expect(result.state.value).toBe(ReplyState.COMPLETED)
+  })
+
+  it('joins the group closest to the replier when there is no overlap - not first, not last', async () => {
+    mockMeValue = { id: 10, lat: REPLIER_LAT, lng: REPLIER_LNG }
+    mockMyidValue = 10
+    mockMyGroupsValue = {} // no memberships at all
+    mockGroupFixtures()
+    mockMessageFetch.mockResolvedValue({
+      id: MSG_ID,
+      groups: [
+        { groupid: GROUP_FAR.id }, // first
+        { groupid: GROUP_CLOSEST.id }, // middle - the correct pick
+        { groupid: GROUP_MEDIUM.id }, // last
+      ],
+    })
+
+    const { result } = mountComposable()
+    result.setRefs({ form: makeFormRef(true), chatButton: makeChatButtonRef() })
+    await doLoggedInSubmit(result)
+
+    expect(mockAuthStore.joinGroup).toHaveBeenCalledWith(
+      10,
+      GROUP_CLOSEST.id,
+      false
+    )
+    expect(result.state.value).toBe(ReplyState.COMPLETED)
+  })
+
+  it('falls back to the last group in the list when the replier has no known location', async () => {
+    mockMeValue = { id: 10 } // no lat/lng
+    mockMyidValue = 10
+    mockMyGroupsValue = {}
+    mockGroupFixtures()
+    mockMessageFetch.mockResolvedValue({
+      id: MSG_ID,
+      groups: [
+        { groupid: GROUP_FAR.id },
+        { groupid: GROUP_CLOSEST.id },
+        { groupid: GROUP_MEDIUM.id }, // last - previous (arbitrary) behaviour
+      ],
+    })
+
+    const { result } = mountComposable()
+    result.setRefs({ form: makeFormRef(true), chatButton: makeChatButtonRef() })
+    await doLoggedInSubmit(result)
+
+    expect(mockAuthStore.joinGroup).toHaveBeenCalledWith(
+      10,
+      GROUP_MEDIUM.id,
+      false
+    )
+    expect(result.state.value).toBe(ReplyState.COMPLETED)
+    // No location known, so there's nothing to look distances up against.
+    expect(mockGroupFetch).not.toHaveBeenCalled()
+  })
+
+  it('joins a single-group post directly without any group-store lookup, even with a known location', async () => {
+    mockMeValue = { id: 10, lat: REPLIER_LAT, lng: REPLIER_LNG }
+    mockMyidValue = 10
+    mockMyGroupsValue = {} // no memberships
+    mockGroupFixtures()
+    mockMessageFetch.mockResolvedValue({
+      id: MSG_ID,
+      groups: [{ groupid: GROUP_CLOSEST.id }],
+    })
+
+    const { result } = mountComposable()
+    result.setRefs({ form: makeFormRef(true), chatButton: makeChatButtonRef() })
+    await doLoggedInSubmit(result)
+
+    expect(mockAuthStore.joinGroup).toHaveBeenCalledWith(
+      10,
+      GROUP_CLOSEST.id,
+      false
+    )
+    expect(result.state.value).toBe(ReplyState.COMPLETED)
+    // A single-group post has a forced answer - no need to look up distance.
+    expect(mockGroupFetch).not.toHaveBeenCalled()
   })
 })
 

--- a/plans/2026-08-02-reply-join-closest-group.md
+++ b/plans/2026-08-02-reply-join-closest-group.md
@@ -1,0 +1,118 @@
+# Reply auto-join: pick the closest group, not an arbitrary one
+
+Status: **implemented and committed, awaiting Edward's push/PR decision** (2026-08-02).
+
+Branch `fix/reply-join-closest-group`, commit `85433db5e`, in worktree `/home/edward/FreegleDocker-replyjoin`
+(based on master tip `f9eeef481`). Not pushed, no PR. Frontend unit suite green: **14705 passed, 0 failed**,
+run via that worktree's own status API on port 12087. eslint clean on both changed files. Not verified in a
+browser - unit coverage was judged the right level for this change.
+
+What landed, against the requirement below:
+
+- Rule 1 was **already correct** and is unchanged - the membership loop still breaks on the first overlap, so
+  a member of any of the post's groups is never re-joined. Now pinned by a test rather than left implicit.
+- Rule 2 is the fix: a new module-level `closestGroupToReplier()` picks by distance from the replier to each
+  candidate group's centre, using the existing `milesAway()` from `~/composables/useDistance` (no new
+  haversine). `groupToJoin` is no longer reassigned on every loop iteration.
+- `msg.groups` does **not** carry lat/lng - only the full Group object does. So each candidate is looked up
+  via `groupStore.fetch()`, parallelised with `Promise.all` and cached by the store. This matches the
+  existing pattern in useChat.js / MessageTag.vue / OurMessage.vue.
+- Unknown replier location falls back to the previous behaviour (last group in the list), now an explicit
+  tested branch rather than an accident of the loop.
+- Single-group posts short-circuit before both the location check and any group-store fetch - the answer is
+  forced regardless of distance, so the common case costs no extra API calls.
+
+Open questions from the original capture, as resolved: distance to group **centre** (polygon/nearest-edge
+noted as a possible future refinement, not built); decided **client-side** in the composable, no new
+endpoint; no-location falls back to previous behaviour. Known minor wrinkle: `milesAway()` rounds, so two
+groups within the same rounded mile tie-break on array order - immaterial at the distances involved.
+
+The rest of this document is the original capture, kept for the reasoning and the evidence.
+
+## Requirement (Edward, 2026-08-02)
+
+> If you reply to a post that is in multiple groups, then we should only join you if you have
+> no groups in common, and then we should join you to the closest group to you, not the home
+> group or a random one.
+
+Two rules:
+
+1. **Only join when there is no overlap.** If the replier is already a member of *any* group the
+   post is on, join nothing.
+2. **When we do join, join the group closest to the replier** - not the post's origin/home group,
+   and not whichever group happens to come first or last in the list.
+
+## Current behaviour
+
+`iznik-nuxt3/composables/useReplyStateMachine.js:972-990`:
+
+```js
+for (const messageGroup of msg.groups) {
+  groupToJoin = messageGroup.groupid        // overwritten every iteration
+  for (const key of Object.keys(myGroups.value || {})) {
+    const group = myGroups.value[key]
+    if (messageGroup.groupid === group.id) { isMember = true; break }
+  }
+  if (isMember) break
+}
+if (!isMember && groupToJoin) {
+  await authStore.joinGroup(myid.value, groupToJoin, false)   // manual=false -> logs text='Auto'
+}
+```
+
+- **Rule 1 is already satisfied.** The loop checks every group on the message and breaks on the
+  first overlap, so an existing member of any of them is never joined again.
+- **Rule 2 is not.** `groupToJoin` is reassigned on every pass, so when there is no overlap it ends
+  up as the **last** entry in `msg.groups` - arbitrary, driven by whatever order the API returned.
+  This is the "random one" to replace.
+
+## What "closest" should mean
+
+Groups expose `lat`/`lng` (group centre) from the Go API - `iznik-server-go/group/group.go:44-45`.
+The replier has their own location. Simplest correct-enough rule: pick the message group whose
+`lat`/`lng` is nearest the replier's location.
+
+Open questions to settle before building:
+
+- Distance to the group **centre** or to its **polygon** (nearest edge)? Centre is easy and
+  available client-side; polygon is more accurate for large or oddly-shaped areas.
+- Should this be decided **client-side** in the composable, or should the API pick? Client-side
+  keeps it in one place and needs no new endpoint, but the member's location has to be reliably
+  available at reply time.
+- What if the replier has no known location? Fall back to current behaviour, or to the post's
+  origin group.
+- Does this interact with the reach gate (`isNotInReachError`, same file, line ~1002)?
+
+## Why this matters (the case that prompted it)
+
+Glen (user 43767304, ChitChat post 616010, 2 Aug 2026):
+
+- 8 Jun: someone posts `OFFERED: outdoor bulkhead lamp (Runcton PO20)` to **Portsmouth_Freegle**.
+  Runcton is near Chichester - close to Glen; Portsmouth is not his nearest community.
+- 14 Jun 08:42:55: Glen replies "Interested" (chat_messages 108946403) and is auto-joined to
+  Portsmouth in the same second (`Group/Joined`, `text='Auto'`).
+- 19 Jun: he leaves Portsmouth.
+
+That post was only on one group, so this change alone would not have altered Glen's case - but it
+is the same complaint ("automatically added to groups an unreasonable distance from their home
+town"), and for any multi-group post the current code can pick the furthest of several.
+
+## Test plan
+
+- Unit tests in `iznik-nuxt3/tests/unit/composables/useReplyStateMachine.spec.js` (the file already
+  exists and covers `joinGroup`):
+  - post on 3 groups, replier is a member of one -> no join at all
+  - post on 3 groups, replier a member of none -> joins the nearest by the replier's location, not
+    the first or last in the list
+  - replier has no location -> defined fallback, whatever we choose above
+- Check the existing spec's current expectations - they may assert the present arbitrary choice and
+  need updating.
+
+## Related, deliberately NOT in scope
+
+Rippling re-adding people to groups they explicitly left (Glen's other complaint, same ChitChat
+post). Investigated 2026-08-02: `ExpandService` only treats a leave as an opt-out when the most
+recent `Group/Joined` was `text='Rippled'`, so leaving an ordinary or `Auto` membership does not
+stop rippling re-adding you. 2,406 current rippled memberships across 1,454 users were created
+after that user had left the group. Edward reviewed and decided **not** to change this. Recorded
+here only so the finding is not rediscovered from scratch.


### PR DESCRIPTION
Replying to a post auto-joins you to one of the groups that post is on. When the post is on
several groups, the group we picked was whichever one happened to be **last** in `msg.groups`,
which is just API ordering. That could easily be the furthest community from you.

Prompted by a ChitChat post (newsfeed 616010): "Does anyone seem to get automatically added to
groups an unreasonable distance from their home town?"

## Summary

- Reply auto-join now picks the group **closest to the replier** rather than an arbitrary one.
  New `closestGroupToReplier()` in `useReplyStateMachine.js` measures from the replier to each
  candidate group's centre using the existing `milesAway()` from `~/composables/useDistance`
  (no new haversine).
- **The "no overlap" rule is unchanged.** If you are already a member of any group the post is
  on, we still join you to nothing. That was already correct; this PR stops it being implicit
  and pins it with a test.
- `groupToJoin` is no longer reassigned on every loop iteration. The membership loop now only
  decides `isMember`, and the group choice is made once, only when there is no overlap.
- **Unknown replier location falls back to the previous behaviour** (last group in the list).
  Previously that was an accident of the loop; it is now an explicit, tested branch.
- **Single-group posts short-circuit** before both the location check and any group-store fetch.
  The answer is forced regardless of distance, so the common case costs no extra API calls.

`msg.groups` does not carry lat/lng (only the full Group object does, `group.go:44-45`), so each
candidate is fetched via `groupStore.fetch()`, parallelised with `Promise.all` and cached by the
store. This matches how `useChat.js`, `MessageTag.vue` and `OurMessage.vue` already get full
group data for a message group.

## Code quality review

- Distance is to the group **centre**. Nearest-polygon-edge would be more accurate for large or
  oddly shaped areas, but centre is simple, available client side, and good enough to stop us
  picking a community 40 miles away over one next door.
- `milesAway()` rounds (whole miles above 2, one decimal below). Two groups within the same
  rounded mile therefore tie-break on array order. Immaterial at the distances involved, and not
  worth working around.
- The membership check still scans `myGroups` per message group. Left as is: group counts per
  message are small, and rewriting it would enlarge the diff without changing behaviour.

## Future improvements

- Nearest-polygon-edge distance instead of centre, if large or irregular group areas prove to
  mis-pick in practice.
- The auto-join itself is arguably worth revisiting: it exists so replies and contact work, but
  it is what puts people in communities they did not choose. Out of scope here.

## Test plan

`iznik-nuxt3/tests/unit/composables/useReplyStateMachine.spec.js`, four new cases:

1. Post on 3 groups, replier is a member of one -> `joinGroup` never called.
2. Post on 3 groups, replier a member of none -> joins the closest. The fixture orders them
   far / closest / medium so the correct answer sits in the **middle** of the array: a naive
   "first wins" and the actual "last wins" bug both fail this test, so it cannot pass by accident.
3. Replier with no known location -> joins the last group, and `mockGroupFetch` is never called.
4. Single-group post with a known location -> joins that group, and `mockGroupFetch` is never
   called (pins the short-circuit).

No existing assertions were modified. The two pre-existing single-group tests still pass
unchanged.

Results:
- Frontend unit suite: **14705 passed, 0 failed** (14704 before, plus the short-circuit test).
  Run via the worktree's own status API.
- `eslint` clean on both changed files.
- Red phase confirmed before implementing: the closest-group test failed on its own (14703 pass,
  1 fail), so it was a genuine failing test rather than a tautology.

Not verified in a browser. Unit coverage is the right level for this logic, and the change is
confined to which id gets passed to an existing call.
