### PR TITLE
fix(chat): keep per-chat Mark read button visible on iOS when opening a chat

### DIFF
--- a/iznik-nuxt3/components/ChatMobileNavbar.vue
+++ b/iznik-nuxt3/components/ChatMobileNavbar.vue
@@ -18,7 +18,13 @@
         </h1>
       </div>
       <button
-        v-if="unseen && !profileCardExpanded"
+        v-if="
+          shouldShowChatMarkReadIcon(
+            unseen,
+            profileCardExpanded,
+            showProfileHint
+          )
+        "
         class="navbar-mark-read"
         @click.stop="markRead"
       >
@@ -266,7 +272,7 @@ import {
 } from '~/composables/useNavbar'
 import { useChatStore } from '~/stores/chat'
 import { useMiscStore } from '~/stores/misc'
-import { setupChat } from '~/composables/useChat'
+import { setupChat, shouldShowChatMarkReadIcon } from '~/composables/useChat'
 import { timeago } from '~/composables/useTimeFormat'
 
 const router = useRouter()

--- a/iznik-nuxt3/composables/useChat.js
+++ b/iznik-nuxt3/composables/useChat.js
@@ -69,6 +69,20 @@ function useChatShared(chatId) {
   }
 }
 
+// Whether the per-chat "Mark read" icon should show in the mobile chat
+// navbar (Discourse 10001). It must stay visible while there are unseen
+// messages and the profile card is expanded only because of the auto-shown
+// first-visit hint - not because the user deliberately tapped the avatar.
+// toggleProfileCard() clears showProfileHint as soon as the user opens the
+// card themselves, so that flag is what tells the two cases apart.
+export function shouldShowChatMarkReadIcon(
+  unseen,
+  profileCardExpanded,
+  showProfileHint
+) {
+  return !!unseen && (!profileCardExpanded || !!showProfileHint)
+}
+
 export function setupChat(selectedChatId, chatMessageId) {
   const { chatStore, authStore, myid, chat, otheruser } =
     useChatShared(selectedChatId)

--- a/iznik-nuxt3/tests/unit/composables/useChatMarkReadIcon.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useChatMarkReadIcon.spec.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { shouldShowChatMarkReadIcon } from '~/composables/useChat'
+
+// Discourse 10001: on the iOS app / mobile web, ChatMobileNavbar's per-chat
+// "Mark read" icon flashed briefly then disappeared when opening a chat,
+// unlike desktop where the equivalent button stays visible. Root cause: the
+// icon's visibility was gated on `!profileCardExpanded`, and a 500ms
+// onMounted timer auto-expands the profile card to show a first-visit hint -
+// which hid the icon even though the user never asked to see the card and
+// never marked the chat read. shouldShowChatMarkReadIcon is the extracted
+// visibility rule the template's v-if now calls, so this exercises the real
+// production logic rather than the template markup.
+describe('shouldShowChatMarkReadIcon (Discourse 10001)', () => {
+  it('stays visible when the profile card is only expanded by the auto-shown first-visit hint', () => {
+    // unseen messages exist; the 500ms hint timer has set profileCardExpanded
+    // and showProfileHint both true; the user never touched the avatar.
+    expect(shouldShowChatMarkReadIcon(3, true, true)).toBe(true)
+  })
+
+  it('hides once the user deliberately opens the profile card themselves', () => {
+    // toggleProfileCard() clears showProfileHint as soon as the user taps the
+    // avatar, so a real, deliberate expansion still hides the icon in favour
+    // of the "Mark read" action inside the expanded card.
+    expect(shouldShowChatMarkReadIcon(3, true, false)).toBe(false)
+  })
+
+  it('shows when there are unseen messages and the card is collapsed', () => {
+    expect(shouldShowChatMarkReadIcon(1, false, false)).toBe(true)
+  })
+
+  it('hides when there are no unseen messages, regardless of card state', () => {
+    expect(shouldShowChatMarkReadIcon(0, false, false)).toBe(false)
+    expect(shouldShowChatMarkReadIcon(0, false, true)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Root Cause
On the mobile navbar (`ChatMobileNavbar.vue`, rendered below the `md` breakpoint - i.e. the iOS app and mobile web), the per-chat "Mark read" icon was gated by `v-if="unseen && !profileCardExpanded"`.

Separately, for any user who hasn't dismissed the first-visit profile hint (`miscStore.vals.profileHintDismissed`, valid for 7 days), `onMounted` starts a 500ms timer that auto-expands the profile card to show that hint (`profileCardExpanded.value = true`). That hides the "Mark read" icon via the shared v-if, even though the user never asked to see the profile card and never marked the chat read. The icon reappears only once the card is dismissed/collapsed.

Desktop's `ChatHeader.vue`/`ChatPane.vue` "Mark read" buttons have no equivalent auto-expanding overlay, so there the button just stays visible whenever `unseen` is truthy - matching the reporter's "works on desktop, flashes and vanishes on iOS".

## Evidence
`npx vitest run tests/unit/composables/useChatMarkReadIcon.spec.js` against the extracted (but not yet fixed) visibility function, reproducing the old inline `unseen && !profileCardExpanded` logic:

```
 ❯ tests/unit/composables/useChatMarkReadIcon.spec.js (4 tests | 1 failed)
   × stays visible when the profile card is only expanded by the auto-shown first-visit hint
     AssertionError: expected false to be true
     ❯ tests/unit/composables/useChatMarkReadIcon.spec.js:17:55
        expect(shouldShowChatMarkReadIcon(3, true, true)).toBe(true)
```

## Fix
`iznik-nuxt3/composables/useChat.js`: added `shouldShowChatMarkReadIcon(unseen, profileCardExpanded, showProfileHint)`, a pure function encoding the visibility rule - visible while unseen, and while the card is either collapsed or only expanded via the auto-shown hint (`showProfileHint`). `toggleProfileCard()` already clears `showProfileHint` as soon as the user taps the avatar to open the card themselves, so a real, deliberate expansion still hides the icon (the full "Mark read" button inside the expanded card remains the way to mark it read in that case).

`iznik-nuxt3/components/ChatMobileNavbar.vue`: the icon's `v-if` now calls this function instead of the old inline expression.

## Other Call Sites
Grepped for `profileCardExpanded`/`showProfileHint` across the codebase - only `ChatMobileNavbar.vue` uses this pattern, so nothing else needed the same fix.

## Prior Attempts
Prior attempt(s): #1276 (closed unmerged) - diagnosed the same root cause and shipped the same v-if change (`unseen && (!profileCardExpanded || showProfileHint)`), but the monitor's adversarial review auto-closed it because its only test was a tautological source-code regex re-encoding the exact string the fix had just inserted into the template - it proved nothing about actual behaviour. This PR keeps the same root-cause diagnosis (it's the correct one) but extracts the visibility rule into an exported pure function (`shouldShowChatMarkReadIcon`) and tests it with real input/output assertions covering the hint-driven case, the deliberate-tap case, the no-unseen case, and the plain-visible case - each of which fails or passes based on actual logic, not string matching.

## Test
- File: `iznik-nuxt3/tests/unit/composables/useChatMarkReadIcon.spec.js`
- Command: `npx vitest run tests/unit/composables/useChatMarkReadIcon.spec.js`
- Proves fail-before/pass-after: reverting `shouldShowChatMarkReadIcon` to the old `!!unseen && !profileCardExpanded` logic makes the "stays visible when...auto-shown first-visit hint" test fail (`expected false to be true`); the fixed logic (`!!unseen && (!profileCardExpanded || !!showProfileHint)`) passes all 4 cases. Also re-ran `ChatMobileNavbar.spec.js` (59 tests) and `useChat.spec.js` (5 tests) - all still pass, so the change doesn't regress the existing (source-regex-based) coverage of this component or desktop behaviour, which doesn't reference `profileCardExpanded`/`showProfileHint` at all.

## Discourse
https://discourse.ilovefreegle.org/t/10001/1