### PR TITLE
Teach every client to understand a Freegle chat prompt (before anything sends one)

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -42,6 +42,7 @@ Read these directly; the pages above link into them rather than copy them:
 | TrashNothing / LoveJunk integration | [./reference/trashnothing.md](./reference/trashnothing.md) |
 | SEO: how posts get found | [./reference/seo.md](./reference/seo.md) |
 | ModTools AI Support Helper | [./reference/ai-support-helper.md](./reference/ai-support-helper.md) |
+| Chat prompts (Freegle's tappable questions) | [./reference/chat-prompts.md](./reference/chat-prompts.md) |
 
 Each component also has its own README (`iznik-nuxt3/README.md`, `iznik-server-go/README.md`,
 `iznik-batch/README.md`, `iznik-routing-go/README.md`, `iznik-spatial-go/README.md`), and

--- a/docs/developers/reference/chat-prompts.md
+++ b/docs/developers/reference/chat-prompts.md
@@ -1,0 +1,77 @@
+---
+last_reviewed: 2026-08-06
+covers:
+  - iznik-server-go/chat/chatprompt.go
+  - iznik-nuxt3/components/ChatMessagePrompt.vue
+  - iznik-nuxt3/components/ChatPromptPost.vue
+---
+
+# Chat Prompts
+
+A **prompt** is a chat message from Freegle with tappable answers - "Could you deliver?", "When
+does it need to go?" - sent into an ordinary `User2User` chat so that delivery, push,
+notification, unread state and history all work with no new machinery.
+
+This page covers the **mechanism**: the message type, how a client renders it, and how an answer
+is applied. It does not cover what decides to send one; that is a separate feature.
+
+## Nothing sends prompts yet
+
+This ships the ability to **understand** a prompt, not to create one. No code here writes a
+`Prompt` message. That is deliberate - see "Why this shipped on its own" below.
+
+## The shape
+
+| Piece | Where |
+|---|---|
+| The message | `chat_messages` with `type = 'Prompt'` and readable text in `message` |
+| The tappable part | `chat_prompts`, keyed on `chatmsgid` |
+| Which posts it covers | `chat_prompts.msgids`, a JSON array |
+| Serving it | `attachPrompts()` in `chat/chatmessage.go` fills `ChatMessage.prompt` |
+| Answering it | `POST /chat/{id}/message/{mid}/prompt` (`chat.AnswerChatPrompt`) |
+| Rendering it | `ChatMessagePrompt.vue`, one `ChatPromptPost.vue` per covered post |
+
+The message carries **normal text whatever happens**, so anything that does not understand the
+type - an email notification, a push, a mod tool, an older app - still has something sensible to
+show.
+
+Answering is server-side only. The server applies what the answer means (setting
+`messages.deadline`, `messages.deliverypossible`) as well as recording it, so a client never has
+to know what "by this weekend" resolves to, and two clients cannot disagree about it.
+
+Rules the endpoint enforces: only the member the prompt was sent to may answer; only an option
+that was actually offered is accepted; only once; and not after the prompt has expired - a
+week-old "could you deliver?" on a long-gone item still renders, but its buttons no longer work.
+
+## Why this shipped on its own
+
+**Old apps cannot be upgraded in arrears.** A client that does not know a message type falls
+through to the catch-all branch in `ChatMessage.vue`. Until this change that branch rendered
+
+```
+Unknown chat message type Prompt, [object] [object]
+```
+
+directly into the member's conversation. That is not hypothetical - it already happened once in
+the wild with the `System` type (`6d833bb62`, "render System chat messages instead of a raw error
+dump").
+
+So the fallback now renders `message` instead of a debug dump, and **any** future type degrades to
+plain readable text rather than something broken.
+
+That fixes clients carrying this build. It does nothing for the app somebody is already running,
+which is why the sending side is a separate change: every client has to be able to understand a
+prompt *before* anything starts sending them.
+
+**There is no way to gate this per member.** `users_builddates` has an `appversion` column, but it
+is empty for every user seen in the last 30 days on live (41,402 of 41,402) - only `webversion` is
+populated. So we can neither suppress prompts for old clients nor measure app adoption from it. The
+control is therefore time and release adoption, not a query, and that is worth fixing before the
+sending side is switched on.
+
+## Testing
+
+`iznik-server-go/test/chatprompt_test.go` covers serving a prompt with its options and every
+answer rule (wrong member, unoffered option, twice, expired, picked date, out-of-range date, and
+"no rush" which records without patching the post). `ChatMessagePrompt.spec.js` and
+`ChatPromptPost.spec.js` cover rendering and the answered state.

--- a/iznik-batch/database/migrations/2026_08_05_000002_add_prompt_to_chat_messages_type_enum.php
+++ b/iznik-batch/database/migrations/2026_08_05_000002_add_prompt_to_chat_messages_type_enum.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Append 'Prompt' to chat_messages.type.
+ *
+ * A Prompt is a question Freegle asks a member inside an ordinary chat, with a
+ * small set of tappable answers ("Could you deliver?" -> Maybe / Collection
+ * only). The question text lives in chat_messages.message as usual so every
+ * existing consumer (email notification, push, search, mod review) renders
+ * something sensible without knowing about prompts; the ANSWERABLE part lives in
+ * the chat_prompts side table keyed on chatmsgid.
+ *
+ * Deliberately a side table rather than new columns here: chat_messages is one of
+ * the largest tables in the database and only a vanishingly small fraction of its
+ * rows will ever be prompts, so a nullable JSON column on it would be pure waste
+ * and a much more expensive ALTER than this one.
+ *
+ * End-append keeps every existing value's ordinal stable, which is what makes
+ * this metadata-only. ALGORITHM=INPLACE, LOCK=NONE (INSTANT is not supported for
+ * ENUM modification on Percona/Galera - see FreegleDocker memory
+ * reference_galera_enum_alter). Galera TOI still pauses cluster writes for the
+ * duration, which is ms-scale for a metadata-only change.
+ */
+return new class extends Migration
+{
+    private const VALUES_WITH_PROMPT = "'Default','System','ModMail','Interested','Promised','Reneged','ReportedUser','Completed','Image','Address','Nudge','Schedule','ScheduleUpdated','Reminder','Prompt'";
+
+    private const VALUES_WITHOUT_PROMPT = "'Default','System','ModMail','Interested','Promised','Reneged','ReportedUser','Completed','Image','Address','Nudge','Schedule','ScheduleUpdated','Reminder'";
+
+    public function up(): void
+    {
+        if (!Schema::hasTable('chat_messages') || $this->hasPromptValue()) {
+            return;
+        }
+
+        DB::statement(
+            'ALTER TABLE chat_messages
+                MODIFY COLUMN `type` ENUM(' . self::VALUES_WITH_PROMPT . ") NOT NULL DEFAULT 'Default',
+                ALGORITHM=INPLACE, LOCK=NONE"
+        );
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('chat_messages') || !$this->hasPromptValue()) {
+            return;
+        }
+
+        // Narrowing fails on any row still holding the removed value, so retype
+        // prompts as System notices first - they read as "an automated message"
+        // either way, and the chat_prompts rows go with the chat messages.
+        DB::table('chat_messages')->where('type', 'Prompt')->update(['type' => 'System']);
+
+        DB::statement(
+            'ALTER TABLE chat_messages
+                MODIFY COLUMN `type` ENUM(' . self::VALUES_WITHOUT_PROMPT . ") NOT NULL DEFAULT 'Default',
+                ALGORITHM=INPLACE, LOCK=NONE"
+        );
+    }
+
+    private function hasPromptValue(): bool
+    {
+        return DB::table('information_schema.columns')
+            ->where('table_schema', DB::raw('DATABASE()'))
+            ->where('table_name', 'chat_messages')
+            ->where('column_name', 'type')
+            ->where('column_type', 'like', '%Prompt%')
+            ->exists();
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_05_000002_add_prompt_to_chat_messages_type_enum_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_05_000002_add_prompt_to_chat_messages_type_enum_migration.sql
@@ -1,0 +1,22 @@
+-- Production idempotent SQL: append 'Prompt' to chat_messages.type.
+--
+-- A Prompt is a question Freegle asks a member inside an ordinary chat, with a small
+-- set of tappable answers. The question text lives in chat_messages.message like any
+-- other message, so email, push, mod review and search need no changes; the tappable
+-- part lives in the chat_prompts side table keyed on chatmsgid. Side table rather than
+-- new columns because chat_messages is one of the largest tables here and only a
+-- vanishing fraction of rows will ever be prompts.
+--
+-- End-append keeps every existing value's ordinal stable, so this is metadata-only.
+-- ALGORITHM=INPLACE, LOCK=NONE (INSTANT is not supported for ENUM modification on
+-- Percona/Galera). Galera TOI still pauses cluster writes for the duration, which is
+-- ms-scale for a metadata-only change. Guarded so a re-run is a no-op.
+SET @has_value := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'chat_messages'
+      AND column_name = 'type' AND column_type LIKE '%Prompt%');
+SET @ddl := IF(@has_value = 0,
+    "ALTER TABLE chat_messages MODIFY COLUMN `type` ENUM('Default','System','ModMail','Interested','Promised','Reneged','ReportedUser','Completed','Image','Address','Nudge','Schedule','ScheduleUpdated','Reminder','Prompt') NOT NULL DEFAULT 'Default', ALGORITHM=INPLACE, LOCK=NONE",
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/iznik-batch/database/migrations/2026_08_05_000003_create_chat_prompts_table.php
+++ b/iznik-batch/database/migrations/2026_08_05_000003_create_chat_prompts_table.php
@@ -1,0 +1,84 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * chat_prompts - the answerable part of a chat message of type 'Prompt'.
+ *
+ * One row per prompt, keyed on the chat message it belongs to. The chat message
+ * carries the human-readable question (so email, push, mod review and search all
+ * work untouched); this row carries the machine-readable options and, once the
+ * member taps one, their answer.
+ *
+ * `kind` says what answering it DOES - 'delivery' patches messages.deliverypossible,
+ * 'deadline' patches messages.deadline, 'views' and 'photo' are informational and
+ * have no options. The side effect lives in PromptService, keyed off this column,
+ * so adding a new kind never means touching the chat plumbing.
+ *
+ * ON DELETE CASCADE from chat_messages: a deleted chat message must not leave an
+ * orphan prompt that the API would try to render.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('chat_prompts')) {
+            return;
+        }
+
+        Schema::create('chat_prompts', function (Blueprint $t) {
+            // One prompt per chat message.
+            $t->unsignedBigInteger('chatmsgid')->primary();
+
+            // The post the prompt is about when it is about exactly one - which is
+            // the exception. Drives the chat message's refmsgid and the item card
+            // in the notification email.
+            $t->unsignedBigInteger('msgid')->nullable()->index('chat_prompts_msgid');
+
+            // The posts the answer applies to. Freegle talks about a member's
+            // outstanding posts as a SET, the way a clearance treats its items:
+            // "your 5 posts have been looked at 47 times between them" beats five
+            // separate conversations, and "could you deliver?" is one question
+            // about all of them rather than one per item. JSON rather than a join
+            // table because it is only ever read whole, with the prompt.
+            $t->json('msgids')->nullable();
+
+            // What answering this prompt does. See PromptService::KIND_*.
+            $t->string('kind', 32)->index('chat_prompts_kind');
+
+            // [{"value": "maybe", "label": "Maybe", "variant": "primary"}, ...]
+            // Empty array for informational prompts with nothing to tap.
+            $t->json('options')->nullable();
+
+            // The `value` of the option the member chose, once they choose one.
+            $t->string('answer', 64)->nullable();
+            $t->timestamp('answered_at')->nullable();
+
+            // After this, the buttons stop being offered - a week-old "could you
+            // deliver?" on a long-gone item should not still be answerable.
+            $t->timestamp('expires_at')->nullable();
+
+            $t->timestamp('created_at')->useCurrent();
+        });
+
+        DB::statement(
+            'ALTER TABLE chat_prompts
+                ADD CONSTRAINT chat_prompts_chatmsgid_foreign
+                FOREIGN KEY (chatmsgid) REFERENCES chat_messages (id) ON DELETE CASCADE'
+        );
+
+        DB::statement(
+            'ALTER TABLE chat_prompts
+                ADD CONSTRAINT chat_prompts_msgid_foreign
+                FOREIGN KEY (msgid) REFERENCES messages (id) ON DELETE CASCADE'
+        );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('chat_prompts');
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_05_000003_create_chat_prompts_table_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_05_000003_create_chat_prompts_table_migration.sql
@@ -1,0 +1,33 @@
+-- Production idempotent SQL: chat_prompts.
+--
+-- The answerable part of a chat message of type 'Prompt'. The chat message carries the
+-- human-readable question; this row carries the machine-readable options and, once the
+-- member taps one, their answer. `kind` says what answering it DOES ('delivery' patches
+-- messages.deliverypossible, 'deadline' patches messages.deadline, 'views' and 'photo'
+-- are informational), and the side effect lives in PromptService keyed off that column.
+--
+-- CREATE TABLE IF NOT EXISTS makes the table itself idempotent; the foreign keys are
+-- created inside the same guard because MySQL has no ADD CONSTRAINT IF NOT EXISTS.
+SET @has_table := (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_name = 'chat_prompts');
+SET @ddl := IF(@has_table = 0,
+    "CREATE TABLE chat_prompts (
+        chatmsgid BIGINT UNSIGNED NOT NULL,
+        msgid BIGINT UNSIGNED NULL,
+        msgids JSON NULL,
+        kind VARCHAR(32) NOT NULL,
+        options JSON NULL,
+        answer VARCHAR(64) NULL,
+        answered_at TIMESTAMP NULL DEFAULT NULL,
+        expires_at TIMESTAMP NULL DEFAULT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (chatmsgid),
+        KEY chat_prompts_msgid (msgid),
+        KEY chat_prompts_kind (kind),
+        CONSTRAINT chat_prompts_chatmsgid_foreign FOREIGN KEY (chatmsgid) REFERENCES chat_messages (id) ON DELETE CASCADE,
+        CONSTRAINT chat_prompts_msgid_foreign FOREIGN KEY (msgid) REFERENCES messages (id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/iznik-batch/database/migrations/2026_08_05_000004_create_firstreply_tables.php
+++ b/iznik-batch/database/migrations/2026_08_05_000004_create_firstreply_tables.php
@@ -1,0 +1,106 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Ledgers for the first-reply work.
+ *
+ * firstreply_scouts   - who we told early about a post that had no replies yet,
+ *                       and why we picked them. Doubles as the per-user fatigue
+ *                       ledger (nobody should become Freegle's unpaid alerting
+ *                       service) and as the attribution source for "did scouting
+ *                       actually produce the reply?".
+ *
+ * firstreply_prompts_sent - which Freegle-chat prompts a MEMBER has already had.
+ *                       Keyed on the member rather than the post, because one
+ *                       message covers everything they have outstanding, so
+ *                       "have they been asked this lately" is a question about
+ *                       them. The cadence engine is idempotent off this: it
+ *                       re-runs every few minutes and must never ask the same
+ *                       question twice.
+ *
+ * firstreply_event_metrics - daily counters, same shape as rippling_event_metrics
+ *                       so the sysadmin dashboards can read both the same way.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('firstreply_scouts')) {
+            Schema::create('firstreply_scouts', function (Blueprint $t) {
+                $t->bigIncrements('id');
+                $t->unsignedBigInteger('msgid');
+                $t->unsignedBigInteger('userid');
+
+                // Which signal picked this person: 'wanted', 'search', 'similar',
+                // 'frequent'. Kept so we can tell which signal is actually earning
+                // its keep rather than guessing.
+                $t->string('reason', 16);
+                $t->float('score')->default(0);
+                $t->timestamp('sent_at')->useCurrent();
+
+                // Set when this scout went on to reply to the post. Written by the
+                // attribution sweep, not at send time.
+                $t->timestamp('replied_at')->nullable();
+
+                $t->unique(['msgid', 'userid'], 'firstreply_scouts_msgid_userid');
+                // Fatigue lookups are "has this user been scouted recently".
+                $t->index(['userid', 'sent_at'], 'firstreply_scouts_userid_sent');
+            });
+
+            DB::statement(
+                'ALTER TABLE firstreply_scouts
+                    ADD CONSTRAINT firstreply_scouts_msgid_foreign
+                    FOREIGN KEY (msgid) REFERENCES messages (id) ON DELETE CASCADE'
+            );
+            DB::statement(
+                'ALTER TABLE firstreply_scouts
+                    ADD CONSTRAINT firstreply_scouts_userid_foreign
+                    FOREIGN KEY (userid) REFERENCES users (id) ON DELETE CASCADE'
+            );
+        }
+
+        if (!Schema::hasTable('firstreply_prompts_sent')) {
+            Schema::create('firstreply_prompts_sent', function (Blueprint $t) {
+                $t->bigIncrements('id');
+
+                // Keyed on the MEMBER, not a post: Freegle asks about their
+                // outstanding posts as a set, so "have they been asked this
+                // lately" is a question about them, not about any one item.
+                $t->unsignedBigInteger('userid');
+                $t->string('kind', 32);
+
+                // How many posts that message covered, for the effectiveness
+                // numbers - a question about six posts is not the same event as
+                // one about a single post.
+                $t->unsignedInteger('postcount')->default(1);
+                $t->timestamp('sent_at')->useCurrent();
+
+                // "has this member had this question recently", and "when did
+                // they last hear from Freegle at all".
+                $t->index(['userid', 'kind', 'sent_at'], 'firstreply_prompts_user_kind_sent');
+                $t->index(['userid', 'sent_at'], 'firstreply_prompts_userid_sent');
+            });
+        }
+
+        if (!Schema::hasTable('firstreply_event_metrics')) {
+            Schema::create('firstreply_event_metrics', function (Blueprint $t) {
+                $t->date('day');
+                $t->string('event', 32);
+                $t->unsignedBigInteger('count')->default(0);
+
+                $t->primary(['day', 'event']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('firstreply_prompts_sent');
+        Schema::dropIfExists('firstreply_scouts');
+        Schema::dropIfExists('firstreply_event_metrics');
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_05_000004_create_firstreply_tables_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_05_000004_create_firstreply_tables_migration.sql
@@ -1,0 +1,64 @@
+-- Production idempotent SQL: first-reply ledgers.
+--
+-- firstreply_scouts        - who we told early about a post nobody had replied to yet,
+--                            and which signal picked them. Doubles as the per-user
+--                            fatigue ledger and the attribution source for "did
+--                            scouting actually produce the reply?".
+-- firstreply_prompts_sent  - which questions a MEMBER has been asked, and how many of
+--                            their posts each covered. Keyed on the member because Freegle
+--                            asks about their outstanding posts as a set.
+-- firstreply_event_metrics - daily counters, same shape as rippling_event_metrics so the
+--                            sysadmin dashboards read both the same way.
+SET @has_table := (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_name = 'firstreply_scouts');
+SET @ddl := IF(@has_table = 0,
+    "CREATE TABLE firstreply_scouts (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        msgid BIGINT UNSIGNED NOT NULL,
+        userid BIGINT UNSIGNED NOT NULL,
+        reason VARCHAR(16) NOT NULL,
+        score FLOAT NOT NULL DEFAULT 0,
+        sent_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        replied_at TIMESTAMP NULL DEFAULT NULL,
+        PRIMARY KEY (id),
+        UNIQUE KEY firstreply_scouts_msgid_userid (msgid, userid),
+        KEY firstreply_scouts_userid_sent (userid, sent_at),
+        CONSTRAINT firstreply_scouts_msgid_foreign FOREIGN KEY (msgid) REFERENCES messages (id) ON DELETE CASCADE,
+        CONSTRAINT firstreply_scouts_userid_foreign FOREIGN KEY (userid) REFERENCES users (id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_table := (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_name = 'firstreply_prompts_sent');
+SET @ddl := IF(@has_table = 0,
+    "CREATE TABLE firstreply_prompts_sent (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        userid BIGINT UNSIGNED NOT NULL,
+        kind VARCHAR(32) NOT NULL,
+        postcount INT UNSIGNED NOT NULL DEFAULT 1,
+        sent_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (id),
+        KEY firstreply_prompts_user_kind_sent (userid, kind, sent_at),
+        KEY firstreply_prompts_userid_sent (userid, sent_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_table := (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_name = 'firstreply_event_metrics');
+SET @ddl := IF(@has_table = 0,
+    "CREATE TABLE firstreply_event_metrics (
+        day DATE NOT NULL,
+        event VARCHAR(32) NOT NULL,
+        count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+        PRIMARY KEY (day, event)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/iznik-nuxt3/api/ChatAPI.js
+++ b/iznik-nuxt3/api/ChatAPI.js
@@ -75,6 +75,16 @@ export default class ChatAPI extends BaseAPI {
     })
   }
 
+  // Answer a Freegle prompt - one of the tappable options on a type='Prompt'
+  // message. The server applies whatever the answer means (e.g. setting the
+  // post's deadline) as well as recording it, so there is nothing to patch here
+  // afterwards.
+  answerPrompt(chatid, chatmsgid, answer) {
+    return this.$postv2(`/chat/${chatid}/message/${chatmsgid}/prompt`, {
+      answer,
+    })
+  }
+
   hideChat(chatid) {
     return this.$postv2('/chatrooms', { id: chatid, status: 'Closed' })
   }

--- a/iznik-nuxt3/components/ChatMessage.vue
+++ b/iznik-nuxt3/components/ChatMessage.vue
@@ -77,6 +77,11 @@
     <div v-else-if="chatmessage?.type === 'Reminder'">
       <chat-message-reminder :id="id" :chatid="chatid" :pov="pov" />
     </div>
+    <!-- A question from Freegle with tappable answers, e.g. "could you deliver?"
+         on a post that has gone quiet. -->
+    <div v-else-if="chatmessage?.type === 'Prompt'">
+      <chat-message-prompt :id="id" :chatid="chatid" :pov="pov" />
+    </div>
     <!-- Synthetic system notices, e.g. "the item you replied about has now been
          taken" posted when a replied-to post is taken/withdrawn. Just the text. -->
     <div
@@ -85,9 +90,19 @@
     >
       <span class="preline forcebreak">{{ chatmessage?.message }}</span>
     </div>
-    <div v-else>
-      Unknown chat message type {{ chatmessage?.type }}, {{ chat }}
-      {{ chatmessage }}
+    <!-- A type this build does not know about. Every message carries readable
+         text in `message` whatever its type, so show that: a client that is
+         simply older than the feature then degrades to a plain message instead
+         of rendering something broken.
+
+         This used to dump the type and two raw objects into the conversation.
+         That is a fine thing to see in development and a terrible one to send to
+         a member - it has already happened once in the wild, with `System`
+         (6d833bb62). The dump does not help them, and they cannot report it
+         usefully. Old apps are not upgradeable in arrears, so the fallback has
+         to be safe for the app somebody is still running two years from now. -->
+    <div v-else class="preline forcebreak">
+      {{ chatmessage?.message }}
     </div>
     <!-- Held-by-rippling notice. Deliberately never shown to the sender: their
          reply should look like an ordinary sent message awaiting a response, so

--- a/iznik-nuxt3/components/ChatMessagePrompt.vue
+++ b/iznik-nuxt3/components/ChatMessagePrompt.vue
@@ -1,0 +1,241 @@
+<template>
+  <div>
+    <b-row>
+      <b-col>
+        <div class="media">
+          <b-card border-variant="info" data-testid="chat-prompt">
+            <b-card-text>
+              <div class="preline forcebreak">{{ emessage }}</div>
+
+              <!-- The posts themselves, rendered properly rather than described
+                   in prose. An item name reads fine as "your dining chairs" and
+                   badly as whatever someone actually typed, and nothing can tell
+                   the two apart - so the wording names none of them and this
+                   says exactly which, however many there are. -->
+              <div v-if="posts.length" class="mt-2 mb-1">
+                <ChatPromptPost
+                  v-for="msgid in shownPosts"
+                  :key="msgid"
+                  :id="msgid"
+                />
+                <b-button
+                  v-if="hiddenCount > 0"
+                  variant="link"
+                  size="sm"
+                  class="ps-0"
+                  @click="showAll = true"
+                >
+                  Show {{ hiddenCount }} more
+                </b-button>
+              </div>
+
+              <!-- Free-input answer: the poster knows their own date, and
+                   "by this weekend" is wrong for someone moving on the 14th. -->
+              <div v-if="showOptions && dateOption" class="mt-3">
+                <label :for="dateId" class="form-label small mb-1">
+                  Gone by
+                </label>
+                <div class="d-flex flex-wrap align-items-start gap-2">
+                  <b-form-input
+                    :id="dateId"
+                    v-model="chosenDate"
+                    type="date"
+                    :min="today"
+                    :max="maxDate"
+                    class="prompt-date"
+                  />
+                  <b-button
+                    variant="primary"
+                    :disabled="answering || !chosenDate"
+                    :data-label="`Prompt: ${prompt.kind}: date`"
+                    @click="answer(dateOption, chosenDate)"
+                  >
+                    {{ dateOption.label }}
+                  </b-button>
+                  <b-button
+                    v-for="option in plainOptions"
+                    :key="option.value"
+                    :variant="option.variant || 'secondary'"
+                    :disabled="answering"
+                    :data-label="`Prompt: ${prompt.kind}: ${option.value}`"
+                    @click="answer(option)"
+                  >
+                    {{ option.label }}
+                  </b-button>
+                </div>
+              </div>
+
+              <div
+                v-else-if="showOptions"
+                class="d-flex flex-wrap gap-2 mt-3"
+                data-testid="chat-prompt-options"
+              >
+                <b-button
+                  v-for="option in plainOptions"
+                  :key="option.value"
+                  :variant="option.variant || 'primary'"
+                  :disabled="answering"
+                  :data-label="`Prompt: ${prompt.kind}: ${option.value}`"
+                  @click="answer(option)"
+                >
+                  {{ option.label }}
+                </b-button>
+              </div>
+
+              <p
+                v-else-if="answeredLabel"
+                class="text-muted small mt-2 mb-0"
+                data-testid="chat-prompt-answered"
+              >
+                You said: {{ answeredLabel }}
+              </p>
+            </b-card-text>
+          </b-card>
+        </div>
+      </b-col>
+    </b-row>
+  </div>
+</template>
+<script setup>
+import { computed, ref } from 'vue'
+import { useRouter } from '#imports'
+import { useChatMessageBase } from '~/composables/useChat'
+import { useChatStore } from '~/stores/chat'
+import { uid } from '~/composables/useId'
+
+// A question from Freegle with tappable answers - "could you deliver?", "when do
+// you need this gone?".
+//
+// The buttons are the whole point. Both of these used to be modals fired the
+// instant someone finished posting, and both are now dead code, which is a fair
+// verdict on that timing: at the moment of posting you are trying to finish, and
+// logistics for an item nobody has asked about yet is noise. Asked hours later,
+// on a post that has gone quiet, the same question is worth answering - and the
+// answer changes what everyone browsing sees.
+//
+// There is no "this is an automated message" line on each card. It is said once,
+// in the chat header, because in this conversation EVERY message is automated
+// and repeating it per message is just noise.
+//
+// One question usually covers SEVERAL posts - Freegle groups a member's
+// outstanding posts the way a clearance groups its items, rather than starting a
+// thread per item. So the card lists them, and the answer applies to all of them.
+
+const props = defineProps({
+  chatid: {
+    type: Number,
+    required: true,
+  },
+  id: {
+    type: Number,
+    required: true,
+  },
+  pov: {
+    type: Number,
+    required: false,
+    default: null,
+  },
+})
+
+const chatStore = useChatStore()
+const router = useRouter()
+const dateId = uid('promptdate')
+
+const { chatmessage, emessage } = useChatMessageBase(
+  props.chatid,
+  props.id,
+  props.pov,
+)
+
+const answering = ref(false)
+
+const prompt = computed(() => chatmessage.value?.prompt ?? null)
+const options = computed(() => prompt.value?.options ?? [])
+
+// The posts this question covers. Usually several - Freegle groups a member's
+// outstanding posts rather than starting a thread per item.
+const posts = computed(() => {
+  const ids = prompt.value?.msgids ?? []
+  if (ids.length) {
+    return ids
+  }
+
+  // Prompts written before grouping carried a single refmsgid.
+  return chatmessage.value?.refmsgid ? [chatmessage.value.refmsgid] : []
+})
+
+// Someone clearing a house can have a lot outstanding, and a wall of items is
+// its own kind of unreadable. The rows are compact, so this can be generous
+// enough that an ordinary member sees all of theirs without tapping.
+const MAX_SHOWN = 5
+const showAll = ref(false)
+const shownPosts = computed(() =>
+  showAll.value ? posts.value : posts.value.slice(0, MAX_SHOWN),
+)
+const hiddenCount = computed(() => posts.value.length - shownPosts.value.length)
+
+// An option that takes a value from the member rather than being a fixed choice.
+const dateOption = computed(() => options.value.find((o) => o.input === 'date'))
+const plainOptions = computed(() => options.value.filter((o) => !o.input))
+
+const today = computed(() =>
+  new Date(Date.now()).toISOString().substring(0, 10),
+)
+const maxDate = computed(() => {
+  const d = new Date(Date.now())
+  d.setFullYear(d.getFullYear() + 1)
+  return d.toISOString().substring(0, 10)
+})
+
+const chosenDate = ref(null)
+
+// Once answered or expired there is nothing to tap. Expired prompts still show
+// their text: a conversation with holes in it is more confusing than a stale
+// question with no buttons.
+const showOptions = computed(
+  () =>
+    Boolean(prompt.value) &&
+    !prompt.value.answered &&
+    !prompt.value.expired &&
+    options.value.length > 0 &&
+    // Support and moderators viewing someone else's chat are looking, not
+    // answering on their behalf.
+    props.pov === null,
+)
+
+const answeredLabel = computed(() => {
+  if (!prompt.value?.answered) {
+    return null
+  }
+
+  const chosen = options.value.find((o) => o.value === prompt.value.answer)
+
+  // A picked date is its own label - there is no option text to look up.
+  return chosen?.label ?? prompt.value.answer
+})
+
+async function answer(option, value) {
+  if (answering.value) {
+    return
+  }
+
+  answering.value = true
+
+  try {
+    await chatStore.answerPrompt(props.chatid, props.id, value ?? option.value)
+
+    // Some options are really a way in to somewhere else - "Add a photo" records
+    // the intent and then has to actually take you to the post.
+    if (option.action === 'editmessage' && chatmessage.value?.refmsgid) {
+      router.push('/mypost/' + chatmessage.value.refmsgid)
+    }
+  } finally {
+    answering.value = false
+  }
+}
+</script>
+<style scoped lang="scss">
+.prompt-date {
+  max-width: 12rem;
+}
+</style>

--- a/iznik-nuxt3/components/ChatPromptPost.vue
+++ b/iznik-nuxt3/components/ChatPromptPost.vue
@@ -1,0 +1,135 @@
+<template>
+  <nuxt-link
+    v-if="message"
+    no-prefetch
+    :to="'/mypost/' + id"
+    class="promptpost"
+    :data-testid="'chat-prompt-post-' + id"
+  >
+    <div class="promptpost__photo" :class="placeholderClass">
+      <OurUploadedImage
+        v-if="message.attachments?.[0]?.ouruid"
+        :src="message.attachments[0].ouruid"
+        :modifiers="message.attachments[0].externalmods"
+        alt=""
+        class="promptpost__img"
+        :width="80"
+        :height="80"
+      />
+      <NuxtPicture
+        v-else-if="message.attachments?.[0]?.externaluid"
+        format="webp"
+        provider="uploadcare"
+        :src="message.attachments[0].externaluid"
+        :modifiers="message.attachments[0].externalmods"
+        alt=""
+        class="promptpost__img"
+        :width="80"
+        :height="80"
+      />
+      <ProxyImage
+        v-else-if="message.attachments?.[0]?.path"
+        class-name="promptpost__img"
+        alt=""
+        :src="message.attachments[0].path"
+        :width="80"
+        :height="80"
+        fit="cover"
+      />
+      <v-icon v-else :icon="categoryIcon" class="promptpost__nophoto" />
+    </div>
+    <span class="promptpost__subject">{{ strippedSubject }}</span>
+  </nuxt-link>
+</template>
+<script setup>
+import { onMounted, toRef } from 'vue'
+import { useMessageDisplay } from '~/composables/useMessageDisplay'
+import { useMessageStore } from '~/stores/message'
+
+// One of a member's posts, listed inside a Freegle prompt.
+//
+// Deliberately a small row rather than the full ChatMessageCard. A prompt talks
+// about everything a member has outstanding, so a house clearance would
+// otherwise stack five full-bleed photo tiles inside one message and bury the
+// question underneath them. This is modelled on the bulk freegling item list,
+// which has the same job: show which things, compactly, however many there are.
+//
+// It exists at all because the wording must not name an item. Interpolating a
+// subject into prose gives you "your pending bookshelf", and nothing can tell a
+// sensible item name from a silly one - so the text names none of them and this
+// says exactly which.
+
+const props = defineProps({
+  id: {
+    type: Number,
+    required: true,
+  },
+})
+
+const messageStore = useMessageStore()
+
+const { message, strippedSubject, placeholderClass, categoryIcon } =
+  useMessageDisplay(toRef(props, 'id'))
+
+// useMessageDisplay only reads the store, so somebody has to put the post in it.
+// Done in onMounted rather than as a top-level await: an async setup makes this
+// a Suspense boundary, and a prompt listing five posts would then hold the whole
+// message back until the slowest of them resolved.
+onMounted(async () => {
+  try {
+    await messageStore.fetch(props.id)
+  } catch (e) {
+    // A post that has since been deleted simply does not appear. The question
+    // still reads correctly without it, and the counts came from the server.
+    console.log('Prompt post fetch failed', props.id, e)
+  }
+})
+</script>
+<style scoped lang="scss">
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'assets/css/_color-vars.scss';
+
+.promptpost {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  color: inherit;
+  text-decoration: none;
+
+  &:hover .promptpost__subject {
+    text-decoration: underline;
+  }
+}
+
+.promptpost__photo {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm, 0.375rem);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: $color-gray-3;
+}
+
+.promptpost__img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+}
+
+.promptpost__nophoto {
+  color: $color-gray--dark;
+}
+
+.promptpost__subject {
+  /* Long subjects must not push the row wide - the question is the point. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+</style>

--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -395,6 +395,19 @@ export const useChatStore = defineStore({
       await api(this.config).chat.nudge(id)
       this.fetchMessages(id)
     },
+    async answerPrompt(chatid, chatmsgid, answer) {
+      const ret = await api(this.config).chat.answerPrompt(
+        chatid,
+        chatmsgid,
+        answer
+      )
+
+      // Refetch so the prompt comes back in its answered state rather than us
+      // guessing what the server did with it.
+      await this.fetchMessages(chatid, true)
+
+      return ret
+    },
     async typing(chatid) {
       await api(this.config).chat.typing(chatid)
     },

--- a/iznik-nuxt3/tests/unit/components/ChatMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMessage.spec.js
@@ -126,6 +126,10 @@ describe('ChatMessage', () => {
             template: '<div class="chat-message-reminder" />',
             props: ['id', 'chatid', 'pov'],
           },
+          ChatMessagePrompt: {
+            template: '<div class="chat-message-prompt" />',
+            props: ['id', 'chatid', 'pov'],
+          },
           ChatMessageDateRead: {
             template: '<div class="chat-message-date-read" />',
             props: ['id', 'chatid', 'last', 'pov'],
@@ -259,6 +263,19 @@ describe('ChatMessage', () => {
       expect(wrapper.find('.chat-message-reminder').exists()).toBe(true)
     })
 
+    // A Freegle prompt - a question with tappable answers. Without its own arm
+    // here it fell through to the raw "Unknown chat message type" debug dump.
+    it('renders Prompt type correctly', async () => {
+      const { setupChat } = await import('~/composables/useChat')
+      setupChat.mockResolvedValueOnce({
+        chat: ref(mockChat),
+        otheruser: ref(mockOtherUser),
+        chatmessage: ref({ ...mockChatMessage, type: 'Prompt' }),
+      })
+      const wrapper = await createWrapper()
+      expect(wrapper.find('.chat-message-prompt').exists()).toBe(true)
+    })
+
     // System notices (e.g. "the item you replied about has now been taken") must
     // render their text, NOT fall through to the raw "Unknown chat message type"
     // debug dump that members were seeing.
@@ -275,6 +292,28 @@ describe('ChatMessage', () => {
       expect(wrapper.find('.system-message').exists()).toBe(true)
       expect(wrapper.text()).toContain('has now been taken')
       expect(wrapper.text()).not.toContain('Unknown chat message type')
+    })
+
+    // The case this build cannot see: a type added AFTER it shipped. An app in
+    // the wild cannot be upgraded in arrears, so the catch-all has to be safe
+    // rather than diagnostic - it used to dump the type and two raw objects into
+    // the member's conversation, which is what happened with System.
+    it('renders an unknown future type as its text rather than a debug dump', async () => {
+      const { setupChat } = await import('~/composables/useChat')
+      const message = 'Could you deliver? Tap below to let people know.'
+      setupChat.mockResolvedValueOnce({
+        chat: ref(mockChat),
+        otheruser: ref(mockOtherUser),
+        chatmessage: ref({
+          ...mockChatMessage,
+          type: 'SomethingInventedLater',
+          message,
+        }),
+      })
+      const wrapper = await createWrapper()
+      expect(wrapper.text()).toContain('Could you deliver?')
+      expect(wrapper.text()).not.toContain('Unknown chat message type')
+      expect(wrapper.text()).not.toContain('SomethingInventedLater')
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/ChatMessagePrompt.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMessagePrompt.spec.js
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+import ChatMessagePrompt from '~/components/ChatMessagePrompt.vue'
+
+const { mockData, answerPrompt, routerPush } = vi.hoisted(() => {
+  return {
+    mockData: {
+      chatmessage: {
+        userid: 2,
+        refmsgid: 999,
+        message: 'Could you drop it off, if it worked for you?',
+        prompt: {
+          kind: 'delivery',
+          msgids: [999],
+          answered: false,
+          expired: false,
+          answer: null,
+          options: [
+            { value: 'maybe', label: 'Maybe, if it works for me' },
+            { value: 'no', label: 'Collection only', variant: 'secondary' },
+          ],
+        },
+      },
+    },
+    answerPrompt: vi.fn().mockResolvedValue({}),
+    routerPush: vi.fn(),
+  }
+})
+
+vi.mock('~/composables/useChat', () => ({
+  useChatMessageBase: () => ({
+    get chatmessage() {
+      return ref(mockData.chatmessage)
+    },
+    get emessage() {
+      return ref(mockData.chatmessage.message)
+    },
+  }),
+}))
+
+vi.mock('~/stores/chat', () => ({
+  useChatStore: () => ({
+    answerPrompt,
+  }),
+}))
+
+// The component imports useRouter from '#imports' (the repo convention), not
+// from vue-router directly.
+vi.mock('#imports', async () => {
+  const actual = await vi.importActual('#imports')
+  return {
+    ...actual,
+    useRouter: () => ({ push: routerPush }),
+  }
+})
+
+describe('ChatMessagePrompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockData.chatmessage = {
+      userid: 2,
+      refmsgid: 999,
+      message: 'Could you drop it off, if it worked for you?',
+      prompt: {
+        kind: 'delivery',
+        msgids: [999],
+        answered: false,
+        expired: false,
+        answer: null,
+        options: [
+          { value: 'maybe', label: 'Maybe, if it works for me' },
+          { value: 'no', label: 'Collection only', variant: 'secondary' },
+        ],
+      },
+    }
+  })
+
+  function createWrapper(props = {}) {
+    return mount(ChatMessagePrompt, {
+      props: {
+        chatid: 123,
+        id: 456,
+        ...props,
+      },
+      global: {
+        stubs: {
+          'b-row': { template: '<div class="row"><slot /></div>' },
+          'b-col': { template: '<div class="col"><slot /></div>' },
+          'b-card': { template: '<div class="card"><slot /></div>' },
+          'b-card-text': { template: '<div class="card-text"><slot /></div>' },
+          'b-form-input': {
+            template:
+              '<input :type="type" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+            props: ['modelValue', 'type', 'min', 'max'],
+          },
+          ChatPromptPost: { template: '<div class="chat-prompt-post" />' },
+          'b-button': {
+            template:
+              '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+            props: ['variant', 'disabled'],
+          },
+        },
+      },
+    })
+  }
+
+  it('shows the question and its options', () => {
+    const wrapper = createWrapper()
+
+    expect(wrapper.text()).toContain('Could you drop it off')
+    const buttons = wrapper.findAll('button')
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0].text()).toBe('Maybe, if it works for me')
+  })
+
+  it('sends the chosen answer', async () => {
+    const wrapper = createWrapper()
+
+    await wrapper.findAll('button')[0].trigger('click')
+    await flushPromises()
+
+    expect(answerPrompt).toHaveBeenCalledWith(123, 456, 'maybe')
+  })
+
+  it('shows what was chosen instead of the buttons once answered', () => {
+    mockData.chatmessage.prompt.answered = true
+    mockData.chatmessage.prompt.answer = 'maybe'
+
+    const wrapper = createWrapper()
+
+    expect(wrapper.findAll('button')).toHaveLength(0)
+    expect(wrapper.text()).toContain('You said: Maybe, if it works for me')
+  })
+
+  it('still shows an expired prompt but stops offering the buttons', () => {
+    // A conversation with holes in it is more confusing than a stale question,
+    // so the text stays even though the answer is no longer wanted.
+    mockData.chatmessage.prompt.expired = true
+
+    const wrapper = createWrapper()
+
+    expect(wrapper.text()).toContain('Could you drop it off')
+    expect(wrapper.findAll('button')).toHaveLength(0)
+  })
+
+  it('does not let support or moderators answer on the member behalf', () => {
+    const wrapper = createWrapper({ pov: 42 })
+
+    expect(wrapper.findAll('button')).toHaveLength(0)
+  })
+
+  it('takes the member to their post when the option asks it to', async () => {
+    mockData.chatmessage.prompt = {
+      kind: 'photo',
+      msgids: [999],
+      answered: false,
+      expired: false,
+      answer: null,
+      options: [
+        { value: 'add', label: 'Add a photo', action: 'editmessage' },
+        { value: 'none', label: "I haven't got a photo" },
+      ],
+    }
+
+    const wrapper = createWrapper()
+    await wrapper.findAll('button')[0].trigger('click')
+    await flushPromises()
+
+    expect(answerPrompt).toHaveBeenCalledWith(123, 456, 'add')
+    expect(routerPush).toHaveBeenCalledWith('/mypost/999')
+  })
+
+  it('does not navigate for an option with no action', async () => {
+    const wrapper = createWrapper()
+
+    await wrapper.findAll('button')[0].trigger('click')
+    await flushPromises()
+
+    expect(routerPush).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing tappable when the payload has no options', () => {
+    mockData.chatmessage.prompt = {
+      kind: 'views',
+      msgids: [999],
+      answered: false,
+      expired: false,
+      answer: null,
+      options: [],
+    }
+    mockData.chatmessage.message = '7 freeglers have opened your post.'
+
+    const wrapper = createWrapper()
+
+    expect(wrapper.text()).toContain('7 freeglers have opened your post.')
+    expect(wrapper.findAll('button')).toHaveLength(0)
+  })
+
+  it('renders the post itself rather than naming it in the prose', async () => {
+    // An item name reads fine as "your dining chairs" and badly as whatever
+    // someone actually typed, and nothing can tell the two apart.
+    const wrapper = createWrapper()
+
+    expect(wrapper.find('.chat-prompt-post').exists()).toBe(true)
+  })
+
+  it('does not repeat an automated-message line on every card', async () => {
+    // It is said once in the chat header instead - in this conversation every
+    // message is automated, so per-message it is just noise.
+    const wrapper = createWrapper()
+
+    expect(wrapper.text()).not.toContain('automated message')
+  })
+
+  it('offers a date picker for the deadline rather than fixed timescales', async () => {
+    mockData.chatmessage.prompt = {
+      kind: 'deadline',
+      msgids: [999],
+      answered: false,
+      expired: false,
+      answer: null,
+      options: [
+        { value: 'date', label: 'Pick a date', input: 'date' },
+        { value: 'norush', label: "There's no rush", variant: 'secondary' },
+      ],
+    }
+
+    const wrapper = createWrapper()
+    const date = wrapper.find('input[type="date"]')
+    expect(date.exists()).toBe(true)
+
+    await date.setValue('2026-09-01')
+    const buttons = wrapper.findAll('button')
+    await buttons[0].trigger('click')
+    await flushPromises()
+
+    expect(answerPrompt).toHaveBeenCalledWith(123, 456, '2026-09-01')
+  })
+
+  it('still lets the poster say there is no rush', async () => {
+    mockData.chatmessage.prompt = {
+      kind: 'deadline',
+      msgids: [999],
+      answered: false,
+      expired: false,
+      answer: null,
+      options: [
+        { value: 'date', label: 'Pick a date', input: 'date' },
+        { value: 'norush', label: "There's no rush", variant: 'secondary' },
+      ],
+    }
+
+    const wrapper = createWrapper()
+    const noRush = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('no rush'))
+    await noRush.trigger('click')
+    await flushPromises()
+
+    expect(answerPrompt).toHaveBeenCalledWith(123, 456, 'norush')
+  })
+
+  it('lists every post the question covers, not just one', async () => {
+    // Freegle groups a member's outstanding posts, so one question usually
+    // covers several and the card has to say which.
+    mockData.chatmessage.prompt.msgids = [11, 22]
+
+    const wrapper = createWrapper()
+
+    expect(wrapper.findAll('.chat-prompt-post')).toHaveLength(2)
+  })
+
+  it('collapses a long list rather than filling the thread with items', async () => {
+    // A house clearance can have a lot outstanding. The rows are compact, so
+    // five show before it starts hiding any.
+    mockData.chatmessage.prompt.msgids = [1, 2, 3, 4, 5, 6, 7, 8]
+
+    const wrapper = createWrapper()
+
+    expect(wrapper.findAll('.chat-prompt-post')).toHaveLength(5)
+    expect(wrapper.text()).toContain('Show 3 more')
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ChatPromptPost.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatPromptPost.spec.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { computed, ref } from 'vue'
+import ChatPromptPost from '~/components/ChatPromptPost.vue'
+
+const { mockData, fetchMessage } = vi.hoisted(() => {
+  return {
+    mockData: {
+      message: {
+        id: 42,
+        subject: 'OFFER: Dining table and 4 chairs (Tuvalu High Street)',
+        attachments: [],
+      },
+      strippedSubject: 'Dining table and 4 chairs (Tuvalu High Street)',
+    },
+    fetchMessage: vi.fn().mockResolvedValue({}),
+  }
+})
+
+vi.mock('~/composables/useMessageDisplay', () => ({
+  useMessageDisplay: () => ({
+    message: computed(() => mockData.message),
+    strippedSubject: computed(() => mockData.strippedSubject),
+    placeholderClass: ref('placeholder-offer'),
+    categoryIcon: ref('gift'),
+  }),
+}))
+
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({ fetch: fetchMessage }),
+}))
+
+// One of a member's posts, listed compactly inside a Freegle prompt. Deliberately
+// not the full ChatMessageCard: a prompt routinely covers five posts, and five
+// full-bleed photo tiles would bury the question under them.
+describe('ChatPromptPost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockData.message = {
+      id: 42,
+      subject: 'OFFER: Dining table and 4 chairs (Tuvalu High Street)',
+      attachments: [],
+    }
+    mockData.strippedSubject = 'Dining table and 4 chairs (Tuvalu High Street)'
+  })
+
+  function createWrapper(id = 42) {
+    return mount(ChatPromptPost, {
+      props: { id },
+      global: {
+        stubs: {
+          OurUploadedImage: { template: '<img class="ouruploaded" />' },
+          NuxtPicture: { template: '<img class="nuxtpicture" />' },
+          ProxyImage: { template: '<img class="proxyimage" />' },
+          'v-icon': { template: '<i class="v-icon" />', props: ['icon'] },
+          'nuxt-link': {
+            template: '<a :href="to"><slot /></a>',
+            props: ['to', 'noPrefetch'],
+          },
+        },
+      },
+    })
+  }
+
+  it('names the post, because the prompt wording deliberately does not', () => {
+    // "your pending bookshelf" is what you get from interpolating a subject into
+    // prose, and nothing can tell a good item name from a silly one. So the
+    // question names nothing and this says exactly which posts it covers.
+    const wrapper = createWrapper()
+
+    expect(wrapper.text()).toContain('Dining table and 4 chairs')
+  })
+
+  it('links to the post so the row is a way in, not just a label', () => {
+    const wrapper = createWrapper(42)
+
+    expect(wrapper.find('a').attributes('href')).toBe('/mypost/42')
+  })
+
+  it('fetches the post itself, since the display composable only reads the store', async () => {
+    createWrapper(42)
+    await flushPromises()
+
+    expect(fetchMessage).toHaveBeenCalledWith(42)
+  })
+
+  it('falls back to an icon when the post has no photo', () => {
+    const wrapper = createWrapper()
+
+    expect(wrapper.find('.v-icon').exists()).toBe(true)
+    expect(wrapper.find('.ouruploaded').exists()).toBe(false)
+  })
+
+  it('shows the photo when there is one', () => {
+    mockData.message.attachments = [{ ouruid: 'abc123', externalmods: null }]
+
+    const wrapper = createWrapper()
+
+    expect(wrapper.find('.ouruploaded').exists()).toBe(true)
+  })
+
+  it('renders nothing for a post that has since been deleted', async () => {
+    // The question still reads correctly without it, and the counts came from
+    // the server - so a missing post is silence, not an error.
+    mockData.message = null
+
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    expect(wrapper.find('a').exists()).toBe(false)
+  })
+
+  it('survives a fetch that fails', async () => {
+    fetchMessage.mockRejectedValueOnce(new Error('gone'))
+
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    expect(wrapper.exists()).toBe(true)
+  })
+})

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -63,9 +63,14 @@ type ChatMessage struct {
 	// message) and for a normal caller on their OWN held reply, so the sender can show a
 	// "waiting to send" indicator. It is NOT set on the poster's view (the delivery gate
 	// removes held replies from their fetch entirely).
-	HeldByRippling bool    `json:"heldbyrippling,omitempty" gorm:"-"`
-	Addressid      *uint64 `json:"addressid" gorm:"-"`
-	Modnote        bool    `json:"modnote" gorm:"-"`
+	HeldByRippling bool `json:"heldbyrippling,omitempty" gorm:"-"`
+	// Prompt is the answerable part of a type='Prompt' message - the tappable
+	// options, and the answer once one is chosen. Nil on every other message
+	// type, which is nearly all of them, so it costs an omitted field rather
+	// than a null on the wire.
+	Prompt    *ChatPrompt `json:"prompt,omitempty" gorm:"-"`
+	Addressid *uint64     `json:"addressid" gorm:"-"`
+	Modnote   bool        `json:"modnote" gorm:"-"`
 	// Replysource is the client-reported surface an Interested reply came from (browse,
 	// search, message_page, notification, ...). Advisory reply-provenance evidence for the
 	// rippling attribution capture - sanitised there, stored in rippling_reply_attribution,
@@ -269,6 +274,10 @@ func FetchChatMessages(chatID, userID uint64, limit int, excludeID uint64, desce
 			}
 		}
 	}
+
+	// Fill in the tappable part of any Freegle prompt in this fetch. No-op (and no
+	// query) unless the fetch actually contains one, which is nearly never.
+	attachPrompts(db, messages)
 
 	// Process images and deleted messages
 	for ix, a := range messages {

--- a/iznik-server-go/chat/chatprompt.go
+++ b/iznik-server-go/chat/chatprompt.go
@@ -1,0 +1,370 @@
+package chat
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/user"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Prompts: questions Freegle asks a member inside an ordinary chat, with a small
+// set of tappable answers.
+//
+// The two questions that most change whether a post succeeds - "could you
+// deliver?" and "when does it need to be gone?" - were modals fired the instant
+// someone finished posting. Both components are still in the frontend tree and
+// neither is wired to anything, which is a fair verdict on the format: at the
+// moment of posting the member is trying to finish, and logistics for an item
+// nobody has asked for yet is noise. The same question three hours later, when
+// nothing has happened, is worth answering.
+//
+// The question is an ordinary chat message (type 'Prompt'), so notification,
+// push, unread state and history all work with no changes. Only the tappable
+// part lives here, in chat_prompts.
+//
+// Email deliberately does not carry the buttons. It carries the question and a
+// link to the chat, because an emailed one-click answer would be answerable by
+// anyone who ever saw the message - including a forwarded copy - and these
+// answers change what the post says.
+
+// PromptOption is one tappable answer.
+type PromptOption struct {
+	Value   string `json:"value"`
+	Label   string `json:"label"`
+	Variant string `json:"variant,omitempty"`
+	// Input marks an option that takes a value from the member rather than being
+	// a fixed choice - currently only "date". The client renders the matching
+	// control and sends what was entered as the answer.
+	Input string `json:"input,omitempty"`
+	// Action is a hint to the client that answering should also take the member
+	// somewhere, e.g. "editmessage" to open the post editor. Advisory only: the
+	// server records the answer either way.
+	Action string `json:"action,omitempty"`
+}
+
+// ChatPrompt is the answerable part of a Prompt message, as served to the client.
+type ChatPrompt struct {
+	Kind string `json:"kind"`
+	// Msgids are the posts the question is about and the answer applies to.
+	// Usually several: Freegle talks about a member's outstanding posts together,
+	// the way a clearance treats its items. The client lists them so the subject
+	// is never ambiguous, which is also why the wording names no post.
+	Msgids   []uint64       `json:"msgids"`
+	Options  []PromptOption `json:"options"`
+	Answer   *string        `json:"answer,omitempty"`
+	Answered bool           `json:"answered"`
+	// Expired prompts still render (the conversation should not develop holes)
+	// but stop offering their buttons.
+	Expired bool `json:"expired"`
+}
+
+type promptRow struct {
+	Chatmsgid  uint64
+	Msgid      *uint64
+	Msgids     []byte
+	Kind       string
+	Options    []byte
+	Answer     *string
+	AnsweredAt *time.Time `gorm:"column:answered_at"`
+	ExpiresAt  *time.Time `gorm:"column:expires_at"`
+}
+
+// posts returns the set the prompt covers, falling back to the single msgid for
+// prompts written before the set existed.
+func (r promptRow) posts() []uint64 {
+	ids := []uint64{}
+
+	if len(r.Msgids) > 0 {
+		_ = json.Unmarshal(r.Msgids, &ids)
+	}
+
+	if len(ids) == 0 && r.Msgid != nil {
+		ids = append(ids, *r.Msgid)
+	}
+
+	return ids
+}
+
+func (r promptRow) toPrompt() *ChatPrompt {
+	options := []PromptOption{}
+	if len(r.Options) > 0 {
+		// A malformed options blob must not take the whole message fetch down;
+		// the prompt then renders as text with nothing to tap, which is exactly
+		// what an old client would show anyway.
+		_ = json.Unmarshal(r.Options, &options)
+	}
+
+	return &ChatPrompt{
+		Kind:     r.Kind,
+		Msgids:   r.posts(),
+		Options:  options,
+		Answer:   r.Answer,
+		Answered: r.AnsweredAt != nil,
+		Expired:  r.ExpiresAt != nil && r.ExpiresAt.Before(time.Now()),
+	}
+}
+
+// attachPrompts fills in the Prompt field on any message that has one. Batched,
+// and a no-op when no message in the fetch is a prompt - which is almost always,
+// so the common case costs one type check per message and no query at all.
+func attachPrompts(db *gorm.DB, messages []ChatMessageQuery) {
+	ids := make([]uint64, 0)
+	idx := make(map[uint64]int, len(messages))
+
+	for i, m := range messages {
+		if m.Type == utils.CHAT_MESSAGE_PROMPT {
+			ids = append(ids, m.ID)
+			idx[m.ID] = i
+		}
+	}
+
+	if len(ids) == 0 {
+		return
+	}
+
+	var rows []promptRow
+	db.Table("chat_prompts").
+		Select("chatmsgid, msgid, msgids, kind, options, answer, answered_at, expires_at").
+		Where("chatmsgid IN ?", ids).
+		Scan(&rows)
+
+	for _, r := range rows {
+		if i, ok := idx[r.Chatmsgid]; ok {
+			messages[i].Prompt = r.toPrompt()
+		}
+	}
+}
+
+type answerPromptPayload struct {
+	Answer string `json:"answer"`
+}
+
+// AnswerChatPrompt records the member's answer to a prompt and does whatever the
+// answer means.
+//
+// One implementation, here, rather than one in the API and another in the batch
+// app: "by this weekend" has to mean the same date wherever it is answered, and
+// two copies of that rule would drift the first time either was touched.
+func AnswerChatPrompt(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	chatid, err := strconv.ParseUint(c.Params("id"), 10, 64)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid chat id")
+	}
+
+	chatmsgid, err := strconv.ParseUint(c.Params("mid"), 10, 64)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid message id")
+	}
+
+	var payload answerPromptPayload
+	if err := c.BodyParser(&payload); err != nil || payload.Answer == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid parameters")
+	}
+
+	db := database.DBConn
+
+	// Only the person who was asked may answer, and only in the room the prompt
+	// is actually in. Joining the room in rather than trusting the path id stops
+	// a prompt in someone else's chat being answered by quoting its id here.
+	//
+	// Flat struct rather than embedding promptRow: GORM's raw Scan matches columns
+	// to top-level fields, and an embedded struct would silently come back zeroed.
+	var row struct {
+		Chatmsgid  uint64
+		Msgid      *uint64
+		Msgids     []byte
+		Kind       string
+		Options    []byte
+		Answer     *string
+		AnsweredAt *time.Time `gorm:"column:answered_at"`
+		ExpiresAt  *time.Time `gorm:"column:expires_at"`
+		User1      uint64
+		User2      uint64
+	}
+
+	db.Table("chat_prompts cp").
+		Select("cp.chatmsgid, cp.msgid, cp.msgids, cp.kind, cp.options, cp.answer, "+
+			"cp.answered_at, cp.expires_at, cr.user1, cr.user2").
+		Joins("INNER JOIN chat_messages cm ON cm.id = cp.chatmsgid").
+		Joins("INNER JOIN chat_rooms cr ON cr.id = cm.chatid").
+		Where("cp.chatmsgid = ? AND cm.chatid = ?", chatmsgid, chatid).
+		Scan(&row)
+
+	if row.Chatmsgid == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Prompt not found")
+	}
+
+	if row.User1 != myid && row.User2 != myid {
+		return fiber.NewError(fiber.StatusForbidden, "Not your prompt")
+	}
+
+	if row.AnsweredAt != nil {
+		return fiber.NewError(fiber.StatusConflict, "Already answered")
+	}
+
+	if row.ExpiresAt != nil && row.ExpiresAt.Before(time.Now()) {
+		return fiber.NewError(fiber.StatusGone, "Prompt expired")
+	}
+
+	asRow := promptRow{
+		Chatmsgid:  row.Chatmsgid,
+		Msgid:      row.Msgid,
+		Msgids:     row.Msgids,
+		Kind:       row.Kind,
+		Options:    row.Options,
+		Answer:     row.Answer,
+		AnsweredAt: row.AnsweredAt,
+		ExpiresAt:  row.ExpiresAt,
+	}
+	prompt := asRow.toPrompt()
+	if !validAnswer(prompt.Options, payload.Answer) {
+		return fiber.NewError(fiber.StatusBadRequest, "Not one of the offered answers")
+	}
+
+	applied := applyPromptAnswer(db, row.Kind, payload.Answer, asRow.posts(), myid)
+
+	// Record last. An answer that changed the post but was not recorded would be
+	// re-askable; one recorded but not applied would silently lose the member's
+	// input. Applying first and recording second means the worst case is a
+	// repeated question, not a lost answer.
+	res := db.Table("chat_prompts").
+		Where("chatmsgid = ? AND answered_at IS NULL", chatmsgid).
+		Updates(map[string]interface{}{
+			"answer":      payload.Answer,
+			"answered_at": gorm.Expr("NOW()"),
+		})
+	if res.Error != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Could not record answer")
+	}
+
+	db.Table("firstreply_event_metrics").Clauses(clause.OnConflict{
+		DoUpdates: clause.Assignments(map[string]interface{}{"count": gorm.Expr("count + 1")}),
+	}).Create(map[string]interface{}{
+		"day":   gorm.Expr("CURDATE()"),
+		"event": gorm.Expr("'prompt_answered'"),
+		"count": gorm.Expr("1"),
+	})
+
+	return c.JSON(fiber.Map{
+		"kind":    row.Kind,
+		"answer":  payload.Answer,
+		"applied": applied,
+	})
+}
+
+// validAnswer accepts one of the offered option values, or - when an option
+// invites free input - a value of that shape.
+//
+// The deadline prompt offers a date picker rather than fixed choices, because
+// "by this weekend" is wrong for somebody moving house on the 14th and the
+// poster already knows their own date. That means the answer cannot be checked
+// against a fixed list, so it is checked against a shape and a sane range
+// instead: a bare date, today or later, within a year.
+func validAnswer(options []PromptOption, answer string) bool {
+	for _, o := range options {
+		if o.Value == answer {
+			return true
+		}
+		if o.Input == "date" && validDateAnswer(answer) {
+			return true
+		}
+	}
+	return false
+}
+
+func validDateAnswer(answer string) bool {
+	d, err := time.Parse("2006-01-02", answer)
+	if err != nil {
+		return false
+	}
+
+	// Compare on the day, not the instant, so "today" is not rejected for being
+	// a few hours in the past.
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	return !d.Before(today) && d.Before(today.AddDate(1, 0, 0))
+}
+
+// applyPromptAnswer is what answering actually DOES. Each kind owns its effect
+// here, so a new kind is a case in this switch and nothing else.
+//
+// Applies across the whole set the question covered - one "could you deliver?"
+// about six offers means six offers, which is the point of grouping them. Posts
+// are matched on fromuser as well as id, so a prompt row pointing somewhere
+// unexpected can never edit a stranger's post, and returns true if it changed
+// anything at all: a member whose posts have partly gone since still gets credit
+// for answering about the ones that remain.
+func applyPromptAnswer(db *gorm.DB, kind string, answer string, msgids []uint64, myid uint64) bool {
+	if len(msgids) == 0 {
+		return false
+	}
+
+	switch kind {
+	case utils.PROMPT_KIND_DELIVERY:
+		// "maybe" is the honest reading of this flag: the poster is open to
+		// delivering, not committed to it.
+		possible := 0
+		if answer == "maybe" {
+			possible = 1
+		}
+		res := db.Table("messages").
+			Where("id IN ? AND fromuser = ?", msgids, myid).
+			Update("deliverypossible", possible)
+		return res.Error == nil && res.RowsAffected > 0
+
+	case utils.PROMPT_KIND_DEADLINE:
+		deadline := deadlineFor(answer)
+		if deadline == "" {
+			// "No rush" is a real answer - it stops us asking again - but it is
+			// not a date, so nothing is patched.
+			return false
+		}
+		res := db.Table("messages").
+			Where("id IN ? AND fromuser = ?", msgids, myid).
+			Update("deadline", deadline)
+		return res.Error == nil && res.RowsAffected > 0
+
+	default:
+		// Informational prompts: the answer is recorded, nothing is patched.
+		return false
+	}
+}
+
+// deadlineFor turns a deadline answer into a date. Empty for "no rush".
+//
+// A picked date is used as given. The named timescales are kept because prompts
+// sent before the picker existed are still answerable, and silently doing
+// nothing with one would lose the member's answer.
+func deadlineFor(answer string) string {
+	now := time.Now()
+
+	if validDateAnswer(answer) {
+		return answer
+	}
+
+	switch answer {
+	case "weekend":
+		// The coming Sunday, or today if it already is one, so "this weekend"
+		// never lands in the past.
+		days := (int(time.Sunday) - int(now.Weekday()) + 7) % 7
+		return now.AddDate(0, 0, days).Format("2006-01-02")
+	case "week":
+		return now.AddDate(0, 0, 7).Format("2006-01-02")
+	case "twoweeks":
+		return now.AddDate(0, 0, 14).Format("2006-01-02")
+	default:
+		return ""
+	}
+}

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -331,6 +331,21 @@ func SetupRoutes(app *fiber.App) {
 		// @Success 200 {object} chat.ChatMessage
 		rg.Post("/chat/:id/message", chat.CreateChatMessage)
 
+		// Answer a Freegle prompt
+		// @Router /chat/{id}/message/{mid}/prompt [post]
+		// @Summary Answer a Freegle chat prompt
+		// @Description Records the member's answer to a type='Prompt' chat message and applies
+		// @Description it to the posts the prompt covers. Only the member the prompt was sent
+		// @Description to may answer, and only once.
+		// @Tags chat
+		// @Accept json
+		// @Produce json
+		// @Param id path integer true "Chat ID"
+		// @Param mid path integer true "Chat message ID"
+		// @Security BearerAuth
+		// @Success 200 {object} map[string]interface{}
+		rg.Post("/chat/:id/message/:mid/prompt", chat.AnswerChatPrompt)
+
 		// Patch Chat Message
 		// @Router /chatmessages [patch]
 		// @Summary Update chat message

--- a/iznik-server-go/test/chatprompt_test.go
+++ b/iznik-server-go/test/chatprompt_test.go
@@ -1,0 +1,488 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// ensureFirstReplyTables creates the tables the first-reply work adds, for test
+// databases loaded from schema rather than migrated.
+func ensureFirstReplyTables(t *testing.T) {
+	db := database.DBConn
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS chat_prompts (
+		chatmsgid BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+		msgid BIGINT UNSIGNED NULL,
+		msgids JSON NULL,
+		kind VARCHAR(32) NOT NULL,
+		options JSON NULL,
+		answer VARCHAR(64) NULL,
+		answered_at TIMESTAMP NULL DEFAULT NULL,
+		expires_at TIMESTAMP NULL DEFAULT NULL,
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		KEY chat_prompts_msgid (msgid)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS firstreply_event_metrics (
+		day DATE NOT NULL,
+		event VARCHAR(32) NOT NULL,
+		count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+		PRIMARY KEY (day, event)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	// max_polygon is added by migration; add it here too so a schema-loaded test
+	// database has it. Errors are ignored: the column may already exist.
+	db.Exec("ALTER TABLE rippling_reach ADD COLUMN max_polygon GEOMETRY NULL SRID 3857")
+	db.Exec("ALTER TABLE rippling_reach ADD COLUMN max_cumulative_users INT UNSIGNED NULL")
+
+	// Likewise chat_prompts.msgids. The CREATE TABLE above only fires when the
+	// table is absent, and the migration that creates it is guarded the same way -
+	// so a database that was migrated BEFORE msgids existed keeps a chat_prompts
+	// with no msgids column, and every prompt test fails on the insert. CI is
+	// unaffected (it migrates fresh); long-lived dev databases are not.
+	db.Exec("ALTER TABLE chat_prompts ADD COLUMN msgids JSON NULL")
+
+	// The 'Prompt' enum value likewise.
+	var colType string
+	db.Raw("SELECT column_type FROM information_schema.columns WHERE table_schema = DATABASE() " +
+		"AND table_name = 'chat_messages' AND column_name = 'type'").Scan(&colType)
+	if colType != "" && !strings.Contains(colType, "Prompt") {
+		db.Exec("ALTER TABLE chat_messages MODIFY COLUMN `type` ENUM('Default','System','ModMail'," +
+			"'Interested','Promised','Reneged','ReportedUser','Completed','Image','Address','Nudge'," +
+			"'Schedule','ScheduleUpdated','Reminder','Prompt') NOT NULL DEFAULT 'Default'")
+	}
+}
+
+// seedRipplingReach gives msgid a current reach of tick 1 and an eventual reach of tick 3.
+
+// seedPrompt creates a Freegle prompt message in a chat and returns its id.
+func seedPrompt(t *testing.T, chatID uint64, freegleID uint64, msgID uint64, kind string, options string) uint64 {
+	db := database.DBConn
+
+	res := db.Exec("INSERT INTO chat_messages (chatid, userid, message, type, refmsgid, date, "+
+		"reviewrequired, processingrequired, processingsuccessful) "+
+		"VALUES (?, ?, 'Could you deliver?', 'Prompt', ?, NOW(), 0, 0, 1)",
+		chatID, freegleID, msgID)
+	if res.Error != nil {
+		t.Fatalf("could not insert prompt message: %v", res.Error)
+	}
+
+	var chatMsgID uint64
+	db.Raw("SELECT id FROM chat_messages WHERE chatid = ? ORDER BY id DESC LIMIT 1", chatID).Scan(&chatMsgID)
+
+	db.Exec("INSERT INTO chat_prompts (chatmsgid, msgid, msgids, kind, options, expires_at, created_at) "+
+		"VALUES (?, ?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL 7 DAY), NOW())",
+		chatMsgID, msgID, fmt.Sprintf("[%d]", msgID), kind, options)
+
+	return chatMsgID
+}
+
+const deliveryOptions = `[{"value":"maybe","label":"Maybe, if it works for me"},{"value":"no","label":"Collection only"}]`
+
+// TestAnswerChatPrompt_DeliveryPatchesThePost: answering has to actually change
+// the post, otherwise it is a survey rather than a feature.
+
+// TestAnswerChatPrompt_DeliveryPatchesThePost: answering has to actually change
+// the post, otherwise it is a survey rather than a feature.
+func TestAnswerChatPrompt_DeliveryPatchesThePost(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frprompt")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: prompt test", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "delivery", deliveryOptions)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	_, token := CreateTestSession(t, posterID)
+
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/chat/%d/message/%d/prompt?jwt=%s", chatID, chatMsgID, token),
+		strings.NewReader(`{"answer":"maybe"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, true, body["applied"])
+
+	var deliveryPossible int
+	db.Raw("SELECT deliverypossible FROM messages WHERE id = ?", msgID).Scan(&deliveryPossible)
+	assert.Equal(t, 1, deliveryPossible, "answering 'maybe' should mark the post as possible to deliver")
+
+	var answer string
+	db.Raw("SELECT answer FROM chat_prompts WHERE chatmsgid = ?", chatMsgID).Scan(&answer)
+	assert.Equal(t, "maybe", answer)
+}
+
+func TestAnswerChatPrompt_DeadlineSetsADate(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frpromptdl")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: deadline test", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	options := `[{"value":"week","label":"Within a week"},{"value":"norush","label":"There's no rush"}]`
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "deadline", options)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	_, token := CreateTestSession(t, posterID)
+
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/chat/%d/message/%d/prompt?jwt=%s", chatID, chatMsgID, token),
+		strings.NewReader(`{"answer":"week"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var deadline string
+	db.Raw("SELECT COALESCE(deadline, '') FROM messages WHERE id = ?", msgID).Scan(&deadline)
+	assert.NotEmpty(t, deadline, "answering with a timescale should set a deadline on the post")
+}
+
+// TestAnswerChatPrompt_OnlyTheMemberAskedMayAnswer: the answer edits somebody's
+// post, so it must not be answerable by anyone who happens to know the id.
+
+// TestAnswerChatPrompt_OnlyTheMemberAskedMayAnswer: the answer edits somebody's
+// post, so it must not be answerable by anyone who happens to know the id.
+func TestAnswerChatPrompt_OnlyTheMemberAskedMayAnswer(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frpromptauth")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	strangerID := CreateTestUser(t, prefix+"_stranger", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: prompt auth", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "delivery", deliveryOptions)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	_, token := CreateTestSession(t, strangerID)
+
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/chat/%d/message/%d/prompt?jwt=%s", chatID, chatMsgID, token),
+		strings.NewReader(`{"answer":"maybe"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.NotEqual(t, 200, resp.StatusCode)
+
+	var deliveryPossible int
+	db.Raw("SELECT deliverypossible FROM messages WHERE id = ?", msgID).Scan(&deliveryPossible)
+	assert.Equal(t, 0, deliveryPossible, "a stranger must not be able to edit someone else's post")
+}
+
+func TestAnswerChatPrompt_RejectsAnAnswerThatWasNotOffered(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frpromptbad")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: prompt bad answer", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "delivery", deliveryOptions)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	_, token := CreateTestSession(t, posterID)
+
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/chat/%d/message/%d/prompt?jwt=%s", chatID, chatMsgID, token),
+		strings.NewReader(`{"answer":"whatever"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestAnswerChatPrompt_CannotBeAnsweredTwice(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frprompttwice")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: prompt twice", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "delivery", deliveryOptions)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	_, token := CreateTestSession(t, posterID)
+	url := fmt.Sprintf("/api/chat/%d/message/%d/prompt?jwt=%s", chatID, chatMsgID, token)
+
+	first := httptest.NewRequest("POST", url, strings.NewReader(`{"answer":"maybe"}`))
+	first.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(first, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	second := httptest.NewRequest("POST", url, strings.NewReader(`{"answer":"no"}`))
+	second.Header.Set("Content-Type", "application/json")
+	resp2, err := getApp().Test(second, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 409, resp2.StatusCode)
+
+	var deliveryPossible int
+	db.Raw("SELECT deliverypossible FROM messages WHERE id = ?", msgID).Scan(&deliveryPossible)
+	assert.Equal(t, 1, deliveryPossible, "the second answer must not overwrite the first")
+}
+
+// TestFetchChatMessages_PromptIsServedWithItsOptions: without this the client has
+// a message it can render but nothing to tap.
+
+// TestFetchChatMessages_PromptIsServedWithItsOptions: without this the client has
+// a message it can render but nothing to tap.
+func TestFetchChatMessages_PromptIsServedWithItsOptions(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frpromptfetch")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: prompt fetch", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "delivery", deliveryOptions)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	_, token := CreateTestSession(t, posterID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/chat/%d/message?jwt=%s", chatID, token), nil)
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body []map[string]interface{}
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	found := false
+	for _, m := range body {
+		idFloat, ok := m["id"].(float64)
+		if !ok || uint64(idFloat) != chatMsgID {
+			continue
+		}
+		found = true
+
+		prompt, ok := m["prompt"].(map[string]interface{})
+		assert.True(t, ok, "a Prompt message must carry its prompt payload")
+		assert.Equal(t, "delivery", prompt["kind"])
+		assert.Equal(t, false, prompt["answered"])
+
+		options, ok := prompt["options"].([]interface{})
+		assert.True(t, ok)
+		assert.Len(t, options, 2)
+	}
+
+	assert.True(t, found, "the prompt message should be in the fetch")
+}
+
+// TestAnswerChatPrompt_AcceptsAPickedDate: the deadline prompt takes a date
+// rather than fixed timescales, so the answer cannot be checked against a list.
+
+// TestAnswerChatPrompt_AcceptsAPickedDate: the deadline prompt takes a date
+// rather than fixed timescales, so the answer cannot be checked against a list.
+func TestAnswerChatPrompt_AcceptsAPickedDate(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frpromptpick")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: picked date", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	options := `[{"value":"date","label":"Pick a date","input":"date"},{"value":"norush","label":"There's no rush"}]`
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "deadline", options)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	_, token := CreateTestSession(t, posterID)
+	want := time.Now().AddDate(0, 0, 9).Format("2006-01-02")
+
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/chat/%d/message/%d/prompt?jwt=%s", chatID, chatMsgID, token),
+		strings.NewReader(`{"answer":"`+want+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var deadline string
+	db.Raw("SELECT COALESCE(DATE_FORMAT(deadline, '%Y-%m-%d'), '') FROM messages WHERE id = ?", msgID).Scan(&deadline)
+	assert.Equal(t, want, deadline, "the date the poster picked should be the deadline")
+}
+
+// A date in the past, or absurdly far ahead, is not a date the poster meant.
+
+// A date in the past, or absurdly far ahead, is not a date the poster meant.
+func TestAnswerChatPrompt_RejectsAnOutOfRangeDate(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frpromptbaddate")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: bad date", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	options := `[{"value":"date","label":"Pick a date","input":"date"}]`
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "deadline", options)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	_, token := CreateTestSession(t, posterID)
+	past := time.Now().AddDate(0, 0, -3).Format("2006-01-02")
+
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/chat/%d/message/%d/prompt?jwt=%s", chatID, chatMsgID, token),
+		strings.NewReader(`{"answer":"`+past+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+// The rollout split has to agree with the batch side's msgid % 100 bucketing, or
+// a post would be in the trial for an emailed reply and out of it for an in-app
+// one - which would make the arms meaningless.
+
+// An expired question still renders, but it must not still be answerable.
+//
+// A week-old "could you deliver?" under an item that has long gone is not
+// merely stale: answering it would edit a finished post. The message stays in
+// the thread so the conversation reads back in order - a gap where a question
+// was is more confusing than a question with no buttons - but the answer is
+// refused.
+func TestAnswerChatPrompt_RefusesAnExpiredPrompt(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frpromptexpired")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: expired prompt", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "delivery", deliveryOptions)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	db.Exec("UPDATE chat_prompts SET expires_at = DATE_SUB(NOW(), INTERVAL 1 DAY) WHERE chatmsgid = ?", chatMsgID)
+
+	_, token := CreateTestSession(t, posterID)
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/chat/%d/message/%d/prompt?jwt=%s", chatID, chatMsgID, token),
+		strings.NewReader(`{"answer":"maybe"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 410, resp.StatusCode)
+
+	var deliveryPossible int
+	db.Raw("SELECT deliverypossible FROM messages WHERE id = ?", msgID).Scan(&deliveryPossible)
+	assert.Equal(t, 0, deliveryPossible, "an expired prompt must not still edit the post")
+}
+
+// "There's no rush" is a real answer that changes nothing.
+//
+// It matters because it is not a refusal: it stops us asking again, so it has to
+// be recorded, but there is no date to write and the post must be left exactly
+// as it was. Conflating "answered" with "changed the post" is what makes the
+// sysadmin answer-rate numbers lie.
+
+// "There's no rush" is a real answer that changes nothing.
+//
+// It matters because it is not a refusal: it stops us asking again, so it has to
+// be recorded, but there is no date to write and the post must be left exactly
+// as it was. Conflating "answered" with "changed the post" is what makes the
+// sysadmin answer-rate numbers lie.
+func TestAnswerChatPrompt_NoRushRecordsWithoutPatchingThePost(t *testing.T) {
+	ensureFirstReplyTables(t)
+	db := database.DBConn
+	prefix := uniquePrefix("frpromptnorush")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	freegleID := CreateTestUser(t, prefix+"_freegle", "User")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: no rush", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, freegleID, &posterID, nil, "User2User")
+	options := `[{"value":"date","label":"Pick a date","input":"date"},{"value":"norush","label":"There's no rush"}]`
+	chatMsgID := seedPrompt(t, chatID, freegleID, msgID, "deadline", options)
+	defer db.Exec("DELETE FROM chat_prompts WHERE chatmsgid = ?", chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+
+	_, token := CreateTestSession(t, posterID)
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/chat/%d/message/%d/prompt?jwt=%s", chatID, chatMsgID, token),
+		strings.NewReader(`{"answer":"norush"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, false, body["applied"], "nothing was patched, and the panel must not claim otherwise")
+
+	var deadline *string
+	db.Raw("SELECT deadline FROM messages WHERE id = ?", msgID).Scan(&deadline)
+	assert.Nil(t, deadline, "no rush is not a date")
+
+	// But it IS recorded, so the question is not asked again.
+	var answer string
+	db.Raw("SELECT answer FROM chat_prompts WHERE chatmsgid = ?", chatMsgID).Scan(&answer)
+	assert.Equal(t, "norush", answer)
+}
+
+// A bare end date means midnight, which silently drops everything that happened
+// TODAY - the most interesting part of the window and the least likely to be
+// questioned, because the panel still looks perfectly plausible. The handler
+// widens a date-only bound to cover its whole day.
+//
+// This is a regression test for a real one: the dashboard's own date filter
+// sends bare dates, and the average "hours earlier" read 5.6 instead of 3.7
+// because the most recent passthroughs were being excluded.

--- a/iznik-server-go/utils/utils.go
+++ b/iznik-server-go/utils/utils.go
@@ -156,6 +156,18 @@ const CHAT_MESSAGE_ADDRESS = "Address"
 const CHAT_MESSAGE_NUDGE = "Nudge"
 const CHAT_MESSAGE_REFER_TO_SUPPORT = "ReferToSupport"
 
+// CHAT_MESSAGE_PROMPT is a question from Freegle with tappable answers. The
+// question text is in chat_messages.message like any other message; the options
+// and the answer live in chat_prompts, keyed on the message id.
+const CHAT_MESSAGE_PROMPT = "Prompt"
+
+// Prompt kinds. Each says what ANSWERING does - see chat.applyPromptAnswer and
+// App\Services\FirstReply\PromptService.
+const PROMPT_KIND_DELIVERY = "delivery"
+const PROMPT_KIND_DEADLINE = "deadline"
+const PROMPT_KIND_VIEWS = "views"
+const PROMPT_KIND_PHOTO = "photo"
+
 const NEWSFEED_TYPE_ALERT = "Alert"
 const NEWSFEED_TYPE_COMMUNITY_EVENT = "CommunityEvent"
 const NEWSFEED_TYPE_VOLUNTEER_OPPORTUNITY = "VolunteerOpportunity"


### PR DESCRIPTION
Split out of #1258 so that **every client can understand a Freegle prompt before anything starts
sending them**. Nothing here creates a prompt - this is inert until the sending side lands.

## Why it has to go first

A client that meets a message type it does not know falls through the catch-all in
`ChatMessage.vue`. Until this change that branch rendered, into the member's conversation:

```
Unknown chat message type Prompt, [object] [object]
```

That is not hypothetical. It already happened in the wild with the `System` type - see
`6d833bb62`, "render System chat messages instead of a raw error dump".

Every chat message carries readable text in `message` whatever its type, so **the fallback now
renders that**. Any future type degrades to a plain message instead of a debug dump. That makes
adding message types safe from here on - but it cannot help an app already in somebody's pocket,
which is exactly why the sending side is a separate PR.

**There is no per-member gate available.** `users_builddates.appversion` is empty for **all 41,402
users seen in the last 30 days** on live; only `webversion` is populated. So we can neither
suppress prompts for old clients nor measure app adoption from it. The control is release
adoption over time, and closing that measurement gap is worth doing before sending starts.

## What a prompt is

| Piece | Where |
|---|---|
| The message | `chat_messages`, `type = 'Prompt'`, readable text in `message` |
| The tappable part | `chat_prompts`, keyed on `chatmsgid` |
| Posts it covers | `chat_prompts.msgids` (JSON array) |
| Serving | `attachPrompts()` in `chat/chatmessage.go` fills `ChatMessage.prompt` |
| Answering | `POST /chat/{id}/message/{mid}/prompt` |
| Rendering | `ChatMessagePrompt.vue`, one `ChatPromptPost.vue` per post |

Answering is server-side only: the server applies what the answer *means* (`messages.deadline`,
`messages.deliverypossible`) as well as recording it, so no client has to know what "by this
weekend" resolves to and two clients cannot disagree. Rules enforced: only the addressee, only an
option that was offered, only once, and not after expiry - an old question still renders, but its
buttons stop working.

## Schema

`Prompt` added to the `chat_messages.type` ENUM, plus `chat_prompts` and the `firstreply_*`
tables (the answer path increments `firstreply_event_metrics`). Empty tables until sending lands.

## Tests

Go 3887 passed, vitest 14781 passed across 700 files, docs-freshness gate green.
`chatprompt_test.go` covers serving a prompt with its options and every answer rule;
`ChatMessage.spec.js` gains a test that an unknown future type renders as text, not a dump.

Reference: `docs/developers/reference/chat-prompts.md`.
