### PR TITLE
fix(sweeper): treat a just-started suite as in-flight, not idle

### DIFF
--- a/.claude/check-push-pr-stale.sh
+++ b/.claude/check-push-pr-stale.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# PreToolUse hook: when pushing a branch that already has an open PR, stop and
+# force a decision about whether the PR text still describes the code.
+#
+# Why: a PR body written at open time silently rots as follow-up commits land.
+# The reviewer reads a description of behaviour the branch no longer has - worse
+# than no description, because it looks authoritative. This has happened
+# repeatedly: corrections get pushed, the PR keeps asserting the original claim.
+#
+# Scope: only pushes that would add commits to a branch with an OPEN PR. First
+# pushes, no-op pushes, dry runs and PR-less branches pass straight through.
+#
+# Escape hatch: prefix the command with PR_UPDATED=1 once you have checked the
+# PR text against the commits below (and updated it if it needed updating).
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
+
+# Only fire for `git push`.
+echo "$COMMAND" | grep -qE '\bgit[[:space:]]+push\b' || exit 0
+
+# Dry runs change nothing.
+echo "$COMMAND" | grep -qE '\-\-dry-run\b' && exit 0
+
+# Explicit acknowledgement (env in the command, or already exported).
+if echo "$COMMAND" | grep -qE '\bPR_UPDATED=1\b' || [ "${PR_UPDATED:-}" = "1" ]; then
+  exit 0
+fi
+
+HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+
+# Determine which repo to check: a leading `cd <path>` in the command wins,
+# else the tool's cwd, else the project dir.
+CD_PATH=$(echo "$COMMAND" | grep -oE '(^|&&|\||;)[[:space:]]*cd[[:space:]]+[^&|;]+' | head -1 \
+  | sed -E 's/^.*cd[[:space:]]+//; s/[[:space:]]+$//' | tr -d '"'"'"'')
+BASE_DIR="${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+if [ -n "$CD_PATH" ]; then
+  case "$CD_PATH" in
+    /*) TARGET_DIR="$CD_PATH" ;;
+    *)  TARGET_DIR="$BASE_DIR/$CD_PATH" ;;
+  esac
+else
+  TARGET_DIR="$BASE_DIR"
+fi
+
+TOPLEVEL=$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null)
+[ -z "$TOPLEVEL" ] && exit 0
+
+BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD 2>/dev/null)
+[ -z "$BRANCH" ] && exit 0
+[ "$BRANCH" = "HEAD" ] && exit 0                      # detached
+case "$BRANCH" in master|main|production) exit 0 ;; esac
+
+# Nothing new to push means nothing new to describe. If the remote branch does
+# not exist yet this is a first push - the PR does not exist either.
+git -C "$TOPLEVEL" rev-parse --verify --quiet "origin/$BRANCH" >/dev/null 2>&1 || exit 0
+NEW_COMMITS=$(git -C "$TOPLEVEL" log --oneline "origin/$BRANCH..HEAD" 2>/dev/null)
+[ -z "$NEW_COMMITS" ] && exit 0
+
+# Look for an open PR. Fail open: no gh, no network, no PR - do not block work.
+PR_JSON=$(cd "$TOPLEVEL" && timeout 15 gh pr list --head "$BRANCH" --state open \
+  --json number,title,url --limit 1 2>/dev/null)
+[ -z "$PR_JSON" ] && exit 0
+
+PR_NUM=$(echo "$PR_JSON" | jq -r '.[0].number // empty' 2>/dev/null)
+[ -z "$PR_NUM" ] && exit 0
+PR_TITLE=$(echo "$PR_JSON" | jq -r '.[0].title // empty' 2>/dev/null)
+PR_URL=$(echo "$PR_JSON" | jq -r '.[0].url // empty' 2>/dev/null)
+
+COUNT=$(echo "$NEW_COMMITS" | grep -c .)
+{
+  echo "STOP. This push adds $COUNT commit(s) to a branch with an OPEN PR:"
+  echo "  #$PR_NUM $PR_TITLE"
+  echo "  $PR_URL"
+  echo ""
+  echo "Commits the PR text has never seen:"
+  echo "$NEW_COMMITS" | head -20
+  [ "$COUNT" -gt 20 ] && echo "  ... and $((COUNT - 20)) more"
+  echo ""
+  echo "A PR body that describes superseded behaviour actively misleads the reviewer."
+  echo "Before pushing, read the CURRENT body and check every claim against the commits:"
+  echo "  gh pr view $PR_NUM --json body --jq .body"
+  echo ""
+  echo "If any claim, root cause, file list, count or test result changed - and"
+  echo "especially if a later commit REVERSES an earlier one - update the body"
+  echo "IMMEDIATELY after the push, in the same turn:"
+  echo "  gh api -X PATCH repos/{owner}/{repo}/pulls/$PR_NUM -f body=\"\$(cat <file>)\""
+  echo ""
+  echo "Then re-run the push prefixed with PR_UPDATED=1 to confirm you have done this."
+} >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -93,6 +93,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/check-push-pr-stale.sh",
+            "timeout": 20
+          }
+        ]
+      },
+      {
         "matcher": "*",
         "hooks": [
           {

--- a/scripts/idle-stack-sweeper/freegle-stack-sweeper.sh
+++ b/scripts/idle-stack-sweeper/freegle-stack-sweeper.sh
@@ -71,8 +71,13 @@ worktree_last_activity() {
 # or just after destroys the evidence that the run happened at all, which is far
 # more costly than the RAM the sweep reclaims.
 #
-# Ask the worktree's own status container instead. Any suite reporting "running"
-# means real work is in flight regardless of what the filesystem looks like.
+# Ask the worktree's own status container instead. Any suite reporting an
+# in-flight state means real work is in flight regardless of what the filesystem
+# looks like. Both non-terminal states count: a suite reports "started" from the
+# POST until the runner actually spawns (test discovery alone is tens of seconds
+# for Playwright), and only then flips to "running". Matching "running" alone
+# left that startup window unguarded, and a sweep landed in it on 2026-08-05,
+# killing a 184-test run seconds after it was kicked off.
 # Fails open (returns 1, "not running") if the port is unknown or unreachable -
 # an unreachable status container is not evidence of activity.
 worktree_suite_running() {
@@ -82,7 +87,9 @@ worktree_suite_running() {
   for suite in go laravel vitest playwright php; do
     state="$(curl -s --max-time 3 "http://localhost:${port}/api/tests/${suite}/status" 2>/dev/null \
              | jq -r '.status // empty' 2>/dev/null)"
-    [ "$state" = "running" ] && return 0
+    case "$state" in
+      running|started) return 0 ;;
+    esac
   done
   return 1
 }


### PR DESCRIPTION
The idle-stack sweeper's mid-run guard was one state string short, and stopped a worktree's 32 containers seconds after a 184-test Playwright run was kicked off.

## Summary

- `worktree_suite_running()` only treated status `running` as in-flight. The status API reports `started` from the POST until the runner actually spawns — for Playwright that is tens of seconds of test discovery alone. A sweep landing in that window saw "no suite running", fell back to the mtime check (which reads a clean tree mid-run as abandoned), and stopped the stack.
- Both non-terminal states now count as in-flight.

## Why it matters

This is the exact failure the guard was added to prevent, and it has now cost runs twice: the comment above the function already records two sweeps on 2026-08-03 that killed runs before their results could be read. The status container keeps its per-test log in memory only, so a sweep mid-run destroys the evidence that the run happened at all.

Separately worth knowing: the deployed copy at `~/.claude/freegle-stack-sweeper.sh` had drifted and contained **no** guard at all — the function existed only in this repo copy. I have re-deployed the repo version (with this fix) over it locally, so the installed timer now has the guard for the first time.

## Code Quality Review

- `case` over two explicit states rather than "anything not terminal": an unknown state should not be able to pin a stack up forever.
- Fail-open behaviour is unchanged — an unreachable or portless status container still counts as not-running, since it is not evidence of activity.

## Test Plan

- `bash -n` clean.
- Confirmed against the real API shapes this guard reads: a freshly POSTed Playwright run reports `{"status":"started",...}` and only later `{"status":"running",...}`; a finished run reports `completed`/`failed`. The old guard matched only the middle one.
- Verified the sweeper log entry for the incident: `10:15:05 STOP freegle-app-fixes ... idle 57090s >= 3600s, 32 containers`, timestamped seconds after the run was started.
