### PR TITLE
fix(image): always write contenttype, and name the flag for what it governs

### DIFF
--- a/iznik-batch/app/Console/Commands/Message/BackfillAttachmentContentTypeCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/BackfillAttachmentContentTypeCommand.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Console\Commands\Message;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Backfill messages_attachments.contenttype for rows the API created without it.
+ *
+ * doCreate omitted contenttype for imgtype=Message on the assumption that the
+ * column did not matter there, so the vast majority of rows carry NULL or ''.
+ * The API now always writes it, but that only fixes rows created from here on -
+ * everything already stored still has nothing to serve a Content-Type from.
+ *
+ * Scope is deliberately narrow: only rows with an externaluid, i.e. uploads that
+ * went through the tus/delivery path the API controls, and which that path
+ * produces as JPEG. Legacy rows holding inline `data` blobs are left alone
+ * because their real type is not knowable from the row, and guessing would
+ * replace "no information" with "wrong information".
+ *
+ * Chunked and resumable: it walks by ascending id and only ever narrows the
+ * candidate set, so it is safe to stop it and run it again, and safe to run in
+ * bounded slices with --limit against a table of this size.
+ */
+class BackfillAttachmentContentTypeCommand extends Command
+{
+    protected $signature = 'messages:backfill-attachment-contenttype
+                            {--value=image/jpeg : contenttype to write}
+                            {--chunk=1000 : Rows per UPDATE}
+                            {--limit=0 : Stop after this many rows (0 = no limit)}
+                            {--include-legacy : Also fill rows with no externaluid (inline data blobs)}
+                            {--dry-run : Report what would change without writing}';
+
+    protected $description = 'Backfill the empty messages_attachments.contenttype left by the old image-create path';
+
+    public function handle(): int
+    {
+        $value = (string) $this->option('value');
+        if (trim($value) === '') {
+            $this->error('--value cannot be empty.');
+
+            return Command::FAILURE;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $chunk = max(1, (int) $this->option('chunk'));
+        $limit = max(0, (int) $this->option('limit'));
+        $includeLegacy = (bool) $this->option('include-legacy');
+
+        $this->info(sprintf(
+            '%s contenttype=%s on messages_attachments (%s)%s',
+            $dryRun ? 'Would set' : 'Setting',
+            $value,
+            $includeLegacy ? 'all rows missing it' : 'rows with an externaluid only',
+            $limit > 0 ? sprintf(', stopping after %d rows', $limit) : '',
+        ));
+
+        $updated = 0;
+        $lastId = 0;
+
+        while (true) {
+            $batch = max(1, $limit > 0 ? min($chunk, $limit - $updated) : $chunk);
+
+            // Select ids first, then update by id. Doing it in one statement with a
+            // LIMIT would still scan from the start of the table each pass; carrying
+            // the high-water mark forward keeps every pass bounded.
+            $ids = $this->candidates($includeLegacy)
+                ->where('id', '>', $lastId)
+                ->orderBy('id')
+                ->limit($batch)
+                ->pluck('id');
+
+            if ($ids->isEmpty()) {
+                break;
+            }
+
+            $lastId = (int) $ids->last();
+
+            if (! $dryRun) {
+                DB::table('messages_attachments')->whereIn('id', $ids)->update(['contenttype' => $value]);
+            }
+
+            $updated += $ids->count();
+            $this->output->write('.');
+
+            if ($limit > 0 && $updated >= $limit) {
+                break;
+            }
+        }
+
+        $this->newLine();
+        $this->info(sprintf('%d row(s) %s.', $updated, $dryRun ? 'would be filled' : 'filled'));
+
+        if (! $dryRun && $updated > 0) {
+            Log::info('messages:backfill-attachment-contenttype', [
+                'value' => $value,
+                'updated' => $updated,
+                'include_legacy' => $includeLegacy,
+                'last_id' => $lastId,
+            ]);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Rows still missing a usable contenttype.
+     */
+    private function candidates(bool $includeLegacy): \Illuminate\Database\Query\Builder
+    {
+        $q = DB::table('messages_attachments')
+            ->select('id')
+            ->where(function ($w) {
+                $w->whereNull('contenttype')->orWhere('contenttype', '');
+            });
+
+        if (! $includeLegacy) {
+            $q->whereNotNull('externaluid')->where('externaluid', '!=', '');
+        }
+
+        return $q;
+    }
+}

--- a/iznik-batch/tests/Feature/Message/BackfillAttachmentContentTypeCommandTest.php
+++ b/iznik-batch/tests/Feature/Message/BackfillAttachmentContentTypeCommandTest.php
@@ -17,7 +17,7 @@ class BackfillAttachmentContentTypeCommandTest extends TestCase
     {
         return (int) DB::table('messages_attachments')->insertGetId(array_merge([
             'externaluid' => 'freegletusd-'.bin2hex(random_bytes(8)),
-            'contenttype' => null,
+            'contenttype' => '',
         ], $attrs));
     }
 
@@ -26,15 +26,19 @@ class BackfillAttachmentContentTypeCommandTest extends TestCase
         return DB::table('messages_attachments')->where('id', $id)->value('contenttype');
     }
 
-    public function testFillsNullAndEmptyContentTypes(): void
+    public function testFillsEmptyContentTypes(): void
     {
-        $nullOne = $this->attachment(['contenttype' => null]);
+        // The schema-parity migration made contenttype VARCHAR(80) NOT NULL, so the
+        // bug state the old create path left behind is '' (non-strict MySQL filled
+        // the omitted column with the implicit default), never NULL. The command
+        // still matches NULL as belt-and-braces for any pre-parity stragglers.
         $emptyOne = $this->attachment(['contenttype' => '']);
+        $emptyTwo = $this->attachment(['contenttype' => '']);
 
         $this->artisan('messages:backfill-attachment-contenttype')->assertSuccessful();
 
-        $this->assertSame('image/jpeg', $this->contentTypeOf($nullOne));
         $this->assertSame('image/jpeg', $this->contentTypeOf($emptyOne));
+        $this->assertSame('image/jpeg', $this->contentTypeOf($emptyTwo));
     }
 
     public function testLeavesRowsThatAlreadyHaveATypeAlone(): void
@@ -53,7 +57,7 @@ class BackfillAttachmentContentTypeCommandTest extends TestCase
 
         $this->artisan('messages:backfill-attachment-contenttype')->assertSuccessful();
 
-        $this->assertNull($this->contentTypeOf($legacy));
+        $this->assertSame('', $this->contentTypeOf($legacy), 'legacy row must be left untouched');
     }
 
     public function testIncludeLegacyOptFillsThoseRowsToo(): void
@@ -71,24 +75,41 @@ class BackfillAttachmentContentTypeCommandTest extends TestCase
 
         $this->artisan('messages:backfill-attachment-contenttype --dry-run')->assertSuccessful();
 
-        $this->assertNull($this->contentTypeOf($id));
+        $this->assertSame('', $this->contentTypeOf($id));
     }
 
     public function testLimitCapsTheRowsTouchedAndIsResumable(): void
     {
         $ids = [$this->attachment(), $this->attachment(), $this->attachment()];
 
+        // Assert on the global candidate count, not on which specific row was
+        // filled: the command walks by ascending id across the whole table, so
+        // under --limit=1 the row it fills may be a baseline row from the test
+        // database rather than one of ours.
+        $before = $this->candidateCount();
+        $this->assertGreaterThanOrEqual(3, $before);
+
         $this->artisan('messages:backfill-attachment-contenttype --limit=1 --chunk=1')->assertSuccessful();
 
-        $filled = collect($ids)->filter(fn ($id) => $this->contentTypeOf($id) === 'image/jpeg')->count();
-        $this->assertSame(1, $filled, 'exactly one row should be filled under --limit=1');
+        $this->assertSame($before - 1, $this->candidateCount(), 'exactly one candidate should be filled under --limit=1');
 
         // Running again picks up where it left off rather than redoing the same row.
         $this->artisan('messages:backfill-attachment-contenttype --chunk=1')->assertSuccessful();
 
+        $this->assertSame(0, $this->candidateCount());
         foreach ($ids as $id) {
             $this->assertSame('image/jpeg', $this->contentTypeOf($id));
         }
+    }
+
+    private function candidateCount(): int
+    {
+        return DB::table('messages_attachments')
+            ->where(function ($w) {
+                $w->whereNull('contenttype')->orWhere('contenttype', '');
+            })
+            ->whereNotNull('externaluid')->where('externaluid', '!=', '')
+            ->count();
     }
 
     public function testHonoursAnExplicitValue(): void
