### PR TITLE
fix(modtools): update chat-review hold state in place without resetting scroll

### DIFF
--- a/iznik-nuxt3/modtools/components/ModChatReview.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReview.vue
@@ -238,7 +238,7 @@
               @handle="whitelist"
             />
             <SpinButton
-              v-if="!message.held || me.id === message.held.id"
+              v-if="!message.held"
               icon-name="pause"
               label="Hold"
               variant="warning"
@@ -476,8 +476,13 @@ async function release() {
 }
 
 async function hold(callback) {
+  // Unlike approve/reject/release/whitelist, holding doesn't remove the message
+  // from the review queue - it should stay in place with its Hold button
+  // replaced by Release, exactly like a held pending post. So this doesn't
+  // emit('reload'): chatStore.holdChat() already updates the held message in
+  // the store directly, and reloading the whole list here would reset scroll
+  // to the top (Discourse #9879/1).
   await chatStore.holdChat(props.messageid)
-  emit('reload')
   checkWork(true)
   callback()
 }

--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -490,6 +490,25 @@ export const useChatStore = defineStore({
     },
     async holdChat(id) {
       await this._sendChatMT({ id, action: 'Hold' })
+
+      // Patch the held message in place instead of making the caller reload the
+      // whole review queue (Discourse #9879/1) - a full reload cleared/refetched
+      // every message, resetting scroll to the top just to pick up one held
+      // flag. Mirrors messageStore.hold()'s in-place update for pending posts.
+      const authStore = useAuthStore()
+      const me = authStore.user
+      const existing = this.listByChatMessageId[id]
+      if (existing && me) {
+        this.listByChatMessageId[id] = {
+          ...existing,
+          held: {
+            id: me.id,
+            name: me.displayname,
+            email: me.email,
+            timestamp: new Date().toISOString(),
+          },
+        }
+      }
     },
     async releaseChat(id) {
       await this._sendChatMT({ id, action: 'Release' })

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
@@ -277,6 +277,23 @@ describe('ModChatReview', () => {
         .find((b) => b.text().includes('Release'))
       expect(releaseButton).toBeUndefined()
     })
+
+    // Discourse #9879/1: unlike pending-post review (ModMessageButtons.vue
+    // v-if="!heldByOnThisGroup" / v-else Release), the chat-review Hold button used
+    // v-if="!message.held || me.id === message.held.id" — which stays true once you
+    // hold it yourself, so the Hold button never disappeared like it does for posts.
+    it('hides the Hold button once held by me, same as pending-post review', () => {
+      const wrapper = mountComponent({ held: heldByMe })
+      const buttons = wrapper.findAll('.spin-button')
+      expect(
+        buttons.find((b) => b.attributes('data-label') === 'Hold')
+      ).toBeUndefined()
+      // Release takes its place, exactly as for pending posts.
+      const releaseButton = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Release'))
+      expect(releaseButton).toBeDefined()
+    })
   })
 
   describe('spammer display', () => {
@@ -472,7 +489,6 @@ describe('ModChatReview', () => {
 
     it.each([
       ['release', mockReleaseChat],
-      ['hold', mockHoldChat],
       ['approve', mockApproveChat],
       ['reject', mockRejectChat],
       ['whitelist', mockApproveAllFutureChat],
@@ -490,6 +506,20 @@ describe('ModChatReview', () => {
         }
       }
     )
+
+    // Discourse #9879/1: hold() used to emit('reload'), which made the parent
+    // (chats/review.vue) clear and refetch the ENTIRE review queue — resetting
+    // scroll to the top and losing the moderator's place after every hold. The
+    // store now updates the held message in place (see stores/chat.js holdChat),
+    // so hold() must NOT trigger that full-list reload.
+    it('hold calls store method with message id, does NOT emit reload, calls callback', async () => {
+      const wrapper = mountComponent()
+      const callback = vi.fn()
+      await wrapper.vm.hold(callback)
+      expect(mockHoldChat).toHaveBeenCalledWith(123)
+      expect(wrapper.emitted('reload')).toBeFalsy()
+      expect(callback).toHaveBeenCalled()
+    })
 
     it('showModnote sets showModChatNoteModal to true and calls callback', () => {
       const wrapper = mountComponent()
@@ -608,7 +638,9 @@ describe('ModChatReview', () => {
         touserid: 200,
         touser: { id: 200, displayname: 'To User', spammer: false },
       })
-      const reviewUsers = wrapper.findAllComponents({ name: 'ModChatReviewUser' })
+      const reviewUsers = wrapper.findAllComponents({
+        name: 'ModChatReviewUser',
+      })
       // First = From:, gets sender's group (groupidfrom)
       expect(reviewUsers[0].props('groupid')).toBe(555)
       // Second = To:, gets recipient's group (groupid)
@@ -624,7 +656,9 @@ describe('ModChatReview', () => {
         touserid: 200,
         touser: { id: 200, displayname: 'To User', spammer: false },
       })
-      const reviewUsers = wrapper.findAllComponents({ name: 'ModChatReviewUser' })
+      const reviewUsers = wrapper.findAllComponents({
+        name: 'ModChatReviewUser',
+      })
       reviewUsers.forEach((u) => {
         expect(u.props('groupid')).toBe(555)
       })
@@ -650,7 +684,9 @@ describe('ModChatReview', () => {
         touser: null,
       })
       // No ModChatReviewUser for To: (userid=0 is not a real user)
-      const reviewUsers = wrapper.findAllComponents({ name: 'ModChatReviewUser' })
+      const reviewUsers = wrapper.findAllComponents({
+        name: 'ModChatReviewUser',
+      })
       expect(reviewUsers.length).toBe(1) // only From:
       // But the chatroom name should appear as the To: label
       expect(wrapper.find('[data-testid="user2mod-to"]').exists()).toBe(true)
@@ -671,7 +707,9 @@ describe('ModChatReview', () => {
         touser: { id: 200, displayname: 'To User', spammer: false },
       })
       expect(wrapper.find('[data-testid="user2mod-to"]').exists()).toBe(false)
-      const reviewUsers = wrapper.findAllComponents({ name: 'ModChatReviewUser' })
+      const reviewUsers = wrapper.findAllComponents({
+        name: 'ModChatReviewUser',
+      })
       expect(reviewUsers.length).toBe(2) // From: and To:
     })
 
@@ -702,17 +740,17 @@ describe('ModChatReview', () => {
 
     it('does not show the rippling held notice when heldbyrippling is false', () => {
       const wrapper = mountComponent({ heldbyrippling: false })
-      expect(wrapper.find('[data-testid="rippling-held-notice"]').exists()).toBe(
-        false
-      )
+      expect(
+        wrapper.find('[data-testid="rippling-held-notice"]').exists()
+      ).toBe(false)
     })
 
     it('does not show the rippling held notice when heldbyrippling is absent', () => {
       const wrapper = mountComponent({})
       // defaultMessage has no heldbyrippling key → should not render the notice
-      expect(wrapper.find('[data-testid="rippling-held-notice"]').exists()).toBe(
-        false
-      )
+      expect(
+        wrapper.find('[data-testid="rippling-held-notice"]').exists()
+      ).toBe(false)
     })
 
     it('can show both manual hold notice and rippling held notice together', () => {

--- a/iznik-nuxt3/tests/unit/stores/chat.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/chat.spec.js
@@ -453,6 +453,40 @@ describe('chat store', () => {
 
       await expect(store.approveChat(42)).rejects.toThrow('Server error')
     })
+
+    // Discourse #9879/1: holdChat used to only send the API action, leaving the
+    // caller (ModChatReview.vue) to emit('reload') and have the parent clear +
+    // refetch the whole review queue just to pick up the new held state — which
+    // reset scroll to the top. holdChat now patches the held message in the store
+    // directly, matching messageStore.hold()'s in-place update for pending posts.
+    it('holdChat sends Hold action and patches the message in place with held info', async () => {
+      const store = useChatStore()
+      store.config = {}
+      store.listByChatMessageId[42] = { id: 42, message: 'hi', held: null }
+
+      await store.holdChat(42)
+
+      expect(mockSendMT).toHaveBeenCalledWith({ id: 42, action: 'Hold' })
+      const updated = store.listByChatMessageId[42]
+      expect(updated.held).toBeTruthy()
+      expect(updated.held.id).toBe(999) // mocked authStore.user.id
+      expect(updated.held.timestamp).toBeTruthy()
+      // Other fields on the message are preserved, not wiped by a refetch.
+      expect(updated.message).toBe('hi')
+    })
+
+    it('holdChat does not clear or refetch the review list', async () => {
+      const store = useChatStore()
+      store.config = {}
+      store.listByChatMessageId[42] = { id: 42, held: null }
+      store.messages.null = [{ id: 42 }, { id: 43 }]
+
+      await store.holdChat(42)
+
+      expect(mockFetchReviewChatsMT).not.toHaveBeenCalled()
+      // The rest of the list is untouched — no reload, no reordering.
+      expect(store.messages.null).toEqual([{ id: 42 }, { id: 43 }])
+    })
   })
 
   describe('openChat', () => {


### PR DESCRIPTION
## Root Cause

Two related bugs in `ModChatReview.vue`'s Hold action, both stemming from chat-review hold not following the pending-post hold pattern:

1. **Scroll jump / list reset**: `hold()` called `emit('reload')`, which the parent (`modtools/pages/chats/review.vue`) handles by `chatStore.clear()` + `chatStore.fetchReviewChatsMT()` — wiping and refetching the *entire* review queue for a single hold action. This resets scroll to the top and re-renders the whole list, unlike approve/reject where the item leaving the list is expected.
2. **Hold button doesn't disappear**: the Hold `SpinButton`'s `v-if="!message.held || me.id === message.held.id"` stays `true` once you've held the message yourself (since `me.id === message.held.id`), so the button never hides — unlike pending-post review (`ModMessageButtons.vue`), which uses `v-if="!heldByOnThisGroup"` / `v-else` Release, hiding Hold unconditionally once held (fixed for posts previously in `0bd23f984`).

## Evidence

- `stores/message.js` `hold()` re-fetches just the one message and does `this.list[message.id] = message` — an in-place patch, no full-list reload.
- `modtools/components/ModMessageButtons.vue:58` — `v-if="!heldByOnThisGroup"` / `v-else` Release — Hold hides for **anyone's** hold, not just other mods'.
- `iznik-server-go/chat/chatmessage.go` `holdChatMessage()` returns only `{ret, status}` — no per-message GET endpoint exists to re-fetch a single review chat message, unlike `message.fetchMT`.
- Discourse: https://discourse.ilovefreegle.org/t/9879/1 — "When you hold in chat review the hold button doesn't disappear like it does when you hold a pending post. Plus it jumps back up to the top."

## Fix

- `stores/chat.js` `holdChat()`: after the API call, patches `listByChatMessageId[id]` in place with an optimistic `held` object (`id`/`name`/`email` from the current mod, timestamp now) — mirroring `messageStore.hold()`'s in-place update, since there's no single-message re-fetch endpoint for chat review.
- `ModChatReview.vue` `hold()`: no longer emits `reload` — the store update above is enough, and the item stays in place in the review list.
- `ModChatReview.vue` template: Hold button `v-if` changed from `!message.held || me.id === message.held.id` to `!message.held`, matching the Release button's exact opposite condition (`message.held && me.id === message.held.id`), so Hold disappears and Release appears in its place for **any** hold, same as pending posts.

## Other Call Sites

`release`, `approve`, `reject`, `whitelist`, `redactEmails` in `ModChatReview.vue` still `emit('reload')` — unchanged and out of scope. Those actions genuinely remove the item from the queue (approve/reject/whitelist) or change its content (redact), so a full refresh is appropriate there; Hold is the only action where the item is meant to stay visible in place.

## Test

- `tests/unit/stores/chat.spec.js`: `holdChat` patches `listByChatMessageId` with held info and does not call `fetchReviewChatsMT` or touch `messages[null]` (AssertFlip: fails on old code with `held` staying `null`).
- `tests/unit/components/modtools/ModChatReview.spec.js`: Hold button hides once held by me (AssertFlip: fails on old code, button stays visible); `hold()` no longer emits `reload` (AssertFlip: fails on old code, which emitted it).
- Ran targeted suites only (`npx vitest run tests/unit/components/modtools/ModChatReview.spec.js tests/unit/stores/chat.spec.js`) — 122/122 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)