### PR TITLE
fix(modtools): redirect to login on session expiry instead of raw API error

### DIFF
--- a/iznik-nuxt3/modtools/pages/chats/[[id]].vue
+++ b/iznik-nuxt3/modtools/pages/chats/[[id]].vue
@@ -88,9 +88,11 @@ import { ref, computed, watch, onMounted } from 'vue'
 import dayjs from 'dayjs'
 import { useRoute, useRouter } from '#imports'
 import { useChatStore } from '~/stores/chat'
+import { useAuthStore } from '~/stores/auth'
 
 // Stores
 const chatStore = useChatStore()
+const authStore = useAuthStore()
 
 // Route
 const route = useRoute()
@@ -145,6 +147,29 @@ watch(search, (newVal, oldVal) => {
 })
 
 // Methods
+
+// A 401 from a chat-list request doesn't by itself prove the session is
+// dead - BaseAPI deliberately leaves auth intact on a 401 from a
+// non-/session endpoint, since a single transient blip on one of
+// ModTools' many background calls shouldn't force a re-login (Discourse
+// #9893). Confirm against the authoritative /session check before
+// treating it as a real session expiry - otherwise a genuinely expired
+// session showed this page's raw "API Error ... status: 401" instead of
+// sending the moderator back to log in (Discourse #9881).
+async function redirectIfSessionExpired(e) {
+  if (e?.response?.status !== 401) {
+    return false
+  }
+
+  await authStore.fetchUser()
+
+  if (!authStore.user) {
+    router.push('/')
+  }
+
+  return true
+}
+
 async function listChats(age, searchTerm) {
   const params = {
     chattypes: ['User2Mod', 'Mod2Mod'],
@@ -156,7 +181,15 @@ async function listChats(age, searchTerm) {
     params.search = searchTerm
   }
 
-  await chatStore.listChatsMT(params, id.value)
+  try {
+    await chatStore.listChatsMT(params, id.value)
+  } catch (e) {
+    if (await redirectIfSessionExpired(e)) {
+      return
+    }
+    throw e
+  }
+
   bump.value++
 }
 

--- a/iznik-nuxt3/tests/unit/pages/modtools/chats.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/chats.spec.js
@@ -29,6 +29,7 @@ vi.mock('~/stores/chat', () => ({
 // Mock auth store
 const mockAuthStore = {
   user: { id: 1, lat: 0, lng: 0 },
+  fetchUser: vi.fn(),
 }
 
 vi.mock('~/stores/auth', () => ({
@@ -139,6 +140,8 @@ describe('chats/[[id]].vue page', () => {
     mockRouteParams.value = { id: undefined }
     mockChatStore.list = []
     mockChatStore.searchSince = null
+    mockAuthStore.user = { id: 1, lat: 0, lng: 0 }
+    mockAuthStore.fetchUser = vi.fn().mockResolvedValue(mockAuthStore.user)
   })
 
   describe('initial state', () => {
@@ -224,6 +227,71 @@ describe('chats/[[id]].vue page', () => {
       const filtered = wrapper.vm.scanChats(false, chats)
       expect(filtered).toHaveLength(1)
       expect(filtered[0].name).toBe('Test Chat')
+    })
+  })
+
+  describe('session expiry on chat load (Discourse 9881)', () => {
+    // Mount first so the automatic onMounted() -> listChats() call consumes
+    // the default (resolving) mock, then queue the scenario for the explicit
+    // wrapper.vm.listChats() call made by each test below.
+    async function mountAndSettle() {
+      const wrapper = mountComponent()
+      await flushPromises()
+      return wrapper
+    }
+
+    it('redirects home instead of throwing a raw API error when the session has genuinely expired', async () => {
+      const wrapper = await mountAndSettle()
+
+      // Simulate a 401 from the chat list endpoint, as happens when the
+      // moderator's session has expired.
+      mockChatStore.listChatsMT.mockRejectedValueOnce({
+        response: { status: 401 },
+        message: 'API Error GET /chat?chattypes=... -> status: 401',
+      })
+
+      // The authoritative /session check (authStore.fetchUser) confirms the
+      // session really is dead by clearing the user.
+      mockAuthStore.fetchUser = vi.fn().mockImplementation(() => {
+        mockAuthStore.user = null
+        return Promise.resolve(null)
+      })
+
+      // Should not reject / bubble up as an unhandled API error.
+      await expect(wrapper.vm.listChats()).resolves.toBeUndefined()
+
+      expect(mockAuthStore.fetchUser).toHaveBeenCalled()
+      expect(mockRouterPush).toHaveBeenCalledWith('/')
+    })
+
+    it('does not redirect when a 401 turns out to be transient (session still valid)', async () => {
+      const wrapper = await mountAndSettle()
+
+      mockChatStore.listChatsMT.mockRejectedValueOnce({
+        response: { status: 401 },
+        message: 'API Error GET /chat?chattypes=... -> status: 401',
+      })
+
+      // The authoritative /session check says we're still logged in - a
+      // background 401 elsewhere shouldn't force a redirect (Discourse #9893).
+      mockAuthStore.fetchUser = vi.fn().mockResolvedValue(mockAuthStore.user)
+
+      await expect(wrapper.vm.listChats()).resolves.toBeUndefined()
+
+      expect(mockAuthStore.fetchUser).toHaveBeenCalled()
+      expect(mockRouterPush).not.toHaveBeenCalledWith('/')
+    })
+
+    it('still throws (and does not redirect) for non-401 errors', async () => {
+      const wrapper = await mountAndSettle()
+
+      mockChatStore.listChatsMT.mockRejectedValueOnce(
+        new Error('Network error')
+      )
+
+      await expect(wrapper.vm.listChats()).rejects.toThrow('Network error')
+      expect(mockAuthStore.fetchUser).not.toHaveBeenCalled()
+      expect(mockRouterPush).not.toHaveBeenCalledWith('/')
     })
   })
 


### PR DESCRIPTION
## Root Cause
`modtools/pages/chats/[[id]].vue`'s `listChats()` (invoked on mount, on search, after "Mark all read", and on "Search old chats") let a failed chat-list fetch propagate uncaught. When the moderator's session had expired, the store call (`chatStore.listChatsMT` → `api(...).chat.listChatsMT`) rejects with an `APIError` for HTTP 401. That uncaught rejection reached Vue's global `errorHandler` (`plugins/something-went-wrong.client.js`), which just calls `miscStore.setErrorDetails(err)` and shows the raw `API Error GET /chat?... -> status: 401` message via the `SomethingWentWrong` toast, instead of sending the moderator back to log in.

A 401 on this endpoint doesn't by itself prove the whole session is dead: `BaseAPI.js` deliberately leaves auth state intact on a 401 from a non-`/session` endpoint (fix in `12c2a3767`, Discourse #9893) because ModTools fires many background calls, and treating every transient 401 as a real logout was forcing moderators to re-login unexpectedly often. So the fix has to distinguish "genuinely expired" from "transient blip" rather than just redirecting on any 401.

## Evidence
- `api/BaseAPI.js:202-229` — 401 handling only clears auth for `path === '/session'`; all other endpoints leave the session "intact" by design.
- `stores/auth.js:344-487` (`fetchUser()`) — the authoritative check: hits `GET /session`, and only clears `authStore.user` when the server confirms there's genuinely no valid session.
- `plugins/something-went-wrong.client.js:10-47` — the global Vue `errorHandler` that turns any uncaught `APIError` into a generic toast via `miscStore.setErrorDetails`.
- `components/SomethingWentWrong.vue:59-61` — renders `errorDetails.message` verbatim, i.e. the raw `API Error ... -> status: 401` text.
- `modtools/composables/useModMessages.js:200-210` — a similar-looking 401 catch on the Pending messages list, but its comment ("BaseAPI already cleared auth state... login modal will show") predates `12c2a3767` and is now stale, since non-session 401s no longer clear auth. Left as-is (different feature area, not touched by this PR) but noted here for visibility.

## Fix
`listChats()` now catches a failed `chatStore.listChatsMT()` call. On a 401, it calls `authStore.fetchUser()` (the authoritative `/session` check) to find out whether the session is really dead:
- If confirmed dead (`authStore.user` becomes falsy), redirect to `/` so the ModTools layout's `<LoginModal v-if="!loggedIn">` shows, instead of the raw error toast.
- If the session is still valid (a transient 401), the failed refresh is a silent no-op - consistent with the existing "don't force logout on transient 401" policy.
- Any non-401 error is rethrown unchanged, preserving existing behaviour (surfaced via Sentry/the generic error toast as before).

## Other Call Sites
Within this page, `markAllRead()` also calls `chatStore.markAllReadMT()` without a catch, so a 401 there could still surface the raw toast - left unfixed to keep this PR scoped to the reported symptom (chat list load). `useModMessages.js`'s Pending-list 401 handling (noted above) is a related but separate, pre-existing issue in a different feature area.

## Test
`tests/unit/pages/modtools/chats.spec.js` - added `describe('session expiry on chat load (Discourse 9881)')`:
- Confirmed-expired 401 → `authStore.fetchUser()` is called and `router.push('/')` fires (no raw error surfaces).
- Transient 401 (session still valid per `fetchUser()`) → no redirect, no error surfaces.
- Non-401 error → still rethrown, no redirect (regression guard for existing behaviour).

AssertFlip: verified the two session-expiry tests fail against the pre-fix code (`promise rejected ... instead of resolving`) and pass once the fix is applied; ran via `vitest run tests/unit/pages/modtools/chats.spec.js` (targeted run only, per task time budget).

## Discourse
https://discourse.ilovefreegle.org/t/9881/1