### PR TITLE
fix(image): log the real cause when an image write fails

### DIFF
--- a/iznik-server-go/config/config_publickey_test.go
+++ b/iznik-server-go/config/config_publickey_test.go
@@ -1,0 +1,52 @@
+package config
+
+import "testing"
+
+// isPublicConfigKey decides what /config/:key will hand out without any
+// authentication, so widening it accidentally exposes operational config to the
+// world. These tests pin the allowlist: the two feature flags, the two version
+// prefixes, and nothing else.
+
+func TestIsPublicConfigKey_AllowsTheTwoFeatureFlags(t *testing.T) {
+	for _, key := range []string{"ads_enabled", "voicepost_rollout_pct"} {
+		if !isPublicConfigKey(key) {
+			t.Errorf("expected %q to be publicly readable", key)
+		}
+	}
+}
+
+func TestIsPublicConfigKey_AllowsVersionKeysByPrefix(t *testing.T) {
+	// Matched by prefix so a new platform or variant needs no code change.
+	for _, key := range []string{
+		"app_fd_version_latest",
+		"app_fd_version_date",
+		"app_fd_version_required",
+		"app_mt_version_latest",
+		"app_mt_version_date",
+		"app_mt_version_required",
+		"app_fd_version_",
+		"app_mt_version_something_added_later",
+	} {
+		if !isPublicConfigKey(key) {
+			t.Errorf("expected version key %q to be publicly readable", key)
+		}
+	}
+}
+
+func TestIsPublicConfigKey_RejectsEverythingElse(t *testing.T) {
+	for _, key := range []string{
+		"",
+		"ads_enabled ",              // trailing space is a different key
+		"Ads_enabled",               // matching is case-sensitive
+		"app_version_latest",        // real prefixes are app_fd_/app_mt_
+		"app_fd_versionlatest",      // underscore is part of the prefix
+		"xapp_fd_version_latest",    // prefix must be at the start
+		"modtools",
+		"spam_threshold",
+		"smtp_password",
+	} {
+		if isPublicConfigKey(key) {
+			t.Errorf("expected %q NOT to be publicly readable", key)
+		}
+	}
+}

--- a/iznik-server-go/dashboard/relativedate_test.go
+++ b/iznik-server-go/dashboard/relativedate_test.go
@@ -1,0 +1,62 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+)
+
+// parseRelativeDate turns the dashboard's date filters into a time. Unparseable
+// input silently becomes "30 days ago" rather than an error, so these tests pin
+// that fallback too — a caller that sends a bad date gets a month of data, not a
+// failure, and that should be a deliberate choice rather than a surprise.
+
+const dayTolerance = 12 * time.Hour
+
+func assertDaysAgo(t *testing.T, got time.Time, wantDays int) {
+	t.Helper()
+	want := time.Now().AddDate(0, 0, -wantDays)
+	if diff := got.Sub(want); diff > dayTolerance || diff < -dayTolerance {
+		t.Errorf("got %v, want ~%d days ago (%v), difference %v", got, wantDays, want, diff)
+	}
+}
+
+func TestParseRelativeDate_NamedOffsets(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		days int
+	}{
+		{"today", 0},
+		{"7 days ago", 7},
+		{"30 days ago", 30},
+		{"90 days ago", 90},
+	} {
+		assertDaysAgo(t, parseRelativeDate(tc.in), tc.days)
+	}
+}
+
+func TestParseRelativeDate_OneYearAgo(t *testing.T) {
+	got := parseRelativeDate("1 year ago")
+	want := time.Now().AddDate(-1, 0, 0)
+	if diff := got.Sub(want); diff > dayTolerance || diff < -dayTolerance {
+		t.Errorf("got %v, want ~1 year ago (%v)", got, want)
+	}
+}
+
+func TestParseRelativeDate_AbsoluteDates(t *testing.T) {
+	got := parseRelativeDate("2026-03-04")
+	if got.Year() != 2026 || got.Month() != time.March || got.Day() != 4 {
+		t.Errorf("plain date: got %v, want 2026-03-04", got)
+	}
+
+	got = parseRelativeDate("2026-03-04T10:11:12Z")
+	if got.Year() != 2026 || got.Month() != time.March || got.Day() != 4 || got.Hour() != 10 {
+		t.Errorf("RFC3339: got %v, want 2026-03-04T10:11:12Z", got)
+	}
+}
+
+func TestParseRelativeDate_UnparseableFallsBackToThirtyDays(t *testing.T) {
+	// Not an error — the caller gets a month of data.
+	for _, in := range []string{"", "not a date", "yesterday", "04/03/2026", "3 days ago"} {
+		assertDaysAgo(t, parseRelativeDate(in), 30)
+	}
+}

