### PR TITLE
fix(app): stop a failed version check costing the app its back button

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -267,12 +267,22 @@ workflows:
             branches:
               only:
                 - production
-      - freegle/auto-submit-ios:
+      - freegle/auto-release-ios:
           filters:
             branches:
               only:
                 - production
-      - freegle/auto-release-ios:
+      # MUST follow auto-release-ios. Only one version can sit in the App Store
+      # submission pipeline at a time, and auto-submit refuses to run (by
+      # design, so a stall is never silent) while a version is
+      # PENDING_DEVELOPER_RELEASE. Run in parallel these two race: on
+      # 2026-08-05 auto-submit-ios failed at 22:07:33 on blocking version
+      # 100.0.873, which auto-release-ios then released successfully at
+      # 22:09:43 — the blocker was cleared two minutes after the job that
+      # tripped over it gave up.
+      - freegle/auto-submit-ios:
+          requires:
+            - freegle/auto-release-ios
           filters:
             branches:
               only:

--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -81,7 +81,11 @@ export const useMobileStore = defineStore({
           platform
         )
         this.mobileVersion = config.public.MOBILE_VERSION
-        this.initApp()
+        // Deliberately not awaited, but DO catch: unhandled rejections here are
+        // invisible on device, and this promise covers the whole of app init.
+        this.initApp().catch((e) => {
+          console.log('initApp failed:', e?.message)
+        })
       } else {
         console.log('Mobile store initialized - running in web browser')
       }
