### PR TITLE
chore(hooks): warn at commit time when a change adds raw SQL

### DIFF
--- a/.claude/check-raw-sql-commit.sh
+++ b/.claude/check-raw-sql-commit.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# PreToolUse hook for git commit: warn when the commit adds new raw SQL.
+#
+# The v2 API and iznik-batch are being moved off hand-written SQL onto GORM /
+# Eloquent a wave at a time. CI enforces this in ci-ratchet.sh gates (b) and
+# (d) - a new raw site with no manifest entry, or a raw+in-progress count above
+# the baseline, fails the build. That feedback arrives minutes after a push.
+# This hook says the same thing at commit time instead.
+#
+# WARNING ONLY - it never blocks. Raw SQL is sometimes right (see keep-raw.json)
+# and test fixtures are exempt by design. The point is to make the author decide
+# deliberately rather than find out from CI.
+#
+# The method surfaces below are copied from the two extractors so this agrees
+# with what CI will actually count:
+#   Go    - sqlMethods + sqlWrappers in tools/orm-migration/extract.go
+#   PHP   - CONNECTION_SQL_METHODS + BUILDER_FRAGMENT_METHODS +
+#           BLUEPRINT_DDL_METHODS in tools/orm-migration/php-extractor/extract.php
+# If either list changes there, change it here too.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+
+# Only fire for git commit.
+if ! echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$REPO_ROOT" 2>/dev/null || exit 0
+
+# What is about to be committed. `git commit -a` sweeps in tracked-but-unstaged
+# changes too, so include those when the flag is present.
+DIFF=$(git diff --cached -U0 2>/dev/null)
+if echo "$COMMAND" | grep -qE '\bgit\s+commit\b[^|;&]*\s-[a-zA-Z]*a'; then
+  DIFF="$DIFF"$'\n'$(git diff -U0 2>/dev/null)
+fi
+[ -z "$DIFF" ] && exit 0
+
+GO_METHODS='Raw|Exec|ExecContext|Query|QueryRow|QueryContext|QueryRowContext|Prepare|PrepareContext'
+GO_WRAPPERS='RetryExec|RetryExecResult|RetryQuery|ExecInsertGetID'
+PHP_CONNECTION='select|selectOne|scalar|cursor|insert|update|delete|statement|unprepared|raw'
+PHP_FRAGMENT='selectRaw|fromRaw|whereRaw|orWhereRaw|groupByRaw|havingRaw|orHavingRaw|orderByRaw'
+PHP_DDL='rawIndex|rawColumn'
+
+# Walk the diff, tracking which file each added line belongs to, and split hits
+# into production vs test/migration. A raw call in a test is normal - the
+# extractor files those as status "test-fixture" - so it gets a quieter note.
+REPORT=$(echo "$DIFF" | awk \
+  -v go_m="$GO_METHODS" -v go_w="$GO_WRAPPERS" \
+  -v php_c="$PHP_CONNECTION" -v php_f="$PHP_FRAGMENT" -v php_d="$PHP_DDL" '
+  /^\+\+\+ b\// { file = substr($0, 7); next }
+  /^\+/ && !/^\+\+\+/ {
+    line = substr($0, 2)
+    if (line ~ /^[[:space:]]*(\/\/|#|\*)/) next          # comments
+
+    hit = ""
+    if (file ~ /\.go$/) {
+      if (line ~ ("\\.(" go_m ")\\(")) hit = "Go"
+      else if (line ~ ("(" go_w ")\\(")) hit = "Go wrapper"
+    } else if (file ~ /\.php$/) {
+      if (line ~ ("DB::(" php_c ")\\(")) hit = "Laravel DB::"
+      else if (line ~ ("->(" php_f ")\\(")) hit = "Laravel fragment"
+      else if (line ~ ("->(" php_d ")\\(")) hit = "Laravel DDL"
+    }
+    if (hit == "") next
+
+    is_test = (file ~ /_test\.go$/ || file ~ /\/tests?\// || file ~ /Test\.php$/ || file ~ /\/database\/migrations\//)
+    gsub(/^[[:space:]]+/, "", line)
+    if (length(line) > 100) line = substr(line, 1, 100) "..."
+    if (is_test) { t[file] = t[file] "      " line "\n"; tn++ }
+    else         { p[file] = p[file] "      " hit ": " line "\n"; pn++ }
+  }
+  END {
+    if (pn == 0 && tn == 0) exit 1
+    printf "PROD=%d\n", pn
+    if (pn > 0) {
+      printf "  %d new raw SQL call(s) in PRODUCTION code:\n", pn
+      for (f in p) printf "    %s\n%s", f, p[f]
+    }
+    if (tn > 0) printf "  %d in test/migration files (normally fine - the extractor files these as test-fixture).\n", tn
+    exit 0
+  }')
+
+[ -z "$REPORT" ] && exit 0
+
+PROD_COUNT=$(echo "$REPORT" | head -1 | cut -d= -f2)
+BODY=$(echo "$REPORT" | tail -n +2)
+
+# Test-only hits get a one-liner. The full explanation is only worth the noise
+# when production code gained raw SQL, which is what CI actually gates on.
+if [ "$PROD_COUNT" = "0" ]; then
+  jq -n --arg b "$BODY" '{systemMessage: ("Raw SQL check: test/migration files only, which CI files as test-fixture. Nothing to do.\n" + $b)}'
+  exit 0
+fi
+
+# Emit as a systemMessage so it is a visible warning, not a block.
+jq -n --arg b "$BODY" '{systemMessage: ("Raw SQL check: this commit adds raw SQL.\n\n" + $b + "\nThe v2 API and iznik-batch are migrating onto GORM/Eloquent. Prefer the query builder. If raw is genuinely right, it needs a manifest entry, and if it changes a converted site'"'"'s SQL it needs an approved-diffs.json entry with a reason.\n\n  cd tools/orm-migration && go run .     # regenerate the manifest\n  bash tools/orm-migration/ci-ratchet.sh # what CI will check\n\nSee docs/developers/reference/orm-migration-harness.md. Warning only - nothing is blocked.")}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,17 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/check-raw-sql-commit.sh",
+            "if": "Bash(git commit*)",
+            "timeout": 10
+          }
+        ]
+      },
+      {
         "matcher": "Skill",
         "hooks": [
           {

--- a/docs/developers/reference/orm-migration-harness.md
+++ b/docs/developers/reference/orm-migration-harness.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-01
+last_reviewed: 2026-08-05
 owner: Freegle dev team
 covers:
   - iznik-server-go/ormharness/
@@ -41,6 +41,14 @@ bash tools/orm-migration/ci-ratchet.sh        # Gate 1, as CI runs it
 `go test`, `go vet` and `go build` are blocked on developer machines by
 `.claude/check-test-command.sh` in favour of the status API, which is why the
 extractor carries its own `-selftest` mode.
+
+`.claude/check-raw-sql-commit.sh` is a commit-time warning that says the same
+thing the ratchet does, minutes earlier. It scans the staged diff for the
+method surfaces both extractors recognise and prints what it finds, splitting
+production hits from test fixtures. It never blocks: raw SQL is sometimes
+right, and only the ratchet has the manifest to judge that. Its two method
+lists are copied from `extract.go` and `php-extractor/extract.php`; change
+them there and change them here too.
 
 ## The two gates
 


### PR DESCRIPTION
## Why

The ORM migration is enforced by `ci-ratchet.sh` gates (b) and (d): a new raw SQL site with no manifest entry, or a raw+in-progress count above the baseline, fails the build. That feedback arrives minutes after a push, by which point the commit is written and the reasoning is cold.

This adds a commit-time warning that says the same thing earlier. It came out of #1261, where a rebase onto the freshly-merged #1230 could easily have reintroduced `db.Raw` at a site that had just been converted.

## What it does

`.claude/check-raw-sql-commit.sh` runs as a `PreToolUse` hook gated on `Bash(git commit*)`. It scans the staged diff (plus unstaged, for `git commit -a`) for raw SQL in added lines and reports what it finds.

Production hits get the full message:

```
Raw SQL check: this commit adds raw SQL.

  1 new raw SQL call(s) in PRODUCTION code:
    iznik-server-go/rawprobe.go
      Go wrapper: database.RetryExec(db, "DELETE FROM x WHERE id = ?", 1)
  1 in test/migration files (normally fine - the extractor files these as test-fixture).

The v2 API and iznik-batch are migrating onto GORM/Eloquent. Prefer the query
builder. If raw is genuinely right, it needs a manifest entry, and if it changes
a converted site's SQL it needs an approved-diffs.json entry with a reason.
  ...
```

Test-only hits get a one-liner instead, because a test fixture using `db.Exec` is normal and the extractor files those as `test-fixture`. Noise fatigue would kill the hook's usefulness faster than missing anything.

**Warning only, never blocking.** Raw SQL is legitimately right in places (that is what `keep-raw.json` is for), and only the ratchet has the manifest to judge a given site. The point is that the author decides deliberately rather than finding out from CI.

## Staying honest with CI

The method surfaces are copied from the two extractors, not invented, so the hook counts what CI counts:

- **Go** - `sqlMethods` + `sqlWrappers` from `tools/orm-migration/extract.go`. Including the wrappers matters: `database.RetryExec` and friends are real raw SQL that a scan knowing only `db.Raw`/`db.Exec` misses, which is exactly the gap the keep-raw review found in `message/markseen.go`.
- **PHP** - `CONNECTION_SQL_METHODS` + `BUILDER_FRAGMENT_METHODS` + `BLUEPRINT_DDL_METHODS` from `tools/orm-migration/php-extractor/extract.php`.

Both the script and the doc note that these lists have to move together with the extractors.

## Verification

`go test`/`go vet`/`go build` are blocked locally and this touches no product code, so there is no suite to run. Verified instead by piping the hook's exact stdin payload for each path:

| Case | Result |
|---|---|
| Go production (`db.Raw`) | full warning |
| Go wrapper (`database.RetryExec`) | full warning, labelled "Go wrapper" |
| Laravel facade (`DB::statement`) | full warning |
| Laravel fragment (`->whereRaw`) | full warning |
| Test file only (`test/*_test.go`) | one-liner |
| Nothing staged | silent, exit 0 |
| Non-commit command (`git status`) | silent, exit 0 |
| Staged change with no SQL | silent, exit 0 |

`jq -e` confirms the settings.json nesting resolves; docs freshness passes.

**Not verified:** that the hook actually fires in a live session. Hooks load from the project root's `.claude/settings.json`, and this was authored in a worktree, so it goes live for each person once this merges and reaches their checkout (`/hooks` or a restart picks it up). The stdin contract is what the pipe tests above pin down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNs5jYnZjvKvXE5S6GWhND
