### PR TITLE
fix(app): back button exits at root; chat auto-capitalise; donation modal above ad; give-flow deadline

### DIFF
--- a/iznik-nuxt3/README-APP.md
+++ b/iznik-nuxt3/README-APP.md
@@ -265,6 +265,11 @@ Several components have mobile-specific behavior:
 5. **Chat Components**
    - Optimized for mobile screens
    - Native sharing integration
+   - The chat box and ChitChat comment box use
+     `autocapitalize="sentences"` except on iOS (app and Safari), where
+     auto-capitalise engages the virtual Shift key so Return arrives as
+     shift+enter and breaks send-on-enter (`composables/useIsIOS.js`;
+     angular/angular#32963 — iOS keyboard design, not a fixed bug)
 
 ### Ads & Analytics
 

--- a/iznik-nuxt3/README-APP.md
+++ b/iznik-nuxt3/README-APP.md
@@ -190,6 +190,16 @@ Mobile-specific Stripe implementation:
    - Timing logic to avoid annoying users
    - Platform-specific app store links
 
+8. **Hardware Back Button (Android)**
+   - `initBackButton()` in `stores/mobile.js` listens for Capacitor's
+     `backButton` event (fired for both the back button and the back
+     gesture)
+   - Navigates back through webview history while there is any, then
+     backgrounds the app with `App.minimizeApp()` at the root — the
+     standard Android behaviour
+   - Without this listener Capacitor swallows back presses once history
+     is empty and the app cannot be exited
+
 </details>
 
 ---
@@ -223,6 +233,7 @@ A dedicated Pinia store handles all mobile-specific state and functionality:
 - `initPushNotifications()`: Configure push notification system
 - `checkForAppUpdate()`: Check for app updates
 - `initWakeUpActions()`: Handle app resume/wake events
+- `initBackButton()`: Android back button/gesture — history back, minimize at root
 
 </details>
 

--- a/iznik-nuxt3/assets/css/global.scss
+++ b/iznik-nuxt3/assets/css/global.scss
@@ -488,6 +488,17 @@ form {
   z-index: 199999 !important;
 }
 
+/*
+ * The sticky ad zone (LayoutCommon .sticky) is z-index 10000, above Bootstrap
+ * modals (1055), so it hid the bottom of the donation ask on mobile and the
+ * modal could not be scrolled clear of it. Lift the donation modal over the ad
+ * (but below JustGiving at 100000 and confirm modals at 200000). The backdrop
+ * is a child of .modal here, so it rides this stacking context too.
+ */
+.donation-modal-stripe {
+  z-index: 10010 !important;
+}
+
 .error__wrapper {
   display: flex;
   flex-direction: column;

--- a/iznik-nuxt3/components/ChatFooter.vue
+++ b/iznik-nuxt3/components/ChatFooter.vue
@@ -111,7 +111,7 @@
             v-model="sendmessage"
             class="h-100"
             enterkeyhint="send"
-            autocapitalize="sentences"
+            :autocapitalize="autocapitalizeMode"
             @keydown="typing"
             @keydown.enter.exact.prevent
             @keyup.enter.exact="sendOnEnter"
@@ -381,6 +381,7 @@ import 'floating-vue/dist/style.css'
 import { action } from '~/composables/useClientLog'
 import { useMe } from '~/composables/useMe'
 import { useTypewriter } from '~/composables/useTypewriter'
+import { isIOS } from '~/composables/useIsIOS'
 import JumpingDots from '~/components/JumpingDots.vue'
 import ChatNotice from '~/components/ChatNotice.vue'
 
@@ -388,6 +389,14 @@ import ChatNotice from '~/components/ChatNotice.vue'
 const props = defineProps({
   id: { type: Number, required: true },
 })
+
+// iOS auto-capitalise engages the virtual Shift key, so Return at a sentence
+// start arrives as shift+enter: keyup.enter.exact never fires and
+// keydown.enter.shift inserts a newline instead of sending (the 2020 bug this
+// box's autocapitalize="none" was added for - angular/angular#32963). That is
+// iOS keyboard design, not a fixed WebKit bug, so keep the workaround there
+// and capitalise everywhere else.
+const autocapitalizeMode = isIOS() ? 'none' : 'sentences'
 
 // Define emits
 const emit = defineEmits(['typing', 'scrollbottom'])

--- a/iznik-nuxt3/components/ChatFooter.vue
+++ b/iznik-nuxt3/components/ChatFooter.vue
@@ -111,7 +111,7 @@
             v-model="sendmessage"
             class="h-100"
             enterkeyhint="send"
-            autocapitalize="none"
+            autocapitalize="sentences"
             @keydown="typing"
             @keydown.enter.exact.prevent
             @keyup.enter.exact="sendOnEnter"

--- a/iznik-nuxt3/components/DonationAskStripe.vue
+++ b/iznik-nuxt3/components/DonationAskStripe.vue
@@ -82,15 +82,6 @@
           <div class="text-center mt-3">
             <b-button variant="secondary" @click="cancel"> Not now </b-button>
           </div>
-
-          <!-- Traditional variant: Show supporter badge info and footnotes -->
-          <DonationTraditionalExtras
-            v-if="!isMinimalVariant"
-            :groupid="groupid"
-            :groupname="groupname"
-            :target-met="targetMet"
-            :hide-thermometer="hideThermometer"
-          />
         </div>
         <!-- Traditional variant: Show thermometer inside container -->
         <DonationThermometer
@@ -100,6 +91,16 @@
           class="ml-md-4 flex-shrink-0"
         />
       </div>
+      <!-- Traditional variant: supporter badge info and footnotes. Outside the
+           two-column row so the text can use the full modal width. -->
+      <DonationTraditionalExtras
+        v-if="!isMinimalVariant"
+        :groupid="groupid"
+        :groupname="groupname"
+        :target-met="targetMet"
+        :hide-thermometer="hideThermometer"
+        class="text-center"
+      />
     </div>
   </div>
 </template>

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -233,7 +233,7 @@
                   spellcheck="true"
                   :placeholder="commentPlaceholder"
                   class="p-0 ps-2 pt-2 entersend"
-                  autocapitalize="sentences"
+                  :autocapitalize="autocapitalizeMode"
                   @keydown.enter.shift.exact.prevent="newlineComment"
                   @keydown.alt.shift.enter.exact.prevent="newlineComment"
                   @focus="focusedComment"
@@ -336,6 +336,7 @@ import {
 } from '~/composables/useScrollAnchor'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
+import { isIOS } from '~/composables/useIsIOS'
 
 // Use standard import to avoid screen-flicker
 import NewsRefer from '~/components/NewsRefer'
@@ -370,6 +371,12 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['rendered', 'expand-duplicates'])
+
+// iOS auto-capitalise engages the virtual Shift key, so Return at a sentence
+// start arrives as shift+enter and the keydown.enter.exact send never fires
+// (angular/angular#32963 - iOS keyboard design, not a fixed bug). Keep the
+// autocapitalize="none" workaround on iOS only.
+const autocapitalizeMode = isIOS() ? 'none' : 'sentences'
 
 const NewsReportModal = defineAsyncComponent(() => import('./NewsReportModal'))
 const NewsConvertModal = defineAsyncComponent(() =>

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -233,7 +233,7 @@
                   spellcheck="true"
                   :placeholder="commentPlaceholder"
                   class="p-0 ps-2 pt-2 entersend"
-                  autocapitalize="none"
+                  autocapitalize="sentences"
                   @keydown.enter.shift.exact.prevent="newlineComment"
                   @keydown.alt.shift.enter.exact.prevent="newlineComment"
                   @focus="focusedComment"

--- a/iznik-nuxt3/composables/useIsIOS.js
+++ b/iznik-nuxt3/composables/useIsIOS.js
@@ -1,0 +1,13 @@
+// iOS detection for keyboard-behaviour workarounds, covering both the
+// Capacitor app and Safari on iPhone/iPad. iPadOS masquerades as MacIntel,
+// so a Mac platform with real touch points is treated as iPad.
+export function isIOS() {
+  if (!process.client) {
+    return false
+  }
+
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  )
+}

--- a/iznik-nuxt3/pages/index.vue
+++ b/iznik-nuxt3/pages/index.vue
@@ -226,7 +226,10 @@ function goHome() {
 
     if (route.path !== nextroute) {
       nextTick(() => {
-        router.push(nextroute)
+        // Replace, don't push: leaving / in the history means the back
+        // button returns to a page that immediately redirects forward again,
+        // so the app's history never empties and back can't exit the app.
+        router.replace(nextroute)
       })
     }
   } catch (e) {

--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -451,7 +451,12 @@ export const useComposeStore = defineStore({
           // Build options for submitDraft with deadline/delivery/aiDeclined if set
           const submitOptions = {}
           if (message.deadline) {
-            submitOptions.deadline = new Date(message.deadline).toISOString()
+            // messages.deadline is a DATE column. Under strict sql_mode MySQL
+            // rejects an ISO datetime outright and apiv2 doesn't surface the
+            // error, so the deadline was silently lost (Discourse #9481).
+            // The date input gives YYYY-MM-DD already; a repost draft may
+            // carry a full ISO datetime from the API, so truncate.
+            submitOptions.deadline = String(message.deadline).substring(0, 10)
           }
           if (message.deliveryPossible !== undefined) {
             submitOptions.deliverypossible = message.deliveryPossible

--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -137,6 +137,7 @@ export const useMobileStore = defineStore({
       await this.initPushNotifications(PushNotifications, Badge)
       await this.checkForAppUpdate()
       this.initWakeUpActions(App)
+      this.initBackButton(App)
     },
 
     async getDeviceInfo(Device) {
@@ -209,6 +210,23 @@ export const useMobileStore = defineStore({
         }
       }
       return urlParams
+    },
+
+    initBackButton(App) {
+      if (process.client) {
+        // Once any JS listener is registered, Capacitor's native default (which
+        // swallows the back button/gesture once the webview history is empty,
+        // trapping the user in the app) no longer runs. Mirror that default's
+        // history navigation, but at the root background the app, which is the
+        // standard Android response to back on a task's topmost screen.
+        App.addListener('backButton', ({ canGoBack }) => {
+          if (canGoBack) {
+            window.history.back()
+          } else {
+            App.minimizeApp()
+          }
+        })
+      }
     },
 
     initWakeUpActions(App) {

--- a/iznik-nuxt3/tests/e2e/fixtures.js
+++ b/iznik-nuxt3/tests/e2e/fixtures.js
@@ -336,6 +336,8 @@ const test = base.test.extend({
       /net::ERR_SOCKET_NOT_CONNECTED.*delivery\.ilovefreegle\.org/, // External CDN not accessible in local/Docker test environments
       /Failed to load resource.*delivery\.ilovefreegle\.org/, // External CDN not accessible in local/Docker test environments
       /Failed to load resource.*yesterday\.ilovefreegle\.org/, // ModYesterday.vue polls the live Yesterday backup host directly (real prod system, not part of the CI Docker stack) — its response code depends on that system's own restore/refresh cycle, outside test control
+      /Failed to load resource.*connect\.facebook\.net/, // Facebook SDK — external script the app runs fine without; container network transiently fails to reach it
+      /Failed to load resource.*gstatic\.com/, // Google Sign-In assets — external script the app runs fine without; container network transiently fails to reach it
       /Your focus-trap must have at least one container/, // Bootstrap Vue focus-trap error during modal transitions (transient, non-critical)
       /Failed to load resource.*adtrafficquality\.google.*sodar/, // Google CSE script internally calls sodar (ad traffic quality) — external service, not our code
     ]
@@ -817,6 +819,7 @@ const test = base.test.extend({
             error.message.includes('ERR_NETWORK_CHANGED') ||
             error.message.includes('net::ERR_') ||
             error.message.includes('Execution context was destroyed') ||
+            error.message.includes('is interrupted by another navigation') ||
             error.message.includes(
               'Target page, context or browser has been closed'
             )
@@ -1686,12 +1689,19 @@ const testWithFixtures = test.extend({
       // and becomes visible in the ModTools pending queue immediately.
       try {
         const statusUrl = process.env.STATUS_API_URL || 'http://localhost:8081'
-        const ccResp = await fetch(`${statusUrl}/api/utility/run-contentcheck`, { method: 'POST' })
+        const ccResp = await fetch(
+          `${statusUrl}/api/utility/run-contentcheck`,
+          { method: 'POST' }
+        )
         if (!ccResp.ok) {
-          console.warn(`postMessage: run-contentcheck returned ${ccResp.status} — message may be hidden in pending queue`)
+          console.warn(
+            `postMessage: run-contentcheck returned ${ccResp.status} — message may be hidden in pending queue`
+          )
         }
       } catch (e) {
-        console.warn(`postMessage: run-contentcheck failed — message may be hidden in pending queue: ${e.message}`)
+        console.warn(
+          `postMessage: run-contentcheck failed — message may be hidden in pending queue: ${e.message}`
+        )
       }
 
       // Return information about the post

--- a/iznik-nuxt3/tests/e2e/utils/user.js
+++ b/iznik-nuxt3/tests/e2e/utils/user.js
@@ -34,11 +34,13 @@ async function waitForAuthPersistence(page) {
       null,
       { timeout: timeouts.ui.appearance }
     ),
-    new Promise((_, reject) =>
+    new Promise((_resolve, reject) =>
       setTimeout(
         () =>
           reject(
-            new Error('waitForAuthPersistence timed out (renderer unresponsive)')
+            new Error(
+              'waitForAuthPersistence timed out (renderer unresponsive)'
+            )
           ),
         timeouts.ui.appearance + 5000
       )
@@ -1148,7 +1150,9 @@ async function loginViaHomepage(
     try {
       const button = allButtons[i]
       const text = await button.textContent().catch(() => 'NO_TEXT')
-      const isVisible = await button.isVisible({ timeout: 5000 }).catch(() => false)
+      const isVisible = await button
+        .isVisible({ timeout: 5000 })
+        .catch(() => false)
       const isDisabled = await button.isDisabled().catch(() => 'UNKNOWN')
       const classes = await button.getAttribute('class').catch(() => 'NO_CLASS')
       const type = await button.getAttribute('type').catch(() => 'NO_TYPE')
@@ -1163,7 +1167,9 @@ async function loginViaHomepage(
   // Debug: Check form state
   try {
     const modal = page.locator('#loginModal')
-    const modalVisible = await modal.isVisible({ timeout: 5000 }).catch(() => false)
+    const modalVisible = await modal
+      .isVisible({ timeout: 5000 })
+      .catch(() => false)
     console.log(`Login modal visible: ${modalVisible}`)
 
     if (modalVisible) {
@@ -1291,7 +1297,9 @@ async function loginViaHomepage(
         )
         for (let i = 0; i < allErrorElements.length; i++) {
           const element = allErrorElements[i]
-          const isVisible = await element.isVisible({ timeout: 5000 }).catch(() => false)
+          const isVisible = await element
+            .isVisible({ timeout: 5000 })
+            .catch(() => false)
           const text = await element.textContent().catch(() => '')
           console.log(`  ${i}: visible=${isVisible}, text="${text.trim()}"`)
         }
@@ -1519,10 +1527,29 @@ async function loginViaModTools(page, email, password = 'freegle') {
   console.log(`Starting ModTools login for: ${email}`)
 
   // Navigate to ModTools root — the layout shows LoginModal when not authenticated.
-  await page.goto(`${modtoolsBaseUrl}/`, {
-    timeout: timeouts.navigation.initial,
-    waitUntil: 'domcontentloaded',
-  })
+  // Retry when a still-settling SPA navigation from the previous page (e.g. the
+  // Freegle site redirecting after logout) interrupts this goto — the same
+  // transient class gotoAndVerify tolerates.
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await page.goto(`${modtoolsBaseUrl}/`, {
+        timeout: timeouts.navigation.initial,
+        waitUntil: 'domcontentloaded',
+      })
+      break
+    } catch (error) {
+      if (
+        attempt < 3 &&
+        error.message.includes('is interrupted by another navigation')
+      ) {
+        console.log(
+          `ModTools goto interrupted by another navigation, retry ${attempt}`
+        )
+        continue
+      }
+      throw error
+    }
+  }
 
   // Wait for the login modal's email field to be visible — this confirms both
   // that Vue has hydrated and the modal is rendered. Playwright locators

--- a/iznik-nuxt3/tests/unit/composables/useIsIOS.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useIsIOS.spec.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { isIOS } from '~/composables/useIsIOS'
+
+function setNavigator(props) {
+  for (const [key, value] of Object.entries(props)) {
+    Object.defineProperty(window.navigator, key, {
+      value,
+      configurable: true,
+    })
+  }
+}
+
+describe('useIsIOS', () => {
+  let originalUserAgent
+  let originalPlatform
+  let originalMaxTouchPoints
+
+  beforeEach(() => {
+    process.client = true
+    originalUserAgent = navigator.userAgent
+    originalPlatform = navigator.platform
+    originalMaxTouchPoints = navigator.maxTouchPoints
+  })
+
+  afterEach(() => {
+    setNavigator({
+      userAgent: originalUserAgent,
+      platform: originalPlatform,
+      maxTouchPoints: originalMaxTouchPoints,
+    })
+    delete process.client
+  })
+
+  it('detects iPhone', () => {
+    setNavigator({
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15',
+      platform: 'iPhone',
+      maxTouchPoints: 5,
+    })
+    expect(isIOS()).toBe(true)
+  })
+
+  it('detects iPad reporting as iPad', () => {
+    setNavigator({
+      userAgent:
+        'Mozilla/5.0 (iPad; CPU OS 16_6 like Mac OS X) AppleWebKit/605.1.15',
+      platform: 'iPad',
+      maxTouchPoints: 5,
+    })
+    expect(isIOS()).toBe(true)
+  })
+
+  it('detects iPadOS masquerading as MacIntel via touch points', () => {
+    setNavigator({
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 5,
+    })
+    expect(isIOS()).toBe(true)
+  })
+
+  it('does not flag desktop Mac Safari', () => {
+    setNavigator({
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+    })
+    expect(isIOS()).toBe(false)
+  })
+
+  it('does not flag Android', () => {
+    setNavigator({
+      userAgent:
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/126.0 Mobile',
+      platform: 'Linux armv81',
+      maxTouchPoints: 5,
+    })
+    expect(isIOS()).toBe(false)
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -597,6 +597,41 @@ describe('compose store', () => {
     })
   })
 
+  describe('submit', () => {
+    it('sends the deadline as a plain date, not an ISO datetime', async () => {
+      const store = useComposeStore()
+      store.init({ public: {} })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      mockMessagePut.mockResolvedValue({ id: 77 })
+      mockJoinAndPost.mockResolvedValue({ groupid: 10 })
+
+      store.setEmail('test@a.com')
+      store.setPostcode({
+        id: 5,
+        name: 'SW1A 1AA',
+        groupsnear: [
+          { id: 10, nameshort: 'Westminster', namedisplay: 'Westminster' },
+        ],
+      })
+      const id = store.add()
+      store.setType({ id, type: 'Offer' })
+      store.setItem({ id, item: 'Table' })
+      store.setDeadline(id, '2026-09-03')
+
+      await store.submit({ type: 'Offer' })
+
+      // messages.deadline is a DATE column: under strict sql_mode MySQL
+      // rejects an ISO datetime ("2026-09-03T00:00:00.000Z") outright, and
+      // the give-flow deadline was silently lost (Discourse #9481).
+      expect(mockJoinAndPost).toHaveBeenCalledWith(
+        77,
+        'test@a.com',
+        expect.objectContaining({ deadline: '2026-09-03' })
+      )
+      logSpy.mockRestore()
+    })
+  })
+
   describe('backToDraft', () => {
     it('calls RejectToDraft and increments progress', async () => {
       const store = useComposeStore()

--- a/iznik-nuxt3/tests/unit/stores/mobile.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/mobile.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
 let mockPlatform = 'web'
@@ -173,17 +173,13 @@ describe('mobile store', () => {
 
     it('returns false when no query string', () => {
       const store = useMobileStore()
-      const result = store.extractQueryStringParams(
-        'https://example.com/path'
-      )
+      const result = store.extractQueryStringParams('https://example.com/path')
       expect(result).toBe(false)
     })
 
     it('handles empty query string', () => {
       const store = useMobileStore()
-      const result = store.extractQueryStringParams(
-        'https://example.com?'
-      )
+      const result = store.extractQueryStringParams('https://example.com?')
       expect(result).toEqual({})
     })
 
@@ -311,11 +307,7 @@ describe('mobile store', () => {
 
     it('ignores legacy notifications without channel_id', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      await store.handleNotification(
-        { data: { route: '/chats/1' } },
-        {},
-        {}
-      )
+      await store.handleNotification({ data: { route: '/chats/1' } }, {}, {})
       expect(store.route).toBe(false)
       logSpy.mockRestore()
     })
@@ -372,10 +364,7 @@ describe('mobile store', () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       mockChatSend.mockResolvedValue({})
 
-      await store.handleReplyAction(
-        { data: { chatids: '42' } },
-        'Hello!'
-      )
+      await store.handleReplyAction({ data: { chatids: '42' } }, 'Hello!')
 
       expect(mockChatSend).toHaveBeenCalledWith({
         roomid: 42,
@@ -790,6 +779,56 @@ describe('mobile store', () => {
       expect(mockFetchChats).toHaveBeenCalledWith(null, false)
       // But registration is not re-triggered off-app.
       expect(plugin.register).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('initBackButton hardware back handler', () => {
+    let store
+    let capturedListener
+    let mockApp
+    let historyBackSpy
+
+    beforeEach(() => {
+      store = useMobileStore()
+      capturedListener = null
+      mockApp = {
+        addListener: vi.fn().mockImplementation((event, fn) => {
+          if (event === 'backButton') capturedListener = fn
+        }),
+        minimizeApp: vi.fn(),
+      }
+      historyBackSpy = vi
+        .spyOn(window.history, 'back')
+        .mockImplementation(() => {})
+      process.client = true
+    })
+
+    afterEach(() => {
+      historyBackSpy.mockRestore()
+      delete process.client
+    })
+
+    it('registers a backButton listener', () => {
+      store.initBackButton(mockApp)
+      expect(mockApp.addListener).toHaveBeenCalledWith(
+        'backButton',
+        expect.any(Function)
+      )
+      expect(capturedListener).not.toBeNull()
+    })
+
+    it('navigates back in history when the webview can go back', () => {
+      store.initBackButton(mockApp)
+      capturedListener({ canGoBack: true })
+      expect(historyBackSpy).toHaveBeenCalled()
+      expect(mockApp.minimizeApp).not.toHaveBeenCalled()
+    })
+
+    it('minimizes the app at the root of the history', () => {
+      store.initBackButton(mockApp)
+      capturedListener({ canGoBack: false })
+      expect(historyBackSpy).not.toHaveBeenCalled()
+      expect(mockApp.minimizeApp).toHaveBeenCalled()
     })
   })
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2948,6 +2948,17 @@ func handleRejectToDraft(c *fiber.Ctx, myid uint64, req PostMessageRequest) erro
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "messagetype": msgType})
 }
 
+// deadlineDate reduces a client-supplied deadline to its date part.
+// messages.deadline is a DATE column; bundled apps send a full ISO datetime
+// ("2026-07-15T00:00:00.000Z"), which strict sql_mode rejects as a DATE
+// literal. Current clients send plain YYYY-MM-DD, which passes through.
+func deadlineDate(deadline string) string {
+	if len(deadline) > 10 {
+		return deadline[:10]
+	}
+	return deadline
+}
+
 // handleJoinAndPost joins a group and posts a message in one action.
 func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	db := database.DBConn
@@ -3064,7 +3075,12 @@ func JoinAndPostAs(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 
 	// Save deadline and deliverypossible if provided.
 	if req.Deadline != nil && *req.Deadline != "" {
-		db.Exec("UPDATE messages SET deadline = ? WHERE id = ?", *req.Deadline, req.ID)
+		// messages.deadline is a DATE column and bundled apps send a full ISO
+		// datetime, which strict sql_mode rejects outright - and with the Exec
+		// error unchecked the deadline was silently lost (Discourse #9481).
+		if err := db.Exec("UPDATE messages SET deadline = ? WHERE id = ?", deadlineDate(*req.Deadline), req.ID).Error; err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, "Invalid deadline")
+		}
 	}
 	if req.Deliverypossible != nil {
 		db.Exec("UPDATE messages SET deliverypossible = ? WHERE id = ?", *req.Deliverypossible, req.ID)
@@ -3287,7 +3303,7 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest, f
 			setClauses = append(setClauses, "deadline = NULL")
 		} else {
 			setClauses = append(setClauses, "deadline = ?")
-			args = append(args, *req.Deadline)
+			args = append(args, deadlineDate(*req.Deadline))
 		}
 	}
 	// Resolve location name to locationid if provided.

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -2494,6 +2494,46 @@ func TestJoinAndPostSavesDeadline(t *testing.T) {
 	assert.Equal(t, "2026-07-15", *deadline)
 }
 
+// Bundled apps (pre-fix webview bundles) send the deadline as a full ISO
+// datetime. messages.deadline is a DATE column: under STRICT_TRANS_TABLES the
+// datetime literal is rejected outright and, with the Exec error unchecked,
+// the deadline was silently lost (Discourse #9481). The handler must
+// normalise to the date part so both client generations save correctly.
+func TestJoinAndPostSavesDeadlineISODatetime(t *testing.T) {
+	prefix := uniquePrefix("msgmod_jap_dliso")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	_, token := CreateTestSession(t, userID)
+
+	// Create a draft message.
+	db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, message, arrival, date, source) VALUES (?, 'Offer', 'Offer: Deadline ISO test', 'Item with deadline', 'Item with deadline', NOW(), NOW(), 'Platform')",
+		userID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", userID).Scan(&msgID)
+	require.NotZero(t, msgID)
+	db.Exec("INSERT INTO messages_drafts (msgid, groupid, userid) VALUES (?, ?, ?)", msgID, groupID, userID)
+
+	// JoinAndPost with an ISO datetime deadline, as bundled apps send it.
+	body := map[string]interface{}{
+		"id":       msgID,
+		"action":   "JoinAndPost",
+		"deadline": "2026-07-15T00:00:00.000Z",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/message?jwt=%s", token), bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var deadline *string
+	db.Raw("SELECT DATE_FORMAT(deadline, '%Y-%m-%d') FROM messages WHERE id = ?", msgID).Scan(&deadline)
+	require.NotNil(t, deadline, "ISO datetime deadline must not be silently lost")
+	assert.Equal(t, "2026-07-15", *deadline)
+}
+
 // TestJoinAndPostNewUserPassword verifies that when a new user (no password)
 // posts via JoinAndPost, the generated password can be used to log in.
 func TestJoinAndPostNewUserPassword(t *testing.T) {


### PR DESCRIPTION
Fixes three Android app issues from user feedback, plus a give-flow deadline bug found while validating.

## Summary

**1. The phone back button/gesture can now exit the app (`652b27f6f`)**
- Two compounding causes trapped users: Capacitor 7's App plugin registers an always-enabled native back callback that *swallows* back presses once webview history is empty when no JS listener exists (we had none), and `goHome()` **pushed** `/browse` from `/`, so `/` always sat underneath and back bounced `/` → `/browse` forever.
- New `initBackButton()` in the mobile store: `history.back()` while there is history, `App.minimizeApp()` at the root — the standard Android 12+ behaviour (backgrounds the app, keeps state). The Android back *gesture* dispatches through the same native callback, so both are covered.
- `goHome()` now uses `router.replace`, so the landing page no longer lingers in history.
- Modal behaviour is unchanged: `useModalHistory` pushes a history state per modal and `history.back()` pops it exactly as Capacitor's default did.

**2. Chat and ChitChat comment boxes auto-capitalise sentences — except on iOS (`2aa6e62d9` + `6e44ae8d4`)**
- `autocapitalize="none"` dated from 2020 (iznik-nuxt `5a5b7c3a9`), added because iOS auto-capitalise broke send-on-enter (angular/angular#32963).
- On review (challenged by Edward, correctly): the root cause is that iOS auto-capitalise **engages the virtual Shift key**, so Return at a sentence start arrives as shift+enter — `keyup.enter.exact` never matches and `keydown.enter.shift.exact` inserts a newline instead of sending. That is documented iOS keyboard *design*, not a fixed WebKit bug; editors still ship iOS-specific shift+enter workarounds (facebook/lexical#4464, 2023).
- So the fix is platform-scoped via a new `useIsIOS` composable (covers the Capacitor app, iPhone/iPad Safari, and iPadOS masquerading as MacIntel): `sentences` everywhere except iOS, where the proven `none` workaround stays. The reported bug was the Android app, which this fixes.

**3. Donation ask modal no longer cut off by the sticky ad; supporter text spans full width (`5203d2219`)**
- The sticky ad zone is `z-index: 10000`, above Bootstrap modals (1055), so on mobile the ad overlaid the bottom of the donation modal and it could never be scrolled clear. The donation modal now sits at 10010 (same pattern as the existing `confirm-modal` rule; still below JustGiving at 100000). The backdrop is a child of `.modal` in bootstrap-vue-next, so it rides the same stacking context and dims the ad.
- The supporter-badge blurb and footnotes moved out of the left column to span the full modal width, instead of being squeezed beside the empty space under the thermometer.

**4. Give-flow deadline was silently lost under strict sql_mode (`7289f0bad` + `5aafc894d`)**
- Found because `test-edit-deadline` failed deterministically in a fresh worktree. The give flow sent `new Date(deadline).toISOString()` (`"2026-09-03T00:00:00.000Z"`) to JoinAndPost; `messages.deadline` is a `DATE` column. Under `STRICT_TRANS_TABLES` MySQL rejects that outright (error 1292), apiv2 never checks the `db.Exec` error, and the deadline is silently NULL — exactly the Discourse #9481 report. It only ever worked where sql_mode is relaxed (live, and CI after setup strips strict).
- Verified directly: the UPDATE errors 1292 under strict mode and coerces with a warning without it; recent worktree test posts all had `deadline NULL` with `deliverypossible` saved from the same request.
- Frontend fix: send the plain `YYYY-MM-DD` (truncating, since repost drafts can carry a full ISO datetime fetched from the API). The edit-modal PATCH path already sent the plain date — both paths now match.
- apiv2 hardening (`5aafc894d`): `deadlineDate()` normalises any ISO datetime to its date part in both the JoinAndPost and PATCH paths — old bundled apps keep sending datetimes until their webview bundle updates — and the JoinAndPost save is now error-checked (400 instead of silent loss). Regression test added; note it cannot go red in the test harness because `setup-test-database.sh` strips `STRICT_TRANS_TABLES` before the suite — the same blind spot that kept CI green while strict-mode connections lost deadlines. The failure mode was proven directly against the DB (error 1292 under strict; coercion warning without).

**5. Playwright harness: stop treating three transients as failures (`86284402d`, `867760399`)**
- Across seven full local runs, three different specs died on two transient classes that have nothing to do with the code under test, each passing in the other runs.
- `page.goto` interrupted by the app's own in-flight SPA navigation ("is interrupted by another navigation") now retries, in `gotoAndVerify` and in the raw goto inside `loginViaModTools`.
- The console-error watchdog treated a failed load of an **external** third-party script as critical, so a container network blip on `connect.facebook.net` or `ssl.gstatic.com` failed the run. Those two hosts join the existing external-CDN allowances; the app is designed to run without either.

## Code Quality Review

- Back button handler is a minimal listener mirroring Capacitor's own default plus the standard exit; no history semantics changed for modals or message pages (`back-navigation.client.js` untouched).
- Donation z-index follows the existing `confirm-modal` escalation pattern in `global.scss` with the rationale documented in place. Discovered in passing: the `confirm-modal` *backdrop* sibling selectors there are dead code in current bootstrap-vue-next (backdrop is a child, not a sibling) — left alone, works via stacking context.
- `README-APP.md` updated for the new mobile-store action.
- Latent lint error fixed in `mobile.spec.js` (`afterEach` used but never imported).

## Future Improvements

- The remaining unchecked `db.Exec` calls around JoinAndPost (deliverypossible, outcomes cleanup) follow the file's prevailing style; a broader error-checking sweep is out of scope here.
- The predictive-back close animation (Android 13+) never shows because Capacitor keeps a native callback registered; cosmetic, upstream limitation.
- The `test-edit-deadline` gap that hid this bug: the harness strips strict sql_mode, so DATE-column literal bugs coerce silently in CI. Running part of the suite under strict mode would catch this class.

## Test Plan

- TDD: 3 new `mobile.spec.js` tests for `initBackButton` (listener registered; `history.back()` when `canGoBack`; `minimizeApp()` at root) — verified failing before implementation, passing after.
- TDD: new `compose.spec.js` test asserting JoinAndPost receives the plain date — verified failing (received ISO datetime) before the fix.
- `TestJoinAndPostSavesDeadlineISODatetime` pins the bundled-app case in Go (see harness caveat above).
- Full frontend unit suite: **14,729 passed, 0 failed** (includes 5 new `useIsIOS` tests).
- Full Go suite: **3,830 passed, 0 failed** (includes the new ISO-deadline regression test).
- Full Playwright e2e suite against a prod container rebuilt from this branch: **184 passed, 0 failed** on the run that validated commits 1-3, and the previously-failing `test-edit-deadline` passes with the deadline fix.
- The run covering the last three commits reached **183 passed, 1 failed**, that one failure being the ModTools-goto transient which `867760399` (test-harness only) fixes. The confirming re-run could not be completed locally, for reasons traced entirely to the worktree environment: the idle sweeper stopped a run mid-flight, the stack came back with the status container's published port dead, and a later run's database-reset step (`DROP DATABASE` + the Laravel migration step) was starved out while the host sat at load average 70, leaving the schema half-built at 48 of 209 tables. Every run after that aborted in global setup reporting all 184 tests *skipped*; re-running on a quiet host restored the schema to 209 tables.
- **CI is green on this exact head** (`867760399`): `build-and-test` and `mark-ci-passed` both succeeded, with all four Coveralls flags reporting - go 84.274%, laravel 70.967%, vitest 71.207%, playwright 21.764%. That is the authoritative full-suite result for this branch.
- Throughout, a *different* set of specs failed in each run (edit-deadline, then ai-illustration, then settings, then modtools-page-loads), which is the signature of starvation rather than a regression: a regression fails the same specs. CI runs the full suite on this PR and is the authoritative check.
- Verified directly in the **production** build after the above, driving a real browser: the chat textarea carries `autocapitalize="sentences"` with `enterkeyhint="send"` intact (non-iOS path); the donation modal computes `z-index: 10010` against the sticky ad's `10000` at both desktop and 375px widths; and returning from the landing-page redirect lands on the home page rather than bouncing back through `/`.
- Browser-verified at mobile viewport: donation modal scrolls to its end above the ad zone (z-index 10010 > 10000) with the supporter text full-width; chat textarea carries `autocapitalize="sentences"`; `/` still redirects logged-in users to their home page.
- Back-button exit needs on-device confirmation on Android (webview history + minimize behaviour can't be exercised in a desktop browser).