### PR TITLE
fix(modtools/stdmsg): moderator feedback on the standard-message editor

### DIFF
--- a/docs/moderators/02-moderating-posts.md
+++ b/docs/moderators/02-moderating-posts.md
@@ -1,9 +1,11 @@
 ---
-last_reviewed: 2026-07-21
+last_reviewed: 2026-08-05
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/modtools/pages/messages/**
   - iznik-nuxt3/modtools/components/ModMessage*.vue
+  - iznik-nuxt3/modtools/components/ModStdMessageModal.vue
+  - iznik-nuxt3/modtools/utils/stdMessageDirectives.js
   # cross-stack behaviour tests (change when the behaviour changes)
   - iznik-nuxt3/tests/e2e/test-modtools-pending-messages.spec.js
   - iznik-nuxt3/tests/e2e/test-modtools-edits.spec.js
@@ -80,6 +82,27 @@ situation (approve, reject, hold, and so on). You configure your sets under Sett
   between "autosend" and "edit first" for a session.
 
 Keep them friendly and personal. A short human note lands far better than a corporate one.
+
+### Fill-in boxes and optional bits
+
+A standard message can mark parts of its wording with `<editthis>...</editthis>` (something
+you must write yourself each time) or `<optional>...</optional>` (something that only
+applies sometimes). You add those tags when you write the message under Settings.
+
+When a message uses either of them, sending it opens the message laid out in order rather
+than as one block of text:
+
+- An **`<editthis>`** part is a highlighted box. Fill it in before you send.
+- An **`<optional>`** part comes with **Keep** and **Remove**. You must choose one, and you
+  can change your mind afterwards either way. The wording itself stays editable, so you can
+  reword it as well as take it or leave it.
+- The rest of the wording is editable too.
+- Between the parts you will see whether there is a **blank line between these paragraphs**,
+  with a click to add or remove one. That is what controls the spacing the member sees, so
+  if a message arrives with its paragraphs run together, this is where you fix it.
+
+If something is still outstanding, sending is refused: nothing goes to the member, the
+outstanding boxes are outlined in red, and the message tells you what is left to do.
 
 ## The edit queue
 

--- a/docs/moderators/04-running-your-community.md
+++ b/docs/moderators/04-running-your-community.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-09
+last_reviewed: 2026-08-05
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/modtools/pages/settings/**
@@ -48,6 +48,11 @@ set.
 Freegle provides plenty of starting-point messages for common situations, and a library
 of whole-community **broadcast** templates (for example bank holidays, keeping it local,
 no-shows, too many emails, safety, reselling). Adapt them to your own voice.
+
+A message can mark part of its wording as something you must fill in each time, or as
+something optional, using `<editthis>` and `<optional>` tags. See
+[fill-in boxes and optional bits](02-moderating-posts.md#fill-in-boxes-and-optional-bits)
+for what a moderator then sees when they send it.
 
 ## Stories and newsletters
 

--- a/iznik-nuxt3/components/AutoHeightTextarea.vue
+++ b/iznik-nuxt3/components/AutoHeightTextarea.vue
@@ -17,7 +17,7 @@
 //
 // We don't shrink.  If you're reading this, why not code it?
 import { storeToRefs } from 'pinia'
-import { ref, watch, onBeforeUnmount } from '#imports'
+import { ref, watch, onMounted, onBeforeUnmount, nextTick } from '#imports'
 import { useMiscStore } from '~/stores/misc'
 
 const props = defineProps({
@@ -86,6 +86,36 @@ const checkRows = () => {
 
   timer.value = setTimeout(checkRows, 100)
 }
+
+// Grow to fit whatever is already in the box. The polling above only starts from
+// the currentValue watcher, which never fires for the value we were mounted with
+// - so a box arriving pre-filled (a standard message template, an edit form) sat
+// at its minimum rows with a scrollbar and the text apparently missing.
+// One bounded pass rather than a permanent timer: pre-filled boxes are common and
+// their content doesn't change until someone types, which starts the timer anyway.
+const growToFit = async () => {
+  const maxRows = Number(props.maxRows)
+
+  while (Number(currentRows.value) < maxRows) {
+    await nextTick()
+
+    if (!ta.value?.$el) {
+      return
+    }
+
+    if (ta.value.$el.scrollHeight <= ta.value.$el.clientHeight) {
+      return
+    }
+
+    currentRows.value = Number(currentRows.value) + 1
+  }
+}
+
+onMounted(() => {
+  if (currentValue.value) {
+    growToFit()
+  }
+})
 
 watch(
   () => props.modelValue,

--- a/iznik-nuxt3/components/ChatMessageText.vue
+++ b/iznik-nuxt3/components/ChatMessageText.vue
@@ -17,8 +17,8 @@
       :class="{ 'chat-empty-message': isEmptyMessage }"
     >
       <div>
-        <!-- ModTools: clickable links enabled -->
-        <template v-if="isModTools">
+        <!-- ModTools, and volunteer chats on Freegle: clickable links enabled -->
+        <template v-if="linksClickable">
           <span v-if="!highlightEmails">
             <span
               v-if="messageIsNew"
@@ -54,7 +54,7 @@
             />
           </span>
         </template>
-        <!-- Freegle: no clickable links for safety -->
+        <!-- Freegle member-to-member chat: no clickable links for safety -->
         <template v-else>
           <span v-if="!highlightEmails">
             <span v-if="messageIsNew" class="prewrap fw-bold">{{
@@ -198,8 +198,17 @@ const postcode = computed(() => {
   return ret
 })
 
-// In ModTools, we make URLs clickable. In Freegle, we don't for safety reasons.
+// In ModTools, we make URLs clickable. In Freegle we don't, because a link from
+// another member could be a scam.
 const isModTools = computed(() => miscStore.modtools)
+
+// ...but a User2Mod chat is the conversation with your own community's
+// volunteers, so that risk doesn't apply. Standard messages routinely point
+// members at a link (e.g. where to edit their post), and on the app that link
+// was dead text with no way to follow it.
+const linksClickable = computed(
+  () => isModTools.value || chat.value?.chattype === 'User2Mod'
+)
 
 // Linkified message for ModTools (without email highlighting)
 const linkifiedMessage = computed(() => {
@@ -226,7 +235,7 @@ onMounted(async () => {
 })
 </script>
 <style scoped lang="scss">
-/* Chat link styling for ModTools - uses :deep() since content is rendered via v-html */
+/* Chat link styling - uses :deep() since content is rendered via v-html */
 :deep(.chat-link) {
   color: var(--color-link);
   text-decoration: underline;

--- a/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
+++ b/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
@@ -67,16 +67,41 @@
            and a keep/remove control per <optional>, filled in order so you never
            have to look back at the template. -->
       <div v-else class="mt-2 segmented-editor border rounded p-3">
-        <p class="text-muted small mb-2">
+        <!-- Red rather than muted: this way of editing is unfamiliar and
+             moderators were reading straight past a grey instruction. -->
+        <p class="text-danger small mb-2">
           Fill in the highlighted boxes and choose Keep or Remove for any
           optional parts. You can edit any of the rest of the wording too. This
           is the message the member will receive.
         </p>
         <div class="segmented-body">
           <template v-for="(seg, i) in segments" :key="'seg' + i">
+            <!-- A text segment which is nothing but the line break(s) between two
+                 blocks: shown as a paragraph-spacing toggle rather than an empty
+                 box, so the spacing is visible and fixable. -->
+            <div
+              v-if="seg.type === 'text' && isGap(seg)"
+              :data-seg="i"
+              class="seg-gap"
+            >
+              <b-button
+                size="sm"
+                variant="link"
+                class="p-0 seg-gap-toggle"
+                @click="toggleGap(i)"
+              >
+                <v-icon :icon="isParagraphGap(seg) ? 'minus' : 'plus'" />
+                {{
+                  isParagraphGap(seg)
+                    ? 'Blank line between these paragraphs (click to remove it)'
+                    : 'No blank line between these paragraphs (click to add one)'
+                }}
+              </b-button>
+            </div>
             <AutoHeightTextarea
-              v-if="seg.type === 'text'"
+              v-else-if="seg.type === 'text'"
               v-model="seg.content"
+              :data-seg="i"
               class="seg-text"
               rows="3"
               max-rows="30"
@@ -84,40 +109,69 @@
             <AutoHeightTextarea
               v-else-if="seg.type === 'editthis'"
               v-model="seg.value"
-              :class="['seg-editthis', { 'seg-todo': !segEdited(seg) }]"
+              :data-seg="i"
+              :class="[
+                'seg-editthis',
+                { 'seg-todo': !segEdited(seg), 'seg-blocked': isBlocked(i) },
+              ]"
               rows="3"
               max-rows="12"
               :placeholder="seg.content"
             />
             <span v-else-if="seg.type === 'optional'" class="seg-optional">
