### PR TITLE
fix(rippling): don't count ripple-created memberships as "already a member"

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -344,6 +344,9 @@ Design spec: `docs/superpowers/specs/2026-06-22-digest-rippling-score-ordering-d
 - `messages_groups.rippled_in = 1` - marks a rippled-in copy (vs the origin membership).
 - `rippling_proximity` - cached "quicker to get to" P/Q points per (msgid, groupid).
 - `logs` `text='Rippled'` - the ripple-join marker used for rejoin suppression.
+- `memberships.rippled = 1` - marks a membership rippling created, when the member's own post
+  rippled into that group and we auto-joined them (§5). Every statistic that asks "were they
+  already a member?" must exclude these - see §10a.
 
 ## 10. The sysadmin analytics tab
 
@@ -390,3 +393,37 @@ cause (slow SQL) is invisible from the console. Two rules follow, both learned t
 
 The component loads the three surfaces independently: a failure or delay in one fills in its own
 panels late (or reports its own error there) rather than blanking the tab.
+
+### 10a. "Was this replier already a member?" - and why ripple-created joins don't count
+
+Almost every effectiveness figure on the tab turns on one test: was the replier an **established
+member of an origin group** of the post? If yes the reply is `home` - they'd have seen it anyway,
+rippling gets no credit. If no, rippling reached them. That single test drives the rippled-reply
+and rippled-taker shares, the reply→take comparison, and the **rescue floor** (posts taken with no
+home-group reply at all - the takes that would otherwise have gone nowhere).
+
+The test has three qualifiers, all load-bearing, and it lives in one place -
+`rippling.EstablishedOriginMemberExists` in `rippling/attribution.go`:
+
+- **origin groups only** (`messages_groups.rippled_in = 0`) - being in a group the post *rippled
+  into* is not being local to it,
+- **joined before the post arrived** - the reply flow joins people to groups in order to reply, so
+  a join made seconds ago is not evidence of anything,
+- **not a ripple-created join** (`memberships.rippled = 0`) - rippling auto-joins a poster to every
+  group their post rippled into (§5), so a frequent poster accumulates memberships of distant
+  groups purely as a side-effect of rippling. When one of those groups later hosts a post of its
+  own, that member is only there to see it *because* of an earlier ripple.
+
+The third qualifier was missing until August 2026, and it mattered: on production 92k memberships
+carry `rippled = 1`, and ~7% of all replies scored `home` were backed by nothing else. Rippling's
+own knock-on reach was being counted in the column that means "rippling had nothing to do with
+this", so every effectiveness figure on the tab read low.
+
+Those replies now have their own attribution channel, `ripple_join`, one rung below `ripple_group`
+in the ladder (`rippling.DeriveAttribution`) - both are membership-level exposure that exists
+because of a ripple. It carries no "did this post ripple?" guard, unlike `ripple_reach`: the ripple
+that earns the credit already happened, to a different post, and left the membership behind as its
+record. The evidence bit is frozen per reply in `rippling_reply_attribution.was_ripple_join`, and
+`ripple:backfill-reply-attribution` reconstructs it for older rows - re-reading a frozen
+`was_home_member` bit as `ripple_join` where the surviving membership shows that provenance, while
+leaving rows whose membership has since decayed away on their original answer.

--- a/iznik-batch/app/Services/Ripple/ReplyAttributionBackfillService.php
+++ b/iznik-batch/app/Services/Ripple/ReplyAttributionBackfillService.php
@@ -13,13 +13,20 @@ use Illuminate\Support\Facades\DB;
  *   was_notified            <- rippling_reach_notified (notified_at <= replied_at)
  *   was_ripple_group_member <- an approved membership of a group the post rippled into, added
  *                              before the copy arrived (decays when members leave, hence freeze)
+ *   was_ripple_join         <- the only origin-group membership they hold is one RIPPLING created
+ *                              (memberships.rippled = 1, from an earlier ripple of their own post)
  *   post_had_rippled        <- a rippled-in copy or a reach row existed by reply time
  *
  * The LOCATION bits (in_origin_catchment / in_reach) are NOT backfillable - locations drift and
- * reach polygons grow - so they stay NULL and the derived attribution for backfilled rows can
- * only be home / ripple_notified / ripple_group / unknown (never organic_local / ripple_reach).
- * The ladder matches rippling.DeriveAttribution in iznik-server-go (home wins - conservative -
- * then notified, then rippled-group, else unknown).
+ * reach polygons grow - so they stay NULL and the derived attribution for backfilled rows can only
+ * be home / ripple_notified / ripple_group / ripple_join / unknown (never organic_local /
+ * ripple_reach). The ladder matches rippling.DeriveAttribution in iznik-server-go (home wins -
+ * conservative - then notified, then rippled-group, then ripple-join, else unknown).
+ *
+ * The home rung is the one place the frozen bit is NOT taken at face value: it was captured
+ * before ripple-created auto-joins were excluded, so a row backed only by such a join has to be
+ * re-read as ripple_join. Leaving it as home credits rippling's own downstream reach to the
+ * bucket that means "rippling had nothing to do with this".
  *
  * Idempotent: only visits attribution IS NULL rows, and every visited row gets attribution set.
  */
@@ -54,6 +61,27 @@ class ReplyAttributionBackfillService
             }
 
             /*
+             * "The only origin-group membership backing this row is one rippling created."
+             * A legacy row's frozen was_home_member bit cannot tell home from ripple_join: the
+             * capture that wrote it did not look at membership provenance. Re-derived here - a
+             * ripple-created origin membership present AND no ordinary one. When both are absent
+             * (they have left since) it is false, so the frozen bit's answer of home stands:
+             * decay must never silently demote a genuine home reply.
+             */
+            $rippleJoinOnly = "(EXISTS(
+                    SELECT 1 FROM messages_groups mgj
+                    INNER JOIN memberships memj ON memj.groupid = mgj.groupid
+                      AND memj.userid = rra.userid AND memj.collection = 'Approved'
+                      AND memj.added < mgj.arrival AND memj.rippled = 1
+                    WHERE mgj.msgid = rra.msgid AND mgj.rippled_in = 0 AND mgj.deleted = 0)
+                AND NOT EXISTS(
+                    SELECT 1 FROM messages_groups mgo
+                    INNER JOIN memberships memo ON memo.groupid = mgo.groupid
+                      AND memo.userid = rra.userid AND memo.collection = 'Approved'
+                      AND memo.added < mgo.arrival AND memo.rippled = 0
+                    WHERE mgo.msgid = rra.msgid AND mgo.rippled_in = 0 AND mgo.deleted = 0))";
+
+            /*
              * One set-based statement per batch. The evidence EXISTS clauses are repeated in
              * the attribution CASE rather than referencing the just-assigned columns: in a
              * multi-table UPDATE, MySQL does not guarantee assignments see earlier ones.
@@ -78,6 +106,7 @@ class ReplyAttributionBackfillService
                           AND mem.added < mg.arrival
                         WHERE mg.msgid = rra.msgid AND mg.rippled_in = 1
                           AND mg.deleted = 0 AND mg.arrival <= rra.replied_at),
+                    rra.was_ripple_join = {$rippleJoinOnly},
                     rra.post_had_rippled = (
                         EXISTS(
                             SELECT 1 FROM messages_groups mg2
@@ -88,7 +117,7 @@ class ReplyAttributionBackfillService
                             WHERE rr.msgid = rra.msgid
                               AND (rr.created_at IS NULL OR rr.created_at <= rra.replied_at))),
                     rra.attribution = CASE
-                        WHEN rra.was_home_member = 1 THEN 'home'
+                        WHEN rra.was_home_member = 1 AND NOT {$rippleJoinOnly} THEN 'home'
                         WHEN EXISTS(
                             SELECT 1 FROM rippling_reach_notified rrn2
                             WHERE rrn2.msgid = rra.msgid AND rrn2.userid = rra.userid
@@ -100,6 +129,7 @@ class ReplyAttributionBackfillService
                               AND mem3.added < mg3.arrival
                             WHERE mg3.msgid = rra.msgid AND mg3.rippled_in = 1
                               AND mg3.deleted = 0 AND mg3.arrival <= rra.replied_at) THEN 'ripple_group'
+                        WHEN {$rippleJoinOnly} THEN 'ripple_join'
                         ELSE 'unknown'
                     END
             ");

--- a/iznik-batch/database/migrations/2026_08_05_000001_add_ripple_join_to_rippling_reply_attribution.php
+++ b/iznik-batch/database/migrations/2026_08_05_000001_add_ripple_join_to_rippling_reply_attribution.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds the ripple_join attribution channel, and the evidence bit behind it.
+ *
+ * Rippling auto-joins a poster to every group their post rippled into (memberships.rippled = 1,
+ * see ExpandService::addPosterMembershipToRippledGroups). When one of those groups later hosts a
+ * post of its own and that member replies, every "was already a member" test counted them as an
+ * established local member and the reply landed in `home` - the bucket that means "would have seen
+ * it anyway, rippling gets no credit". But that membership exists ONLY because of an earlier
+ * ripple, so without rippling they would never have seen the post at all. The effect was to hand
+ * rippling's own downstream reach to the home column and understate its effectiveness.
+ *
+ *   was_ripple_join - established member of an ORIGIN group of this post via a RIPPLE-CREATED
+ *                     membership only (no ordinary membership of any of its origin groups).
+ *                     Durable-ish (leavers/retractions decay it), so the capture freezes it and
+ *                     the backfill can reconstruct it for legacy rows.
+ *
+ * ripple_join sits in the ladder immediately below ripple_group: both are membership-level
+ * exposure that exists because of a ripple, and both outrank organic_local for the same reason
+ * ripple_group already does - a member sees the post in their own feed and digest, which is
+ * stronger evidence than "might have come across it in Browse".
+ *
+ * ENUM values can only be appended in place on a live table without a rebuild, so ripple_join
+ * goes on the END rather than in ladder position - the order of the enum has never carried
+ * meaning here (readers match on the string). See the reply capture in chat/chatmessage.go and
+ * the ladder in rippling/attribution.go.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasColumn('rippling_reply_attribution', 'was_ripple_join')) {
+            Schema::table('rippling_reply_attribution', function (Blueprint $t) {
+                $t->boolean('was_ripple_join')->nullable()->after('was_ripple_group_member');
+            });
+        }
+
+        // Appended, not reordered: adding a value at the end of an ENUM is metadata-only in
+        // MySQL 8, whereas inserting one mid-list rewrites every row.
+        $type = DB::selectOne(
+            "SELECT COLUMN_TYPE AS t FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'rippling_reply_attribution'
+               AND COLUMN_NAME = 'attribution'"
+        );
+        if ($type && !str_contains($type->t, "'ripple_join'")) {
+            DB::statement(
+                "ALTER TABLE rippling_reply_attribution MODIFY COLUMN attribution " .
+                "ENUM('home','ripple_notified','ripple_group','organic_local','ripple_reach'," .
+                "'unknown','ripple_join') NULL DEFAULT NULL"
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        // Rows already carrying the new value would become '' on a narrowing MODIFY, so fold
+        // them back to the bucket they used to sit in before dropping the value.
+        DB::statement("UPDATE rippling_reply_attribution SET attribution = 'home' WHERE attribution = 'ripple_join'");
+        DB::statement(
+            "ALTER TABLE rippling_reply_attribution MODIFY COLUMN attribution " .
+            "ENUM('home','ripple_notified','ripple_group','organic_local','ripple_reach','unknown') " .
+            "NULL DEFAULT NULL"
+        );
+
+        if (Schema::hasColumn('rippling_reply_attribution', 'was_ripple_join')) {
+            Schema::table('rippling_reply_attribution', function (Blueprint $t) {
+                $t->dropColumn('was_ripple_join');
+            });
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_05_000001_add_ripple_join_to_rippling_reply_attribution_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_05_000001_add_ripple_join_to_rippling_reply_attribution_migration.sql
@@ -1,0 +1,24 @@
+-- Production idempotent SQL: the ripple_join attribution channel + its evidence bit.
+--
+-- Rippling auto-joins a poster to every group their post rippled into (memberships.rippled = 1).
+-- Replies from those members were counted as established local membership (`home`), which handed
+-- rippling's own downstream reach to the bucket that means "rippling gets no credit". ripple_join
+-- separates them out. See 2026_08_05_000001_add_ripple_join_to_rippling_reply_attribution.php.
+--
+-- Both statements are metadata-only in MySQL 8: a nullable bool is an INSTANT add, and appending
+-- a value to the END of an ENUM does not rewrite rows (inserting one mid-list would).
+SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'rippling_reply_attribution'
+      AND column_name = 'was_ripple_join');
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE rippling_reply_attribution ADD COLUMN was_ripple_join TINYINT(1) NULL DEFAULT NULL AFTER was_ripple_group_member',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_value := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'rippling_reply_attribution'
+      AND column_name = 'attribution' AND column_type LIKE "%'ripple_join'%");
+SET @ddl2 := IF(@has_value = 0,
+    "ALTER TABLE rippling_reply_attribution MODIFY COLUMN attribution ENUM('home','ripple_notified','ripple_group','organic_local','ripple_reach','unknown','ripple_join') NULL DEFAULT NULL",
+    'SELECT 1');
+PREPARE stmt2 FROM @ddl2; EXECUTE stmt2; DEALLOCATE PREPARE stmt2;

--- a/iznik-batch/tests/Unit/Services/Ripple/ReplyAttributionBackfillServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ReplyAttributionBackfillServiceTest.php
@@ -146,6 +146,88 @@ class ReplyAttributionBackfillServiceTest extends TestCase
         $this->assertSame('unknown', $row->attribution);
     }
 
+    /**
+     * Rippling auto-joins a poster to every group their post rippled into (memberships.rippled=1).
+     * A legacy row's frozen was_home_member bit was set for those members too, so the backfill has
+     * to look at the membership's PROVENANCE: backed only by a ripple-created join it is
+     * ripple_join (rippling's own downstream effect, not pre-existing local membership); backed by
+     * an ordinary join it stays home.
+     */
+    public function test_home_bit_backed_only_by_a_ripple_join_becomes_ripple_join(): void
+    {
+        $poster = $this->createTestUser();
+        $originGroup = $this->createTestGroup();
+        $message = $this->createTestMessage($poster, $originGroup, ['arrival' => now()->subDays(10)]);
+        DB::table('messages_groups')->where('msgid', $message->id)
+            ->update(['arrival' => now()->subDays(10)]);
+
+        // Auto-joined by an EARLIER ripple of their own post, long before this post existed.
+        $rippleJoined = $this->createTestUser();
+        $this->createMembership($rippleJoined, $originGroup, [
+            'added' => now()->subDays(30),
+            'rippled' => 1,
+        ]);
+        $this->insertLegacyRow($message->id, $rippleJoined->id, 1);
+
+        // Ordinary member of the same group, equally established.
+        $ordinary = $this->createTestUser();
+        $this->createMembership($ordinary, $originGroup, [
+            'added' => now()->subDays(30),
+            'rippled' => 0,
+        ]);
+        $this->insertLegacyRow($message->id, $ordinary->id, 1);
+
+        // Membership gone entirely (they left since): nothing survives to reclassify against, so
+        // the frozen bit must be honoured rather than the row being demoted.
+        $departed = $this->createTestUser();
+        $this->insertLegacyRow($message->id, $departed->id, 1);
+
+        $this->service->backfill();
+
+        $joined = $this->attributionRow($message->id, $rippleJoined->id);
+        $this->assertSame('ripple_join', $joined->attribution);
+        $this->assertSame(1, (int) $joined->was_ripple_join);
+
+        $home = $this->attributionRow($message->id, $ordinary->id);
+        $this->assertSame('home', $home->attribution);
+        $this->assertSame(0, (int) $home->was_ripple_join);
+
+        $gone = $this->attributionRow($message->id, $departed->id);
+        $this->assertSame('home', $gone->attribution, 'a decayed membership keeps the frozen bit');
+    }
+
+    /**
+     * Holding BOTH kinds of membership of the post's origin groups is home: the ordinary one alone
+     * would have shown them the post, so rippling gets no credit for the reply.
+     */
+    public function test_ordinary_membership_alongside_a_ripple_join_stays_home(): void
+    {
+        $poster = $this->createTestUser();
+        $groupA = $this->createTestGroup();
+        $groupB = $this->createTestGroup();
+        $message = $this->createTestMessage($poster, $groupA);
+        DB::table('messages_groups')->where('msgid', $message->id)
+            ->update(['arrival' => now()->subDays(10)]);
+        // Cross-posted: a second ORIGIN group (rippled_in = 0).
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id,
+            'groupid' => $groupB->id,
+            'collection' => 'Approved',
+            'arrival' => now()->subDays(10),
+            'rippled_in' => 0,
+        ]);
+
+        $replier = $this->createTestUser();
+        $this->createMembership($replier, $groupA, ['added' => now()->subDays(30), 'rippled' => 1]);
+        $this->createMembership($replier, $groupB, ['added' => now()->subDays(30), 'rippled' => 0]);
+        $this->insertLegacyRow($message->id, $replier->id, 1);
+
+        $this->service->backfill();
+
+        $row = $this->attributionRow($message->id, $replier->id);
+        $this->assertSame('home', $row->attribution);
+    }
+
     public function test_already_derived_rows_are_untouched_and_limit_respected(): void
     {
         $poster = $this->createTestUser();

--- a/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
@@ -376,7 +376,9 @@
       <p class="text-muted small mb-2">
         Each reply attributed at reply time to the channel that led the replier
         to the post. Greens are rippling; teal is your own established members;
-        greys couldn't be credited either way.
+        greys couldn't be credited either way. "Rippled into the group before"
+        means they are only in the group because an earlier ripple of their own
+        post joined them to it — so that reply is rippling's doing too.
       </p>
       <div class="panel">
         <div class="panel-body">
@@ -546,11 +548,20 @@ const heldSourceBreakdown = computed(() => {
     .join(' · ')
 })
 
+/*
+ * Non-rippling channels first (greys/teal), then the rippling ones (greens) - the stack reads
+ * top-to-bottom as "would have seen it anyway" down to "only saw it because of rippling".
+ * ripple_join is a rippling channel: those members are in the group ONLY because an earlier
+ * ripple of their own post auto-joined them there, so without rippling they would never have
+ * seen the post. It used to be counted under Home members, which hid rippling's own knock-on
+ * reach inside the bucket that means rippling gets no credit.
+ */
 const CHANNELS = [
   { key: 'home', label: 'Home members' },
   { key: 'organic_local', label: 'Local non-members' },
   { key: 'unknown', label: 'Unknown' },
   { key: 'ripple_group', label: 'Rippled into their group' },
+  { key: 'ripple_join', label: 'Rippled into the group before' },
   { key: 'ripple_notified', label: 'Ripple mail' },
   { key: 'ripple_reach', label: 'Reach-fed browse' },
 ]
@@ -588,13 +599,15 @@ function channelStackOptions() {
     hAxis: { format: 'dd MMM', textStyle: { fontSize: 10 } },
     annotations: { style: 'line' },
     areaOpacity: 0.85,
+    /* Index order tracks CHANNELS: 0-2 non-rippling (teal/grey), 3-6 rippling (greens). */
     series: {
       0: { color: '#1592a6' },
       1: { color: '#6c757d' },
       2: { color: '#98a2ab' },
       3: { color: '#28a745' },
-      4: { color: '#146c43' },
-      5: { color: '#45b463' },
+      4: { color: '#1c8c3a' },
+      5: { color: '#146c43' },
+      6: { color: '#45b463' },
     },
   }
 }

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
@@ -365,6 +365,49 @@ describe('ModSysAdminRipplingAnalytics', () => {
     wrapper.unmount()
   })
 
+  // ripple_join = a reply from someone who is only in the group because an earlier ripple of their
+  // own post auto-joined them there. It is a rippling channel, so it needs its own band on the
+  // attribution chart - folded into "Home members" it would read as pre-existing local membership
+  // and hide rippling's own downstream effect.
+  it('charts the ripple-join channel as its own band', async () => {
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
+    mockFetchMetrics.mockResolvedValueOnce({
+      reply_source_split: [
+        {
+          day: '2026-06-24',
+          home: 5,
+          ripple_notified: 2,
+          ripple_group: 1,
+          ripple_join: 4,
+          ripple_reach: 1,
+          organic_local: 3,
+          unknown: 0,
+        },
+      ],
+    })
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const charts = wrapper.findAllComponents({ name: 'GChart' })
+    const attribution = charts.find((c) =>
+      (c.props('data')?.[0] || []).includes('Home members')
+    )
+    expect(attribution).toBeTruthy()
+
+    const header = attribution.props('data')[0]
+    const label = 'Rippled into the group before'
+    expect(header).toContain(label)
+
+    // The seeded day's row must carry the count in the ripple_join column, not anywhere else.
+    const row = attribution
+      .props('data')
+      .slice(1)
+      .find((r) => r[header.indexOf(label)] === 4)
+    expect(row).toBeTruthy()
+    expect(row[header.indexOf('Home members')]).toBe(5)
+    wrapper.unmount()
+  })
+
   // The metrics endpoint feeds only the attribution + hotspot panels. It used to be awaited in the
   // same Promise.all as the KPIs, so when it 504'd on production (its heavy KPI queries ran for
   // minutes, and a gateway timeout reads to the browser as a CORS failure) the whole tab showed

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -386,11 +386,12 @@ type replyReachEvidence struct {
 func recordReplyAttribution(db *gorm.DB, myid uint64, refmsgid uint64, reach replyReachEvidence, clientSource *string) {
 	// Established member of an ORIGIN (non-rippled-in) group of the post, whose membership
 	// predates this reply by more than the join grace (300s)? A join made to reply
-	// (added ~ now) is excluded.
+	// (added ~ now) is excluded, and so is a membership rippling itself created - see
+	// wasRippleJoin below.
 	var wasHome int
 	db.Raw("SELECT EXISTS(SELECT 1 FROM messages_groups mg "+
 		"INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ? "+
-		"AND mem.collection = ? AND mem.added < NOW() - INTERVAL 300 SECOND "+
+		"AND mem.collection = ? AND mem.added < NOW() - INTERVAL 300 SECOND AND mem.rippled = 0 "+
 		"WHERE mg.msgid = ? AND mg.rippled_in = 0 AND mg.deleted = 0)",
 		myid, utils.COLLECTION_APPROVED, refmsgid).Scan(&wasHome)
 
@@ -417,6 +418,20 @@ func recordReplyAttribution(db *gorm.DB, myid uint64, refmsgid uint64, reach rep
 		"AND mem.collection = ? AND mem.added < mg.arrival "+
 		"WHERE mg.msgid = ? AND mg.rippled_in = 1 AND mg.deleted = 0)",
 		myid, utils.COLLECTION_APPROVED, refmsgid).Scan(&wasRippleGroup)
+
+	// Member of an ORIGIN group of the post, but only via a membership RIPPLING created (their
+	// own post rippled into that group, so we auto-joined them - ExpandService in iznik-batch).
+	// They saw this post in that group's feed/digest, and they are only in that group because of
+	// an earlier ripple, so the reply belongs to rippling and not to home. Same 300s join grace
+	// as wasHome. Both bits can be set at once on a cross-post (one origin group joined
+	// ordinarily, another via a ripple); the ladder gives home precedence, because the ordinary
+	// membership alone would have shown them the post.
+	var wasRippleJoin int
+	db.Raw("SELECT EXISTS(SELECT 1 FROM messages_groups mg "+
+		"INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ? "+
+		"AND mem.collection = ? AND mem.added < NOW() - INTERVAL 300 SECOND AND mem.rippled = 1 "+
+		"WHERE mg.msgid = ? AND mg.rippled_in = 0 AND mg.deleted = 0)",
+		myid, utils.COLLECTION_APPROVED, refmsgid).Scan(&wasRippleJoin)
 
 	// Had the post rippled AT ALL by reply time (a rippled-in copy, or a reach row)? This is
 	// the ladder's hard guard: when 0, the reply can never be ripple-attributed. Reuse the
@@ -459,14 +474,15 @@ func recordReplyAttribution(db *gorm.DB, myid uint64, refmsgid uint64, reach rep
 		}
 	}
 
-	attribution := rippling.DeriveAttribution(wasHome, wasNotified, wasRippleGroup, postHadRippled, inOrigin, inReach)
+	attribution := rippling.DeriveAttribution(wasHome, wasNotified, wasRippleGroup, wasRippleJoin,
+		postHadRippled, inOrigin, inReach)
 
 	db.Exec("INSERT IGNORE INTO rippling_reply_attribution "+
 		"(msgid, userid, replied_at, was_home_member, was_notified, was_ripple_group_member, "+
-		"in_origin_catchment, in_reach, post_had_rippled, attribution, client_source) "+
-		"VALUES (?, ?, NOW(), ?, ?, ?, ?, ?, ?, ?, ?)",
-		refmsgid, myid, wasHome, wasNotified, wasRippleGroup, inOrigin, inReach, postHadRippled,
-		attribution, rippling.SanitizeClientSource(clientSource))
+		"was_ripple_join, in_origin_catchment, in_reach, post_had_rippled, attribution, client_source) "+
+		"VALUES (?, ?, NOW(), ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		refmsgid, myid, wasHome, wasNotified, wasRippleGroup, wasRippleJoin, inOrigin, inReach,
+		postHadRippled, attribution, rippling.SanitizeClientSource(clientSource))
 }
 
 func CreateChatMessage(c *fiber.Ctx) error {

--- a/iznik-server-go/rippling/analytics.go
+++ b/iznik-server-go/rippling/analytics.go
@@ -346,10 +346,7 @@ func fetchDriveSample(db *gorm.DB, start, end, stratumSQL string, sampleN int) [
 		SELECT samp.msgid, ml.lat AS plat, ml.lng AS plng, ul.lat AS rlat, ul.lng AS rlng,
 		       DATE_FORMAT(cm.date, '%Y-%m-%d') AS day,
 		       EXISTS(SELECT 1 FROM messages_by mb WHERE mb.msgid = samp.msgid AND mb.userid = cm.userid) AS taker,
-		       (NOT EXISTS(SELECT 1 FROM messages_groups og
-		                   INNER JOIN memberships mem ON mem.groupid = og.groupid AND mem.userid = cm.userid
-		                     AND mem.collection = 'Approved' AND mem.added < og.arrival
-		                   WHERE og.msgid = samp.msgid AND og.rippled_in = 0 AND og.deleted = 0)) AS rippled
+		       (NOT `+EstablishedOriginMemberExists("samp.msgid", "cm.userid")+`) AS rippled
 		FROM (
 		    SELECT rr.msgid
 		    FROM rippling_reach rr
@@ -844,14 +841,11 @@ func rippledOutSection(db *gorm.DB, start, end, stratumSQL string) Section3Rippl
 			       SUM(client_rippled) AS client_rippled
 			FROM (
 			    SELECT
-			      (NOT EXISTS(SELECT 1 FROM messages_groups og
-			                  INNER JOIN memberships mem ON mem.groupid = og.groupid AND mem.userid = cm.userid
-			                    AND mem.collection = 'Approved' AND mem.added < og.arrival
-			                  WHERE og.msgid = cm.refmsgid AND og.rippled_in = 0 AND og.deleted = 0)) AS rippled,
+			      (NOT `+EstablishedOriginMemberExists("cm.refmsgid", "cm.userid")+`) AS rippled,
 			      EXISTS(SELECT 1 FROM messages_by mb WHERE mb.msgid = cm.refmsgid AND mb.userid = cm.userid) AS is_taker,
 			      EXISTS(SELECT 1 FROM rippling_reply_attribution rra
 			             WHERE rra.msgid = cm.refmsgid AND rra.userid = cm.userid
-			               AND rra.attribution IN ('ripple_notified','ripple_group','ripple_reach')) AS client_rippled
+			               AND rra.attribution IN ('ripple_notified','ripple_group','ripple_join','ripple_reach')) AS client_rippled
 			    FROM chat_messages cm
 			    JOIN rippling_reach rr ON rr.msgid = cm.refmsgid AND rr.total_freeglers > 0`+stratumSQL+`
 			    JOIN messages m ON m.id = cm.refmsgid AND m.type = 'Offer'
@@ -874,6 +868,9 @@ func rippledOutSection(db *gorm.DB, start, end, stratumSQL string) Section3Rippl
 
 	// Rescue floor: DISTINCT posts that were taken AND had at least one reply AND had NO reply
 	// from an established home-group member - so the take could only have come via rippling.
+	// The membership test must match EstablishedOriginMemberExists (same clauses, mem.rippled = 0
+	// included) but is spelled out as a flat join rather than calling it: this is the slowest
+	// query on the tab and nesting an EXISTS per chat_messages row changes its plan.
 	var rescued int
 	go func() {
 		defer wg.Done()
@@ -892,7 +889,7 @@ func rippledOutSection(db *gorm.DB, start, end, stratumSQL string) Section3Rippl
 			          SELECT 1 FROM chat_messages ch
 			          INNER JOIN messages_groups og ON og.msgid = ch.refmsgid AND og.rippled_in = 0 AND og.deleted = 0
 			          INNER JOIN memberships mem ON mem.groupid = og.groupid AND mem.userid = ch.userid
-			            AND mem.collection = 'Approved' AND mem.added < og.arrival
+			            AND mem.collection = 'Approved' AND mem.added < og.arrival AND mem.rippled = 0
 			          WHERE ch.refmsgid = rr.msgid AND ch.type = 'Interested')
 			) x`, w[0], w[1]).Scan(&chunkRescued).Error; err != nil {
 				// As above: all-or-nothing rather than a silent undercount.

--- a/iznik-server-go/rippling/attribution.go
+++ b/iznik-server-go/rippling/attribution.go
@@ -13,10 +13,33 @@ const (
 	AttributionHome           = "home"
 	AttributionRippleNotified = "ripple_notified"
 	AttributionRippleGroup    = "ripple_group"
+	AttributionRippleJoin     = "ripple_join"
 	AttributionOrganicLocal   = "organic_local"
 	AttributionRippleReach    = "ripple_reach"
 	AttributionUnknown        = "unknown"
 )
+
+// EstablishedOriginMemberExists builds the EXISTS(...) test every rippling statistic uses for
+// "was this replier already a member here, independently of rippling?" - an approved membership of
+// an ORIGIN group of the post (never a rippled-in copy's group), joined before the post arrived so
+// a join-made-in-order-to-reply never counts.
+//
+// The mem.rippled = 0 clause is the load-bearing part. Rippling auto-joins a poster to every group
+// their post rippled into (memberships.rippled = 1, ExpandService::addPosterMembershipToRippledGroups
+// in iznik-batch), so a frequent poster accumulates memberships of distant groups purely as a
+// side-effect of rippling. Counting those as pre-existing local membership meant that when one of
+// those groups later hosted a post of its own, the reply was scored as one rippling had nothing to
+// do with - the exact opposite of the truth, since without rippling that member would not have
+// been in the group to see it. That mis-scored ~7% of all "home" replies on production.
+//
+// msgCol/userCol are the caller's outer columns to correlate against; the fragment owns the
+// aliases og/mem, so it can be nested anywhere those two are free.
+func EstablishedOriginMemberExists(msgCol, userCol string) string {
+	return `EXISTS(SELECT 1 FROM messages_groups og
+	                  INNER JOIN memberships mem ON mem.groupid = og.groupid AND mem.userid = ` + userCol + `
+	                    AND mem.collection = 'Approved' AND mem.added < og.arrival AND mem.rippled = 0
+	                  WHERE og.msgid = ` + msgCol + ` AND og.rippled_in = 0 AND og.deleted = 0)`
+}
 
 var attributionSchemaOnce sync.Once
 var attributionSchemaWide bool
@@ -40,26 +63,34 @@ func AttributionSchemaReady(db *gorm.DB) bool {
 // DeriveAttribution runs the attribution ladder over the evidence bits captured at reply time
 // and returns the channel. Precedence, and why:
 //
-//  1. home - an established origin-group member. Wins over all ripple evidence (conservative:
-//     when exposure is ambiguous we do NOT credit rippling).
+//  1. home - an established origin-group member, by a membership rippling did not create. Wins
+//     over all ripple evidence (conservative: when exposure is ambiguous we do NOT credit
+//     rippling). See EstablishedOriginMemberExists for why the provenance qualifier matters.
 //  2. ripple_notified - we sent this user the ripple mail for this post. Direct delivery evidence.
 //  3. ripple_group - they were already a member of a group the post rippled into, so they saw it
 //     in their own group's feed/digest because of the ripple.
-//  4. organic_local - non-member inside an origin group's catchment: they'd plausibly have seen
+//  4. ripple_join - they are a member of an ORIGIN group, but only because an earlier ripple (of
+//     their own post) auto-joined them there. Same shape of evidence as 3 - membership-level
+//     exposure that exists because of a ripple - so it is ranked with it, above the location
+//     rungs. Needs no postHadRippled guard: the ripple that earns the credit already happened,
+//     to a different post, and left the membership behind as its record.
+//  5. organic_local - non-member inside an origin group's catchment: they'd plausibly have seen
 //     the post in Browse regardless of rippling. Deliberately ranked ABOVE ripple_reach because
 //     the reach polygon always covers the origin area - without this ordering every local
 //     non-member would mis-classify as reach.
-//  5. ripple_reach - outside the origin catchment but inside the reach polygon: their Browse
+//  6. ripple_reach - outside the origin catchment but inside the reach polygon: their Browse
 //     exposure existed only because the ripple extended there (the nearby feed is reach-fed).
-//  6. unknown - nothing resolvable (search / deep link / share, or no location on file).
+//  7. unknown - nothing resolvable (search / deep link / share, or no location on file).
 //
 // The hard guard - a post that never rippled can never be ripple-attributed - is structural:
 // with no ripple there are no notified-ledger rows and no rippled-in copies (so 2-3 can't fire),
-// and 5 additionally requires postHadRippled.
+// and 6 additionally requires postHadRippled. Rung 4 is deliberately outside the guard, being
+// evidence about a PREVIOUS ripple rather than this post's.
 //
 // inOriginCatchment/inReach are pointers because location evidence can be unavailable
 // (replier has no location on file): nil = unknown, distinct from a definite 0.
-func DeriveAttribution(wasHomeMember, wasNotified, wasRippleGroupMember, postHadRippled int, inOriginCatchment, inReach *int) string {
+func DeriveAttribution(wasHomeMember, wasNotified, wasRippleGroupMember, wasRippleJoinMember,
+	postHadRippled int, inOriginCatchment, inReach *int) string {
 	switch {
 	case wasHomeMember == 1:
 		return AttributionHome
@@ -67,6 +98,8 @@ func DeriveAttribution(wasHomeMember, wasNotified, wasRippleGroupMember, postHad
 		return AttributionRippleNotified
 	case wasRippleGroupMember == 1:
 		return AttributionRippleGroup
+	case wasRippleJoinMember == 1:
+		return AttributionRippleJoin
 	case inOriginCatchment != nil && *inOriginCatchment == 1:
 		return AttributionOrganicLocal
 	case postHadRippled == 1 && inReach != nil && *inReach == 1:

--- a/iznik-server-go/rippling/attribution_test.go
+++ b/iznik-server-go/rippling/attribution_test.go
@@ -9,56 +9,89 @@ import (
 
 func intp(v int) *int { return &v }
 
-// DeriveAttribution runs the six-rung precedence ladder. Every rung must be
+// DeriveAttribution runs the seven-rung precedence ladder. Every rung must be
 // individually reachable, and where two rungs' evidence is simultaneously
 // true the HIGHER-precedence rung must win.
 func TestDeriveAttribution_Ladder(t *testing.T) {
 	cases := []struct {
-		name                                                             string
-		wasHomeMember, wasNotified, wasRippleGroupMember, postHadRippled int
-		inOriginCatchment, inReach                                       *int
-		want                                                             string
+		name                                             string
+		wasHomeMember, wasNotified, wasRippleGroupMember int
+		wasRippleJoinMember, postHadRippled              int
+		inOriginCatchment, inReach                       *int
+		want                                             string
 	}{
 		// ---- Individual rungs, all other evidence absent ----
-		{"home wins with nothing else set", 1, 0, 0, 0, nil, nil, AttributionHome},
-		{"ripple_notified when only notified evidence set", 0, 1, 0, 0, nil, nil, AttributionRippleNotified},
-		{"ripple_group when only group-membership evidence set", 0, 0, 1, 0, nil, nil, AttributionRippleGroup},
-		{"organic_local when only catchment evidence set", 0, 0, 0, 0, intp(1), nil, AttributionOrganicLocal},
-		{"ripple_reach when post rippled and reach evidence set", 0, 0, 0, 1, nil, intp(1), AttributionRippleReach},
-		{"unknown when nothing resolvable", 0, 0, 0, 0, nil, nil, AttributionUnknown},
+		{"home wins with nothing else set", 1, 0, 0, 0, 0, nil, nil, AttributionHome},
+		{"ripple_notified when only notified evidence set", 0, 1, 0, 0, 0, nil, nil, AttributionRippleNotified},
+		{"ripple_group when only group-membership evidence set", 0, 0, 1, 0, 0, nil, nil, AttributionRippleGroup},
+		{"ripple_join when only ripple-created origin membership set", 0, 0, 0, 1, 0, nil, nil, AttributionRippleJoin},
+		{"organic_local when only catchment evidence set", 0, 0, 0, 0, 0, intp(1), nil, AttributionOrganicLocal},
+		{"ripple_reach when post rippled and reach evidence set", 0, 0, 0, 0, 1, nil, intp(1), AttributionRippleReach},
+		{"unknown when nothing resolvable", 0, 0, 0, 0, 0, nil, nil, AttributionUnknown},
 
 		// ---- Precedence collisions: higher rung must win over lower ones ----
-		{"home beats notified", 1, 1, 0, 0, nil, nil, AttributionHome},
-		{"home beats ripple_group", 1, 0, 1, 0, nil, nil, AttributionHome},
-		{"home beats organic_local", 1, 0, 0, 0, intp(1), nil, AttributionHome},
-		{"home beats ripple_reach", 1, 0, 0, 1, nil, intp(1), AttributionHome},
-		{"home beats everything at once", 1, 1, 1, 1, intp(1), intp(1), AttributionHome},
-		{"notified beats ripple_group", 0, 1, 1, 0, nil, nil, AttributionRippleNotified},
-		{"notified beats organic_local", 0, 1, 0, 0, intp(1), nil, AttributionRippleNotified},
-		{"notified beats ripple_reach", 0, 1, 0, 1, nil, intp(1), AttributionRippleNotified},
-		{"ripple_group beats organic_local", 0, 0, 1, 0, intp(1), nil, AttributionRippleGroup},
-		{"ripple_group beats ripple_reach", 0, 0, 1, 1, nil, intp(1), AttributionRippleGroup},
-		{"organic_local beats ripple_reach - deliberately ranked above reach", 0, 0, 0, 1, intp(1), intp(1), AttributionOrganicLocal},
+		{"home beats notified", 1, 1, 0, 0, 0, nil, nil, AttributionHome},
+		{"home beats ripple_group", 1, 0, 1, 0, 0, nil, nil, AttributionHome},
+		{"home beats organic_local", 1, 0, 0, 0, 0, intp(1), nil, AttributionHome},
+		{"home beats ripple_reach", 1, 0, 0, 0, 1, nil, intp(1), AttributionHome},
+		{"home beats everything at once", 1, 1, 1, 1, 1, intp(1), intp(1), AttributionHome},
+		{"notified beats ripple_group", 0, 1, 1, 0, 0, nil, nil, AttributionRippleNotified},
+		{"notified beats ripple_join", 0, 1, 0, 1, 0, nil, nil, AttributionRippleNotified},
+		{"notified beats organic_local", 0, 1, 0, 0, 0, intp(1), nil, AttributionRippleNotified},
+		{"notified beats ripple_reach", 0, 1, 0, 0, 1, nil, intp(1), AttributionRippleNotified},
+		{"ripple_group beats ripple_join", 0, 0, 1, 1, 0, nil, nil, AttributionRippleGroup},
+		{"ripple_group beats organic_local", 0, 0, 1, 0, 0, intp(1), nil, AttributionRippleGroup},
+		{"ripple_group beats ripple_reach", 0, 0, 1, 0, 1, nil, intp(1), AttributionRippleGroup},
+		{"ripple_join beats organic_local - membership exposure outranks maybe-saw-it-in-Browse", 0, 0, 0, 1, 0, intp(1), nil, AttributionRippleJoin},
+		{"ripple_join beats ripple_reach", 0, 0, 0, 1, 1, nil, intp(1), AttributionRippleJoin},
+		{"organic_local beats ripple_reach - deliberately ranked above reach", 0, 0, 0, 0, 1, intp(1), intp(1), AttributionOrganicLocal},
 
 		// ---- inOriginCatchment / inReach: nil vs 0 vs 1 ----
-		{"catchment nil does not trigger organic_local", 0, 0, 0, 0, nil, nil, AttributionUnknown},
-		{"catchment 0 does not trigger organic_local", 0, 0, 0, 0, intp(0), nil, AttributionUnknown},
-		{"catchment 1 triggers organic_local", 0, 0, 0, 0, intp(1), nil, AttributionOrganicLocal},
-		{"reach nil does not trigger ripple_reach even if post rippled", 0, 0, 0, 1, nil, nil, AttributionUnknown},
-		{"reach 0 does not trigger ripple_reach even if post rippled", 0, 0, 0, 1, nil, intp(0), AttributionUnknown},
-		{"reach 1 without postHadRippled does not trigger ripple_reach", 0, 0, 0, 0, nil, intp(1), AttributionUnknown},
-		{"reach 1 with postHadRippled triggers ripple_reach", 0, 0, 0, 1, nil, intp(1), AttributionRippleReach},
+		{"catchment nil does not trigger organic_local", 0, 0, 0, 0, 0, nil, nil, AttributionUnknown},
+		{"catchment 0 does not trigger organic_local", 0, 0, 0, 0, 0, intp(0), nil, AttributionUnknown},
+		{"catchment 1 triggers organic_local", 0, 0, 0, 0, 0, intp(1), nil, AttributionOrganicLocal},
+		{"reach nil does not trigger ripple_reach even if post rippled", 0, 0, 0, 0, 1, nil, nil, AttributionUnknown},
+		{"reach 0 does not trigger ripple_reach even if post rippled", 0, 0, 0, 0, 1, nil, intp(0), AttributionUnknown},
+		{"reach 1 without postHadRippled does not trigger ripple_reach", 0, 0, 0, 0, 0, nil, intp(1), AttributionUnknown},
+		{"reach 1 with postHadRippled triggers ripple_reach", 0, 0, 0, 0, 1, nil, intp(1), AttributionRippleReach},
 
 		// ---- Structural guard: a post that never rippled cannot be ripple-attributed via reach ----
-		{"postHadRippled=0 blocks ripple_reach even with reach evidence present", 0, 0, 0, 0, nil, intp(1), AttributionUnknown},
+		{"postHadRippled=0 blocks ripple_reach even with reach evidence present", 0, 0, 0, 0, 0, nil, intp(1), AttributionUnknown},
+
+		// ---- ripple_join needs no postHadRippled guard: the membership IS the ripple evidence.
+		//      It was created by a PREVIOUS ripple (of the member's own post), so it stands even
+		//      though THIS post never rippled anywhere.
+		{"ripple_join stands on a post that never rippled", 0, 0, 0, 1, 0, nil, nil, AttributionRippleJoin},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := DeriveAttribution(c.wasHomeMember, c.wasNotified, c.wasRippleGroupMember, c.postHadRippled, c.inOriginCatchment, c.inReach)
+			got := DeriveAttribution(c.wasHomeMember, c.wasNotified, c.wasRippleGroupMember,
+				c.wasRippleJoinMember, c.postHadRippled, c.inOriginCatchment, c.inReach)
 			assert.Equal(t, c.want, got, c.name)
 		})
 	}
+}
+
+// The "was already a member" test that every rippling stat leans on must ignore memberships
+// rippling ITSELF created (memberships.rippled = 1 - the auto-join written when the member's own
+// post rippled into that group). Counting those as pre-existing local membership makes rippling
+// look less effective than it is: the member is only in that group because of an earlier ripple.
+func TestEstablishedOriginMemberExists(t *testing.T) {
+	sql := EstablishedOriginMemberExists("cm.refmsgid", "cm.userid")
+
+	assert.Contains(t, sql, "mem.rippled = 0",
+		"ripple-created auto-joins must never count as pre-existing membership")
+	assert.Contains(t, sql, "og.rippled_in = 0",
+		"only ORIGIN groups count - a rippled-in copy's group is not the member's home")
+	assert.Contains(t, sql, "og.deleted = 0")
+	assert.Contains(t, sql, "mem.collection = 'Approved'")
+	assert.Contains(t, sql, "mem.added < og.arrival",
+		"established = joined before the post arrived, so a join-to-reply never counts")
+	assert.Contains(t, sql, "og.msgid = cm.refmsgid", "correlates on the caller's message column")
+	assert.Contains(t, sql, "mem.userid = cm.userid", "correlates on the caller's user column")
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(sql), "EXISTS("),
+		"returns an EXISTS fragment the caller can negate")
 }
 
 // SanitizeClientSource validates the client-reported reply surface against

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -97,12 +97,14 @@ type CaptureSummary struct {
 // ReplySourceRow is the daily split of Interested replies by attribution channel (the graded
 // ladder captured at reply time in rippling_reply_attribution - see rippling/attribution.go):
 // home (established origin-group member), ripple_notified (we mailed them the post via the
-// ripple), ripple_group (saw it in their own group because it rippled in), ripple_reach
-// (Browse exposure that existed only because the reach extended to them), organic_local
-// (non-member who'd have seen it in Browse anyway), unknown (search / deep link / no location).
-// Rows the backfill hasn't derived yet fold into home/unknown off the legacy was_home_member
-// bit. Ripple/RipplePct is the headline: channels that are DEFINITELY rippling - unlike the
-// old replies-minus-home number, unknown is not credited to rippling.
+// ripple), ripple_group (saw it in their own group because it rippled in), ripple_join (in the
+// origin group only because an earlier ripple auto-joined them there), ripple_reach (Browse
+// exposure that existed only because the reach extended to them), organic_local (non-member
+// who'd have seen it in Browse anyway), unknown (search / deep link / no location).
+// Rows the backfill hasn't derived yet are bucketed live off the legacy was_home_member bit,
+// qualified by the surviving membership's provenance. Ripple/RipplePct is the headline: channels
+// that are DEFINITELY rippling - unlike the old replies-minus-home number, unknown is not
+// credited to rippling.
 type ReplySourceRow struct {
 	Day     string `json:"day"     gorm:"column:day"`
 	Replies int    `json:"replies" gorm:"column:replies"`
@@ -110,11 +112,12 @@ type ReplySourceRow struct {
 
 	RippleNotified int `json:"ripple_notified" gorm:"column:ripple_notified"`
 	RippleGroup    int `json:"ripple_group"    gorm:"column:ripple_group"`
+	RippleJoin     int `json:"ripple_join"     gorm:"column:ripple_join"`
 	RippleReach    int `json:"ripple_reach"    gorm:"column:ripple_reach"`
 	OrganicLocal   int `json:"organic_local"   gorm:"column:organic_local"`
 	Unknown        int `json:"unknown"         gorm:"column:unknown"`
 
-	Ripple    int     `json:"ripple"`     // computed in Go (notified + group + reach)
+	Ripple    int     `json:"ripple"`     // computed in Go (notified + group + join + reach)
 	RipplePct float64 `json:"ripple_pct"` // computed in Go
 }
 
@@ -143,15 +146,32 @@ type GroupOption struct {
 //     migration landing and the backfill running would read as a misleading zero-ripple
 //     chart (every attribution NULL folding to home/unknown).
 //   - legacy (graded columns not yet migrated): derive the durable channels live from the
-//     notified ledger and rippled-group memberships. Correct for home/notified/group; the
-//     location channels (ripple_reach/organic_local) are not derivable retrospectively
-//     (locations drift, polygons grow) so they read 0 and those replies sit in unknown.
+//     notified ledger, rippled-group memberships and origin-membership provenance. Correct for
+//     home/notified/group/join; the location channels (ripple_reach/organic_local) are not
+//     derivable retrospectively (locations drift, polygons grow) so they read 0 and those
+//     replies sit in unknown.
 //
 // srcGroup is the optional origin-group scoping JOIN (aliases rra); it takes one bind arg
 // before the two replied_at window args.
 func ReplySourceSplitSQL(wide bool, srcGroup string) string {
+	// "The only origin-group membership backing this row is one rippling created" - the frozen
+	// was_home_member bit on a legacy row cannot tell home from ripple_join, because the capture
+	// that wrote it did not look at membership provenance. Re-derived here from the surviving
+	// memberships: a ripple-created one present AND no ordinary one. When BOTH are absent (the
+	// member has left since) this is false and the frozen bit's answer of home stands - decay
+	// must not silently demote a genuine home reply.
+	rippleJoinOnly := `(EXISTS(SELECT 1 FROM messages_groups mgj
+	                   INNER JOIN memberships memj ON memj.groupid = mgj.groupid
+	                     AND memj.userid = rra.userid AND memj.collection = 'Approved'
+	                     AND memj.added < mgj.arrival AND memj.rippled = 1
+	                   WHERE mgj.msgid = rra.msgid AND mgj.rippled_in = 0 AND mgj.deleted = 0)
+	              AND NOT EXISTS(SELECT 1 FROM messages_groups mgo
+	                   INNER JOIN memberships memo ON memo.groupid = mgo.groupid
+	                     AND memo.userid = rra.userid AND memo.collection = 'Approved'
+	                     AND memo.added < mgo.arrival AND memo.rippled = 0
+	                   WHERE mgo.msgid = rra.msgid AND mgo.rippled_in = 0 AND mgo.deleted = 0))`
 	derive := `CASE
-	       WHEN rra.was_home_member = 1 THEN 'home'
+	       WHEN rra.was_home_member = 1 AND NOT ` + rippleJoinOnly + ` THEN 'home'
 	       WHEN EXISTS(SELECT 1 FROM rippling_reach_notified rrn
 	                   WHERE rrn.msgid = rra.msgid AND rrn.userid = rra.userid
 	                     AND rrn.notified_at <= rra.replied_at) THEN 'ripple_notified'
@@ -161,6 +181,7 @@ func ReplySourceSplitSQL(wide bool, srcGroup string) string {
 	                     AND mem.added < mgr.arrival
 	                   WHERE mgr.msgid = rra.msgid AND mgr.rippled_in = 1
 	                     AND mgr.deleted = 0 AND mgr.arrival <= rra.replied_at) THEN 'ripple_group'
+	       WHEN ` + rippleJoinOnly + ` THEN 'ripple_join'
 	       ELSE 'unknown'
 	       END`
 	bucket := derive
@@ -173,6 +194,7 @@ func ReplySourceSplitSQL(wide bool, srcGroup string) string {
 		       SUM(bucket = 'home') AS home,
 		       SUM(bucket = 'ripple_notified') AS ripple_notified,
 		       SUM(bucket = 'ripple_group') AS ripple_group,
+		       SUM(bucket = 'ripple_join') AS ripple_join,
 		       SUM(bucket = 'ripple_reach') AS ripple_reach,
 		       SUM(bucket = 'organic_local') AS organic_local,
 		       SUM(bucket = 'unknown') AS unknown
@@ -433,8 +455,9 @@ func Metrics(c *fiber.Ctx) error {
 	//     reply time - the only sound attribution, since replying joins the member to the group).
 	//     Two variants sharing one output shape:
 	//     - wide: read the attribution channel the Go reply handler derived at capture time.
-	//       Rows the backfill hasn't visited (attribution NULL) fold into home/unknown off the
-	//       legacy was_home_member bit.
+	//       Rows the backfill hasn't visited (attribution NULL) are bucketed live off the legacy
+	//       was_home_member bit, qualified by the surviving membership's provenance so a
+	//       ripple-created auto-join reads as ripple_join rather than home.
 	//     - legacy (graded columns not yet migrated, e.g. production before the deploy): derive
 	//       the durable channels live from the notified ledger and rippled-group memberships.
 	//       Correct for notified/group/home; the location channels (ripple_reach/organic_local)
@@ -493,7 +516,8 @@ func Metrics(c *fiber.Ctx) error {
 	// channels that are DEFINITELY rippling - unknown is not credited (the old replies-minus-home
 	// number silently attributed every un-evidenced reply to rippling).
 	for i := range replySources {
-		replySources[i].Ripple = replySources[i].RippleNotified + replySources[i].RippleGroup + replySources[i].RippleReach
+		replySources[i].Ripple = replySources[i].RippleNotified + replySources[i].RippleGroup +
+			replySources[i].RippleJoin + replySources[i].RippleReach
 		if replySources[i].Replies > 0 {
 			replySources[i].RipplePct = float64(replySources[i].Ripple) / float64(replySources[i].Replies) * 100
 		}

--- a/iznik-server-go/rippling/metrics_test.go
+++ b/iznik-server-go/rippling/metrics_test.go
@@ -17,11 +17,12 @@ func TestReplySourceSplitSQL_LegacyNarrow(t *testing.T) {
 
 	// Legacy path derives the bucket live - no COALESCE(rra.attribution, ...) wrapper.
 	assert.NotContains(t, sql, "COALESCE(rra.attribution")
-	assert.Contains(t, sql, "WHEN rra.was_home_member = 1 THEN 'home'")
+	assert.Contains(t, sql, "THEN 'home'")
 	assert.Contains(t, sql, "WHEN EXISTS(SELECT 1 FROM rippling_reach_notified rrn")
 	assert.Contains(t, sql, "THEN 'ripple_notified'")
 	assert.Contains(t, sql, "WHEN EXISTS(SELECT 1 FROM messages_groups mgr")
 	assert.Contains(t, sql, "THEN 'ripple_group'")
+	assert.Contains(t, sql, "THEN 'ripple_join'")
 	assert.Contains(t, sql, "ELSE 'unknown'")
 
 	// Output shape: one row per day with every channel summed off the bucket.
@@ -30,6 +31,7 @@ func TestReplySourceSplitSQL_LegacyNarrow(t *testing.T) {
 	assert.Contains(t, sql, "SUM(bucket = 'home') AS home")
 	assert.Contains(t, sql, "SUM(bucket = 'ripple_notified') AS ripple_notified")
 	assert.Contains(t, sql, "SUM(bucket = 'ripple_group') AS ripple_group")
+	assert.Contains(t, sql, "SUM(bucket = 'ripple_join') AS ripple_join")
 	assert.Contains(t, sql, "SUM(bucket = 'ripple_reach') AS ripple_reach")
 	assert.Contains(t, sql, "SUM(bucket = 'organic_local') AS organic_local")
 	assert.Contains(t, sql, "SUM(bucket = 'unknown') AS unknown")
@@ -54,8 +56,41 @@ func TestReplySourceSplitSQL_WideWrapsWithCoalesce(t *testing.T) {
 	// Wide path prefers the captured column, falling back to the same live
 	// derivation used by the legacy path for rows the backfill hasn't reached.
 	assert.Contains(t, sql, "COALESCE(rra.attribution, CASE")
-	assert.Contains(t, sql, "WHEN rra.was_home_member = 1 THEN 'home'")
+	assert.Contains(t, sql, "THEN 'home'")
 	assert.Contains(t, sql, "END) AS bucket")
+}
+
+// The live derivation reads the frozen was_home_member bit, which on rows captured before this
+// fix was set for ripple-created auto-joins too. Such a row must not read as home: the member is
+// only in the group because an earlier ripple put them there. The derivation therefore qualifies
+// the home rung by the surviving membership's PROVENANCE, and keeps the rungs in ladder order -
+// ripple_join sits below notified and group, exactly as in DeriveAttribution.
+func TestReplySourceSplitSQL_RippleJoinRefinesTheFrozenHomeBit(t *testing.T) {
+	sql := ReplySourceSplitSQL(false, "")
+
+	homeIdx := strings.Index(sql, "THEN 'home'")
+	notifiedIdx := strings.Index(sql, "THEN 'ripple_notified'")
+	groupIdx := strings.Index(sql, "THEN 'ripple_group'")
+	joinIdx := strings.Index(sql, "THEN 'ripple_join'")
+	unknownIdx := strings.Index(sql, "ELSE 'unknown'")
+	if assert.True(t, homeIdx >= 0 && notifiedIdx >= 0 && groupIdx >= 0 && joinIdx >= 0) {
+		assert.Less(t, homeIdx, notifiedIdx, "ladder order: home first")
+		assert.Less(t, notifiedIdx, groupIdx)
+		assert.Less(t, groupIdx, joinIdx, "ripple_join ranks below ripple_group, as in DeriveAttribution")
+		assert.Less(t, joinIdx, unknownIdx)
+	}
+
+	// Both halves of "only a ripple-created membership backs the home bit" must be present:
+	// a ripple-created origin membership exists, AND no ordinary one does.
+	assert.Contains(t, sql, "memj.rippled = 1",
+		"ripple_join needs a ripple-created origin membership")
+	assert.Contains(t, sql, "memo.rippled = 0",
+		"...and no ordinary origin membership, else it is genuinely home")
+
+	// The home rung is guarded by the negation of that same test, so a row whose only surviving
+	// origin membership is a ripple-join can never fall through to home.
+	assert.Contains(t, sql, "rra.was_home_member = 1 AND NOT (",
+		"the frozen home bit is qualified, not trusted blindly")
 }
 
 func TestReplySourceSplitSQL_SrcGroupSplicedIntoFROM(t *testing.T) {

--- a/iznik-server-go/test/chatmessage_reach_test.go
+++ b/iznik-server-go/test/chatmessage_reach_test.go
@@ -180,6 +180,7 @@ type attributionRow struct {
 	WasHomeMember  int     `gorm:"column:was_home_member"`
 	WasNotified    *int    `gorm:"column:was_notified"`
 	WasRippleGroup *int    `gorm:"column:was_ripple_group_member"`
+	WasRippleJoin  *int    `gorm:"column:was_ripple_join"`
 	InOrigin       *int    `gorm:"column:in_origin_catchment"`
 	InReach        *int    `gorm:"column:in_reach"`
 	PostHadRippled *int    `gorm:"column:post_had_rippled"`
@@ -190,7 +191,7 @@ type attributionRow struct {
 func fetchAttribution(t *testing.T, msgID, uid uint64) (attributionRow, bool) {
 	var rows []attributionRow
 	database.DBConn.Raw("SELECT was_home_member, was_notified, was_ripple_group_member, "+
-		"in_origin_catchment, in_reach, post_had_rippled, attribution, client_source "+
+		"was_ripple_join, in_origin_catchment, in_reach, post_had_rippled, attribution, client_source "+
 		"FROM rippling_reply_attribution WHERE msgid = ? AND userid = ?", msgID, uid).Scan(&rows)
 	if len(rows) == 0 {
 		return attributionRow{}, false
@@ -390,4 +391,84 @@ func TestCreateChatMessage_AttributionLadder(t *testing.T) {
 		assert.Equal(t, 0, *row.InOrigin)
 	}
 	assert.Nil(t, row.ClientSource, "an ill-formed client surface is dropped")
+}
+
+// Rippling auto-joins a poster to every group their post rippled into (memberships.rippled = 1).
+// When one of those groups later hosts a post of its own and that member replies, the reply is NOT
+// home: the member is only in that group because of an earlier ripple, so without rippling they
+// would never have seen it. Counting them as an established local member - which is what every
+// "was already a member" test did before this - hands rippling's own downstream effect to the
+// home column and makes rippling read as less effective than it is.
+func TestCreateChatMessage_RippleJoinedMemberIsNotHome(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("ripplejoin")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	// A post that never rippled anywhere: proves the ripple-join rung stands on the membership's
+	// own provenance and needs no ripple on THIS post.
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: ripple-join attribution test item", 51.5, -0.1)
+	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = ?", msgID)
+
+	// Ripple-created membership: long-established, but rippling put them there.
+	joinedID := CreateTestUser(t, prefix+"_ripplejoined", "User")
+	CreateTestMembership(t, joinedID, groupID, "Member")
+	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 30 DAY, collection = 'Approved', rippled = 1 "+
+		"WHERE userid = ? AND groupid = ?", joinedID, groupID)
+
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, joinedID, posterID, msgID, ""))
+	row, ok := fetchAttribution(t, msgID, joinedID)
+	assert.True(t, ok, "attribution row recorded for the ripple-joined member's reply")
+	assert.Equal(t, 0, row.WasHomeMember,
+		"a ripple-created auto-join is not evidence of established local membership")
+	if assert.NotNil(t, row.WasRippleJoin) {
+		assert.Equal(t, 1, *row.WasRippleJoin, "the ripple-join evidence bit is frozen in the row")
+	}
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "ripple_join", *row.Attribution,
+			"credited to rippling: the membership itself is a ripple side-effect")
+	}
+
+	// Control: an ordinary member of the SAME group, equally established, still reads as home.
+	// Only the provenance of the membership differs, so this pins the fix to memberships.rippled
+	// rather than to anything about the post or the group.
+	ordinaryID := CreateTestUser(t, prefix+"_ordinary", "User")
+	CreateTestMembership(t, ordinaryID, groupID, "Member")
+	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 30 DAY, collection = 'Approved', rippled = 0 "+
+		"WHERE userid = ? AND groupid = ?", ordinaryID, groupID)
+
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, ordinaryID, posterID, msgID, ""))
+	row, ok = fetchAttribution(t, msgID, ordinaryID)
+	assert.True(t, ok)
+	assert.Equal(t, 1, row.WasHomeMember, "an ordinary membership is still home")
+	if assert.NotNil(t, row.WasRippleJoin) {
+		assert.Equal(t, 0, *row.WasRippleJoin)
+	}
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "home", *row.Attribution)
+	}
+
+	// A member holding BOTH kinds of membership of origin groups of one post is home: the
+	// ordinary one alone would have shown them the post, so rippling gets no credit. (Cross-posts
+	// are the real-world case - one origin group joined normally, another via a ripple.)
+	secondGroupID := CreateTestGroup(t, prefix+"_second")
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) "+
+		"VALUES (?, ?, NOW(), 'Approved', 0, 0)", msgID, secondGroupID)
+	bothID := CreateTestUser(t, prefix+"_both", "User")
+	CreateTestMembership(t, bothID, groupID, "Member")
+	CreateTestMembership(t, bothID, secondGroupID, "Member")
+	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 30 DAY, collection = 'Approved', rippled = 1 "+
+		"WHERE userid = ? AND groupid = ?", bothID, groupID)
+	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 30 DAY, collection = 'Approved', rippled = 0 "+
+		"WHERE userid = ? AND groupid = ?", bothID, secondGroupID)
+
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, bothID, posterID, msgID, ""))
+	row, ok = fetchAttribution(t, msgID, bothID)
+	assert.True(t, ok)
+	assert.Equal(t, 1, row.WasHomeMember)
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "home", *row.Attribution,
+			"one ordinary origin membership is enough for home, whatever else they hold")
+	}
 }