@@ -106,6 +127,6 @@ class BackfillAttachmentContentTypeCommandTest extends TestCase
 
         $this->artisan('messages:backfill-attachment-contenttype --value=" "')->assertFailed();
 
-        $this->assertNull($this->contentTypeOf($id));
+        $this->assertSame('', $this->contentTypeOf($id));
     }
 }

--- a/iznik-batch/tests/Feature/Message/BackfillAttachmentContentTypeCommandTest.php
+++ b/iznik-batch/tests/Feature/Message/BackfillAttachmentContentTypeCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Message;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The backfill fills messages_attachments.contenttype for rows the old image
+ * create path stored without one. It must leave alone anything whose type it
+ * cannot honestly infer: rows that already have a type, and legacy inline-data
+ * rows with no externaluid.
+ */
+class BackfillAttachmentContentTypeCommandTest extends TestCase
+{
+    private function attachment(array $attrs = []): int
+    {
+        return (int) DB::table('messages_attachments')->insertGetId(array_merge([
+            'externaluid' => 'freegletusd-'.bin2hex(random_bytes(8)),
+            'contenttype' => null,
+        ], $attrs));
+    }
+
+    private function contentTypeOf(int $id): ?string
+    {
+        return DB::table('messages_attachments')->where('id', $id)->value('contenttype');
+    }
+
+    public function testFillsNullAndEmptyContentTypes(): void
+    {
+        $nullOne = $this->attachment(['contenttype' => null]);
+        $emptyOne = $this->attachment(['contenttype' => '']);
+
+        $this->artisan('messages:backfill-attachment-contenttype')->assertSuccessful();
+
+        $this->assertSame('image/jpeg', $this->contentTypeOf($nullOne));
+        $this->assertSame('image/jpeg', $this->contentTypeOf($emptyOne));
+    }
+
+    public function testLeavesRowsThatAlreadyHaveATypeAlone(): void
+    {
+        $existing = $this->attachment(['contenttype' => 'image/png']);
+
+        $this->artisan('messages:backfill-attachment-contenttype')->assertSuccessful();
+
+        $this->assertSame('image/png', $this->contentTypeOf($existing));
+    }
+
+    public function testSkipsLegacyRowsWithNoExternalUidByDefault(): void
+    {
+        // No externaluid: an inline-data row whose real type we cannot infer.
+        $legacy = $this->attachment(['externaluid' => null]);
+
+        $this->artisan('messages:backfill-attachment-contenttype')->assertSuccessful();
+
+        $this->assertNull($this->contentTypeOf($legacy));
+    }
+
+    public function testIncludeLegacyOptFillsThoseRowsToo(): void
+    {
+        $legacy = $this->attachment(['externaluid' => null]);
+
+        $this->artisan('messages:backfill-attachment-contenttype --include-legacy')->assertSuccessful();
+
+        $this->assertSame('image/jpeg', $this->contentTypeOf($legacy));
+    }
+
+    public function testDryRunWritesNothing(): void
+    {
+        $id = $this->attachment();
+
+        $this->artisan('messages:backfill-attachment-contenttype --dry-run')->assertSuccessful();
+
+        $this->assertNull($this->contentTypeOf($id));
+    }
+
+    public function testLimitCapsTheRowsTouchedAndIsResumable(): void
+    {
+        $ids = [$this->attachment(), $this->attachment(), $this->attachment()];
+
+        $this->artisan('messages:backfill-attachment-contenttype --limit=1 --chunk=1')->assertSuccessful();
+
+        $filled = collect($ids)->filter(fn ($id) => $this->contentTypeOf($id) === 'image/jpeg')->count();
+        $this->assertSame(1, $filled, 'exactly one row should be filled under --limit=1');
+
+        // Running again picks up where it left off rather than redoing the same row.
+        $this->artisan('messages:backfill-attachment-contenttype --chunk=1')->assertSuccessful();
+
+        foreach ($ids as $id) {
+            $this->assertSame('image/jpeg', $this->contentTypeOf($id));
+        }
+    }
+
+    public function testHonoursAnExplicitValue(): void
+    {
+        $id = $this->attachment();
+
+        $this->artisan('messages:backfill-attachment-contenttype --value=image/webp')->assertSuccessful();
+
+        $this->assertSame('image/webp', $this->contentTypeOf($id));
+    }
+
+    public function testRejectsAnEmptyValue(): void
+    {
+        $id = $this->attachment();
+
+        $this->artisan('messages:backfill-attachment-contenttype --value=" "')->assertFailed();
+
+        $this->assertNull($this->contentTypeOf($id));
+    }
+}

