### PR TITLE
fix(monitor): let the coverage-jitter boost actually run

### DIFF
--- a/monitor-fsm/src/__tests__/driver.coverage_loop.test.ts
+++ b/monitor-fsm/src/__tests__/driver.coverage_loop.test.ts
@@ -105,10 +105,11 @@ describe('Driver: iteration loop logic', () => {
     const MAX_FIX_ATTEMPTS = 3
 
     // Mirror of coverage_gate_decide's target selection.
-    const decide = (redPRs: Array<{ number: number; attempts: number }>, opts: { dirty?: boolean; pending?: number; prCount?: number } = {}) => {
+    const decide = (redPRs: Array<{ number: number; attempts: number }>, opts: { dirty?: boolean; pending?: number; prCount?: number; jitter?: number } = {}) => {
       const pickableRedCount = redPRs.filter(p => p.attempts < MAX_FIX_ATTEMPTS).length
       if (pickableRedCount > 0) return 'CI_ROUTER'
       if (opts.dirty) return 'REBASE_DIRTY_PRS'
+      if ((opts.jitter ?? 0) > 0) return 'WRITE_COVERAGE'
       if ((opts.pending ?? 0) > 0) return 'WRAP_UP'
       if ((opts.prCount ?? 0) > 0) return 'WRAP_UP'
       return 'WRITE_COVERAGE'
@@ -137,6 +138,51 @@ describe('Driver: iteration loop logic', () => {
 
     it('routes to WRITE_COVERAGE when there are no red PRs at all', () => {
       expect(decide([])).toBe('WRITE_COVERAGE')
+    })
+  })
+
+  describe('COVERAGE_GATE coverage-jitter routing', () => {
+    // Regression: a coverage-jitter PR (tests green, red only on a Coveralls delta) is
+    // excluded from redPRs on purpose, so the fix-CI path will never touch it. The ONLY
+    // thing that can clear it is WRITE_COVERAGE's STEP 0 boost, which pushes coverage to
+    // that same branch. Both WRAP_UP arms exist to avoid CREATING new PRs, which the
+    // boost does not do — so if they win, the jitter PR stays red forever. #1240, #1241
+    // and #1246 sat red across whole iterations for exactly this reason.
+    const MAX_FIX_ATTEMPTS = 3
+
+    const decide = (redPRs: Array<{ number: number; attempts: number }>, opts: { dirty?: boolean; pending?: number; prCount?: number; jitter?: number } = {}) => {
+      const pickableRedCount = redPRs.filter(p => p.attempts < MAX_FIX_ATTEMPTS).length
+      if (pickableRedCount > 0) return 'CI_ROUTER'
+      if (opts.dirty) return 'REBASE_DIRTY_PRS'
+      if ((opts.jitter ?? 0) > 0) return 'WRITE_COVERAGE'
+      if ((opts.pending ?? 0) > 0) return 'WRAP_UP'
+      if ((opts.prCount ?? 0) > 0) return 'WRAP_UP'
+      return 'WRITE_COVERAGE'
+    }
+
+    it('boosts a jitter PR even when this iteration already created a PR', () => {
+      expect(decide([], { jitter: 1, prCount: 1 })).toBe('WRITE_COVERAGE')
+    })
+
+    it('boosts a jitter PR even while other CI is still pending', () => {
+      // Drain mode is about not creating new coverage PRs; the boost creates none.
+      expect(decide([], { jitter: 3, pending: 2 })).toBe('WRITE_COVERAGE')
+    })
+
+    it('boosts a jitter PR when both wrap-up conditions hold at once', () => {
+      // The real starvation case: productive iteration, CI busy, jitter PRs waiting.
+      expect(decide([], { jitter: 3, pending: 2, prCount: 1 })).toBe('WRITE_COVERAGE')
+    })
+
+    it('still puts genuinely red CI and dirty branches first', () => {
+      expect(decide([{ number: 1245, attempts: 0 }], { jitter: 3 })).toBe('CI_ROUTER')
+      expect(decide([], { jitter: 3, dirty: true })).toBe('REBASE_DIRTY_PRS')
+    })
+
+    it('leaves the no-jitter behaviour exactly as it was', () => {
+      expect(decide([], { pending: 2 })).toBe('WRAP_UP')
+      expect(decide([], { prCount: 1 })).toBe('WRAP_UP')
+      expect(decide([], {})).toBe('WRITE_COVERAGE')
     })
   })
 

--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -2923,7 +2923,7 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
 
   {
     name: 'coverage_gate_decide',
-    description: 'Pure-logic branch for COVERAGE_GATE. Priority: (1) PICKABLE (non-exhausted) red CI → CI_ROUTER; (2) dirty/needs-rebase PRs → REBASE_DIRTY_PRS; (3) PRs created this iteration → WRAP_UP; (4) else → WRITE_COVERAGE. Red PRs whose fix-attempt budget is exhausted are NOT counted as actionable CI (otherwise they ping-pong COVERAGE_GATE↔CI_ROUTER and starve coverage/Sentry).',
+    description: 'Pure-logic branch for COVERAGE_GATE. Priority: (1) PICKABLE (non-exhausted) red CI → CI_ROUTER; (2) dirty/needs-rebase PRs → REBASE_DIRTY_PRS; (3) coverage-jitter PRs → WRITE_COVERAGE (STEP 0 boost — it pushes to an existing branch rather than creating a PR, so the WRAP_UP arms below must not pre-empt it, otherwise those PRs stay red forever); (4) CI still pending → WRAP_UP; (5) PRs created this iteration → WRAP_UP; (6) else → WRITE_COVERAGE. Red PRs whose fix-attempt budget is exhausted are NOT counted as actionable CI (otherwise they ping-pong COVERAGE_GATE↔CI_ROUTER and starve coverage/Sentry).',
     paramsSchema: { type: 'object', properties: {} },
     handler: async (_params, context) => {
       const verifyDef = actions.find(a => a.name === 'verify_pr_created')!
@@ -2971,9 +2971,18 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
       let target: string
       if (pickableRedCount > 0) target = 'CI_ROUTER'
       else if (dirtyPRs.length > 0) target = 'REBASE_DIRTY_PRS'
+      // A coverage-jitter PR can ONLY be cleared by WRITE_COVERAGE's STEP 0 boost.
+      // check_my_open_pr_ci deliberately keeps these out of redPRs (their tests pass, so
+      // the fix-CI path has nothing to fix), and no other state pushes to their branch.
+      // Both WRAP_UP arms below exist to avoid *creating new PRs* — drain mode while CI
+      // is busy, and "this iteration already produced one". The boost creates no PR; it
+      // pushes to an existing branch. So neither reason applies to it, and letting them
+      // win means a jitter PR stays red indefinitely: any iteration with pending CI or a
+      // PR created wraps up before ever reaching the booster.
+      else if (coverageJitterPRs.length > 0) target = 'WRITE_COVERAGE'
       else if (pendingCount > 0) target = 'WRAP_UP'  // drain mode — CI running, don't create coverage PRs
       else if (prCount > 0) target = 'WRAP_UP'
-      else target = 'WRITE_COVERAGE'  // all red PRs exhausted/held → coverage (incl. jitter-boost, see WRITE_COVERAGE STEP 0); lets Sentry run too
+      else target = 'WRITE_COVERAGE'  // all red PRs exhausted/held → coverage; lets Sentry run too
       if (coverageJitterPRs.length > 0) {
         out(`coverage_gate_decide: ${coverageJitterPRs.length} coverage-jitter PR(s) [${coverageJitterPRs.map((p: any) => '#' + p.number).join(', ')}] — booster will add genuine coverage to clear the noise floor`)
       }


### PR DESCRIPTION
## Summary

`check_my_open_pr_ci` deliberately keeps coverage-jitter PRs out of `redPRs` — their
tests pass, so the fix-CI path has nothing to fix. That is the right call, but it leaves
exactly one thing in the machine that can clear them: `WRITE_COVERAGE`'s STEP 0 boost,
which adds genuine coverage to that same branch and pushes.

`coverage_gate_decide` reached `WRITE_COVERAGE` only when there were no pickable red PRs,
no dirty branches, **no pending CI, and no PR created this iteration**. On any productive
iteration one of the last two holds, so the boost did not run and the jitter PR stayed red
with nothing able to touch it.

## Change

Route to `WRITE_COVERAGE` as soon as `coverageJitterPRs` is non-empty, placed above both
`WRAP_UP` arms and below the two genuinely urgent cases.

Both `WRAP_UP` arms exist to avoid *creating new PRs* — drain mode while CI is busy, and
"this iteration already produced one". The boost creates no PR; it pushes to an existing
branch. Neither reason applies to it, which is why letting them win was wrong rather than
merely conservative.

Priority is now: pickable red CI, dirty branches, coverage jitter, drain, PR-created,
rotation.

## Observed

PRs #1240, #1241 and #1246 were all red on Coveralls alone and sat that way across whole
iterations. `coverage_gate_decide` logged them as jitter on every pass and still routed
elsewhere, so the booster never saw them.

## Test plan

- `tsc --noEmit` clean.
- New `COVERAGE_GATE coverage-jitter routing` block covers: boost wins over PR-created,
  over pending CI, and over both at once; genuinely red CI and dirty branches still take
  precedence; and the no-jitter path is unchanged.
- Full monitor-fsm suite: 330 tests across 20 files pass.

## Known limits

- The boost still handles one jitter PR per visit (`pick the first entry`). With several
  waiting it takes several iterations to clear them, which is now possible rather than
  never.
- This makes the existing STEP 0 reachable; it does not change what STEP 0 does once it
  runs.
