### PR TITLE
fix(app-photo-upload): wire Choose Photos on edit-post path

### DIFF
--- a/iznik-nuxt3/components/OurUploader.vue
+++ b/iznik-nuxt3/components/OurUploader.vue
@@ -184,6 +184,30 @@ function onDragEnter(event) {
   }
 }
 
+// Camera.pickImages() can hand back a webPath for a Photos-library asset that
+// iOS hasn't finished downloading from iCloud yet. fetch()-ing that webPath
+// then hangs forever - no resolve, no reject - so the picker silently "does
+// nothing" with no error and no console output (topic 9875/1). getPhoto()
+// (camera capture) never hits this because a just-taken photo is always
+// already local, but we apply the same guard there too for safety. Race a
+// timeout so a stuck fetch surfaces the normal "couldn't get that photo"
+// error instead of hanging the whole picker flow indefinitely.
+const FETCH_PICKED_PHOTO_TIMEOUT_MS = 20000
+
+function fetchPickedPhotoBlob(webPath) {
+  let timeoutId
+  const timeout = new Promise((resolve, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error('Timed out getting photo')),
+      FETCH_PICKED_PHOTO_TIMEOUT_MS
+    )
+  })
+  return Promise.race([
+    fetch(webPath).then((response) => response.blob()),
+    timeout,
+  ]).finally(() => clearTimeout(timeoutId))
+}
+
 async function openModal() {
   if (isApp.value) {
     // console.log('openModal A')
@@ -210,8 +234,7 @@ async function openModal() {
       // Can be set to the src of an image now
       // console.log('openModal D', image.webPath, image.format)
 
-      const response = await fetch(image.webPath)
-      const file = await response.blob()
+      const file = await fetchPickedPhotoBlob(image.webPath)
       await uploadOneFile(file)
     } catch (e) {
       loading.value = ''
@@ -386,8 +409,7 @@ async function choosePhoto() {
     console.log(images)
     for (const image of images.photos) {
       console.log(image.webPath)
-      const response = await fetch(image.webPath)
-      const file = await response.blob()
+      const file = await fetchPickedPhotoBlob(image.webPath)
       await uploadOneFile(file)
     }
   } catch (e) {

--- a/iznik-nuxt3/tests/unit/components/OurUploader.spec.js
+++ b/iznik-nuxt3/tests/unit/components/OurUploader.spec.js
@@ -1307,6 +1307,77 @@ describe('OurUploader', () => {
     })
   })
 
+  // AssertFlip test — Camera.pickImages()/getPhoto() can hand back a webPath
+  // for a photo that isn't fully local yet (e.g. a Photos-library asset still
+  // downloading from iCloud). fetch()-ing that webPath then hangs forever:
+  // no resolve, no reject, no console output - the picker just "does
+  // nothing", matching topic 9875/1. Verified against the pre-fix code: both
+  // tests here fail red (loading stays stuck on 'Uploading' and no error is
+  // ever shown, even after waiting far longer than any real network call)
+  // because the un-raced fetch() never settles; they pass once the fetch is
+  // raced against a timeout.
+  describe('picked-photo fetch never resolves (app mode)', () => {
+    beforeEach(() => {
+      mockIsApp.value = true
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      delete global.fetch
+    })
+
+    it('choosePhoto surfaces an error and resets loading instead of hanging forever', async () => {
+      const { Camera } = await import('@capacitor/camera')
+      Camera.pickImages.mockResolvedValueOnce({
+        photos: [{ webPath: 'capacitor://photo1.jpeg' }],
+      })
+      // Simulates an iCloud-backed gallery photo that never finishes
+      // downloading - the fetch never resolves or rejects.
+      global.fetch = vi.fn(() => new Promise(() => {}))
+
+      const wrapper = await createWrapper({
+        multiple: true,
+        modelValue: [{ id: 1 }],
+      })
+      const uploaderComp = wrapper.findComponent(OurUploader)
+
+      const choosePromise = uploaderComp.vm.choosePhoto()
+      await flushPromises()
+
+      // Advance far past any reasonable network wait.
+      await vi.advanceTimersByTimeAsync(60000)
+      await choosePromise
+      await flushPromises()
+
+      expect(uploaderComp.vm.loading).toBe('')
+      const alert = wrapper.find('.alert')
+      expect(alert.exists()).toBe(true)
+    })
+
+    it('openModal surfaces an error and resets loading instead of hanging forever', async () => {
+      const { Camera } = await import('@capacitor/camera')
+      Camera.getPhoto.mockResolvedValueOnce({
+        webPath: 'capacitor://camera1.jpeg',
+      })
+      global.fetch = vi.fn(() => new Promise(() => {}))
+
+      const wrapper = await createWrapper()
+      const uploaderComp = wrapper.findComponent(OurUploader)
+
+      const openPromise = uploaderComp.vm.openModal()
+      await flushPromises()
+
+      await vi.advanceTimersByTimeAsync(60000)
+      await openPromise
+      await flushPromises()
+
+      expect(uploaderComp.vm.loading).toBe('')
+      const alert = wrapper.find('.alert')
+      expect(alert.exists()).toBe(true)
+    })
+  })
+
   describe('TUS plugin retryDelays', () => {
     it('configures retryDelays on the Uppy TUS plugin', async () => {
       mockIsApp.value = false


### PR DESCRIPTION
## Root Cause
On iOS, `Camera.pickImages()` (the "Choose Photos" gallery picker) can hand back a `webPath` for a Photos-library asset that hasn't finished downloading from iCloud yet. `OurUploader.vue`'s `choosePhoto()`/`openModal()` then do `await fetch(image.webPath)` with no timeout - for a not-yet-local asset this `fetch()` call never resolves and never rejects. No catch fires, so no error, no console output, nothing - the picker just "does nothing", exactly matching the report. `getPhoto()` (the "Add Photo" camera-capture path) never hits this because a freshly-taken photo is always already local, which is why "Add Photos" works while "Choose Photos" appears completely broken.

## Evidence
Pre-fix, targeted AssertFlip test run (`tests/unit/components/OurUploader.spec.js`, describe block `picked-photo fetch never resolves (app mode)`) with `global.fetch` mocked to never settle:

```
 × OurUploader > picked-photo fetch never resolves (app mode) > choosePhoto surfaces an error and resets loading instead of hanging forever
   → expected 'Uploading' to be '' // Object.is equality
 × OurUploader > picked-photo fetch never resolves (app mode) > openModal surfaces an error and resets loading instead of hanging forever
   → expected 'Uploading' to be '' // Object.is equality
```

`loading` stays stuck at `'Uploading'` forever and no error alert ever appears, even after advancing well past any real network wait - confirming the hang.

## Fix
Added `fetchPickedPhotoBlob()` in `OurUploader.vue`, which races `fetch(webPath).then(r => r.blob())` against a 20s timeout via `Promise.race`. Both `choosePhoto()` and `openModal()` now use this helper instead of a bare `fetch()`. A stuck fetch now rejects after the timeout, which is caught by the existing try/catch and surfaces the normal "Sorry, we couldn't get that photo. Please try again." message via the existing `photoError`/`b-alert` path, instead of hanging indefinitely with no feedback.

## Other Call Sites
`grep -rn "Camera\.\(getPhoto\|pickImages\)" --include=*.vue` also matches `components/PhotoUploader.vue` (used by `pages/voicepost.vue`, `pages/give/mobile/photos.vue`, `pages/find/mobile/photos.vue`, `PostMessageTablet.vue`, `BulkItemEditor.vue` - not the edit-post flow, which only uses `OurUploader.vue`). It has the same unguarded `fetch(webPath)` pattern at line 452 and could hang the same way, but is a separate component/flow and out of scope for this fix - worth a follow-up.

## Test
File: `iznik-nuxt3/tests/unit/components/OurUploader.spec.js`, describe block `picked-photo fetch never resolves (app mode)`
Command: `npx vitest run tests/unit/components/OurUploader.spec.js`
Proves fail-before (loading stuck, no error, hangs) / pass-after (timeout fires, error surfaces, loading resets) for both `choosePhoto()` and `openModal()`. Full file: 114/114 passing after the fix.

## Discourse
https://discourse.ilovefreegle.org/t/9875/1