--- a/iznik-server-go/test/rippling_attribution_test.go
+++ b/iznik-server-go/test/rippling_attribution_test.go
@@ -7,36 +7,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func iptr(v int) *int { return &v }
+func iptr(v int) *int       { return &v }
 func sptr(s string) *string { return &s }
 
 // The attribution ladder over the evidence bits. Precedence and the hard guard are the whole
 // point of the graded scheme, so every rung and the interesting overlaps are pinned here.
 func TestDeriveAttribution(t *testing.T) {
 	cases := []struct {
-		name                                             string
-		wasHome, wasNotified, wasRippleGroup, hadRippled int
-		inOrigin, inReach                                *int
-		want                                             string
+		name                                 string
+		wasHome, wasNotified, wasRippleGroup int
+		wasRippleJoin, hadRippled            int
+		inOrigin, inReach                    *int
+		want                                 string
 	}{
-		{"home member", 1, 0, 0, 1, nil, nil, rippling.AttributionHome},
+		{"home member", 1, 0, 0, 0, 1, nil, nil, rippling.AttributionHome},
 		{"home wins over ripple evidence (conservative: never over-credit rippling)",
-			1, 1, 1, 1, iptr(1), iptr(1), rippling.AttributionHome},
-		{"notified ledger hit", 0, 1, 0, 1, nil, nil, rippling.AttributionRippleNotified},
-		{"notified outranks rippled-group membership", 0, 1, 1, 1, nil, nil, rippling.AttributionRippleNotified},
-		{"established member of a rippled-into group", 0, 0, 1, 1, nil, nil, rippling.AttributionRippleGroup},
+			1, 1, 1, 1, 1, iptr(1), iptr(1), rippling.AttributionHome},
+		{"notified ledger hit", 0, 1, 0, 0, 1, nil, nil, rippling.AttributionRippleNotified},
+		{"notified outranks rippled-group membership", 0, 1, 1, 0, 1, nil, nil, rippling.AttributionRippleNotified},
+		{"established member of a rippled-into group", 0, 0, 1, 0, 1, nil, nil, rippling.AttributionRippleGroup},
+		{"origin-group member only because an earlier ripple auto-joined them",
+			0, 0, 0, 1, 1, nil, nil, rippling.AttributionRippleJoin},
+		{"a ripple-created membership is credited even on a post that never rippled",
+			0, 0, 0, 1, 0, nil, nil, rippling.AttributionRippleJoin},
 		{"non-member inside origin catchment: would have seen it in Browse anyway",
-			0, 0, 0, 1, iptr(1), iptr(1), rippling.AttributionOrganicLocal},
+			0, 0, 0, 0, 1, iptr(1), iptr(1), rippling.AttributionOrganicLocal},
 		{"outside catchment, inside reach: exposure existed only because of the ripple",
-			0, 0, 0, 1, iptr(0), iptr(1), rippling.AttributionRippleReach},
+			0, 0, 0, 0, 1, iptr(0), iptr(1), rippling.AttributionRippleReach},
 		{"inside reach but post never rippled: hard guard blocks ripple_reach",
-			0, 0, 0, 0, iptr(0), iptr(1), rippling.AttributionUnknown},
-		{"no location on file: reach containment unknowable", 0, 0, 0, 1, nil, nil, rippling.AttributionUnknown},
-		{"outside both", 0, 0, 0, 1, iptr(0), iptr(0), rippling.AttributionUnknown},
+			0, 0, 0, 0, 0, iptr(0), iptr(1), rippling.AttributionUnknown},
+		{"no location on file: reach containment unknowable", 0, 0, 0, 0, 1, nil, nil, rippling.AttributionUnknown},
+		{"outside both", 0, 0, 0, 0, 1, iptr(0), iptr(0), rippling.AttributionUnknown},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := rippling.DeriveAttribution(c.wasHome, c.wasNotified, c.wasRippleGroup, c.hadRippled, c.inOrigin, c.inReach)
+			got := rippling.DeriveAttribution(c.wasHome, c.wasNotified, c.wasRippleGroup,
+				c.wasRippleJoin, c.hadRippled, c.inOrigin, c.inReach)
 			assert.Equal(t, c.want, got)
 		})
 	}

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -304,14 +304,16 @@ func TestRipplingMetricsReplyKPIs(t *testing.T) {
 	_, token := CreateTestSession(t, adminID)
 
 	db := database.DBConn
-	// Four replies on an isolated day (5 days ago), one per interesting bucket: a home
-	// member, a graded ripple_notified capture, a graded ripple_reach capture, and a
-	// legacy pre-migration row (attribution NULL, was_home_member=0) which must fold into
+	// Five replies on an isolated day (5 days ago), one per interesting bucket: a home
+	// member, a graded ripple_notified capture, a graded ripple_reach capture, a graded
+	// ripple_join capture (someone rippling itself put in the group), and a legacy
+	// pre-migration row (attribution NULL, was_home_member=0) which must fold into
 	// unknown - NOT be credited to rippling as the old replies-minus-home number did.
 	db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member, attribution) VALUES " +
 		"(900000091, 900000091, NOW() - INTERVAL 5 DAY, 1, 'home'), " +
 		"(900000091, 900000092, NOW() - INTERVAL 5 DAY, 0, 'ripple_notified'), " +
 		"(900000091, 900000093, NOW() - INTERVAL 5 DAY, 0, 'ripple_reach'), " +