+              <!-- Undecided: the wording is editable while you decide, and you
+                   must pick one before the message can go. -->
               <span
                 v-if="seg.removed === undefined"
-                class="seg-optional-undecided"
+                :data-seg="i"
+                :class="[
+                  'seg-optional-undecided',
+                  { 'seg-blocked': isBlocked(i) },
+                ]"
               >
-                <span class="seg-optional-text">{{ seg.content }}</span>
+                <AutoHeightTextarea
+                  v-model="seg.content"
+                  class="seg-text seg-optional-text"
+                  rows="2"
+                  max-rows="20"
+                />
+                <span class="seg-optional-buttons">
+                  <b-button
+                    size="sm"
+                    variant="outline-success"
+                    @click="decideOptional(i, false)"
+                  >
+                    Keep
+                  </b-button>
+                  <b-button
+                    size="sm"
+                    variant="outline-danger"
+                    class="ms-1"
+                    @click="decideOptional(i, true)"
+                  >
+                    Remove
+                  </b-button>
+                </span>
+              </span>
+              <!-- Kept: still editable, and you can change your mind. -->
+              <span v-else-if="seg.removed === false" class="seg-optional-kept">
+                <AutoHeightTextarea
+                  v-model="seg.content"
+                  :data-seg="i"
+                  class="seg-text"
+                  rows="2"
+                  max-rows="20"
+                />
                 <b-button
                   size="sm"