@@ -105,6 +109,17 @@ export const useMobileStore = defineStore({
       // to the share flow - which delayed the give-flow navigation on a
       // share-triggered cold start with nothing on screen in the meantime.
       this.initShareIntent(App)
+
+      // Register the App-plugin listeners FIRST. They need nothing but `App`,
+      // and everything below here can reject: initApp() has no try/catch and
+      // its caller neither awaits nor catches it, so one failed await used to
+      // silently abandon the rest of init. When that happened the back button
+      // was never registered and Capacitor's native default swallowed the back
+      // gesture at the root — trapping the user in the app, the very thing the
+      // handler exists to prevent. Registering up front means a later failure
+      // can cost us a version check, but never the back button.
+      this.initBackButton(App)
+      this.initWakeUpActions(App)
 
       // Log app and plugin versions for debugging
       const runtimeConfig = useRuntimeConfig()
@@ -151,8 +166,6 @@ export const useMobileStore = defineStore({
       this.initTextZoom(App)
       await this.initPushNotifications(PushNotifications, Badge)
       await this.checkForAppUpdate()
-      this.initWakeUpActions(App)
-      this.initBackButton(App)
     },
 
     // Log a second session_start now that we know both the real installed app
@@ -922,16 +935,26 @@ export const useMobileStore = defineStore({
         ? 'app_fd_version_ios_required'
         : 'app_fd_version_android_required'
 
-      const reqdValues = await api(this.config).config.fetchv2(requiredKey)
-      if (reqdValues && reqdValues.length === 1) {
-        const requiredVersion = reqdValues[0].value
-        if (requiredVersion) {
-          this.apprequiredversion = requiredVersion
-          if (this.versionOutOfDate(requiredVersion)) {
-            this.appupdaterequired = true
-            console.log('==========appupdate required!')
+      // Best-effort: this runs partway through initApp(), which has no
+      // try/catch and is called without await or .catch(). An APIError from
+      // this fetch (offline cold start, slow or failing API) used to escape as
+      // a silent unhandled rejection and abandon the REST of app init — which
+      // is where the back button and resume handlers get registered. Never let
+      // a version check cost the app its back button.
+      try {
+        const reqdValues = await api(this.config).config.fetchv2(requiredKey)
+        if (reqdValues && reqdValues.length === 1) {
+          const requiredVersion = reqdValues[0].value
+          if (requiredVersion) {
+            this.apprequiredversion = requiredVersion
+            if (this.versionOutOfDate(requiredVersion)) {
+              this.appupdaterequired = true
+              console.log('==========appupdate required!')
+            }
           }
         }
+      } catch (e) {
+        console.log('Failed to check for app update:', e?.message)
       }
     },
 

--- a/iznik-nuxt3/tests/unit/stores/mobile.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/mobile.spec.js
@@ -141,8 +141,9 @@ describe('mobile store', () => {
       const store = useMobileStore()
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       mockPlatform = 'ios'
-      // Mock initApp to avoid Capacitor imports
-      store.initApp = vi.fn()
+      // Mock initApp to avoid Capacitor imports. It is async and init()
+      // attaches a .catch() to it, so the stub must return a promise.
+      store.initApp = vi.fn().mockResolvedValue(undefined)
       store.init({ public: { MOBILE_VERSION: '2.0.0' } })
       expect(store.isApp).toBe(true)
       expect(store.isiOS).toBe(true)
@@ -155,10 +156,32 @@ describe('mobile store', () => {
       const store = useMobileStore()
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       mockPlatform = 'android'
-      store.initApp = vi.fn()
+      store.initApp = vi.fn().mockResolvedValue(undefined)
       store.init({ public: { MOBILE_VERSION: '2.0.0' } })
       expect(store.isApp).toBe(true)
       expect(store.isiOS).toBe(false)
+      logSpy.mockRestore()
+    })
+
+    // initApp() is deliberately not awaited, so a rejection has nowhere to go.
+    // Left uncaught it is invisible on device, which is how a failed config
+    // fetch silently cost the app its back-button handler.
+    it('catches an initApp rejection instead of leaving it unhandled', async () => {
+      const store = useMobileStore()
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const unhandled = vi.fn()
+      process.on('unhandledRejection', unhandled)
+      mockPlatform = 'android'
+      store.initApp = vi.fn().mockRejectedValue(new Error('init exploded'))
+
+      expect(() =>
+        store.init({ public: { MOBILE_VERSION: '2.0.0' } })
+      ).not.toThrow()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      process.off('unhandledRejection', unhandled)
+      expect(unhandled).not.toHaveBeenCalled()
+      expect(logSpy).toHaveBeenCalledWith('initApp failed:', 'init exploded')
       logSpy.mockRestore()
     })
   })
@@ -493,6 +516,24 @@ describe('mobile store', () => {
       mockConfigFetchv2.mockResolvedValue([{ value: '1.0.0' }])
 
       await store.checkForAppUpdate()
+      expect(store.appupdaterequired).toBe(false)
+    })
+
+    // This check is best-effort and runs partway through initApp(), which has
+    // no try/catch and is called without await or .catch(). When the config
+    // fetch threw, the rejection escaped initApp() as a silent unhandled
+    // rejection and every later step was skipped — including
+    // initBackButton(), so no JS backButton listener was ever registered and
+    // Capacitor's native default swallowed the back gesture at the root. A
+    // failed version check must never cost the app its back button.
+    it('swallows an API failure instead of rejecting', async () => {
+      const store = useMobileStore()
+      store.config = { public: {} }
+      store.isiOS = false
+
+      mockConfigFetchv2.mockRejectedValue(new Error('Network request failed'))
+
+      await expect(store.checkForAppUpdate()).resolves.toBeUndefined()
       expect(store.appupdaterequired).toBe(false)
     })
 


### PR DESCRIPTION
## Summary

The Android back button still trapped users after the fix that was meant to free them (`652b27f6f`). That fix was correct, and its unit tests pass — which is exactly why the problem survived review. The handler simply never ran.

`initApp()` registered it as the very last thing it did, behind `await this.checkForAppUpdate()`:

```js
await this.checkForAppUpdate()   // throws APIError on any network failure
this.initWakeUpActions(App)      // never runs
this.initBackButton(App)         // never runs
```

`checkForAppUpdate()` awaited a config fetch with no `try/catch`, and `BaseAPI` throws `APIError` on failure — an offline cold start, a slow or 500-ing API. `initApp()` has no `try/catch` either, and its caller neither awaited nor caught it, so the rejection vanished as an unhandled rejection, invisible on device, and everything after it was skipped. With no JS `backButton` listener registered, Capacitor's native default took over and swallowed the back gesture once the webview history emptied — precisely the trap the original fix existed to escape.

`initWakeUpActions()` sits on the line above, so the same failure also cost the app its resume handling: notification counts, chat refresh and push re-registration.

Three changes, so no single failure can strand the rest again:

- `checkForAppUpdate()` swallows its own errors. It is best-effort and must never take the rest of init down with it.
- `initBackButton()` and `initWakeUpActions()` register immediately after the `App` import, before anything that can reject. They need nothing but `App`.
- `init()` attaches a `.catch()` to the deliberately-unawaited `initApp()`, so a future failure is logged rather than silent.

Also included: in the `manual-promote-submit` workflow, `auto-submit-ios` now requires `auto-release-ios`.

`auto-submit-ios` fails, deliberately rather than warning, while any version sits in `PENDING_DEVELOPER_RELEASE`, so a stalled iOS release cannot pass silently. `auto-release-ios` is the job that clears that state. With both scheduled in parallel the workflow's outcome depended on which finished first: if the submit checked before the release completed, it failed on a blocker that was about to be removed, reddening the promote with nothing wrong. The dependency makes the ordering deterministic.

## Code Quality Review

- Registering the listeners early is the structural fix; the `try/catch` and the `.catch()` are defence in depth. Any one of the three would have prevented this specific failure, but only the ordering change protects the handler from whatever gets added to `initApp()` next.
- `checkForAppUpdate()` logs the swallowed error rather than discarding it silently, so a persistently failing version check is still diagnosable.
- The two `init` platform tests stubbed `initApp` with `vi.fn()`, returning `undefined`; they now stub it as the async method it actually is. That mismatch was a real gap — the stub did not represent the function it replaced.
- No production code was made defensive to accommodate a test mock.

## Future Improvements

- `initApp()` is a long sequence of independent init steps sharing one failure domain. Wrapping each step individually (or driving them from a list with per-step error handling) would remove this class of bug rather than this instance of it.
- Nothing asserts that `initApp()` actually reaches its later steps; the dynamic Capacitor imports make that awkward to test. A seam for those imports would let the whole sequence be covered.

## Test Plan

- Full Vitest suite via the status API: **14767 passed, 0 failed** (698 files).
- Go suite: **3880 passed**. Laravel suite: **5259 passed**. Both required the local `freegle-batch` container to be recreated first: it predated the `ripple_join` migration (leaving `was_ripple_join` absent from the cloned Go test schema) and the `orm-migration-manifest` mount. No code change was needed for either.
- New: `checkForAppUpdate` resolves rather than rejecting when the API throws, leaving `appupdaterequired` false.
- New: `init()` catches an `initApp` rejection — asserts no `unhandledRejection` fires and the failure is logged.
- `.circleci/continue-config.yml` validated with `circleci config validate`.
- Not verified on device: this needs an Android build to confirm the back gesture now exits from the root.
