### PR TITLE
fix(compose): a photo stuck mid-upload no longer bricks posting for good

### DIFF
--- a/iznik-nuxt3/components/PhotoCard.vue
+++ b/iznik-nuxt3/components/PhotoCard.vue
@@ -41,11 +41,13 @@
       </div>
     </div>
 
-    <!-- Controls (when selected and not uploading) -->
-    <template v-if="selected && !uploading && !error">
-      <!-- Rotate button -->
+    <!-- Controls (when selected).  Delete stays available while uploading:
+         an upload that never settles otherwise leaves no way out at all,
+         because Skip and Next are both unavailable too. -->
+    <template v-if="selected && !error">
+      <!-- Rotate button - needs a photo that made it to the server -->
       <button
-        v-if="showRotate"
+        v-if="showRotate && !uploading"
         class="control-button control-rotate"
         title="Rotate"
         @click.stop="emit('rotate')"

--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -24,6 +24,9 @@ export const useComposeStore = defineStore({
   id: 'compose',
   persist: {
     storage: piniaPluginPersistedstate.localStorage(),
+    // Transient upload state must not survive a reload - see
+    // sanitiseRestoredAttachments() for what goes wrong when it does.
+    afterHydrate: (ctx) => ctx.store.sanitiseRestoredAttachments(),
   },
   // We allow composing of multiple posts for the same location/email, so messages and attachments are indexed by
   // id.  The id is a client-only index; it becomes a real id once the items are posted.
@@ -382,6 +385,45 @@ export const useComposeStore = defineStore({
       this.ensureMessage(id)
       this.messages[id].attachments = attachments
       this.attachmentBump++
+    },
+    // PhotoUploader puts a photo into attachments with uploading:true BEFORE
+    // the upload finishes, and this store persists to localStorage - so an
+    // upload interrupted by a reload or a navigation leaves uploading:true on
+    // disk with nothing left running to clear it.  Nothing else ever resets
+    // it, and the give flow hides Skip and the delete control and disables
+    // Next while a photo is uploading, so the member was locked out of posting
+    // on that device until they cleared site data (Discourse SR-B9W2Q).
+    //
+    // Reconcile on hydrate.  An attachment that never reached the server has
+    // only a preview blob: URL, which died with the page that made it, so
+    // there is nothing left to show and it goes.  One that did reach the
+    // server is simply no longer uploading.
+    sanitiseRestoredAttachments() {
+      let changed = false
+
+      for (const message of this.messages) {
+        if (!message?.attachments?.length) {
+          continue
+        }
+
+        const kept = message.attachments.filter((a) => !a?.uploading || a?.id)
+
+        if (kept.length !== message.attachments.length) {
+          message.attachments = kept
+          changed = true
+        }
+
+        for (const attachment of kept) {
+          if (attachment?.uploading) {
+            attachment.uploading = false
+            changed = true
+          }
+        }
+      }
+
+      if (changed) {
+        this.attachmentBump++
+      }
     },
     removeAttachment(params) {
       console.log('Remove attachment', JSON.stringify(params))

--- a/iznik-nuxt3/tests/unit/components/PhotoCard.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PhotoCard.spec.js
@@ -133,10 +133,20 @@ describe('PhotoCard', () => {
       expect(wrapper.find('.control-delete').exists()).toBe(false)
     })
 
-    it('hides control buttons when uploading', () => {
+    // An upload that never settles used to leave the member with no way to
+    // get rid of the photo - no delete here, no Skip, and Next disabled - so
+    // keep delete reachable while uploading.  Rotate still needs a server-side
+    // photo, so it stays hidden.
+    it('keeps delete available while uploading, but hides rotate', () => {
       const wrapper = createWrapper({ selected: true, uploading: true })
       expect(wrapper.find('.control-rotate').exists()).toBe(false)
-      expect(wrapper.find('.control-delete').exists()).toBe(false)
+      expect(wrapper.find('.control-delete').exists()).toBe(true)
+    })
+
+    it('emits remove when deleting a photo that is still uploading', async () => {
+      const wrapper = createWrapper({ selected: true, uploading: true })
+      await wrapper.find('.control-delete').trigger('click')
+      expect(wrapper.emitted('remove')).toBeTruthy()
     })
 
     it('hides control buttons when error state', () => {

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -333,6 +333,98 @@ describe('compose store', () => {
     })
   })
 
+  // A photo is pushed into the attachments with uploading:true BEFORE the
+  // upload finishes, and this store persists to localStorage - so an
+  // interrupted upload (reload, navigation, abort) leaves uploading:true on
+  // disk with nothing left running to clear it. On the mobile give flow that
+  // permanently disabled Next, hid the delete control and hid Skip, locking
+  // the member out of posting on that device until they cleared site data.
+  describe('sanitiseRestoredAttachments', () => {
+    let store
+
+    beforeEach(() => {
+      store = useComposeStore()
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      store.add()
+      logSpy.mockRestore()
+    })
+
+    it('drops an attachment left mid-upload with no server id', () => {
+      // Its preview is a blob: URL that died with the previous page, and it
+      // has no server id, so there is nothing recoverable to show.
+      store.messages[0].attachments = [
+        {
+          tempId: 'temp-1',
+          preview: 'blob:https://www.ilovefreegle.org/dead',
+          uploading: true,
+          progress: 100,
+          error: false,
+        },
+      ]
+
+      store.sanitiseRestoredAttachments()
+
+      expect(store.messages[0].attachments).toEqual([])
+    })
+
+    it('clears uploading on an attachment that did reach the server', () => {
+      store.messages[0].attachments = [
+        {
+          id: 45447044,
+          path: 'https://x/img.jpg',
+          uploading: true,
+          progress: 100,
+        },
+      ]
+
+      store.sanitiseRestoredAttachments()
+
+      expect(store.messages[0].attachments).toHaveLength(1)
+      expect(store.messages[0].attachments[0].uploading).toBe(false)
+      expect(store.messages[0].attachments[0].id).toBe(45447044)
+    })
+
+    it('leaves completed attachments untouched', () => {
+      const done = [
+        { id: 1, path: 'a.jpg' },
+        { id: 2, path: 'b.jpg' },
+      ]
+      store.messages[0].attachments = [...done]
+
+      store.sanitiseRestoredAttachments()
+
+      expect(store.messages[0].attachments).toEqual(done)
+    })
+
+    it('keeps the good photos when only one was mid-upload', () => {
+      store.messages[0].attachments = [
+        { id: 1, path: 'a.jpg' },
+        { tempId: 'temp-9', preview: 'blob:dead', uploading: true },
+        { id: 2, path: 'b.jpg' },
+      ]
+
+      store.sanitiseRestoredAttachments()
+
+      expect(store.messages[0].attachments.map((a) => a.id)).toEqual([1, 2])
+    })
+
+    it('bumps attachmentBump so the UI re-reads', () => {
+      const before = store.attachmentBump
+      store.messages[0].attachments = [{ tempId: 't', uploading: true }]
+
+      store.sanitiseRestoredAttachments()
+
+      expect(store.attachmentBump).toBeGreaterThan(before)
+    })
+
+    it('copes with messages that have no attachments', () => {
+      store.messages[0].attachments = undefined
+      store.messages.push(null)
+
+      expect(() => store.sanitiseRestoredAttachments()).not.toThrow()
+    })
+  })
+
   describe('deleteMessage', () => {
     it('removes message by id', () => {
       const store = useComposeStore()


### PR DESCRIPTION
## What was wrong

A member could not post an OFFER from their phone at all. Their last photo sat at 100% in the progress circle, Next was greyed out, Skip was not there, and there was no way to delete the photo - only drag it around. Refreshing, logging out and logging back in changed nothing.

Reported through the AI Support Helper, **SR-B9W2Q**.

## Root cause

`PhotoUploader` pushes a photo into the attachments with `uploading: true` *before* the upload finishes, and `stores/compose.js` persists to `localStorage`. An upload interrupted by a reload or a navigation therefore writes `uploading: true` to disk with nothing left running to clear it - and nothing anywhere resets it on the way back in.

The give flow then removes every exit at once:

| Escape | Why it was gone |
|---|---|
| Next | `:disabled="anyUploading"` in `pages/give/mobile/photos.vue` |
| Delete / rotate | `PhotoCard` rendered its controls only `v-if="selected && !uploading && !error"` |
| Skip | only rendered inside the empty state, `v-if="photos.length === 0"` |

Thumbnails offer drag-reorder and nothing else, which is exactly the "all he can do is move their position about" in the report.

## Evidence from production

The uploads were never the problem. For that member on 6 Aug: **21 × `POST /apiv2/image`, every one HTTP 200 in 1-14ms**, and 20 client-side `upload_succeeded`.

What the client logs show instead:

```
08:16:45  upload_succeeded ×3          <- last upload completes
08:17:38  page_view /give/mobile/photos <- full reload, nothing in flight
08:17:40-54  click: Next ×25, dblclick ×4   <- still dead
08:18:02  session_start (new session)   <- logged out and back in
08:18:08-13  click: Next ×12            <- still dead
```

Next was dead 53 seconds after the last upload finished, across a reload *and* a re-login - the state was purely rehydrated `localStorage`. They were still stuck at 13:53, five and a half hours later: 65 `click: Next` and 30 `click: 100%` (tapping the frozen overlay) across the day. They gave up and used `/find/mobile/photos`, which is a different draft and worked fine.

## The fix

**Reconcile on hydrate** (`afterHydrate` -> `sanitiseRestoredAttachments()`):

- an attachment that never reached the server has only a `preview` blob: URL, which died with the page that created it, so there is nothing recoverable to show - it goes, which restores the empty state and with it Skip;
- one that did reach the server is simply no longer uploading, so the flag is cleared and the photo is kept.

This repairs members who are **already stuck**, on their next page load, without them having to clear site data.

**Keep delete reachable while uploading** (`PhotoCard`), so a hang that happens live is escapable without a reload. Rotate needs a server-side photo, so it stays hidden.

## Deliberately not in this PR

Two other never-settling paths turned up while tracing this. Neither caused this bug, and both need their own thought about Sentry noise:

- `BaseAPI.$requestv2` returns `new Promise(function (resolve) {})` when a request is aborted (`api/BaseAPI.js:227` and `:245`);
- `miscStore.waitForOnline()` polls forever with no timeout.

Any caller awaiting either hangs for good.

## Testing

- 8 new unit tests (6 on the store reconciliation, 2 on the delete control), each watched to fail first.
- One existing `PhotoCard` test asserted the old "hide delete while uploading" behaviour and has been updated - it encoded the bug.
- Full vitest suite green.
- Verified in a real browser: poisoned `localStorage` with the exact stuck attachment shape, reloaded, and confirmed the attachment is dropped, the empty state and a clickable Skip return, and no progress overlay or dead Next remains.
