### PR TITLE
fix(ads): stop the sticky job-ads banner showing the page through its gap

### DIFF
--- a/iznik-nuxt3/components/LayoutCommon.vue
+++ b/iznik-nuxt3/components/LayoutCommon.vue
@@ -436,14 +436,6 @@ onBeforeUnmount(() => {
 @import 'bootstrap/scss/mixins/_breakpoints';
 @import 'assets/css/sticky-banner.scss';
 
-/* Light-grey background behind the sticky bottom ad (the "drop ads" / job ads)
-   so the advertising zone reads as visually distinct from the white bottom nav
-   bar sitting above it — otherwise both are white and the bar doesn't stand out.
-   #E9ECEF is $color-gray-3 (used by hex to avoid a colour-var import here). */
-.sticky-ad-zone {
-  background-color: #e9ecef;
-}
-
 html {
   box-sizing: border-box;
 }
@@ -496,6 +488,22 @@ body.modal-open {
 
   @include media-breakpoint-up(lg) {
     background-color: transparent;
+  }
+
+  /* Light-grey background behind the sticky bottom ad (the "drop ads" / job
+     ads) so the advertising zone reads as distinct from the white bottom nav
+     bar above it, and so the zone reads as one surface. The banner reserves a
+     fixed height (sticky-banner.scss) but the ad, or the jobs block standing
+     in for it, only takes its natural height. With few jobs the remainder was
+     left showing the page straight through a position:fixed banner. Same
+     $gray-200 as .jobs-slot in JobsDaSlot, so the leftover space reads as part
+     of the block rather than a hole.
+
+     Nested inside .sticky on purpose: as a flat .sticky-ad-zone rule it had
+     equal specificity to the lg transparent above and lost on source order,
+     so the tint was dead on desktop from the day it was added. */
+  &.sticky-ad-zone {
+    background-color: $gray-200;
   }
 
   z-index: 10000;

--- a/iznik-nuxt3/tests/unit/components/StickyAdZoneBackground.spec.js
+++ b/iznik-nuxt3/tests/unit/components/StickyAdZoneBackground.spec.js
@@ -1,0 +1,77 @@
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+import { describe, it, expect } from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// The sticky bottom banner reserves a FIXED height (sticky-banner.scss: 113px,
+// or 273px on a tall desktop) but the ad, or the WhatJobs block that stands in
+// for it, only takes its natural height. With few jobs the remainder is empty,
+// and because `.sticky` is position:fixed over the page that remainder showed
+// the page content straight through it: a transparent hole under the job ads.
+//
+// `.sticky-ad-zone` was added to tint that zone, but it was declared BEFORE
+// `.sticky`'s `background-color: transparent` at lg+. Same specificity, later
+// wins, so on desktop the tint never applied at all. Verified on production:
+// the element carried class `sticky-ad-zone` and still computed
+// `rgba(0, 0, 0, 0)` at a 1280px viewport.
+//
+// These assertions are on the cascade, not just on the colour, because a
+// colour-only test passed happily throughout the whole period the tint was dead.
+describe('Sticky ad zone background', () => {
+  const layout = readFileSync(
+    resolve(__dirname, '../../../components/LayoutCommon.vue'),
+    'utf-8'
+  )
+  const jobs = readFileSync(
+    resolve(__dirname, '../../../components/JobsDaSlot.vue'),
+    'utf-8'
+  )
+
+  const stripComments = (s) => s.replace(/\/\*[\s\S]*?\*\//g, '')
+
+  it('tints the ad zone the same colour as the jobs block it surrounds', () => {
+    const idx = layout.indexOf('.sticky-ad-zone {')
+    expect(idx, 'LayoutCommon must style .sticky-ad-zone').toBeGreaterThan(-1)
+    const rule = stripComments(layout.substring(idx, layout.indexOf('}', idx)))
+    const tint = rule.match(/background-color:\s*([^;]+);/)?.[1]?.trim()
+    expect(tint, '.sticky-ad-zone must set a background-color').toBeTruthy()
+
+    const jobsIdx = jobs.indexOf('.jobs-slot {')
+    const jobsRule = stripComments(jobs.substring(jobsIdx, jobs.indexOf('}', jobsIdx)))
+    const jobsBg = jobsRule.match(/background:\s*([^;]+);/)?.[1]?.trim()
+
+    // Same surface, so the leftover space reads as part of the block rather
+    // than a gap. $gray-200 is #e9ecef; accept either spelling on either side.
+    const norm = (c) => (c || '').toLowerCase().replace('$gray-200', '#e9ecef')
+    expect(norm(tint), 'ad zone tint must match the jobs slot background').toBe(
+      norm(jobsBg)
+    )
+  })
+
+  it('tints the zone in a way the lg+ transparent rule cannot override', () => {
+    // `.sticky` turns its background transparent from lg up. That is correct
+    // when no ad rendered (no .sticky-ad-zone class), but it must not win over
+    // the ad-zone tint — which it does whenever the tint is a plain
+    // `.sticky-ad-zone` rule sitting earlier in the file.
+    const transparentIdx = layout.search(/background-color:\s*transparent/)
+    if (transparentIdx === -1) return // rule gone entirely: nothing to override
+
+    const nestedIdx = layout.indexOf('&.sticky-ad-zone {')
+    if (nestedIdx > -1) {
+      // Nested inside `.sticky` → specificity (0,2,0) beats (0,1,0) whatever
+      // the source order. This is the robust form.
+      expect(nestedIdx).toBeGreaterThan(-1)
+      return
+    }
+
+    const flatIdx = layout.indexOf('.sticky-ad-zone {')
+    expect(
+      flatIdx,
+      'a flat .sticky-ad-zone rule must come AFTER the lg transparent rule, ' +
+        'or be nested as &.sticky-ad-zone so specificity decides'
+    ).toBeGreaterThan(transparentIdx)
+  })
+})


### PR DESCRIPTION
## Summary

Reported: a margin under the job ads, see-through rather than blank.

The sticky bottom banner reserves a **fixed** height (`sticky-banner.scss`: 113px, or 273px when the window is at least 950px tall) while the WhatJobs block that fills it only takes its natural content height. `LayoutCommon` passes the ad slot a `max-height` but no `min-height`, so when there are few jobs the remainder of the banner is empty. Because `.sticky` is `position: fixed` over the page, that remainder showed the page content straight through what looks like part of the ad banner.

The tint meant to cover exactly this (`.sticky-ad-zone`, added in 3f5b6b28b on 2026-06-14) **never applied on desktop at all**. It was a flat rule declared *before* `.sticky`'s `background-color: transparent` at `lg` and up; equal specificity, so the transparent won on source order.

Verified on production before changing anything: the element carried class `sticky-ad-zone` and still computed `rgba(0, 0, 0, 0)` at a 1280px viewport, with the banner 113px tall and only a 23px CTA in it.

The fix nests it as `&.sticky-ad-zone` inside `.sticky`, so specificity decides instead of source order, and uses the same `$gray-200` as `.jobs-slot` so the leftover space reads as part of the block rather than a hole. The no-ad case (element without the `.sticky-ad-zone` class) stays transparent exactly as before.

This became noticeable recently because 6f80b7d72 (2026-08-01) gave the jobs block a `$gray-200` background and a visible `$gray-300` border, which made its boundary clear and so made the empty area below it read as a margin.

## Code Quality Review

- Only the tinted (ad-rendered) state changes. Verified by A/B: with the `.sticky-ad-zone` class the compiled CSS now yields `rgb(233, 236, 239)`; without it, still `rgba(0, 0, 0, 0)`.
- Colour is taken from the same Bootstrap variable the jobs slot uses rather than the previous magic `#e9ecef`, so the two cannot drift apart.
- The underlying reservation (fixed banner height vs natural content height) is untouched. This change makes the gap invisible; it does not remove it. Noted under Future Improvements.

## Future Improvements

- The ad row could `flex-grow` to fill the reserved height, so there is no leftover region at all. That risks stretching the jobs block, so it is a separate change.
- The 273px tall-desktop reservation is large relative to what the jobs block actually renders; worth revisiting against real ad fill rates.

## Test Plan

- New `tests/unit/components/StickyAdZoneBackground.spec.js` (2 tests, written first and confirmed RED: it failed with "expected 14730 to be greater than 15573", i.e. the tint declared before the transparent rule). It asserts both that the tint matches the jobs-slot colour and that it is declared so the `lg+` transparent rule cannot override it. A colour-only assertion was deliberately not enough, since one would have passed throughout the whole period the tint was dead.
- Cascade verified in a real browser by compiling the component's SCSS and reading `getComputedStyle`, run against both the pre-fix and post-fix file.
- Full JS unit suite via the status API: 697 files, 14726 tests, all passing.