-                  variant="outline-success"
-                  class="ms-1"
-                  @click="decideOptional(i, false)"
-                >
-                  Keep
-                </b-button>
-                <b-button
-                  size="sm"
-                  variant="outline-danger"
-                  class="ms-1"
+                  variant="link"
+                  class="p-0 seg-optional-change"
                   @click="decideOptional(i, true)"
                 >
-                  Remove
+                  remove this bit after all
                 </b-button>
               </span>
-              <span
-                v-else-if="seg.removed === false"
-                class="seg-optional-kept"
-                >{{ seg.content }}</span
-              >
-              <span v-else class="seg-optional-removed">
+              <span v-else :data-seg="i" class="seg-optional-removed">
                 <s class="text-muted">{{ seg.content }}</s>
                 <b-button
                   size="sm"
@@ -223,7 +277,7 @@
   </b-modal>
 </template>
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import dayjs from 'dayjs'
 import { setupKeywords } from '~/composables/useKeywords'
 import { useUserStore } from '~/stores/user'
@@ -335,9 +389,86 @@ function decideOptional(index, removed) {
   const seg = segments.value[index]
   if (seg && seg.type === 'optional') seg.removed = removed
 }
+
+// A text segment which is nothing but the line break(s) separating two blocks.
+// Rendered as an empty box it looked like a field you'd forgotten to fill in,
+// and gave no clue that it held the paragraph spacing - so a template written
+// with single line breaks produced a message with its paragraphs run together
+// and no obvious way to fix it. Shown as a toggle instead.
+// Needs a line break in it: a separator of only spaces is genuinely inline
+// wording, not paragraph spacing, and turning it into a paragraph control would
+// be wrong.
+function isGap(seg) {
+  return (
+    seg.type === 'text' &&
+    !!seg.content &&
+    /^\s*$/.test(seg.content) &&
+    seg.content.includes('\n')
+  )
+}
+function isParagraphGap(seg) {
+  return (seg.content?.match(/\n/g) || []).length > 1
+}
+function toggleGap(index) {
+  const seg = segments.value[index]
+  if (seg && isGap(seg)) seg.content = isParagraphGap(seg) ? '\n' : '\n\n'
+}
+
+// Which segments are holding the send up. Set when a send is refused so the
+// message points at the actual boxes rather than just complaining, and kept in
+// step as they're dealt with.
+const blockedSegments = ref([])
+function isBlocked(index) {
+  return blockedSegments.value.includes(index)
+}
+watch(
+  segments,
+  () => {
+    if (blockedSegments.value.length) {
+      const sb = segmentsSendBlockers(segments.value)
+      blockedSegments.value = [...sb.unedited, ...sb.undecided]
+      // Keep the wording honest as they work through it, rather than leaving it
+      // asking for things they have already done.
+      directiveWarning.value = sb.ok ? null : blockerMessage(sb)
+    }
+  },
+  { deep: true }
+)
+
 // Live gate for the segmented editor: outstanding editthis boxes + undecided
 // optionals. Mirrors sendBlockers() for the textarea path.
 const segmentBlockers = computed(() => segmentsSendBlockers(segments.value))
