### PR TITLE
Add user:list-mods artisan command porting v1 fix_listmods

### DIFF
--- a/iznik-batch/app/Console/Commands/User/ListModsCommand.php
+++ b/iznik-batch/app/Console/Commands/User/ListModsCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands\User;
+
+use App\Services\ListModsService;
+use Illuminate\Console\Command;
+
+/**
+ * Port of the V1 script scripts/fix/fix_listmods.php: CSV of every group
+ * moderator/owner with their emails, name, last access and mod groups.
+ */
+class ListModsCommand extends Command
+{
+    protected $signature = 'user:list-mods
+                            {--output= : Write CSV to this file path instead of stdout}';
+
+    protected $description = 'List all group moderators/owners as CSV (port of V1 fix_listmods)';
+
+    public function handle(ListModsService $service): int
+    {
+        $path = $this->option('output');
+        $handle = fopen($path ?: 'php://stdout', 'w');
+
+        if ($handle === FALSE) {
+            $this->error("Could not open {$path} for writing");
+
+            return Command::FAILURE;
+        }
+
+        foreach ($service->rows() as $row) {
+            fputcsv($handle, $row);
+        }
+
+        fclose($handle);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Services/ListModsService.php
+++ b/iznik-batch/app/Services/ListModsService.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Membership;
+use App\Models\User;
+use App\Models\UserEmail;
+
+/**
+ * Generates the moderator-list CSV rows.
+ *
+ * Port of the V1 script scripts/fix/fix_listmods.php: one row per user who
+ * is a Moderator or Owner of any group, with their preferred email, name,
+ * last access date, active/backup mod group lists and other known emails.
+ *
+ * Deliberate deviation from V1: getName()'s invent-a-name branch (which
+ * generated and STORED a replacement for blank/placeholder names) is
+ * omitted - a listing must not write to the database, so such rare names
+ * pass through unchanged.
+ */
+class ListModsService
+{
+    public const HEADER = [
+        'userid',
+        'email',
+        'name',
+        'lastaccess',
+        'activemod',
+        'backupmod',
+        'other known emails',
+    ];
+
+    /**
+     * @return \Generator<int, array> header row first, then one row per mod
+     */
+    public function rows(): \Generator
+    {
+        yield self::HEADER;
+
+        $modIds = Membership::query()
+            ->whereIn('role', [Membership::ROLE_MODERATOR, Membership::ROLE_OWNER])
+            ->distinct()
+            ->pluck('userid');
+
+        foreach ($modIds as $userid) {
+            $user = User::find($userid);
+
+            if (!$user) {
+                continue;
+            }
+
+            // V1 ordered by preferred DESC, email ASC - the alphabetical
+            // tiebreak matters, so don't reuse User::getEmailPreferredAttribute
+            // (which breaks ties on validated DESC).
+            $emails = UserEmail::query()
+                ->where('userid', $user->id)
+                ->orderByDesc('preferred')
+                ->orderBy('email')
+                ->pluck('email');
+
+            $preferred = NULL;
+
+            foreach ($emails as $candidate) {
+                if (!User::isInternalEmail($candidate)) {
+                    $preferred = $candidate;
+                    break;
+                }
+            }
+
+            // V1 filtered "other known emails" on Mail::ourDomain() alone,
+            // NOT the wider preferred-email filter - so e.g. a yahoogroups
+            // address appears here even though it can never be preferred.
+            $otherEmails = [];
+
+            foreach ($emails as $candidate) {
+                if (!$this->isOurDomain($candidate) && $candidate !== $preferred) {
+                    $otherEmails[] = $candidate;
+                }
+            }
+
+            [$active, $backup] = $this->modGroups($user->id);
+
+            yield [
+                $user->id,
+                $preferred,
+                $this->name($user),
+                $user->lastaccess ? $user->lastaccess->format('Y-m-d') : NULL,
+                implode(',', $active),
+                implode(',', $backup),
+                implode(',', $otherEmails),
+            ];
+        }
+    }
+
+    /**
+     * The user's mod/owner groups split into active and backup, ordered as
+     * V1 getMemberships did: LOWER(namefull ?? nameshort) ASC.  V1 CLI
+     * scripts ran with Session::modtools() TRUE, so there is deliberately
+     * no groups.publish filter here.
+     *
+     * @return array{0: string[], 1: string[]} [active nameshorts, backup nameshorts]
+     */
+    private function modGroups(int $userid): array
+    {
+        $modships = Membership::query()
+            ->join('groups', 'groups.id', '=', 'memberships.groupid')
+            ->where('memberships.userid', $userid)
+            ->whereIn('memberships.role', [Membership::ROLE_MODERATOR, Membership::ROLE_OWNER])
+            ->orderByRaw('LOWER(COALESCE(groups.namefull, groups.nameshort)) ASC')
+            ->select('memberships.*', 'groups.nameshort AS group_nameshort')
+            ->get();
+
+        $active = [];
+        $backup = [];
+
+        foreach ($modships as $modship) {
+            if ($modship->isActiveMod()) {
+                $active[] = $modship->group_nameshort;
+            } else {
+                $backup[] = $modship->group_nameshort;
+            }
+        }
+
+        return [$active, $backup];
+    }
+
+    /**
+     * V1 User::getName() minus the invent-a-name branch: fullname else
+     * first/last, strip from '@', truncate long names, disambiguate purely
+     * numeric ones, drop the TrashNothing -gNNN suffix - in that order.
+     */
+    private function name(User $user): ?string
+    {
+        $name = NULL;
+
+        if ($user->fullname) {
+            $name = $user->fullname;
+        } elseif ($user->firstname || $user->lastname) {
+            $name = $user->firstname && $user->lastname
+                ? "{$user->firstname} {$user->lastname}"
+                : ($user->firstname ?: $user->lastname);
+        }
+
+        if ($name === NULL) {
+            return NULL;
+        }
+
+        if (str_contains($name, '@')) {
+            $name = substr($name, 0, strpos($name, '@'));
+        }
+
+        $name = strlen($name) > 32 ? (substr($name, 0, 32) . '...') : $name;
+        $name = is_numeric($name) ? "$name." : $name;
+
+        return User::removeTNGroup($name);
+    }
+
+    /**
+     * V1 Mail::ourDomain(): internal domains only, without the extra
+     * yahoogroups/group-domain patterns used for preferred-email selection.
+     */
+    private function isOurDomain(string $email): bool
+    {
+        foreach (config('freegle.mail.internal_domains', []) as $domain) {
+            if (stripos($email, '@' . $domain) !== FALSE) {
+                return TRUE;
+            }
+        }
+
+        return FALSE;
+    }
+}

--- a/iznik-batch/tests/Feature/User/ListModsCommandTest.php
+++ b/iznik-batch/tests/Feature/User/ListModsCommandTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use App\Models\Group;
+use App\Models\Membership;
+use App\Models\User;
+use App\Models\UserEmail;
+use Tests\TestCase;
+
+/**
+ * Tests for user:list-mods, the port of V1 scripts/fix/fix_listmods.php.
+ *
+ * The command emits a CSV of every user who is a Moderator or Owner of any
+ * group: userid, preferred email, name, last access date, active-mod groups,
+ * backup-mod groups, and other known (non-internal) emails.
+ */
+class ListModsCommandTest extends TestCase
+{
+    private const HEADER = [
+        'userid',
+        'email',
+        'name',
+        'lastaccess',
+        'activemod',
+        'backupmod',
+        'other known emails',
+    ];
+
+    private string $outputPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->outputPath = tempnam(sys_get_temp_dir(), 'listmods');
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->outputPath);
+        parent::tearDown();
+    }
+
+    /**
+     * Run the command and parse the CSV it wrote into rows keyed by userid.
+     *
+     * @return array{header: array, rows: array<int, array>}
+     */
+    private function runAndParse(): array
+    {
+        $this->artisan('user:list-mods', ['--output' => $this->outputPath])
+            ->assertExitCode(0);
+
+        $lines = file($this->outputPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $this->assertNotEmpty($lines, 'CSV output should at least contain a header row');
+
+        $header = str_getcsv(array_shift($lines));
+        $rows = [];
+
+        foreach ($lines as $line) {
+            $fields = str_getcsv($line);
+            $this->assertCount(count(self::HEADER), $fields);
+            $rows[(int) $fields[0]] = array_combine(self::HEADER, $fields);
+        }
+
+        return ['header' => $header, 'rows' => $rows];
+    }
+
+    /** Create a bare user (no email) so email tests control users_emails exactly. */
+    private function createBareUser(array $attributes = []): User
+    {
+        return User::create(array_merge([
+            'firstname' => NULL,
+            'lastname' => NULL,
+            'fullname' => 'Bare User',
+            'added' => now(),
+        ], $attributes));
+    }
+
+    private function addEmail(User $user, string $email, int $preferred = 0): UserEmail
+    {
+        return UserEmail::create([
+            'userid' => $user->id,
+            'email' => $email,
+            'preferred' => $preferred,
+            'added' => now(),
+        ]);
+    }
+
+    public function test_outputs_header_and_exactly_one_row_per_existing_mod(): void
+    {
+        // The suite shares one test DB and some earlier tests commit
+        // moderators that DatabaseTransactions cannot roll back, so an empty
+        // DB cannot be assumed: assert the command emits the header plus
+        // exactly one row per distinct mod/owner userid present at run time.
+        $expected = Membership::query()
+            ->whereIn('role', [Membership::ROLE_MODERATOR, Membership::ROLE_OWNER])
+            ->distinct()
+            ->pluck('userid')
+            ->map(fn ($id) => (int) $id)
+            ->sort()
+            ->values()
+            ->all();
+
+        $parsed = $this->runAndParse();
+
+        $this->assertSame(self::HEADER, $parsed['header']);
+
+        $actual = array_keys($parsed['rows']);
+        sort($actual);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function test_lists_moderators_and_owners_but_not_members(): void
+    {
+        $group = $this->createTestGroup();
+        $mod = $this->createTestUser();
+        $owner = $this->createTestUser();
+        $member = $this->createTestUser();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+        $this->createMembership($owner, $group, ['role' => Membership::ROLE_OWNER]);
+        $this->createMembership($member, $group, ['role' => Membership::ROLE_MEMBER]);
+
+        $rows = $this->runAndParse()['rows'];
+
+        $this->assertArrayHasKey($mod->id, $rows);
+        $this->assertArrayHasKey($owner->id, $rows);
+        $this->assertArrayNotHasKey($member->id, $rows);
+    }
+
+    public function test_moderator_of_two_groups_appears_once_with_groups_sorted_by_name(): void
+    {
+        $groupA = $this->createTestGroup();
+        $groupB = $this->createTestGroup();
+        $mod = $this->createTestUser();
+        $this->createMembership($mod, $groupA, ['role' => Membership::ROLE_MODERATOR]);
+        $this->createMembership($mod, $groupB, ['role' => Membership::ROLE_OWNER]);
+
+        $rows = $this->runAndParse()['rows'];
+
+        $this->assertArrayHasKey($mod->id, $rows);
+
+        // V1 ordered memberships by LOWER(namefull ?? nameshort) but emitted nameshort.
+        $expected = [$groupA, $groupB];
+        usort($expected, fn ($a, $b) => strcmp(
+            strtolower($a->namefull ?? $a->nameshort),
+            strtolower($b->namefull ?? $b->nameshort)
+        ));
+        $expected = implode(',', array_map(fn ($g) => $g->nameshort, $expected));
+
+        $this->assertSame($expected, $rows[$mod->id]['activemod']);
+        $this->assertSame('', $rows[$mod->id]['backupmod']);
+    }
+
+    public function test_backup_mod_split_uses_settings_active_and_legacy_showmessages(): void
+    {
+        $mod = $this->createTestUser();
+        $noSettings = $this->createTestGroup();
+        $activeFalse = $this->createTestGroup();
+        $showmessagesOff = $this->createTestGroup();
+        $activeWinsOverShowmessages = $this->createTestGroup();
+
+        $this->createMembership($mod, $noSettings, ['role' => Membership::ROLE_MODERATOR]);
+        $this->createMembership($mod, $activeFalse, [
+            'role' => Membership::ROLE_MODERATOR,
+            'settings' => ['active' => FALSE],
+        ]);
+        $this->createMembership($mod, $showmessagesOff, [
+            'role' => Membership::ROLE_MODERATOR,
+            'settings' => ['showmessages' => 0],
+        ]);
+        $this->createMembership($mod, $activeWinsOverShowmessages, [
+            'role' => Membership::ROLE_MODERATOR,
+            'settings' => ['active' => 1, 'showmessages' => 0],
+        ]);
+
+        $row = $this->runAndParse()['rows'][$mod->id];
+
+        $active = explode(',', $row['activemod']);
+        $backup = explode(',', $row['backupmod']);
+
+        $this->assertContains($noSettings->nameshort, $active);
+        $this->assertContains($activeWinsOverShowmessages->nameshort, $active);
+        $this->assertContains($activeFalse->nameshort, $backup);
+        $this->assertContains($showmessagesOff->nameshort, $backup);
+    }
+
+    public function test_preferred_email_skips_internal_domains_and_orders_alphabetically(): void
+    {
+        $group = $this->createTestGroup();
+
+        // Internal domain wins the preferred flag but must be skipped.
+        $internalPreferred = $this->createBareUser();
+        $this->addEmail($internalPreferred, 'mod123@users.ilovefreegle.org', preferred: 1);
+        $this->addEmail($internalPreferred, 'real@example.com');
+        $this->createMembership($internalPreferred, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        // Two candidates with equal preferred flag: email ASC decides, not
+        // insertion order.  users_emails.email is unique, so per-user addresses.
+        $alphabetical = $this->createBareUser();
+        $this->addEmail($alphabetical, 'zzz.alpha@example.com');
+        $this->addEmail($alphabetical, 'aaa.alpha@example.com');
+        $this->createMembership($alphabetical, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        // The preferred flag beats alphabetical order.
+        $flagged = $this->createBareUser();
+        $this->addEmail($flagged, 'aaa.flag@example.com');
+        $this->addEmail($flagged, 'zzz.flag@example.com', preferred: 1);
+        $this->createMembership($flagged, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $rows = $this->runAndParse()['rows'];
+
+        $this->assertSame('real@example.com', $rows[$internalPreferred->id]['email']);
+        $this->assertSame('aaa.alpha@example.com', $rows[$alphabetical->id]['email']);
+        $this->assertSame('zzz.flag@example.com', $rows[$flagged->id]['email']);
+    }
+
+    public function test_other_emails_excludes_preferred_and_internal_but_keeps_yahoogroups(): void
+    {
+        // V1 used two different filters: the preferred email skips internal
+        // domains AND @yahoogroups., but "other known emails" only skips
+        // internal domains - so a yahoogroups address shows up there.
+        $group = $this->createTestGroup();
+        $mod = $this->createBareUser();
+        $this->addEmail($mod, 'main@example.com', preferred: 1);
+        $this->addEmail($mod, 'second@example.com');
+        $this->addEmail($mod, 'mod123@users.ilovefreegle.org');
+        $this->addEmail($mod, 'old@yahoogroups.com');
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $row = $this->runAndParse()['rows'][$mod->id];
+
+        $this->assertSame('main@example.com', $row['email']);
+        $others = explode(',', $row['other known emails']);
+        $this->assertContains('second@example.com', $others);
+        $this->assertContains('old@yahoogroups.com', $others);
+        $this->assertNotContains('mod123@users.ilovefreegle.org', $others);
+        $this->assertNotContains('main@example.com', $others);
+    }
+
+    public function test_user_with_no_emails_has_blank_email_columns(): void
+    {
+        $group = $this->createTestGroup();
+        $mod = $this->createBareUser();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $row = $this->runAndParse()['rows'][$mod->id];
+
+        $this->assertSame('', $row['email']);
+        $this->assertSame('', $row['other known emails']);
+    }
+
+    public function test_lastaccess_formatted_as_date(): void
+    {
+        // users.lastaccess is NOT NULL DEFAULT CURRENT_TIMESTAMP, so the
+        // blank case in V1's null-guard is unreachable; only the date
+        // formatting is observable.
+        $group = $this->createTestGroup();
+
+        $active = $this->createTestUser(['lastaccess' => '2026-07-01 12:34:56']);
+        $this->createMembership($active, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $rows = $this->runAndParse()['rows'];
+
+        $this->assertSame('2026-07-01', $rows[$active->id]['lastaccess']);
+    }
+
+    public function test_name_transformations_match_v1_getname(): void
+    {
+        $group = $this->createTestGroup();
+
+        $cases = [
+            // [user attributes, expected name]
+            [['fullname' => 'Bob The Builder-g123'], 'Bob The Builder'],
+            [['fullname' => NULL, 'firstname' => 'Jane', 'lastname' => NULL], 'Jane'],
+            [['fullname' => NULL, 'firstname' => 'Jane', 'lastname' => 'Doe'], 'Jane Doe'],
+            [['fullname' => 'someone@example.com'], 'someone'],
+            [['fullname' => str_repeat('x', 40)], str_repeat('x', 32) . '...'],
+            [['fullname' => '12345'], '12345.'],
+        ];
+
+        $users = [];
+        foreach ($cases as [$attributes, $expected]) {
+            $user = $this->createBareUser($attributes);
+            $this->createMembership($user, $group, ['role' => Membership::ROLE_MODERATOR]);
+            $users[] = [$user, $expected];
+        }
+
+        $rows = $this->runAndParse()['rows'];
+
+        foreach ($users as [$user, $expected]) {
+            $this->assertSame($expected, $rows[$user->id]['name'], "user {$user->id}");
+        }
+    }
+
+    public function test_includes_unpublished_groups(): void
+    {
+        // V1 CLI scripts ran with Session::modtools() defaulting TRUE, so the
+        // memberships query did NOT filter on groups.publish.
+        $group = $this->createTestGroup(['publish' => 0]);
+        $mod = $this->createTestUser();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $rows = $this->runAndParse()['rows'];
+
+        $this->assertArrayHasKey($mod->id, $rows);
+        $this->assertSame($group->nameshort, $rows[$mod->id]['activemod']);
+    }
+
+    public function test_writes_csv_to_stdout_without_output_option(): void
+    {
+        $group = $this->createTestGroup();
+        $mod = $this->createTestUser();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        // fputcsv to php://stdout bypasses the console output buffer, so just
+        // assert the command succeeds when no --output is given.
+        $this->artisan('user:list-mods')->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Ports the V1 script `scripts/fix/fix_listmods.php` (removed with V1 in `c14a7125b`) to a Laravel artisan command: `php artisan user:list-mods [--output=path]`.
- Emits the same CSV: `userid, email, name, lastaccess, activemod, backupmod, other known emails` — one row per user who is a Moderator or Owner of any group, to stdout or `--output`.
- Logic is an exact port, preserving three V1 subtleties that are easy to lose:
  - **No `groups.publish` filter**: V1 CLI scripts ran with `Session::modtools()` defaulting TRUE, so unpublished groups were included.
  - **Two different email filters**: the preferred email skips internal domains *and* `@yahoogroups.` / group-domain addresses, but "other known emails" only skips internal domains — a yahoogroups address can appear there.
  - **Email ordering `preferred DESC, email ASC`**: the alphabetical tiebreak differs from the existing `User::email_preferred` accessor (which breaks ties on `validated DESC`), so the service runs its own query.
- One deliberate deviation, documented in the service docblock: V1 `getName()`'s invent-a-name branch (which generated and **stored** a replacement for blank/placeholder names) is omitted — a listing must not write to the database. All other name transformations are ported in V1 order (fullname/first+last, strip from `@`, 32-char truncate + `...`, numeric-name `.` suffix, TrashNothing `-gNNN` strip).

## Code Quality Review

- Reuses existing exact-parity helpers instead of duplicating: `User::isInternalEmail()` (V1 `Mail::ourDomain()` + yahoogroups/group-domain), `Membership::isActiveMod()` (V1 `User::activeModForGroup()`), `User::removeTNGroup()`.
- Thin command + service class, `--output` option and `fputcsv` per the existing `GiftAidClaimCommand` pattern.
- Query-builder only, no raw interpolation; `fopen` failure handled with a clear error and non-zero exit.
- Per-mod query pattern (3 queries per moderator) matches V1's cost profile; acceptable for an occasional operator listing.

## Future Improvements

- Batch the per-user queries (single pass over `memberships`/`users_emails` with grouping) if this ever needs to run on a schedule rather than ad hoc.
- V1's `lastaccess` null-guard is retained but unreachable (`users.lastaccess` is `NOT NULL DEFAULT CURRENT_TIMESTAMP`); could be dropped if the column is ever tightened further.

## Test Plan

- TDD: `tests/Feature/User/ListModsCommandTest.php` (11 tests) written first and verified failing with `CommandNotFoundException` before implementation.
- Tests cover: header-only output on empty DB; Moderator + Owner included, Member excluded; one row per user with groups sorted by `LOWER(namefull ?? nameshort)`; active/backup split via `settings.active` with legacy `showmessages` fallback and default-active; preferred-email selection (internal domains skipped, `preferred DESC` then `email ASC` tiebreak); other-emails filter (yahoogroups kept, internal + preferred excluded); blank columns for a user with no emails; `lastaccess` date formatting; unpublished groups included; stdout mode exit code.
- Full Laravel suite via the status API: **5152 passed, 0 failed**.
- The first full-suite run exposed that the shared test DB contains moderators committed by earlier tests (not rolled back by `DatabaseTransactions`), so the original "header only on empty DB" test was rewritten to assert the stronger property: header plus exactly one row per distinct mod/owner userid present at run time.
