### PR TITLE
fix(sweeper): do not stop a worktree that is running a test suite

### DIFF
--- a/scripts/idle-stack-sweeper/freegle-stack-sweeper.sh
+++ b/scripts/idle-stack-sweeper/freegle-stack-sweeper.sh
@@ -59,6 +59,34 @@ worktree_last_activity() {
   printf '%s' "$best"
 }
 
+# Is a test suite running in this worktree right now?
+#
+# worktree_last_activity above measures git refs and changed-file mtimes, so a
+# worktree whose only current activity is a LONG TEST RUN looks completely idle:
+# a clean tree, no edits, no git operations, for the ten to fifteen minutes a Go
+# suite takes. That is indistinguishable from abandonment by mtime alone, and it
+# bit twice in ninety minutes on 2026-08-03 - both sweeps landing just as a run
+# finished, killing the containers before the detailed result could be read. The
+# status container holds its per-test log in memory only, so stopping it mid-run
+# or just after destroys the evidence that the run happened at all, which is far
+# more costly than the RAM the sweep reclaims.
+#
+# Ask the worktree's own status container instead. Any suite reporting "running"
+# means real work is in flight regardless of what the filesystem looks like.
+# Fails open (returns 1, "not running") if the port is unknown or unreachable -
+# an unreachable status container is not evidence of activity.
+worktree_suite_running() {
+  local wt="$1" port suite state
+  port="$(grep -E '^PORT_STATUS=' "$wt/.env" 2>/dev/null | cut -d= -f2)"
+  [ -n "$port" ] || return 1
+  for suite in go laravel vitest playwright php; do
+    state="$(curl -s --max-time 3 "http://localhost:${port}/api/tests/${suite}/status" 2>/dev/null \
+             | jq -r '.status // empty' 2>/dev/null)"
+    [ "$state" = "running" ] && return 0
+  done
+  return 1
+}
+
 stopped=0 considered=0
 while IFS= read -r wt; do
   [ -n "$wt" ] || continue
@@ -80,6 +108,12 @@ while IFS= read -r wt; do
   idle=$((now - last))
   if (( idle < IDLE_SECS )); then
     continue                                       # active recently -> leave it
+  fi
+
+  # Idle by mtime, but a suite may still be running - see worktree_suite_running.
+  if worktree_suite_running "$wt"; then
+    log "SKIP $proj — idle ${idle}s by mtime, but a test suite is RUNNING; leaving ${running} containers up"
+    continue
   fi
 
   if [ "$DRYRUN" = "1" ]; then


### PR DESCRIPTION
The sweeper decides idleness from git ref mtimes plus the mtimes of files git
reports as changed. A worktree whose only current activity is a **long test run**
produces neither: clean tree, no edits, no git operations, for the ten to fifteen
minutes a Go suite takes. By that measure it is indistinguishable from an
abandoned one.

Stopping it then costs more than the containers. The status container holds its
per-test log **in memory only**, so a stop mid-run — or shortly after one finishes
— destroys the evidence that the run happened at all. A suite that completed but
whose result cannot be read has to be run again from scratch.

## Change

A check consulted **only** once a worktree already looks idle by mtime: ask its own
status container whether any suite reports `running`, and skip it if so.

Fails open. An unknown `PORT_STATUS` or an unreachable status container returns
"not running", because an unreachable status container is not evidence of
activity — the existing mtime rule then applies exactly as before.

## Scope — this is a latent bug, not tonight's outage

Worth stating plainly so nobody reads this as the fix for something it did not
cause.

`FreegleDocker-orm-v2` lost its stack four times in ninety minutes tonight. That
was **not** this sweeper. Its own log records `stopped 0` on every sweep across
the whole window. The cause was the monitor FSM, which logs:

```
check_my_open_pr_ci: PR #1230 green — stopped 30 worktree container(s) at /home/edward/FreegleDocker-orm-v2
```

It stops a worktree's containers as housekeeping whenever the matching PR goes
green, with no check that the worktree is in use. That is being reviewed
separately and is not touched here.

This sweeper flaw is real regardless: it stopped two other worktrees earlier the
same night, and had either been mid-suite the damage would have been identical.

## Test plan

- `bash -n` clean.
- Dry run (`FREEGLE_SWEEP_DRYRUN=1 FREEGLE_SWEEP_IDLE_SECS=1`) against the real
  worktree set completes and logs normally, with the new check in the path.
- Fails open by construction: a worktree with no `PORT_STATUS` in its `.env`, or
  whose status container is down, takes the same branch it did before this change.

## Known limits

- It asks the status container, so it only knows about suites started through it.
  A suite run some other way still looks idle. That is acceptable — the status API
  is the sanctioned route for running tests in this repo, and anything else is
  already outside the conventions the sweeper assumes.
- One HTTP call per suite name per idle worktree, with a 3s timeout, only for
  worktrees already past the idle threshold. Negligible against a sweep that runs
  every ~33 minutes.
