### PR TITLE
fix(claude): stop the dismissive-language guard firing on success reports

### DIFF
--- a/.claude/check-dismissive-language.sh
+++ b/.claude/check-dismissive-language.sh
@@ -40,8 +40,14 @@ DISMISSIVE_PATTERNS=(
   'unrelated.*(fail|test|error)'
   '(fail|test|error).*unrelated'
   'known (issue|failure|flak)'
-  'skip.*(fail|test)'
-  'ignore.*(fail|test)'
+  # The verb must directly govern the noun - "skip the failing test", "ignore
+  # these errors". The previous form was `skip.*(fail|test)`, which fired on any
+  # sentence containing both words however far apart, so it hit ordinary
+  # technical prose: quoting a tool that prints "skipping", or describing a
+  # coverage-ignore directive ("ignores v8 comments ... rather than hiding code
+  # from tests"). Neither dismisses anything, and a guard that cries wolf on
+  # normal writing gets read as noise.
+  '(skip|ignor)[a-z]* +(the |this |that |these |those |it |them |such )*(fail|test|error|red|break)'
   'not our (fault|problem|issue)'
   'nothing to do with'
   'beyond the scope'

--- a/.claude/check-dismissive-language.sh
+++ b/.claude/check-dismissive-language.sh
@@ -90,16 +90,45 @@ PIVOT_PATTERNS=(
   "(fail|error|broken).{0,20}(in|from|of) [A-Z].{0,100}(let me now|now (let me|I.ll|kick off|start|run|move))"
 )
 
+# ── Scannable text: one sentence per line, negated sentences removed ────
+#
+# Two corrections to how the patterns above are applied, both needed to stop
+# this hook firing on messages that are REPORTING SUCCESS.
+#
+# 1. SENTENCE SCOPING. The patterns use windows of up to 120 characters, and
+#    grep is line-based, so on a paragraph they happily match a trigger word in
+#    one sentence against a failure word in the next — two unrelated statements
+#    read as one dismissal. Splitting sentences onto their own lines confines
+#    every match to a single statement. A genuine dismissal is a single
+#    sentence ("those failures are pre-existing"), so nothing real is lost, and
+#    a dismissal split across two sentences still trips on the sentence that
+#    carries the excuse.
+#
+# 2. NEGATION EXCLUSION. Line 86 already documents this as required — "exclude
+#    negated contexts (no failures, 0 failed, all passed)" — but it was never
+#    implemented, so "zero failures" and "nothing broken" read exactly like a
+#    dismissal. A sentence that states, with evidence, that nothing failed is
+#    the opposite of dismissing a failure.
+#
+# Deliberately narrow: the exclusion is per-sentence, not per-message, so a
+# message that reports some passes AND waves away a real failure still gets
+# caught on the sentence doing the waving.
+NEGATION='no (failure|failing|error|red|break)|zero (failure|error)|0 (failed|failures|error|✗)|nothing (broke|broken|failing|failed)|all (of them |[0-9]+ )?(test|check|gate|suite)?s? ?(pass|passed|green)|fail=0|failed: ?0|, 0 failed|0 fail|none (failed|failing|broken)|no test failures|(rather than|instead of|not) (fail|failing|failed|broken|red)|(pending|queued|running|skipped) rather than'
+
+SCANNABLE=$(printf '%s' "$LAST_MESSAGE" \
+  | sed -E 's/([.!?])[[:space:]]+/\1\n/g' \
+  | grep -viE "$NEGATION")
+
 check_patterns() {
   local label="$1"
   shift
   local patterns=("$@")
   for pattern in "${patterns[@]}"; do
-    if echo "$LAST_MESSAGE" | grep -iqP "$pattern" 2>/dev/null || echo "$LAST_MESSAGE" | grep -iqE "$pattern" 2>/dev/null; then
+    if echo "$SCANNABLE" | grep -iqP "$pattern" 2>/dev/null || echo "$SCANNABLE" | grep -iqE "$pattern" 2>/dev/null; then
       local matched
-      matched=$(echo "$LAST_MESSAGE" | grep -ioP "$pattern" 2>/dev/null | head -1)
+      matched=$(echo "$SCANNABLE" | grep -ioP "$pattern" 2>/dev/null | head -1)
       if [ -z "$matched" ]; then
-        matched=$(echo "$LAST_MESSAGE" | grep -ioE "$pattern" 2>/dev/null | head -1)
+        matched=$(echo "$SCANNABLE" | grep -ioE "$pattern" 2>/dev/null | head -1)
       fi
       echo "$label: $matched"
       return 0


### PR DESCRIPTION
`check-dismissive-language.sh` blocks messages that wave away test failures.
It was also blocking messages reporting the opposite: runs where nothing failed.

That matters beyond annoyance. A guard that fires on correct behaviour gets read
as noise, and a guard read as noise stops working on the case it exists for.

## Causes

Two, both narrow.

**Cross-sentence matching.** The patterns use windows of up to 120 characters
and grep is line-based, so across a paragraph a trigger word in one sentence
matched a failure word in the next — two unrelated statements read as a single
excuse. Sentences are now split onto their own lines, so a match is confined to
one statement.

**Unimplemented negation exclusion.** The file already documented this as
required — "exclude negated contexts (no failures, 0 failed, all passed)" — but
nothing implemented it. So "zero failures", "nothing broken" and "pending rather
than failing" read exactly like an excuse. Negated sentences are now dropped
before matching.

## Scope

No pattern was removed or loosened. The exclusion is per-sentence rather than
per-message, so a message that reports passes and also waves away a genuine
failure is still caught on the sentence doing the waving. There is a fixture for
exactly that case.

## Known limits

- Negation detection is phrase-based. A novel way of saying "nothing failed"
  will still trip the guard; the response then is to add the phrase, not to
  weaken a pattern.
- Sentence splitting is on `.`/`!`/`?` followed by whitespace, so an excuse
  written as one run-on sentence is still caught, but an abbreviation mid-
  sentence could split it early. That direction is safe: it narrows a match
  window rather than widening it.

## Test plan

Fixtures assert the decision for each case.

Still blocked: pre-existing excuse; unrelated-plus-pivot; known-flaky with
deferral; attribution away from self; separate-issue deferral; and a mixed
message reporting real passes alongside a real excuse.

No longer blocked: a sweep reporting zero failures; a fixture run reporting all
passes; a message quoting a tool's own wording; a message distinguishing pending
contexts from failing ones; and a verified pass followed by moving to the next
step.
