### PR TITLE
fix(ModTools): show Approve button after member posting-status change

### DIFF
--- a/iznik-nuxt3/modtools/stores/member.js
+++ b/iznik-nuxt3/modtools/stores/member.js
@@ -261,6 +261,23 @@ export const useMemberStore = defineStore({
 
     async updateMembership(params) {
       await api(this.config).memberships.save(params)
+
+      /*
+       * ourPostingStatus gates the Approve button on a pending message
+       * elsewhere (ModMessage.vue's membership computed feeds
+       * ModMessageButtons' :cantpost prop). No event tells the frontend
+       * about the write, so the cached userStore entry for params.userid
+       * keeps the pre-change value and that gate keeps failing on the next
+       * render - a mod flipping Can't Post -> Moderated on the pending
+       * message's own page (ModModeration.vue) saw no Approve button appear
+       * until something unrelated forced a re-fetch (Discourse #10008 post
+       * 1). Force-refresh the cached entry so the next render picks up the
+       * new posting status.
+       */
+      if (params.userid && params.ourPostingStatus) {
+        const userStore = useUserStore()
+        await userStore.fetch(params.userid, true)
+      }
     },
 
     async remove(userid, groupid, membershipid) {
@@ -315,8 +332,13 @@ export const useMemberStore = defineStore({
        * "Trainee not showing as a Mod in the group logs" report on
        * Discourse #9481 post 545. Force-refresh the cached entry so the
        * next render picks up the new systemrole.
+       *
+       * ourPostingStatus (e.g. changed via ModSupportMembership.vue) needs
+       * the same treatment: it gates the Approve button on a pending
+       * message elsewhere and otherwise stays stale in the cache
+       * (Discourse #10008 post 1).
        */
-      if (params.userid && params.role) {
+      if (params.userid && (params.role || params.ourPostingStatus)) {
         const userStore = useUserStore()
         await userStore.fetch(params.userid, true)
       }

--- a/iznik-nuxt3/tests/unit/stores/member.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/member.spec.js
@@ -7,6 +7,7 @@ const mockFetchMembers = vi.fn()
 const mockMergeAsk = vi.fn().mockResolvedValue()
 const mockMergeIgnore = vi.fn().mockResolvedValue()
 const mockMembershipsUpdate = vi.fn().mockResolvedValue({ ret: 0 })
+const mockMembershipsSave = vi.fn().mockResolvedValue({ ret: 0 })
 
 vi.mock('~/api', () => ({
   default: () => ({
@@ -15,6 +16,7 @@ vi.mock('~/api', () => ({
       remove: mockRemoveMember,
       fetchMembers: mockFetchMembers,
       update: mockMembershipsUpdate,
+      save: mockMembershipsSave,
     },
     merge: {
       ask: mockMergeAsk,
@@ -453,6 +455,24 @@ describe('member store', () => {
       expect(mockUserStoreFetch).not.toHaveBeenCalled()
     })
 
+    it('force-refreshes on an ourPostingStatus change too (Discourse 10008/1)', async () => {
+      // ModSupportMembership.vue changes a member's posting status through this
+      // action. Like the role case above, the cached userStore entry is not
+      // otherwise invalidated, so a pending message's Approve button (gated on
+      // membership.ourpostingstatus !== 'PROHIBITED') keeps reading the stale
+      // pre-change value.
+      const store = useMemberStore()
+      store.config = {}
+
+      await store.update({
+        userid: 42,
+        groupid: 7,
+        ourPostingStatus: 'MODERATED',
+      })
+
+      expect(mockUserStoreFetch).toHaveBeenCalledWith(42, true)
+    })
+
     it('does NOT force-refresh when role is set but userid is missing (defensive: bad caller, nothing to invalidate)', async () => {
       const store = useMemberStore()
       store.config = {}
@@ -477,6 +497,65 @@ describe('member store', () => {
       })
 
       expect(data).toEqual({ ret: 0, status: 'Success' })
+    })
+  })
+
+  /*
+   * Regression — Discourse #10008 post 1. A mod on a pending message's own page
+   * used ModModeration.vue (embedded via ModMessageUserInfo.vue) to change a TN
+   * member's posting status from PROHIBITED ("Can't Post") to MODERATED. That
+   * control calls memberStore.updateMembership (a separate action from update(),
+   * though both PATCH the same /memberships endpoint) which never force-refreshed
+   * the cached userStore entry. ModMessage.vue's own `membership` computed reads
+   * that same cached entry to decide whether to show the Approve button
+   * (:cantpost="membership.ourpostingstatus === 'PROHIBITED'"), so it kept
+   * reading the stale PROHIBITED value and hid Approve until something unrelated
+   * (e.g. a full page reload) eventually re-fetched the user.
+   */
+  describe('updateMembership — force-refresh userStore on posting-status change (Discourse 10008/1)', () => {
+    it('calls userStore.fetch(userid, true) when params include ourPostingStatus', async () => {
+      const store = useMemberStore()
+      store.config = {}
+
+      await store.updateMembership({
+        userid: 42,
+        groupid: 7,
+        ourPostingStatus: 'MODERATED',
+      })
+
+      expect(mockMembershipsSave).toHaveBeenCalledWith({
+        userid: 42,
+        groupid: 7,
+        ourPostingStatus: 'MODERATED',
+      })
+      expect(mockUserStoreFetch).toHaveBeenCalledTimes(1)
+      expect(mockUserStoreFetch).toHaveBeenCalledWith(42, true)
+    })
+
+    it('does NOT force-refresh when params lack ourPostingStatus (e.g. an emailfrequency-only patch from ModStdMessageModal)', async () => {
+      const store = useMemberStore()
+      store.config = {}
+
+      await store.updateMembership({
+        userid: 42,
+        groupid: 7,
+        emailfrequency: 24,
+      })
+
+      expect(mockMembershipsSave).toHaveBeenCalled()
+      expect(mockUserStoreFetch).not.toHaveBeenCalled()
+    })
+
+    it('does NOT force-refresh when ourPostingStatus is set but userid is missing (defensive: bad caller, nothing to invalidate)', async () => {
+      const store = useMemberStore()
+      store.config = {}
+
+      await store.updateMembership({
+        groupid: 7,
+        ourPostingStatus: 'MODERATED',
+      })
+
+      expect(mockUserStoreFetch).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
No prior attempt found for this area (searched PRs/commits for "approve button posting status"; only match was an unrelated open PR #639 about post-moderation auto-publish).

## Root Cause

A mod viewing a pending message's own page can change the member's posting status right there via `ModModeration.vue` (embedded through `ModMessageUserInfo.vue`), which calls `memberStore.updateMembership()`. That action PATCHed `/memberships` but never invalidated the cached `userStore` entry for that user. No event tells the frontend the write happened, so `ModMessage.vue`'s `membership` computed (`modtools/components/ModMessage.vue:1239`, sourced from `fromUser.value.memberships` i.e. `userStore.byId(...)`) kept returning the stale `ourpostingstatus: 'PROHIBITED'`, and `ModMessage.vue:759` (`:cantpost="membership && membership.ourpostingstatus === 'PROHIBITED'"`) kept hiding the Approve button in `ModMessageButtons.vue` even though the DB write had already succeeded.

The same class of bug exists in `memberStore.update()`, used by `ModSupportMembership.vue`'s posting-status selector on the member support page — it only force-refreshed the cache for `role` changes (added for Discourse #9481), not for `ourPostingStatus`.

This matches the reporter's own follow-up: "the settings seem to have stuck and the approved button has appeared" some time later — the backend write succeeded immediately; only the already-open tab's cached membership snapshot was stale until something else (e.g. a full page reload) forced a re-fetch.

## Evidence (failing-test output, before fix)

```
 × member store > update — force-refresh userStore on role change > force-refreshes on an ourPostingStatus change too (Discourse 10008/1)
   → expected "spy" to be called with arguments: [ 42, true ]
   Number of calls: 0

 × member store > updateMembership — force-refresh userStore on posting-status change (Discourse 10008/1) > calls userStore.fetch(userid, true) when params include ourPostingStatus
   → expected "spy" to be called 1 times, but got 0 times
```

## Fix

`iznik-nuxt3/modtools/stores/member.js`:
- `updateMembership()` now force-refreshes the cached user (`userStore.fetch(userid, true)`) whenever the patch includes `ourPostingStatus`. This is the action used by `ModModeration.vue` (the control on the pending-message page itself) and `ModStdMessageModal.vue`.
- `update()`'s existing role-change refresh condition is extended to also cover `ourPostingStatus`, fixing the same staleness for `ModSupportMembership.vue`'s posting-status selector on the support page.

## Other Call Sites

Grepped `ourpostingstatus`/`PROHIBITED`/`updateMembership`:
- `ModModeration.vue` (`memberStore.updateMembership`) — fixed by this PR.
- `ModStdMessageModal.vue` (`memberStore.updateMembership`, standard-reply flow) — fixed by this PR (same action).
- `ModSupportMembership.vue` (`memberStore.update`) — fixed by this PR.
- `ModMemberExportButton.vue:164` — reads `ourpostingstatus` for a CSV export column only; no UI gating, not affected.
- `ModMessage.vue:414,1041` (auto-approve-eligibility checks) — read the same `membership` computed already fixed indirectly by the userStore refresh; no separate change needed.

## Test

- File: `iznik-nuxt3/tests/unit/stores/member.spec.js`
- Command: `npx vitest run tests/unit/stores/member.spec.js`
- Proves fail-before/pass-after: added `updateMembership — force-refresh userStore on posting-status change (Discourse 10008/1)` describe block plus one `update()` case; both new assertions failed against pre-fix code (see Evidence above) and pass after the fix. Also re-ran `ModModeration.spec.js`, `ModSupportMembership.spec.js`, `ModMessage.spec.js`, and `ModMessageButtons.spec.js` (all still green — no regressions).

## Discourse

https://discourse.ilovefreegle.org/t/10008/1