### PR TITLE
fix(apiv2): don't invent a display name that sanitisation will reject

### DIFF
--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -323,6 +323,43 @@ func TestInventNameFallsBackToGeneratedName(t *testing.T) {
 	assert.NotEqual(t, "A freegler", u.Displayname)
 }
 
+func TestInventNameRejectsAuthorityEmailLocalPart(t *testing.T) {
+	db := database.DBConn
+
+	// Role addresses like info@ are common, and "info" is an authority word, so
+	// SanitizeDisplayName rewrites it to "A freegler" on every read. Storing it
+	// would strand the user there permanently: InventName only runs when the
+	// stored fullname is "A freegler", which it no longer would be.
+	db.Exec("INSERT INTO users (fullname, systemrole) VALUES ('A freegler', 'User')")
+	var targetID uint64
+	db.Raw("SELECT id FROM users ORDER BY id DESC LIMIT 1").Scan(&targetID)
+	require.NotZero(t, targetID)
+
+	db.Exec("INSERT INTO users_emails (userid, email, preferred) VALUES (?, 'info@example.com', 1)", targetID)
+
+	prefix := uniquePrefix("invent_authority")
+	viewerID := CreateTestUser(t, prefix+"_viewer", "User")
+	_, viewerToken := CreateTestSession(t, viewerID)
+
+	url := fmt.Sprintf("/api/user/%d?jwt=%s", targetID, viewerToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var u user2.User
+	err = json.NewDecoder(resp.Body).Decode(&u)
+	assert.NoError(t, err)
+	assert.NotEqual(t, "info", u.Displayname, "an authority local part must not be used as the invented name")
+	assert.NotEqual(t, "A freegler", u.Displayname)
+	assert.NotEmpty(t, u.Displayname)
+
+	// The name we stored must be one that survives sanitisation, otherwise the
+	// next read shows "A freegler" again with no way back.
+	var storedFullname string
+	db.Raw("SELECT fullname FROM users WHERE id = ?", targetID).Scan(&storedFullname)
+	assert.Equal(t, u.Displayname, storedFullname)
+}
+
 func TestGetUsersBatch(t *testing.T) {
 	t.Run("Batch fetch multiple users returns all users", func(t *testing.T) {
 		// Create two test users

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -415,6 +415,26 @@ func GetMemberships(id uint64) []Membership {
 // GetActiveModGroupIDs returns group IDs where the user is an active moderator/owner.
 // A moderator is "active" unless their membership settings JSON has active=0.
 // A moderator is "active" unless their membership settings JSON has active=0.
+// inventNameAttempts bounds the retries when the generated name is one we
+// cannot keep. Each attempt is independent, so a handful is plenty.
+const inventNameAttempts = 10
+
+// usableInventedName reports whether a candidate is one we can store as a
+// user's fullname.
+//
+// The isSuspiciousName check is the important one, and it is not paranoia:
+// SanitizeDisplayName rewrites a suspicious name back to "A freegler" on
+// every read, but InventName is only reached when the stored fullname *is*
+// "A freegler". So storing a suspicious name is a one-way trap — the user
+// displays as "A freegler" forever and we never invent again.
+//
+// Both sources can produce one. Role addresses (info@, support@, admin@) are
+// common, and a trigram-generated word lands on an authority word like "team"
+// or "update" often enough to have failed CI.
+func usableInventedName(name string) bool {
+	return name != "" && name != "A freegler" && !isSuspiciousName(name)
+}
+
 // InventName derives a display name from the user's email address and stores it
 // as the user's fullname. Returns the invented name, or "A freegler"
 // if no usable email is found.
@@ -428,12 +448,19 @@ func InventName(db *gorm.DB, id uint64) string {
 		name = utils.TidyName(email[:at])
 	}
 
-	// Fall back to trigram-generated name when email local part is unusable.
-	if name == "" || name == "A freegler" {
-		name = utils.GenerateName()
+	// Fall back to a trigram-generated name when the email local part is
+	// unusable, retrying until we get one we can actually keep.
+	if !usableInventedName(name) {
+		name = ""
+		for i := 0; i < inventNameAttempts; i++ {
+			if candidate := utils.GenerateName(); usableInventedName(candidate) {
+				name = candidate
+				break
+			}
+		}
 	}
 
-	if name == "" || name == "A freegler" {
+	if name == "" {
 		return "A freegler"
 	}
 


### PR DESCRIPTION
## Summary

`InventName` chooses a display name and stores it as the user's `fullname`, but never
checked the candidate against `isSuspiciousName` — the rule `SanitizeDisplayName`
applies on every read.

When the two disagree the user is stranded:

- the suspicious name is stored, so every read rewrites it to "A freegler";
- `InventName` only runs when the stored fullname *is* "A freegler", so it never runs
  again and there is no way back.

Both candidate sources can produce such a name:

- **Email local part.** Role addresses (`info@`, `support@`, `admin@`, `contact@`) are
  ordinary, and those local parts are Tier B authority words.
- **Generated name.** `utils.GenerateName()` returns a trigram-built lowercase word, and
  Tier B contains ordinary English words — `team`, `help`, `trust`, `system`, `update`,
  `service`, `agent`, `review`, `audit`. Rule 4 of `isSuspiciousName` fires when every
  token is an authority word, which a single generated word satisfies by being one.

## Change

Add `usableInventedName` — non-empty, not "A freegler", and not something
`isSuspiciousName` rejects — and require it of both sources. When the email local part is
unusable, retry the generator up to `inventNameAttempts` times. If nothing usable comes
back, return "A freegler" without storing, so a later read can try again.

## Which half is which

The generated-name half is the intermittent one, and is why this surfaced:
`TestInventNameFallsBackToGeneratedName` asserts that a user with no email does not
display as "A freegler", and it does whenever the generated word happens to be Tier B.

The stored-name half is the one that reaches members, and it is not intermittent. A user
whose preferred address is a role address has that local part stored and displays as
"A freegler" from then on.

## Confirmed on production

Counted against the live database: 370 undeleted users have a fullname that is exactly one
of these authority words. 45 of those carry `inventedname = 1`, meaning this code chose and
stored the name rather than the member typing it.

Sampling two of the 45 — both stored as `admin`, both `inventedname = 1` — and fetching
them from the live API returns `displayname` "A freegler" for each. That is the stranded
state end to end on current code: we invented the name, we stored it, and it is unusable
on every read.

## Test plan

- New `TestInventNameRejectsAuthorityEmailLocalPart`: a user with fullname "A freegler"
  and `info@example.com` must display as neither "info" nor "A freegler", and the stored
  fullname must equal what was displayed — i.e. it survives sanitisation on the next read.
- `TestInventNameFallsBackToGeneratedName` and `TestInventNamePersistsBadStoredNames`
  continue to pass.
- Full Go suite run locally via the status API against a rebuilt apiv2.

## Known limits

- The new test takes the target id with `SELECT id FROM users ORDER BY id DESC LIMIT 1`
  after an INSERT, matching the three existing tests around it. That pattern is not safe
  in general, but changing it is a separate concern from this defect and is left alone.
- `inventNameAttempts` bounds the retry. If every attempt is unusable the caller still
  gets "A freegler", exactly as today — the difference is that nothing is stored, so the
  user is not stranded there.
- The 45 users already stranded are not repaired here. Their stored fullname is a
  suspicious name, which does not trigger re-invention. Clearing `fullname` for users where
  `inventedname = 1` and the stored name is suspicious would let this code re-invent them
  correctly on next read, but that is a data change and is left as a separate decision.
- The count covers single-word authority names, which is the shape this code produces. It
  does not attempt to reproduce the fuzzy Tier A matching in SQL, so it is a floor rather
  than a total.
