### PR TITLE
fix(app): respect the OS accessibility text-size setting

### DIFF
--- a/iznik-nuxt3/README-APP.md
+++ b/iznik-nuxt3/README-APP.md
@@ -172,20 +172,31 @@ Mobile-specific Stripe implementation:
 4. **Pinch Zoom**
    - Enabled for Android
    - Native zoom gestures
+   - Transient magnifier: scales the whole WebView viewport (navbars included)
+     while zoomed; distinct from the permanent text-size preference below
 
-5. **Device Information**
+5. **System Text Size (accessibility)**
+   - `@capacitor/text-zoom`: on startup (and again on resume) the app reads
+     the OS-preferred text zoom - iOS Dynamic Type / Android font scale - and
+     applies it to the WebView (`stores/mobile.js` `initTextZoom()`)
+   - Without this, WKWebView ignores iOS Dynamic Type entirely, so the app
+     rendered at a fixed text size whatever the member set in Settings →
+     Accessibility
+   - Text grows with reflow, and the navbars are unaffected
+
+6. **Device Information**
    - Collect device details for debugging
    - Persistent device ID
    - OS version tracking
    - Send to Sentry for error context
 
-6. **App Updates**
+7. **App Updates**
    - Check for required updates
    - Check for available updates
    - Version comparison logic
    - Update prompts
 
-7. **Rate App**
+8. **Rate App**
    - Native rating prompts
    - Timing logic to avoid annoying users
    - Platform-specific app store links

--- a/iznik-nuxt3/capacitor.config.dev.js
+++ b/iznik-nuxt3/capacitor.config.dev.js
@@ -52,6 +52,7 @@ const config = {
       '@capacitor/camera',
       '@capacitor/share',
       '@capacitor/app',
+      '@capacitor/text-zoom', // C7 - apply system accessibility text size to the WebView
       '@capacitor/screen-orientation',
     ],
     // Debug build - no signing required
@@ -78,6 +79,7 @@ const config = {
       '@capacitor/camera',
       '@capacitor/share',
       '@capacitor/app',
+      '@capacitor/text-zoom', // C7 - apply system accessibility text size to the WebView
       '@capacitor/screen-orientation',
     ],
   },