+		"(900000091, 900000095, NOW() - INTERVAL 5 DAY, 0, 'ripple_join'), " +
 		"(900000091, 900000094, NOW() - INTERVAL 5 DAY, 0, NULL)")
 	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = 900000091")
 
@@ -327,21 +329,83 @@ func TestRipplingMetricsReplyKPIs(t *testing.T) {
 	assert.Equal(t, true, result["attribution_channels_available"],
 		"graded columns exist on the migrated test DB")
 
-	// The seeded day's split row: 4 replies -> 1 home, 1 notified, 1 reach, 1 unknown;
-	// ripple share counts only the definite ripple channels (2/4 = 50%).
+	// The seeded day's split row: 5 replies -> 1 home, 1 notified, 1 reach, 1 join, 1 unknown;
+	// ripple share counts only the definite ripple channels (3/5 = 60%).
 	found := false
 	for _, r := range split {
-		if m, ok := r.(map[string]interface{}); ok && m["replies"] == float64(4) && m["home"] == float64(1) {
+		if m, ok := r.(map[string]interface{}); ok && m["replies"] == float64(5) && m["home"] == float64(1) {
 			found = true
 			assert.Equal(t, float64(1), m["ripple_notified"], "one notified-ledger reply")
 			assert.Equal(t, float64(1), m["ripple_reach"], "one reach-fed browse reply")
+			assert.Equal(t, float64(1), m["ripple_join"], "one ripple-created-membership reply")
 			assert.Equal(t, float64(1), m["unknown"],
 				"a legacy un-evidenced row folds into unknown, not ripple")
-			assert.Equal(t, float64(2), m["ripple"], "ripple = notified + group + reach only")
-			assert.Equal(t, float64(50), m["ripple_pct"])
+			assert.Equal(t, float64(3), m["ripple"], "ripple = notified + group + join + reach")
+			assert.Equal(t, float64(60), m["ripple_pct"])
 		}
 	}
 	assert.True(t, found, "the seeded channel split is surfaced")
+}
+
+// Rows captured before the ripple-join fix froze was_home_member = 1 for members rippling itself
+// auto-joined. The live derivation (used for any row the backfill has not yet visited) must sort
+// those into ripple_join off the membership's surviving provenance, while a row backed by an
+// ordinary membership still reads home. Without this, the un-backfilled tail of the chart keeps
+// crediting rippling's own side-effect to the home column.
+func TestRipplingMetricsLegacyHomeBitSplitsByMembershipProvenance(t *testing.T) {
+	prefix := uniquePrefix("ripplejoinderive")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: legacy derive test item", 51.5, -0.1)
+	// The post arrived a month ago, so both memberships below predate it.
+	db.Exec("UPDATE messages_groups SET arrival = NOW() - INTERVAL 30 DAY WHERE msgid = ?", msgID)
+
+	joinedID := CreateTestUser(t, prefix+"_ripplejoined", "User")
+	CreateTestMembership(t, joinedID, groupID, "Member")
+	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 60 DAY, collection = 'Approved', rippled = 1 "+
+		"WHERE userid = ? AND groupid = ?", joinedID, groupID)
+
+	ordinaryID := CreateTestUser(t, prefix+"_ordinary", "User")
+	CreateTestMembership(t, ordinaryID, groupID, "Member")
+	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 60 DAY, collection = 'Approved', rippled = 0 "+
+		"WHERE userid = ? AND groupid = ?", ordinaryID, groupID)
+
+	// A user with no membership left at all: their frozen home bit is all the evidence there is,
+	// so it must be honoured rather than reclassified.
+	goneID := CreateTestUser(t, prefix+"_gone", "User")
+
+	// Legacy shape: was_home_member = 1, attribution NULL (backfill has not run).
+	day := "2020-03-15 12:00:00"
+	db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member) VALUES "+
+		"(?, ?, ?, 1), (?, ?, ?, 1), (?, ?, ?, 1)",
+		msgID, joinedID, day, msgID, ordinaryID, day, msgID, goneID, day)
+	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = ?", msgID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf(
+		"/api/rippling/metrics?start=2020-03-01%%2000:00:00&end=2020-04-01%%2000:00:00&jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	split, _ := result["reply_source_split"].([]interface{})
+
+	found := false
+	for _, r := range split {
+		if m, ok := r.(map[string]interface{}); ok && m["day"] == "2020-03-15" {
+			found = true
+			assert.Equal(t, float64(1), m["ripple_join"],
+				"the ripple-created membership reclassifies out of home")
+			assert.Equal(t, float64(2), m["home"],
+				"the ordinary membership - and the decayed one - stay home")
+			assert.Equal(t, float64(1), m["ripple"], "ripple_join counts towards the ripple share")
+		}
+	}
+	assert.True(t, found, "the seeded legacy day is surfaced")
 }
 
 // The ?start= / ?end= range bounds every headline KPI so a treatment group's before-vs-after can