--- a/iznik-server-go/image/image.go
+++ b/iznik-server-go/image/image.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"database/sql"
 	"encoding/json"
 	"os"
 	"strconv"
@@ -16,22 +15,28 @@ import (
 
 // imageTypeConfig maps imgtype names to their database table and parent ID column.
 type imageTypeConfig struct {
-	Table          string
-	IDColumn       string
-	HasContentType bool // All image tables except messages_attachments have a NOT NULL contenttype column.
+	Table    string
+	IDColumn string
+	// TrustStoredContentType says whether a row's stored contenttype can be
+	// believed when serving a legacy `data` blob. It is NOT "does this table
+	// have the column" - all ten do, NOT NULL with no default. Message is false
+	// because historic messages_attachments rows were written without it (see
+	// below), so their stored value is blank and must not be served as a
+	// Content-Type.
+	TrustStoredContentType bool
 }
 
 var typeConfigs = map[string]imageTypeConfig{
-	"Message":        {Table: "messages_attachments", IDColumn: "msgid", HasContentType: false},
-	"Group":          {Table: "groups_images", IDColumn: "groupid", HasContentType: true},
-	"Newsletter":     {Table: "newsletters_images", IDColumn: "articleid", HasContentType: true},
-	"CommunityEvent": {Table: "communityevents_images", IDColumn: "eventid", HasContentType: true},
-	"Volunteering":   {Table: "volunteering_images", IDColumn: "opportunityid", HasContentType: true},
-	"ChatMessage":    {Table: "chat_images", IDColumn: "chatmsgid", HasContentType: true},
-	"User":           {Table: "users_images", IDColumn: "userid", HasContentType: true},
-	"Newsfeed":       {Table: "newsfeed_images", IDColumn: "newsfeedid", HasContentType: true},
-	"Story":          {Table: "users_stories_images", IDColumn: "storyid", HasContentType: true},
-	"Noticeboard":    {Table: "noticeboards_images", IDColumn: "noticeboardid", HasContentType: true},
+	"Message":        {Table: "messages_attachments", IDColumn: "msgid", TrustStoredContentType: false},
+	"Group":          {Table: "groups_images", IDColumn: "groupid", TrustStoredContentType: true},
+	"Newsletter":     {Table: "newsletters_images", IDColumn: "articleid", TrustStoredContentType: true},
+	"CommunityEvent": {Table: "communityevents_images", IDColumn: "eventid", TrustStoredContentType: true},
+	"Volunteering":   {Table: "volunteering_images", IDColumn: "opportunityid", TrustStoredContentType: true},
+	"ChatMessage":    {Table: "chat_images", IDColumn: "chatmsgid", TrustStoredContentType: true},
+	"User":           {Table: "users_images", IDColumn: "userid", TrustStoredContentType: true},
+	"Newsfeed":       {Table: "newsfeed_images", IDColumn: "newsfeedid", TrustStoredContentType: true},
+	"Story":          {Table: "users_stories_images", IDColumn: "storyid", TrustStoredContentType: true},
+	"Noticeboard":    {Table: "noticeboards_images", IDColumn: "noticeboardid", TrustStoredContentType: true},
 }
 
 // PostRequest handles all POST /image operations.
@@ -253,18 +258,27 @@ func doCreate(c *fiber.Ctx, req *PostRequest) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "Database error")
 	}
 