--- a/iznik-nuxt3/capacitor.config.modtools.js
+++ b/iznik-nuxt3/capacitor.config.modtools.js
@@ -28,6 +28,7 @@ const config = {
       '@capawesome/capacitor-badge',
       '@capgo/capacitor-social-login',
       '@capacitor/app',
+      '@capacitor/text-zoom', // C7 - apply system accessibility text size to the WebView
       '@capacitor/status-bar',
       '@capacitor/network',
       '@capacitor/device',
@@ -49,6 +50,7 @@ const config = {
       '@capgo/capacitor-social-login',
       '@capacitor-community/apple-sign-in',
       '@capacitor/app',
+      '@capacitor/text-zoom', // C7 - apply system accessibility text size to the WebView
       '@capacitor/status-bar',
       '@capacitor/network',
       '@capacitor/device',

--- a/iznik-nuxt3/capacitor.config.ts
+++ b/iznik-nuxt3/capacitor.config.ts
@@ -63,6 +63,7 @@ const config: CapacitorConfig = {
       "@capacitor/camera", // C7 OK
       "@capacitor/share",
       "@capacitor/app",
+      "@capacitor/text-zoom", // C7 - apply system accessibility text size to the WebView
       "@capacitor/screen-orientation",
     ],
     buildOptions: { // new creds which are not used. unsigned version needs signed with FREEGLE_KEYSTORE and FREEGLE_KEYSTORE_PASSWORD
@@ -93,6 +94,7 @@ const config: CapacitorConfig = {
       "@capacitor/camera",
       "@capacitor/share",
       "@capacitor/app",
+      "@capacitor/text-zoom", // C7 - apply system accessibility text size to the WebView
       "@capacitor/screen-orientation",
     ]
   },

--- a/iznik-nuxt3/package-lock.json
+++ b/iznik-nuxt3/package-lock.json
@@ -21,6 +21,7 @@
         "@capacitor/screen-orientation": "^7.0.2",
         "@capacitor/share": "^7.0.0",
         "@capacitor/status-bar": "^7.0.0",
+        "@capacitor/text-zoom": "^7.0.4",
         "@capawesome/capacitor-badge": "^7.0.1",
         "@capgo/capacitor-social-login": "^7.2.3",
         "@chenfengyuan/vue-number-input": "^2.0.1",
@@ -2218,6 +2219,15 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.3.tgz",
       "integrity": "sha512-JyRpVnKwHij9hgPWolF6PK+HT3e2HSPjN11/h2OmKxq8GAdPGARFLv+97eZl0pvuvm0Kka/LpiLb5whXISBg7Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/text-zoom": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/text-zoom/-/text-zoom-7.0.4.tgz",
+      "integrity": "sha512-CNVZqZu6ggi+tl9u/dyPERId3SEOZ8oqu4toEe7dEpAuCD9cQ3w9t+8NZiqGfJYMZmgl1AFf8VR8VRPFVxip3g==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"

--- a/iznik-nuxt3/package.json
+++ b/iznik-nuxt3/package.json
@@ -108,6 +108,7 @@
     "@capacitor/screen-orientation": "^7.0.2",
     "@capacitor/share": "^7.0.0",
     "@capacitor/status-bar": "^7.0.0",
+    "@capacitor/text-zoom": "^7.0.4",
     "@capawesome/capacitor-badge": "^7.0.1",
     "@capgo/capacitor-social-login": "^7.2.3",
     "@chenfengyuan/vue-number-input": "^2.0.1",

--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -134,9 +134,44 @@ export const useMobileStore = defineStore({
       this.fixWindowOpen(AppLauncher)
       this.initDeepLinks(App)
       this.initShareIntent(App)
+      this.initTextZoom(App)
       await this.initPushNotifications(PushNotifications, Badge)
       await this.checkForAppUpdate()
       this.initWakeUpActions(App)
+    },
+
+    async initTextZoom(App) {
+      // Respect the OS accessibility text-size setting. WKWebView ignores iOS
+      // Dynamic Type for web content entirely, so without this the app renders
+      // at a fixed text size no matter what the member set in Settings ->
+      // Accessibility. getPreferred() returns the zoom the system wants
+      // (Dynamic Type on iOS, font scale on Android); applying it makes text
+      // grow WITH REFLOW, unlike pinch zoom which scales the whole viewport
+      // including the navbars.
+      try {
+        const { TextZoom } = await import('@capacitor/text-zoom')
+
+        const apply = async () => {
+          try {
+            const { value } = await TextZoom.getPreferred()
+            if (value && value > 0) {
+              await TextZoom.set({ value })
+              dbg()?.info('Applied preferred text zoom', { value })
+            }
+          } catch (e) {
+            dbg()?.debug('Text zoom apply failed', e?.message)
+          }
+        }
+
+        await apply()
+
+        // The member can change the OS setting while we're backgrounded, and
+        // getPreferred() only reflects it on next read - re-apply on resume.
+        App.addListener('resume', apply)
+      } catch (e) {
+        // Plugin unavailable (old installed build without it) - nothing to do.
+        dbg()?.debug('Text zoom unavailable', e?.message)
+      }
     },
 
     async getDeviceInfo(Device) {

--- a/iznik-nuxt3/tests/unit/stores/mobile.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/mobile.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
 let mockPlatform = 'web'
@@ -6,6 +6,15 @@ vi.mock('@capacitor/core', () => ({
   Capacitor: {
     getPlatform: () => mockPlatform,
     isNativePlatform: () => mockPlatform !== 'web',
+  },
+}))
+
+const mockTextZoomGetPreferred = vi.fn()
+const mockTextZoomSet = vi.fn()
+vi.mock('@capacitor/text-zoom', () => ({
+  TextZoom: {
+    getPreferred: (...args) => mockTextZoomGetPreferred(...args),
+    set: (...args) => mockTextZoomSet(...args),
   },
 }))
 
@@ -173,17 +182,13 @@ describe('mobile store', () => {
 
     it('returns false when no query string', () => {
       const store = useMobileStore()
-      const result = store.extractQueryStringParams(
-        'https://example.com/path'
-      )
+      const result = store.extractQueryStringParams('https://example.com/path')
       expect(result).toBe(false)
     })
 
     it('handles empty query string', () => {
       const store = useMobileStore()
-      const result = store.extractQueryStringParams(
-        'https://example.com?'
-      )
+      const result = store.extractQueryStringParams('https://example.com?')
       expect(result).toEqual({})
     })
 
@@ -311,11 +316,7 @@ describe('mobile store', () => {
 
     it('ignores legacy notifications without channel_id', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      await store.handleNotification(
-        { data: { route: '/chats/1' } },
-        {},
-        {}
-      )
+      await store.handleNotification({ data: { route: '/chats/1' } }, {}, {})
       expect(store.route).toBe(false)
       logSpy.mockRestore()
     })
@@ -372,10 +373,7 @@ describe('mobile store', () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       mockChatSend.mockResolvedValue({})
 
-      await store.handleReplyAction(
-        { data: { chatids: '42' } },
-        'Hello!'
-      )
+      await store.handleReplyAction({ data: { chatids: '42' } }, 'Hello!')
 
       expect(mockChatSend).toHaveBeenCalledWith({
         roomid: 42,
@@ -970,6 +968,68 @@ describe('mobile store', () => {
         currentRoute: { value: { path: '/' } },
       }))
       logSpy.mockRestore()
+    })
+  })
+
+  // The OS accessibility text-size setting is a PERMANENT preference: WKWebView
+  // ignores iOS Dynamic Type for web content, so without applying the preferred
+  // zoom the app renders at a fixed size whatever the member set in Settings.
+  // (Distinct from pinch zoom, which is a transient gesture.)
+  describe('initTextZoom', () => {
+    function fakeApp() {
+      const listeners = {}
+      return {
+        addListener: vi.fn((event, cb) => {
+          listeners[event] = cb
+        }),
+        fire: (event) => listeners[event]?.(),
+      }
+    }
+
+    it('applies the preferred zoom on startup', async () => {
+      mockTextZoomGetPreferred.mockResolvedValue({ value: 1.3 })
+      const store = useMobileStore()
+
+      await store.initTextZoom(fakeApp())
+
+      expect(mockTextZoomSet).toHaveBeenCalledWith({ value: 1.3 })
+    })
+
+    it('re-applies when the app resumes with a changed setting', async () => {
+      mockTextZoomGetPreferred.mockResolvedValue({ value: 1.0 })
+      const store = useMobileStore()
+      const app = fakeApp()
+
+      await store.initTextZoom(app)
+      expect(app.addListener).toHaveBeenCalledWith(
+        'resume',
+        expect.any(Function)
+      )
+
+      // Member changes the OS setting while we're backgrounded.
+      mockTextZoomGetPreferred.mockResolvedValue({ value: 1.5 })
+      await app.fire('resume')
+
+      expect(mockTextZoomSet).toHaveBeenLastCalledWith({ value: 1.5 })
+    })
+
+    it('does not set a zoom when the preferred value is unusable', async () => {
+      mockTextZoomGetPreferred.mockResolvedValue({ value: 0 })
+      const store = useMobileStore()
+
+      await store.initTextZoom(fakeApp())
+
+      expect(mockTextZoomSet).not.toHaveBeenCalled()
+    })
+
+    it('survives the plugin being unavailable', async () => {
+      mockTextZoomGetPreferred.mockRejectedValue(new Error('not implemented'))
+      const store = useMobileStore()
+
+      // Must not throw - an old installed build without the plugin still boots.
+      await store.initTextZoom(fakeApp())
+
+      expect(mockTextZoomSet).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Symptom (Edward, from device)

The FD app ignores the OS accessibility text-size setting — definitely on iOS, possibly
Android.

## Root cause

WKWebView does not apply iOS Dynamic Type to web content at all: web pages sized in px
render at a fixed size whatever the member sets in Settings → Accessibility → Display &
Text Size. Nothing in the app compensated. (Android's Chrome WebView usually follows the
system font scale by default, which is why Android may have looked partially right —
but nothing guaranteed or refreshed it.)

## Change

`@capacitor/text-zoom` (official plugin, Capacitor 7). `stores/mobile.js` gains
`initTextZoom()`: on startup it reads the OS-preferred zoom via `getPreferred()` —
Dynamic Type on iOS, font scale on Android — and applies it to the WebView with
`set()`. Re-applied on `resume` so a setting change while the app is backgrounded takes
effect when it comes back. Fail-open everywhere: an old installed build without the
plugin, or a platform error, leaves behaviour exactly as today.

The plugin is added to all six `includePlugins` allowlists (FD, ModTools, dev ×
android/ios) — the allowlist silently drops unlisted plugins from native builds.

This is the PERMANENT size preference. It is deliberately distinct from pinch zoom,
which stays as-is: a transient whole-viewport magnifier. Text sized this way grows
with reflow, and the navbars are unaffected.

## Tests

`tests/unit/stores/mobile.spec.js` gains an `initTextZoom` block: applies preferred
zoom on startup; re-applies on resume with the changed value; skips an unusable
preferred value; and survives the plugin rejecting (old installed builds must still
boot). Store-level unit tests with the plugin mocked — the real Dynamic Type read
needs a device.

## Verification

- eslint + `node --check` clean on changed files (the pre-known `capacitor.config.ts`
  parse quirk is why that file is lint-ignored; `tsc` confirms my two inserted lines
  parse, with the file's one legacy `bundledWebRuntime` complaint unchanged).
- Unit suite runs in CI — no local runner in this checkout.
- On-device confirmation needs a build from this branch: set a large text size in
  iOS Settings, open the app, text should be large; change it while the app is
  backgrounded, resume, size should update.