### PR DESCRIPTION
## The bug

Every rippling effectiveness figure on the sysadmin tab turns on one test: **was the replier
already a member of an origin group of the post?** If yes the reply is `home` — they'd have seen it
anyway and rippling gets no credit.

That test counted memberships **rippling itself created**. When a post ripples into a group we
auto-join the poster to it (`memberships.rippled = 1`,
`ExpandService::addPosterMembershipToRippledGroups`), so a frequent poster accumulates memberships
of distant groups purely as a side-effect of rippling. When one of those groups later hosted a post
of its own and that member replied, the reply was scored `home` — even though without rippling that
member would never have been in the group to see it.

So rippling's own downstream reach was being counted in the column that means "rippling had nothing
to do with this."

## Scale on production

| | last 30 days |
|---|---|
| Replies with attribution | 19,489 |
| ...credited to rippling | 2,354 (12.1%) |
| ...read as `home` | 15,283 |
| **of which backed *only* by a ripple-created membership** | **1,031 (6.7% of home)** |

92,394 memberships on production carry `rippled = 1`. Correcting those 1,031 replies raises the
ripple-credited share from 12.1% to 17.4% — a ~44% increase in replies credited to rippling. The
rescue floor (posts taken with no home-group reply at all) was understated the same way.

## The fix

