### PR TITLE
fix(discourse): thread replies to the correct post

### DIFF
--- a/monitor-fsm/src/__tests__/actions.persist_classifications.test.ts
+++ b/monitor-fsm/src/__tests__/actions.persist_classifications.test.ts
@@ -238,6 +238,29 @@ describe('persist_classifications action', () => {
     expect(newBug?.state).toBe('fix-queued')
     expect(newBug?.pr_number).toBe(200)
   })
+
+  // 9982/12: a reporter's UNRELATED bug, posted in a topic that already has an
+  // active PR for a DIFFERENT symptom, must NOT be linked to that PR. Linking it
+  // makes queue_deployed_reply_drafts auto-post a "possible fix applied, please
+  // retest" reply threaded under THIS post once the (unrelated) PR deploys — the
+  // reply appears attached to the wrong post, claiming to fix something it didn't.
+  it('does not link an unrelated bug to an active same-topic PR when symptom tags share zero overlap', async () => {
+    upsertDiscourseBug(db, {
+      topic: 998, post: 5, state: 'fix-queued', prNumber: 500,
+      symptomTags: ['login', 'crash'],
+    })
+    const result = await persistClassificationsHandler({}, {
+      classifications: [{
+        topic: 998, post: 12, type: 'bug', user: 'Neville_Reid',
+        symptom_tags: ['photo', 'upload', 'fail'],
+        summary: 'Photo upload fails with a spinner that never completes',
+      }],
+    })
+    expect(result.upserted).toBe(1)
+    const newBug = getDiscourseBug(db, 998, 12)
+    expect(newBug?.state).toBe('open')
+    expect(newBug?.pr_number).toBeNull()
+  })
 })
 
 describe('regression detection in persist_classifications', () => {

--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -3239,23 +3239,38 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
           : []
         const codeArea: string | null = typeof c.code_area === 'string' ? c.code_area : null
 
-        // Dedup level 1: same Discourse topic already has an active PR → link, don't open new
+        // Dedup level 1: same Discourse topic already has an active PR → link, don't open new.
+        // Only when the two reports aren't PROVABLY different bugs: if both have symptom_tags
+        // and share ZERO overlap, this is an independent bug that happens to share a topic, not
+        // a follow-up — linking it would make queue_deployed_reply_drafts auto-post a "possible
+        // fix applied, please retest" reply threaded under THIS post once the (unrelated) PR
+        // deploys, i.e. a reply that looks attached to the wrong post (9982/12). Mirrors the
+        // isIndependentBug check below for the already-fixed regression case. With no tag data
+        // on either side we can't tell them apart, so — as before — default to linking.
         const topicPrRow = db.prepare(
-          `SELECT pr_number FROM discourse_bug
+          `SELECT pr_number, symptom_tags FROM discourse_bug
            WHERE topic = ? AND post != ? AND pr_number IS NOT NULL
-           AND state IN ('open', 'investigating', 'fix-queued')`
-        ).get(c.topic, c.post) as { pr_number: number } | undefined
+           AND state IN ('open', 'investigating', 'fix-queued')
+           ORDER BY first_seen_at ASC LIMIT 1`
+        ).get(c.topic, c.post) as { pr_number: number; symptom_tags: string | null } | undefined
         if (topicPrRow) {
-          upsertDiscourseBug(db, {
-            topic: Number(c.topic), post: Number(c.post),
-            topicTitle: c.topicTitle ?? null, reporter: c.user ?? null,
-            excerpt: c.summary ?? c.originalPostText?.slice(0, 200) ?? null,
-            state: 'fix-queued', prNumber: topicPrRow.pr_number,
-            featureArea: c.featureArea ?? undefined, symptomTags, codeArea: codeArea ?? undefined,
-          })
-          out(`persist_classifications: topic ${c.topic}/${c.post} linked to existing PR #${topicPrRow.pr_number} (same topic)`)
-          upserted++
-          continue
+          const topicPrTags: string[] = (() => {
+            try { return JSON.parse(topicPrRow.symptom_tags ?? '[]') } catch { return [] }
+          })()
+          const isIndependentBug = symptomTags.length > 0 && topicPrTags.length > 0 && tagJaccard(symptomTags, topicPrTags) === 0
+          if (!isIndependentBug) {
+            upsertDiscourseBug(db, {
+              topic: Number(c.topic), post: Number(c.post),
+              topicTitle: c.topicTitle ?? null, reporter: c.user ?? null,
+              excerpt: c.summary ?? c.originalPostText?.slice(0, 200) ?? null,
+              state: 'fix-queued', prNumber: topicPrRow.pr_number,
+              featureArea: c.featureArea ?? undefined, symptomTags, codeArea: codeArea ?? undefined,
+            })
+            out(`persist_classifications: topic ${c.topic}/${c.post} linked to existing PR #${topicPrRow.pr_number} (same topic)`)
+            upserted++
+            continue
+          }
+          out(`persist_classifications: topic ${c.topic}/${c.post} shares zero symptom tags with same-topic PR #${topicPrRow.pr_number} — treating as an independent bug, not linking`)
         }
 
         // Dedup level 2: cross-topic tag similarity — if an open bug in a DIFFERENT topic


### PR DESCRIPTION
No prior attempt found for this specific same-topic PR-linking dedup gap (the related, already-merged fix in `matchDirectMasterFixCommits` — commit b5737c3a8 — addressed a different function: bare-topic commit-message matching, not this classification-time dedup).

## Root Cause
`persist_classifications`' "Dedup level 1" (same-topic active-PR linking, `monitor-fsm/src/actions/index.ts`) linked **any** new `type: 'bug'` classification in a Discourse topic to an existing active PR purely because they shared a topic — with no check that the two reports actually described the same problem. Once that PR merged and its deploy was confirmed live, `queue_deployed_reply_drafts` auto-posted the verbatim "AI Edward: possible fix applied, please retest" reply, threaded (`reply_to_post_number`) under the newly-linked post. If that post's issue was actually unrelated to what the PR fixed, the reply still lands attached to it — reading, from the reporter's side, as a reply threaded to the wrong post making an untrue claim about their report.

## Evidence
- `postDiscourseReply`/`postToDiscourse` (the only two places that ever set `reply_to_post_number`) both just pass through whatever `post` value is stored on the `discourse_bug` row — so a wrong thread target can only originate from that row being linked to the wrong PR in the first place.
- The same file already has an `isIndependentBug` check (symptom-tag Jaccard overlap) for the analogous "prior **fixed** bug in this topic" regression case, but the "prior **active-PR** bug in this topic" linking case (added in 0b8cba39a for genuine same-topic follow-ups, e.g. "Carol post 219 after post 218 already has PR #313") had no equivalent safeguard.
- `matchDirectMasterFixCommits` (a different, PR-less matching path in the same file) already had a comment documenting a near-identical incident: a bare topic reference false-matching an unrelated open bug and posting a bogus retest reply, reported by "Neville" on 2026-07-22 (topic 9808/633) — same failure class, different call site.

## Fix
`persist_classifications`' same-topic dedup now only auto-links to the topic's active PR when there's no positive evidence the two reports are different bugs: if both the new classification and the existing linked bug have `symptom_tags` and they share **zero** overlap, it's treated as an independent bug (falls through to normal open-bug handling) instead of being silently linked. With no tag data on either side — the common generic "same problem" follow-up case this dedup was built for — behaviour is unchanged (still links), so existing same-topic follow-up handling is preserved.

## Other Call Sites
Grepped `reply_to_post_number` (2 hits: `dashboard-server.ts` human-approved draft path, `actions/index.ts` `postDiscourseReply`) and `upsertDiscourseBug`/DB-insert sites for `discourse_bug`. Only `persist_classifications`' same-topic dedup had the "same topic ⇒ any post" pattern with no similarity check feeding directly into the *unreviewed, auto-posted* reply path (`queue_deployed_reply_drafts`). `work_router_decide`'s `topicsWithActivePr` filter uses the same "topic already has an active PR" signal but only skips dispatching a duplicate fix *this iteration* — it never links `pr_number` or triggers a reply, so it isn't the same defect.

## Test
`monitor-fsm/src/__tests__/actions.persist_classifications.test.ts`: new test "does not link an unrelated bug to an active same-topic PR when symptom tags share zero overlap" (topic 998, post 5 fix-queued under PR 500 with tags `['login','crash']`; new post 12 classified with disjoint tags `['photo','upload','fail']`). AssertFlip verified: fails against pre-fix code (`topic 998/12 linked to existing PR #500`, `state='fix-queued'`), passes after the fix (`state='open'`, `pr_number=null`). All 37 tests in the file pass, including the pre-existing no-tag-data same-topic linking tests (behaviour there is unchanged). `tsc --noEmit` clean.

## Discourse
https://discourse.ilovefreegle.org/t/9982/12