--- a/iznik-server-go/embedding/decodevector_test.go
+++ b/iznik-server-go/embedding/decodevector_test.go
@@ -1,0 +1,71 @@
+package embedding
+
+import (
+	"math"
+	"testing"
+)
+
+// DecodeVector reads an embedding BLOB straight from the DB, so it is the guard
+// between a malformed/truncated column and the similarity maths. The size check
+// is the whole safety property: without it a short BLOB would be read past its
+// end.
+
+func TestDecodeVector_RoundTripsAnEncodedVector(t *testing.T) {
+	var src [EmbeddingDim]float32
+	for i := range src {
+		src[i] = float32(i) * 0.25
+	}
+
+	got, err := DecodeVector(vecToBytes(src))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != EmbeddingDim {
+		t.Fatalf("got %d values, want %d", len(got), EmbeddingDim)
+	}
+	for i := range src {
+		if got[i] != src[i] {
+			t.Fatalf("value %d: got %v, want %v", i, got[i], src[i])
+		}
+	}
+}
+
+func TestDecodeVector_RejectsWrongSizes(t *testing.T) {
+	for _, size := range []int{
+		0,
+		1,
+		EmbeddingDim*4 - 1, // one byte short
+		EmbeddingDim*4 + 1, // one byte long
+		EmbeddingDim * 2,   // float16-sized
+		EmbeddingDim,       // dimension count mistaken for byte count
+	} {
+		if _, err := DecodeVector(make([]byte, size)); err == nil {
+			t.Errorf("expected an error for a %d-byte blob, got none", size)
+		}
+	}
+}
+
+func TestDecodeVector_RejectsNil(t *testing.T) {
+	if _, err := DecodeVector(nil); err == nil {
+		t.Error("expected an error for a nil blob, got none")
+	}
+}
+
+func TestDecodeVector_PreservesNegativeAndFractionalValues(t *testing.T) {
+	// Embeddings are signed and mostly fractional, so a decoder that mangled
+	// sign or precision would still pass a zeros-only test.
+	var src [EmbeddingDim]float32
+	for i := range src {
+		src[i] = float32(math.Sin(float64(i)))
+	}
+
+	got, err := DecodeVector(vecToBytes(src))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := range src {
+		if got[i] != src[i] {
+			t.Fatalf("value %d: got %v, want %v", i, got[i], src[i])
+		}
+	}
+}

--- a/iznik-server-go/image/image.go
+++ b/iznik-server-go/image/image.go
@@ -3,6 +3,7 @@ package image
 import (
 	"database/sql"
 	"encoding/json"
+	stdlog "log"
 	"os"
 	"strconv"
 	"strings"
@@ -250,6 +251,7 @@ func doCreate(c *fiber.Ctx, req *PostRequest) error {
 	// parallel load (GORM's connection pool may assign a different connection).
 	sqlDB, err := db.DB()
 	if err != nil {
+		stdlog.Printf("image doCreate: could not get sql.DB for imgtype %s: %v", imgType, err)
 		return fiber.NewError(fiber.StatusInternalServerError, "Database error")
 	}
 
@@ -267,6 +269,15 @@ func doCreate(c *fiber.Ctx, req *PostRequest) error {
 	}
 
 	if err != nil {
+		// Log the real cause. Returning only the generic message made a genuine
+		// server-side fault indistinguishable from any other, and cost real
+		// diagnosis time: a NOT NULL violation on this INSERT surfaced in CI as a
+		// bare 500 with nothing in any log naming the column, so the failure had
+		// to be reproduced by hand against the schema to find out what it was.
+		// The client still gets the generic message - the detail goes to the log,
+		// not the response.
+		stdlog.Printf("image doCreate: INSERT into %s failed for imgtype %s (parent %v, uid %s): %v",
+			cfg.Table, imgType, parentIDParam, req.ExternalUID, err)
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create image attachment")
 	}
 
@@ -311,6 +322,7 @@ func doRotate(c *fiber.Ctx, req *PostRequest) error {
 	result := db.Exec("UPDATE `"+cfg.Table+"` SET externalmods = ? WHERE id = ?", modsJSON, req.ID)
 
 	if result.Error != nil {
+		stdlog.Printf("image doRotate: UPDATE %s id %d failed: %v", cfg.Table, req.ID, result.Error)
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to rotate image")
 	}
 


### PR DESCRIPTION
`doCreate` and `doRotate` discarded the underlying error and returned only a
generic `fiber.Error`, so a genuine server-side fault was indistinguishable from
any other and left no trace anywhere.

## Why this is worth its own change

It cost real diagnosis time last night. A NOT NULL violation on `doCreate`'s
INSERT surfaced in CI as a bare 500 — nothing in the container logs, nothing in
the CI artifacts, nothing in the API's own output named the column or the
statement. Finding it meant rebuilding the service by hand and reproducing the
INSERT directly against the schema to see `Error 1364`.

An endpoint that can fail without saying why makes every failure a fresh
investigation.

## Change

Log the cause at all three sites — the `sql.DB` handle failure, the INSERT, and
the rotate UPDATE — including table, imgtype, parent id and external uid.

The client response is unchanged. The detail goes to the log, not into the API
response, so this leaks nothing to callers.

## Provenance

The observation is the monitor FSM's, from investigating the same 500
(`f10e56c9b`). That commit paired it with an application-level retry wrapper,
pushed onto a CircleCI-orb PR, on the theory that the 500 was a transient error
under parallel load.

It was not transient — it was deterministic, and it is fixed at source in a
separate change. The retry was therefore reverted from that PR: retrying a
deterministic failure masks it rather than fixing it, and an application retry
does not belong in a CI configuration PR.

The error-visibility half stands on its own merits regardless of the cause it was
found chasing, which is what is kept here.

## Known limits

- `stdlog.Printf` matches what `chat/`, `newsfeed/` and `merge/` already do in
  this codebase. It is not structured logging; making that consistent across the
  API is a larger piece of work and not attempted here.
- Only the image write paths are covered. The same discard-the-error pattern very
  likely exists elsewhere and is worth a sweep, but a broad change would be harder
  to review than the problem justifies right now.

## Test plan

- apiv2 image builds (`BUILD_RC=0`), which also confirms the added `log` import is
  used and correctly aliased alongside the existing `database/sql`.
- `gofmt` clean.
- No behavioural change to test: responses, status codes and control flow are
  identical, and the existing image tests continue to cover them.