+
+// Say what's outstanding, and that nothing has gone out - mods hit Send, saw the
+// button spin and had no idea a decision was missing.
+function blockerMessage(sb) {
+  const bits = []
+  if (sb.unedited.length) {
+    bits.push(
+      sb.unedited.length === 1
+        ? 'fill in the highlighted box'
+        : `fill in the ${sb.unedited.length} highlighted boxes`
+    )
+  }
+  if (sb.undecided.length) {
+    bits.push(
+      sb.undecided.length === 1
+        ? 'choose Keep or Remove for the highlighted optional wording'
+        : `choose Keep or Remove for the ${sb.undecided.length} highlighted optional sections`
+    )
+  }
+  return `Nothing has been sent yet - please ${bits.join(' and ')}.`
+}
+
+// Point the moderator at the first thing that needs doing.
+async function showBlocked(indices) {
+  blockedSegments.value = indices
+  await nextTick()
+  const el = window.document?.querySelector?.(
+    `#stdmsgmodal [data-seg="${indices[0]}"]`
+  )
+  el?.scrollIntoView?.({ block: 'center' })
+}
 
 const keywordList = ['Offer', 'Taken', 'Wanted', 'Received', 'Other']
 const recentDays = 31
@@ -847,14 +978,17 @@ async function process(callback) {
   // un-personalised, and don't send an <optional> section without a Keep/Remove
   // decision. Block here (like the too-short check) rather than send.
   directiveWarning.value = null
+  blockedSegments.value = []
   if (useSegmentedEditor.value) {
     // Segmented editor: gate on outstanding editthis boxes / undecided optionals,
     // and assemble the body the recipient sees from the segments before sending.
     const sb = segmentBlockers.value
     if (!sb.ok) {
-      directiveWarning.value = sb.unedited.length
-        ? 'Please fill in the highlighted “edit this” box(es) before sending.'
-        : 'Please choose Keep or Remove for each optional section before sending.'
+      directiveWarning.value = blockerMessage(sb)
+      await showBlocked([...sb.unedited, ...sb.undecided])
+      // Stop the Send button spinning. Without this it span until SpinButton's
+      // 20s "callback forgotten" timeout, which reads as the send having hung.
+      if (callback) callback()
       return
     }
     body.value = assembleSegments(segments.value)
@@ -862,8 +996,9 @@ async function process(callback) {
     const blockers = sendBlockers(body.value || '', originalEditThis.value)
     if (!blockers.ok) {
       directiveWarning.value = blockers.editThis.length
-        ? 'Please personalise the highlighted “edit this” wording before sending.'
-        : 'Please choose Keep or Remove for each optional section before sending.'
+        ? 'Nothing has been sent yet - please personalise the highlighted “edit this” wording before sending.'
+        : 'Nothing has been sent yet - please choose Keep or Remove for each optional section before sending.'
+      if (callback) callback()
       return
     }
   }
@@ -1135,16 +1270,41 @@ defineExpose({ fillin, show, modal })
   /* dashed amber outline = "fill me in"; becomes a plain solid box once edited */
   border: 1px dashed #e0a800;
 }
+/* An optional section: its wording is editable while you decide (and after you
+   keep it), because mods want to reword these as well as take them or leave
+   them. Removing is reversible in both directions - Keep used to be final. */
 .seg-optional-undecided {
-  display: inline;
+  display: block;
   background-color: #e2e3e5;
   border-radius: 4px;
-  padding: 1px 4px;
+  padding: 4px;
+  margin: 4px 0;
 }
 .seg-optional-text {
   font-style: italic;
 }
+.seg-optional-kept {
+  display: block;
+}
+.seg-optional-change,
+.seg-gap-toggle {
+  font-size: 0.8125rem;
+}
 .seg-optional-removed {
   white-space: normal;
+}
+/* Paragraph spacing between two blocks, shown as a toggle rather than an empty
+   textarea nobody could interpret. */
+.seg-gap {
+  margin: 2px 0;
+}
+/* What's stopping the send. Set only when a send is refused, cleared as each one
+   is dealt with. Wins over the focus styling above, or clicking into the box
+   would hide the very thing we're pointing at. */
+.seg-blocked,
+.seg-blocked:focus,
+.seg-blocked:focus-visible {
+  border: 1px solid #dc3545;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.4);
 }
 </style>

--- a/iznik-nuxt3/modtools/composables/useStdMsgs.js
+++ b/iznik-nuxt3/modtools/composables/useStdMsgs.js
@@ -38,7 +38,11 @@ export function variant(stdmsg) {
     case 'Edit':
       return 'primary'
     case 'Hold Message':
-      return 'warning'
+      // Amber is what the rejects use. Holding a post keeps it, so it belongs
+      // with the greens; sorted alphabetically it otherwise ran into the block
+      // of rejects and got picked by mistake. The pause icon still tells them
+      // apart from the plain leaves.
+      return 'primary'
     default:
       return 'white'
   }

--- a/iznik-nuxt3/tests/unit/components/AutoHeightTextarea.spec.js
+++ b/iznik-nuxt3/tests/unit/components/AutoHeightTextarea.spec.js
@@ -177,6 +177,54 @@ describe('AutoHeightTextarea', () => {
       expect(textarea.attributes('rows')).toBe('3')
     })
 
+    // The growth check only ran off the currentValue watcher, which never fires
+    // for the value we were mounted with - so a box arriving pre-filled (a
+    // standard message template) sat at its minimum rows with a scrollbar, and
+    // moderators reported the wording looking like it wasn't there at all.
+    it('grows to fit content it was mounted with', async () => {
+      const wrapper = createWrapper({
+        rows: 3,
+        maxRows: 10,
+        modelValue: 'A standard message that wraps over rather a lot of lines.',
+      })
+
+      const el = wrapper.find('textarea').element
+      Object.defineProperty(el, 'scrollHeight', {
+        value: 500,
+        configurable: true,
+      })
+      Object.defineProperty(el, 'clientHeight', {
+        value: 20,
+        configurable: true,
+      })
+
+      await flushPromises()
+
+      expect(Number(wrapper.find('textarea').attributes('rows'))).toBe(10)
+    })
+
+    it('leaves a pre-filled box alone when it already fits', async () => {
+      const wrapper = createWrapper({
+        rows: 3,
+        maxRows: 10,
+        modelValue: 'Short.',
+      })
+
+      const el = wrapper.find('textarea').element
+      Object.defineProperty(el, 'scrollHeight', {
+        value: 20,
+        configurable: true,
+      })
+      Object.defineProperty(el, 'clientHeight', {
+        value: 60,
+        configurable: true,
+      })
+
+      await flushPromises()
+
+      expect(wrapper.find('textarea').attributes('rows')).toBe('3')
+    })
+
     // The box grows as you type but only ever grew. Sending a comment clears
     // the text, so an empty box kept the height it had reached - on mobile that
     // left an 8-row box with nothing in it, pushed up against the last reply.

--- a/iznik-nuxt3/tests/unit/components/ChatMessageText.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMessageText.spec.js
@@ -159,4 +159,34 @@ describe('ChatMessageText', () => {
     const wrapperWithHighlight = createWrapper({ highlightEmails: true })
     expect(wrapperWithHighlight.find('.highlighter').exists()).toBe(true)
   })
+
+  // Links stay plain text in member-to-member chat, where a link could be a
+  // scam. A User2Mod chat is the conversation with your own community's
+  // volunteers, and their standard messages routinely point you at a link
+  // (e.g. where to edit your post) - which on the app was dead text.
+  describe('clickable links', () => {
+    // The linkified branch renders through v-html; the plain branch renders
+    // through the Highlighter component, so the stub tells them apart.
+    const linkified = (wrapper) => !wrapper.find('.highlighter').exists()
+
+    it('leaves links plain in member-to-member chat', async () => {
+      const { useChatMessageBase } = await import('~/composables/useChat')
+      useChatMessageBase.mockReturnValueOnce({
+        ...mockComposableReturn,
+        chat: { value: { ...mockChat, chattype: 'User2User' } },
+      })
+
+      expect(linkified(createWrapper({ highlightEmails: true }))).toBe(false)
+    })
+
+    it('makes links clickable in a chat with the volunteers', async () => {
+      const { useChatMessageBase } = await import('~/composables/useChat')
+      useChatMessageBase.mockReturnValueOnce({
+        ...mockComposableReturn,
+        chat: { value: { ...mockChat, chattype: 'User2Mod' } },
+      })
+
+      expect(linkified(createWrapper({ highlightEmails: true }))).toBe(true)
+    })
+  })
 })

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSettingsStandardMessageButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSettingsStandardMessageButton.spec.js
@@ -92,8 +92,14 @@ describe('ModSettingsStandardMessageButton - useStdMsgs composable', () => {
       expect(variant({ action: 'Edit' })).toBe('primary')
     })
 