-	var sqlResult sql.Result
-	if cfg.HasContentType {
-		sqlResult, err = sqlDB.Exec(
-			"INSERT INTO `"+cfg.Table+"` (`"+cfg.IDColumn+"`, externaluid, externalmods, hash, contenttype) VALUES (?, ?, ?, ?, 'image/jpeg')",
-			parentIDParam, req.ExternalUID, modsStr, utils.NilIfEmpty(req.Hash),
-		)
-	} else {
-		sqlResult, err = sqlDB.Exec(
-			"INSERT INTO `"+cfg.Table+"` (`"+cfg.IDColumn+"`, externaluid, externalmods, hash) VALUES (?, ?, ?, ?)",
-			parentIDParam, req.ExternalUID, modsStr, utils.NilIfEmpty(req.Hash),
-		)
-	}
+	// Always write contenttype. Every one of the ten tables declares it NOT NULL
+	// with no default, so omitting it is only survivable when the server is not
+	// in strict mode: MySQL then substitutes '' and the row is written with a
+	// meaningless content type. Under STRICT_TRANS_TABLES the same INSERT fails
+	// outright with Error 1364 and the caller sees a 500.
+	//
+	// Both happen in practice. Production's sql_mode has no STRICT_TRANS_TABLES,
+	// which is why this never surfaced as an outage - but of the most recent
+	// 200,000 messages_attachments rows, 54,057 carry contenttype='' against
+	// 3,544 with 'image/jpeg'. In CI the mode is not even constant within a run:
+	// scripts/setup-test-database.sh issues SET GLOBAL sql_mode partway through,
+	// and a connection opened before that still sees strict, so the same upload
+	// could 500 early in a run and succeed later (Playwright's HEIC mobile give
+	// flow, intermittently).
+	//
+	// A single unconditional statement removes the dependency on server mode
+	// entirely, which is the only version that is correct in both.
+	sqlResult, err := sqlDB.Exec(
+		"INSERT INTO `"+cfg.Table+"` (`"+cfg.IDColumn+"`, externaluid, externalmods, hash, contenttype) VALUES (?, ?, ?, ?, 'image/jpeg')",
+		parentIDParam, req.ExternalUID, modsStr, utils.NilIfEmpty(req.Hash),
+	)
 
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create image attachment")
@@ -462,7 +476,7 @@ func Get(c *fiber.Ctx) error {
 	// work again. We fetch `data` only HERE, not in the main SELECT above, so the
 	// common external/archived path never loads a longblob.
 	blobCols := "data"
-	if cfg.HasContentType {
+	if cfg.TrustStoredContentType {
 		blobCols += ", COALESCE(NULLIF(contenttype, ''), 'image/jpeg') AS contenttype"
 	} else {
 		blobCols += ", 'image/jpeg' AS contenttype"

--- a/iznik-server-go/image/image_test.go
+++ b/iznik-server-go/image/image_test.go
@@ -182,16 +182,20 @@ func TestTypeConfigsMessageHasNoContentType(t *testing.T) {
 	cfg := typeConfigs["Message"]
 	assert.Equal(t, "messages_attachments", cfg.Table)
 	assert.Equal(t, "msgid", cfg.IDColumn)
-	assert.False(t, cfg.HasContentType)
+	// Message alone cannot trust a stored contenttype: rows written before the
+	// INSERT always set it carry '', which must not be served as a Content-Type.
+	// This says nothing about whether the column exists - it does, on all ten.
+	assert.False(t, cfg.TrustStoredContentType)
 }
 
-func TestTypeConfigsOtherTablesHaveContentType(t *testing.T) {
-	// All tables except messages_attachments must set HasContentType=true so the
-	// INSERT statement includes the NOT NULL contenttype column.
+func TestTypeConfigsOtherTablesTrustStoredContentType(t *testing.T) {
+	// Every table except messages_attachments has always had contenttype written
+	// on insert, so the stored value is meaningful and the legacy blob-read path
+	// can use it rather than assuming JPEG.
 	for name, cfg := range typeConfigs {
 		if name == "Message" {
 			continue
 		}
-		assert.True(t, cfg.HasContentType, "%s should have HasContentType=true", name)
+		assert.True(t, cfg.TrustStoredContentType, "%s should trust its stored contenttype", name)
 	}
 }

--- a/iznik-server-go/test/image_test.go
+++ b/iznik-server-go/test/image_test.go
@@ -98,6 +98,19 @@ func TestCreateImageNoAuthUnlinked(t *testing.T) {
 	var result map[string]interface{}
 	json.Unmarshal(rsp(resp), &result)
 	assert.Equal(t, float64(0), result["ret"])
+
+	// Read the row back rather than trusting the 200. messages_attachments.contenttype
+	// is NOT NULL with no default, and doCreate used to omit it for imgtype=Message:
+	// under a lenient sql_mode MySQL silently substituted '' and the endpoint still
+	// answered 200, so a status-only assertion passed while the column was junk. It
+	// stayed that way long enough for 54,057 of the most recent 200,000 production
+	// rows to carry ''. Asserting the stored value is what makes this test able to
+	// fail for the reason it exists.
+	db := database.DBConn
+	var contenttype string
+	db.Raw("SELECT contenttype FROM messages_attachments WHERE id = ?",
+		uint64(result["id"].(float64))).Scan(&contenttype)
+	assert.Equal(t, "image/jpeg", contenttype)
 }
 
 // TestCreateImageCrossUserDenied verifies a logged-in user cannot attach an image to another


### PR DESCRIPTION
`messages_attachments.contenttype` is NOT NULL with no default, exactly like the
other nine image tables. `doCreate` omitted it for `imgtype=Message` because
`imageTypeConfig.HasContentType` claimed `messages_attachments` was the one table
without the column. It is not — all ten declare it.

## Why it matters

Omitting a NOT NULL column with no default is only survivable when the server is
not in strict mode. MySQL then substitutes `''` and writes a row with a
meaningless content type. Under `STRICT_TRANS_TABLES` the same INSERT fails with
`Error 1364` and the caller gets a 500.

Both happen.

**In production**, `sql_mode` has no `STRICT_TRANS_TABLES`, so this has never been
an outage — but it has been quietly writing bad data. Of the most recent 200,000
`messages_attachments` rows:

| contenttype | rows |
|---|---|
| *(empty)* | 54,057 |
| `image/jpeg` | 3,544 |

**In CI**, the mode is not even constant within a run.
`scripts/setup-test-database.sh` issues `SET GLOBAL sql_mode` partway through,
and connections opened before that still see strict. So the same upload can 500
early in a run and succeed later, which is what has been failing
`tests/e2e/test-heic-upload.spec.js`'s mobile give flow intermittently — including
on branches that change no application code at all.

## Change

Write the column unconditionally. That removes the dependence on server mode,
which is the only form correct under both.

Rename `HasContentType` to `TrustStoredContentType`, because after this change
the flag governs one thing: whether a row's stored `contenttype` can be believed
when serving a legacy `data` blob. Message stays `false` — rows written before
this fix hold `''` and must not have that served as a Content-Type. The old name
asserted something untrue about the schema, which is how the bug survived.

Both `typeConfigs` tests are rewritten rather than renamed: their names and
comments encoded the same incorrect premise.

## Known limits

- Existing rows are not backfilled. 54,057 rows still hold `''`; correcting them
  is a separate change and a separate decision.
- The `SET GLOBAL sql_mode` in `setup-test-database.sh` is itself a hazard for any
  other NOT-NULL-no-default column, since it makes CI behaviour depend on
  connection age. Not addressed here.
- This overlaps PR #1230, which carries the same fix in its converted (GORM) form.
  Whichever lands second will conflict in `image.go`; the two are semantically
  identical, so the resolution is to keep the converted form and confirm
  `contenttype` is written unconditionally.

## Test plan

- apiv2 image builds. A real check rather than a formality: collapsing the two
  INSERT branches leaves `database/sql` unused, and Go refuses to compile that.
- Go suite via the status API: 3816 passed, **0 build failures, 0 `FAIL` lines
  across 45 packages**, with `ok iznik-server-go/image`. Read from the log rather
  than the summary counter, because a package that fails to build contributes zero
  passes *and* zero failures.
- `Error 1364` reproduced directly against the real schema under
  `STRICT_TRANS_TABLES` before the change, and confirmed resolved after. Note that
  reproducing requires restarting the containers after `SET GLOBAL`: pooled
  connections cache `sql_mode` from connect time, so testing without a restart
  silently exercises stale lenient sessions and shows a false green.