One shared predicate, `rippling.EstablishedOriginMemberExists`, now defines "already a member" for
every rippling statistic, with `mem.rippled = 0` alongside the existing origin-group and
joined-before-arrival qualifiers. Applied to:

- the reply-time capture (`chat/chatmessage.go`),
- the "is rippling helping?" block — rippled-reply/taker shares, reply→take conversion, and the
  rescue floor (`rippling/analytics.go`),
- the drive-time sample's rippled-out tagging,
- the reply-attribution split and its live derivation (`rippling/metrics.go`),
- the Laravel backfill for legacy rows.

Those replies get their own channel, **`ripple_join`**, one rung below `ripple_group` in the ladder
— both are membership-level exposure that exists because of a ripple. It carries no "did this post
ripple?" guard, unlike `ripple_reach`: the ripple that earns the credit already happened, to a
different post, and left the membership behind as its record. It counts towards the headline ripple
share and gets its own band on the attribution chart.

Where the frozen `was_home_member` bit is re-read (the live derivation and the backfill), a row is
only reclassified when a ripple-created origin membership survives **and** no ordinary one does. If
both have decayed away the frozen bit's answer of `home` stands, so leavers never silently demote a
genuine home reply.

## Migration

`2026_08_05_000001` adds `rippling_reply_attribution.was_ripple_join` and appends `ripple_join` to
the `attribution` enum. Both are metadata-only in MySQL 8 (nullable bool = INSTANT add; appending
to the end of an enum does not rewrite rows). Idempotent `_migration.sql` twin included for prod.

## Tests

TDD — tests written first, and the ladder-order assertion was corrected once writing it exposed
that `ripple_join` had to sit *below* `notified`/`group`, not above `home`.

- `DeriveAttribution` ladder: every rung reachable, every precedence collision pinned, plus
  `ripple_join` standing on a post that never rippled.
- `EstablishedOriginMemberExists`: the shared predicate carries all three qualifiers.
- Reply capture, end to end: a ripple-joined member replying → `ripple_join`, an ordinary member of
  the same group with an identical membership age → `home`, and a member holding both → `home`.
- Metrics: `ripple_join` counted in the split and in the ripple share; a legacy row re-read by
  membership provenance, with a decayed membership left as `home`.
- Laravel backfill: same three cases against real fixtures.
- Dashboard: `ripple_join` charted as its own band, in its own column.

---

Go 3833 ✓ · Laravel 5156 ✓ · Vitest 14725 ✓ (all run locally in an isolated worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lp1Jn9RaaEd3EUCSpTLWwE
