### PR TITLE
fix(ModTools mobile app): clamp OS accessibility text zoom so the app shell doesn't break

### DIFF
--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -21,6 +21,11 @@ import { useDebugStore } from '~/stores/debug'
 import { setAppVersion, useClientLog } from '~/composables/useClientLog'
 import api from '~/api'
 
+// Ceiling for the OS-preferred text zoom we'll apply to the WebView - the
+// standard Android "Largest" font-size step / non-accessibility Dynamic Type
+// max. See initTextZoom().
+const MAX_TEXT_ZOOM = 1.3
+
 // Helper to get debug store safely (may not be initialized early)
 function dbg() {
   try {
@@ -182,6 +187,13 @@ export const useMobileStore = defineStore({
       // (Dynamic Type on iOS, font scale on Android); applying it makes text
       // grow WITH REFLOW, unlike pinch zoom which scales the whole viewport
       // including the navbars.
+      //
+      // Clamp to the standard OS font-size slider's max (Android's "Largest" /
+      // iOS's non-accessibility Dynamic Type ceiling). Samsung's separate
+      // Accessibility > Font size setting can push Configuration.fontScale up to
+      // ~3x, which the ModTools/app shell's fixed-width navbar and left menu were
+      // never designed to reflow at - applying it uncapped breaks that chrome
+      // (reported as the screen looking "narrower" after an app update).
       try {
         const { TextZoom } = await import('@capacitor/text-zoom')
 
@@ -189,8 +201,12 @@ export const useMobileStore = defineStore({
           try {
             const { value } = await TextZoom.getPreferred()
             if (value && value > 0) {
-              await TextZoom.set({ value })
-              dbg()?.info('Applied preferred text zoom', { value })
+              const clamped = Math.min(value, MAX_TEXT_ZOOM)
+              await TextZoom.set({ value: clamped })
+              dbg()?.info('Applied preferred text zoom', {
+                value,
+                clamped,
+              })
             }
           } catch (e) {
             dbg()?.debug('Text zoom apply failed', e?.message)

--- a/iznik-nuxt3/tests/unit/stores/mobile.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/mobile.spec.js
@@ -71,7 +71,9 @@ const mockSessionStart = vi.fn()
 const mockSetAppVersion = vi.fn()
 vi.mock('~/composables/useClientLog', () => ({
   setAppVersion: (...args) => mockSetAppVersion(...args),
-  useClientLog: () => ({ sessionStart: (...args) => mockSessionStart(...args) }),
+  useClientLog: () => ({
+    sessionStart: (...args) => mockSessionStart(...args),
+  }),
 }))
 
 vi.mock('~/stores/debug', () => ({
@@ -1064,10 +1066,10 @@ describe('mobile store', () => {
       )
 
       // Member changes the OS setting while we're backgrounded.
-      mockTextZoomGetPreferred.mockResolvedValue({ value: 1.5 })
+      mockTextZoomGetPreferred.mockResolvedValue({ value: 1.15 })
       await app.fire('resume')
 
-      expect(mockTextZoomSet).toHaveBeenLastCalledWith({ value: 1.5 })
+      expect(mockTextZoomSet).toHaveBeenLastCalledWith({ value: 1.15 })
     })
 
     it('does not set a zoom when the preferred value is unusable', async () => {
@@ -1077,6 +1079,23 @@ describe('mobile store', () => {
       await store.initTextZoom(fakeApp())
 
       expect(mockTextZoomSet).not.toHaveBeenCalled()
+    })
+
+    // Samsung's "Accessibility > Font size and style" setting (distinct from the
+    // standard Display font-size slider, whose max is 1.3 - see the "applies the
+    // preferred zoom on startup" test above) can push Configuration.fontScale up
+    // to ~3.0. Applying that directly to the WebView blows up ModTools' fixed-width
+    // navbar/left-menu shell (min-width/px-based, not designed to reflow at 2-3x
+    // text size), which is what topic 10010/1 reported as the screen "narrower" /
+    // differently sized after upgrading the app. Clamp to the standard slider's
+    // max so extreme accessibility settings can't break the shell chrome.
+    it('clamps an extreme preferred zoom so the ModTools shell does not break', async () => {
+      mockTextZoomGetPreferred.mockResolvedValue({ value: 2.6 })
+      const store = useMobileStore()
+
+      await store.initTextZoom(fakeApp())
+
+      expect(mockTextZoomSet).toHaveBeenCalledWith({ value: 1.3 })
     })
 
     it('survives the plugin being unavailable', async () => {


### PR DESCRIPTION
## Root Cause
`initTextZoom()` in `stores/mobile.js` (shared by the FD and ModTools Capacitor apps) applies `Configuration.fontScale` (Android) / Dynamic Type (iOS) to the WebView uncapped via `@capacitor/text-zoom`. Samsung's separate "Accessibility > Font size and style" setting can push `fontScale` up to ~3x the standard slider's max of 1.3. Applying that directly distorts ModTools' fixed-width mobile shell (navbar, left menu - `min-width`/px-based, never designed to reflow at 2-3x text size), which reads to the member as the screen having become "narrower" or differently sized.

No prior attempt found for this area.

## Evidence
- `git log` shows commit `1ac245d47` ("respect the OS accessibility text-size setting") landed 2026-08-03, three days before this report, and is the only layout/text-scaling change to the shared app shell in the last 30 days.
- The reporter is on a Samsung Galaxy and says the change appeared "just" after upgrading the ModTools app - consistent with picking up that commit in a new build.
- "The chrome browser version of ModTools is unaffected" - `@capacitor/text-zoom` only runs inside the native Capacitor WebView (`stores/mobile.js` `initApp()`), never on the web build, which matches the reported scope exactly.
- Confirmed via the plugin's Android source (`TextZoom.java`) that `getPreferred()` returns `Configuration.fontScale` directly, unclamped.

## Fix
Clamp the applied zoom to `MAX_TEXT_ZOOM = 1.3` (the standard, non-accessibility-extreme Android "Largest" font-size step) in `stores/mobile.js`. Members with a moderate readability preference (up to 1.3, e.g. Android's standard slider) still get the full accessibility benefit; only the extreme Samsung-accessibility range that breaks the fixed-width shell is capped.

## Other Call Sites
`initTextZoom` has one caller (`initApp()` in the same file). `stores/mobile.js` is imported directly by both the FD and ModTools apps (no ModTools-specific override), so the fix protects both.

## Test
`tests/unit/stores/mobile.spec.js` - added a case asserting a 2.6 preferred zoom (Samsung accessibility range) is clamped to 1.3 before being applied; confirmed it fails against the pre-fix code (asserts 1.3, pre-fix code calls `set` with 2.6) and passes after the fix. Updated an existing case that asserted an uncapped 1.5 was applied verbatim to use 1.15 (within the new cap) so it continues to test resume re-application distinctly from the new clamp behaviour. Full `tests/unit/stores/mobile.spec.js` run: 67/67 passing (verified just before opening this PR).

## Discourse
https://discourse.ilovefreegle.org/t/10010/1