-    it('returns warning for Hold Message action', () => {
-      expect(variant({ action: 'Hold Message' })).toBe('warning')
+    // Hold used to be amber like the rejects, so in an alphabetically sorted
+    // set of buttons it ran into that block and got picked by mistake. Holding
+    // a post keeps it, so it belongs with the greens; the pause icon still
+    // tells it apart from a plain leave.
+    it('returns primary for Hold Message action, not the amber of the rejects', () => {
+      expect(variant({ action: 'Hold Message' })).toBe('primary')
+      expect(variant({ action: 'Reject' })).toBe('warning')
+      expect(icon({ action: 'Hold Message' })).toBe('pause')
     })
 
     it('returns white as default for unknown action', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModStdMessageModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModStdMessageModal.spec.js
@@ -651,6 +651,179 @@ describe('ModStdMessageModal', () => {
     })
   })
 
+  // Shape of the standard messages moderators actually configure: a must-fill
+  // box, then two optional bits separated by single line breaks.
+  const optionalsStdmsg = () =>
+    createStdmsg({
+      action: 'Leave',
+      body:
+        'Hello,\n\nThanks for using $groupname.  <editthis></editthis>\n' +
+        '<optional>You can edit your post at $editlink</optional>\n' +
+        '<optional>Please get back to us if you have any questions.</optional>\n\n' +
+        'With kind regards,\n$myname',
+      insert: 'Top',
+    })
+
+  const optionalIndexes = (wrapper) =>
+    wrapper.vm.segments
+      .map((seg, i) => (seg.type === 'optional' ? i : -1))
+      .filter((i) => i >= 0)
+
+  describe('segmented editor — a send that is refused', () => {
+    it('stops the send button spinning', async () => {
+      const wrapper = mountComponent({}, { stdmsgData: optionalsStdmsg() })
+      await wrapper.vm.fillin()
+
+      const callback = vi.fn()
+      await wrapper.vm.process(callback)
+
+      expect(mockMessageStore.reply).not.toHaveBeenCalled()
+      // Without this the button span on until SpinButton's 20s "callback
+      // forgotten" timeout, which reads as the send having hung.
+      expect(callback).toHaveBeenCalled()
+    })
+
+    it('says nothing has been sent and marks what is outstanding', async () => {
+      const wrapper = mountComponent({}, { stdmsgData: optionalsStdmsg() })
+      await wrapper.vm.fillin()
+
+      await wrapper.vm.process(vi.fn())
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.vm.directiveWarning).toContain('Nothing has been sent yet')
+      expect(wrapper.vm.directiveWarning).toContain('Keep or Remove')
+      // One must-fill box plus two undecided optionals.
+      expect(wrapper.vm.blockedSegments).toHaveLength(3)
+      expect(wrapper.find('.seg-blocked').exists()).toBe(true)
+    })
+
+    it('drops each mark as that bit is dealt with', async () => {
+      const wrapper = mountComponent({}, { stdmsgData: optionalsStdmsg() })
+      await wrapper.vm.fillin()
+      await wrapper.vm.process(vi.fn())
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.blockedSegments).toHaveLength(3)
+
+      const [first, second] = optionalIndexes(wrapper)
+      wrapper.vm.decideOptional(first, false)
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.blockedSegments).toHaveLength(2)
+
+      wrapper.vm.decideOptional(second, true)
+      await wrapper.vm.$nextTick()
+      // The wording keeps up, rather than still asking for the optionals once
+      // they have both been decided.
+      expect(wrapper.vm.blockedSegments).toHaveLength(1)
+      expect(wrapper.vm.directiveWarning).not.toContain('Keep or Remove')
+      expect(wrapper.vm.directiveWarning).toContain('highlighted box')
+
+      wrapper.vm.segments.find((s) => s.type === 'editthis').value =
+        'Please could you add the size to your post.'
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.blockedSegments).toHaveLength(0)
+      expect(wrapper.vm.directiveWarning).toBe(null)
+    })
+  })
+
+  describe('segmented editor — optional sections', () => {
+    it('lets you undo a Keep and reword the wording you kept', async () => {
+      const wrapper = mountComponent({}, { stdmsgData: optionalsStdmsg() })
+      await wrapper.vm.fillin()
+
+      wrapper.vm.segments.find((s) => s.type === 'editthis').value =
+        'Please could you add the size to your post.'
+
+      const [first, second] = optionalIndexes(wrapper)
+      wrapper.vm.decideOptional(first, false)
+      wrapper.vm.decideOptional(second, false)
+      await wrapper.vm.$nextTick()
+
+      // Kept wording is still an editable box, not fixed text.
+      expect(wrapper.findAll('.seg-optional-kept textarea').length).toBe(2)
+
+      wrapper.vm.segments[first].content =
+        'You can edit your post on your My Posts page.'
+      // Keep used to be final - you could only undo a Remove.
+      wrapper.vm.decideOptional(second, true)
+
+      await wrapper.vm.process()
+
+      const bodyArg = mockMessageStore.reply.mock.calls[0][0].body
+      expect(bodyArg).toContain('You can edit your post on your My Posts page.')
+      expect(bodyArg).not.toContain(
+        'Please get back to us if you have any questions.'
+      )
+    })
+  })
+
+  describe('segmented editor — paragraph spacing', () => {
+    it('shows the line break between blocks as a toggle, not an empty box', async () => {
+      const wrapper = mountComponent({}, { stdmsgData: optionalsStdmsg() })
+      await wrapper.vm.fillin()
+      await wrapper.vm.$nextTick()
+
+      // The single "\n" between the two optionals rendered as a full-height
+      // empty textarea, which read as a field someone had forgotten to fill in.
+      expect(wrapper.find('.seg-gap-toggle').exists()).toBe(true)
+    })
+
+    it('adds a blank line between paragraphs when toggled', async () => {
+      const wrapper = mountComponent({}, { stdmsgData: optionalsStdmsg() })
+      await wrapper.vm.fillin()
+
+      wrapper.vm.segments.find((s) => s.type === 'editthis').value =
+        'Please could you add the size to your post.'
+      optionalIndexes(wrapper).forEach((i) =>
+        wrapper.vm.decideOptional(i, false)
+      )
+
+      const gaps = wrapper.vm.segments
+        .map((seg, i) => (wrapper.vm.isGap(seg) ? i : -1))
+        .filter((i) => i >= 0)
+      expect(gaps.length).toBeGreaterThan(0)
+      expect(wrapper.vm.isParagraphGap(wrapper.vm.segments[gaps[0]])).toBe(
+        false
+      )
+
+      gaps.forEach((i) => wrapper.vm.toggleGap(i))
+      expect(wrapper.vm.isParagraphGap(wrapper.vm.segments[gaps[0]])).toBe(true)
+
+      await wrapper.vm.process()
+
+      const bodyArg = mockMessageStore.reply.mock.calls[0][0].body
+      expect(bodyArg).toContain(
+        'add the size to your post.\n\nYou can edit your post at'
+      )
+    })
+
+    it('leaves an inline space between blocks alone', async () => {
+      const inline = createStdmsg({
+        action: 'Leave',
+        body: 'Hello. <optional>One.</optional> <optional>Two.</optional>\n\nBye.',
+        insert: 'Top',
+      })
+      const wrapper = mountComponent({}, { stdmsgData: inline })
+      await wrapper.vm.fillin()
+      await wrapper.vm.$nextTick()
+
+      // The single space between the two optionals is wording, not paragraph
+      // spacing, so it must not become a blank-line control.
+      expect(wrapper.vm.segments.some((s) => wrapper.vm.isGap(s))).toBe(false)
+      expect(wrapper.find('.seg-gap-toggle').exists()).toBe(false)
+    })
+
+    it('takes the blank line back out again', async () => {
+      const wrapper = mountComponent({}, { stdmsgData: optionalsStdmsg() })
+      await wrapper.vm.fillin()
+
+      const gap = wrapper.vm.segments.findIndex((seg) => wrapper.vm.isGap(seg))
+      wrapper.vm.toggleGap(gap)
+      expect(wrapper.vm.isParagraphGap(wrapper.vm.segments[gap])).toBe(true)
+      wrapper.vm.toggleGap(gap)
+      expect(wrapper.vm.isParagraphGap(wrapper.vm.segments[gap])).toBe(false)
+    })
+  })
+
   describe('editLink — TrashNothing awareness', () => {
     const tnMessage = () =>
       createMessage({


### PR DESCRIPTION
Acts on moderator feedback about the standard-message editor (the `<editthis>` /
`<optional>` directives), plus the member-facing end of it.

## The send that looked like it had hung

Hitting **Send** with an `<editthis>` box unfilled or an `<optional>` section
undecided set a warning and returned - without calling the `SpinButton`
callback. The button then span for 20 seconds until SpinButton's
"callback forgotten" timeout, which also fired a Sentry report each time. Two
moderators independently reported this as the send hanging, with no idea what
was wrong.

The callback is now returned, so the button stops. The message says **nothing
has been sent yet** and what is left to do, the outstanding boxes are outlined
in red, the first is scrolled to, and both the outlines and the wording update
as each one is dealt with.

![send refused](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/stdmsg-mod-feedback/02-send-refused.png)

## Optional sections

- **Keep was final.** Only a Remove could be undone. Both are reversible now.
- **The wording was fixed text.** It is an editable box, so an optional bit can
  be reworded as well as taken or left.

## Paragraph spacing

The line break between two blocks rendered as an empty full-height textarea. It
read as a field someone had forgotten to fill in, and gave no clue that it held
the paragraph spacing - so a message built from a template written with single
line breaks arrived with its paragraphs run together, and there was no obvious
way to fix it.

It is now a toggle saying whether there is a blank line there, with one click to
add or remove one. A separator of only spaces is left alone: that is inline
wording, not paragraph spacing.

| Editor as opened | After the decisions, with blank lines added |
|---|---|
| ![editor](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/stdmsg-mod-feedback/01-editor.png) | ![decided](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/stdmsg-mod-feedback/03-decided.png) |

## Boxes that looked empty

`AutoHeightTextarea` only started its row-growth check from the `currentValue`
watcher, which never fires for the value the component was mounted with. So
every pre-filled box - the standard-message template being the case that
matters - sat at its minimum rows with a scrollbar, and moderators reported the
wording looking like it was not there at all. It now grows to fit on mount, in
one bounded pass.

This is a shared component. Boxes that start empty (chat, ChitChat) are
unaffected: the pass only runs when there is something to fit.

## Hold buttons

`variant()` returned `warning` for `Hold Message`, the same amber as the
rejects, so in an alphabetically sorted set of buttons the holds ran into that
block and got picked by mistake. Holding a post keeps it, so they are now green
like the leaves (`rgb(51, 136, 8)` against the rejects' `rgb(227, 141, 19)`);
the pause icon still distinguishes them from a plain leave.

## Clickable links in volunteer chat

Freegle-side chat deliberately does not linkify URLs, because a link from
another member could be a scam. A `User2Mod` chat is the conversation with your
own community's volunteers, so that reasoning does not apply - and it left the
`$editlink` in a standard message as dead text in the app, with no way to follow
it. Those chats now linkify. **Member-to-member chat is unchanged**, and a test
asserts it stays plain.

![volunteer chat](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/stdmsg-mod-feedback/04-volunteer-chat-link.png)

## Also

The fill-in instruction at the top of the editor is red again rather than muted
grey. It was set red deliberately in #752 and turned back to muted by a later
tidy-up; moderators were reading straight past the grey version.

## Not in this PR

There is a related request to have a standard message **also append a preset
note to the post itself**, so that everyone who sees the post knows the
situation and not just the poster. There is no combined reply-and-edit action
today and adding one is a design decision (a new standard-message field or
directive, plus the post-patch path), so it is deliberately left out rather than
bolted on here.

## Testing

- Full vitest suite green locally (14736), including new tests for the
  send-refused callback and highlighting, undoing a Keep, editing kept wording,
  the paragraph toggle, the space-only separator, mount-time growth, and the
  linkify split.
- Full Playwright suite run locally against rebuilt production containers:
  183/184, then the one failure (`test-browse.spec.js` search, a
  `net::ERR_ABORTED` on the signup homepage navigation, where the harness
  deliberately allows no retries) re-run and passing 6/6. That path is not
  touched by this change.
- Walked through by hand in ModTools against a seeded directive standard
  message, and in Freegle chat for both `User2Mod` and `User2User`.
- Moderator docs updated here too: `docs/moderators/02-moderating-posts.md`
  gains a section on the fill-in and optional parts, and now `covers:` the modal
  and the directive helpers.

The `pr-assets/stdmsg-mod-feedback` branch holding the screenshots is throwaway
and can be deleted after merge.
