### PR TITLE
fix(ModTools): keep edited pending message in pending list after save

### DIFF
--- a/iznik-nuxt3/modtools/composables/useModMessages.js
+++ b/iznik-nuxt3/modtools/composables/useModMessages.js
@@ -41,11 +41,20 @@ const pendingWorkRefresh = ref(null)
 
 // Bootstrap sets <body> overflow:hidden while a modal is open, so use that as a
 // cross-component "is any modal open?" signal. The typeof guard keeps it
-// SSR-safe (no document on the server).
-function aModalIsOpen() {
+// SSR-safe (no document on the server). A moderator editing a Pending message
+// in place (ModMessage.vue's inline Edit/Save - not a modal) sets
+// miscStore.modtoolsediting instead ("do not check for work" - stores/misc.js).
+// Treat that the same as a modal being open: otherwise a workdetail change
+// landing while editing (or in the instant after Save flips modtoolsediting
+// back off and the work-poll catches up) forces an unprotected full-list
+// reload that can drop the message the moderator just saved, reappearing only
+// on a manual page reload (Discourse 10001/2).
+function refreshMustWait() {
+  const miscStore = useMiscStore()
   return (
-    typeof document !== 'undefined' &&
-    document.body?.style?.overflow === 'hidden'
+    (typeof document !== 'undefined' &&
+      document.body?.style?.overflow === 'hidden') ||
+    !!miscStore.modtoolsediting
   )
 }
 
@@ -292,12 +301,14 @@ export function setupModMessages(reset) {
     const newTotal = Number(newVal?.total ?? 0)
     const oldTotal = Number(oldVal?.total ?? 0)
     if (newTotal > oldTotal) {
-      // ...but NOT while a modal is open. Refreshing re-renders the message
-      // list, which unmounts an open modal (e.g. a moderator part-way through
-      // typing a rejection reason) and loses their draft. Park the refresh and
-      // apply it when the modal closes (see the observer below), so the new
-      // message still appears without a manual reload.
-      if (aModalIsOpen()) {
+      // ...but NOT while a modal is open, or a message is being edited in
+      // place. Refreshing re-renders the message list, which unmounts an
+      // open modal (e.g. a moderator part-way through typing a rejection
+      // reason) - or the ModMessage a moderator is editing - and loses their
+      // draft. Park the refresh and apply it when the modal closes / editing
+      // finishes (see the observers below), so the new message still appears
+      // without a manual reload.
+      if (refreshMustWait()) {
         pendingWorkRefresh.value = newVal
         return
       }
@@ -309,7 +320,7 @@ export function setupModMessages(reset) {
     // already handled): keep the existing suppression so the list does not
     // reload under the user's feet.
     if (miscStore.deferGetMessages) return
-    if (aModalIsOpen()) {
+    if (refreshMustWait()) {
       // Park it, exactly as the total-increased branch above does. Do NOT drop
       // it: another moderator holding a message moves it from `pending` to
       // `pendingother` (see groupWork.go), so the total never changes and this
@@ -334,7 +345,7 @@ export function setupModMessages(reset) {
     typeof MutationObserver !== 'undefined'
   ) {
     const bodyOverflowObserver = new MutationObserver(() => {
-      if (pendingWorkRefresh.value && !aModalIsOpen()) {
+      if (pendingWorkRefresh.value && !refreshMustWait()) {
         const deferred = pendingWorkRefresh.value
         pendingWorkRefresh.value = null
         getMessages(deferred)
@@ -348,6 +359,20 @@ export function setupModMessages(reset) {
       onScopeDispose(() => bodyOverflowObserver.disconnect())
     }
   }
+
+  // Apply a refresh that was deferred because a message was being edited in
+  // place, as soon as editing finishes (mirrors the modal-close observer
+  // above). ModMessage.vue's save()/cancelEdit() clear modtoolsediting.
+  watch(
+    () => useMiscStore().modtoolsediting,
+    (editing) => {
+      if (!editing && pendingWorkRefresh.value && !refreshMustWait()) {
+        const deferred = pendingWorkRefresh.value
+        pendingWorkRefresh.value = null
+        getMessages(deferred)
+      }
+    }
+  )
 
   return {
     busy,

--- a/iznik-nuxt3/tests/unit/composables/useModMessages.editingAutoRefresh.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMessages.editingAutoRefresh.spec.js
@@ -1,0 +1,112 @@
+/**
+ * Discourse 10001/2: a moderator edits a Pending message in place
+ * (ModMessage.vue's inline Edit/Save - not a Bootstrap modal) and clicks
+ * Save; the row can vanish from the Pending list, reappearing only on a
+ * full page reload.
+ *
+ * ModMessage.vue already sets miscStore.modtoolsediting while an in-place
+ * edit is open ("do not check for work" - stores/misc.js), and that flag IS
+ * wired into the periodic work-count poll (useModMe.js checkWork()). But the
+ * pending-list auto-refresh guard in useModMessages.js only ever checked
+ * whether a Bootstrap modal was open (<body> overflow:hidden) before
+ * deciding to run a full getMessages() reload - it never checked
+ * modtoolsediting. So a workdetail change landing while a moderator is
+ * editing in place (or in the instant after Save flips modtoolsediting back
+ * to false and the next work-poll tick catches up) triggers an unprotected
+ * clear-and-refetch of the entire Pending list, unlike every other mutating
+ * mod action (approve/reject/hold/etc, via checkWorkDeferGetMessages), which
+ * IS covered by this same guard when a rejection-reason modal is open.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+const mockWork = ref({ pending: 0, pendingother: 0, total: 0 })
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    get work() {
+      return mockWork.value
+    },
+  }),
+}))
+
+const mockFetchMessagesMT = vi.fn()
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({
+    clearContext: vi.fn(),
+    clear: vi.fn(),
+    fetchMessagesMT: mockFetchMessagesMT,
+    get all() {
+      return []
+    },
+    getByGroup: vi.fn(() => []),
+    get context() {
+      return null
+    },
+    list: {},
+  }),
+}))
+
+const mockModtoolsediting = ref(false)
+vi.mock('@/stores/misc', () => ({
+  useMiscStore: () => ({
+    deferGetMessages: false,
+    get modtoolsediting() {
+      return mockModtoolsediting.value
+    },
+    get: vi.fn(() => undefined),
+  }),
+}))
+
+describe('useModMessages — pending list auto-refresh while inline-editing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mockWork.value = { pending: 0, pendingother: 0, total: 0 }
+    mockModtoolsediting.value = false
+    mockFetchMessagesMT.mockResolvedValue([])
+    document.body.style.overflow = ''
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    document.body.style.overflow = ''
+  })
+
+  it('defers the refresh while a message is being edited in place and applies it once editing finishes', async () => {
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { workType, collection } = setupModMessages(true)
+    collection.value = 'Pending'
+    workType.value = ['pending', 'pendingother']
+
+    await nextTick()
+    await flushPromises()
+    vi.clearAllMocks()
+
+    // The moderator starts editing a Pending message in place (ModMessage.vue
+    // startEdit() sets this).
+    mockModtoolsediting.value = true
+
+    // Meanwhile a work-count change lands - e.g. another moderator actions a
+    // different pending message, or the queued work-poll catches up.
+    mockWork.value = { pending: 1, pendingother: 0, total: 1 }
+    await nextTick()
+    await flushPromises()
+
+    // Must NOT reload the list while the moderator is editing - that unmounts
+    // the ModMessage they are working on and can drop it from the list.
+    expect(mockFetchMessagesMT).not.toHaveBeenCalled()
+
+    // Editing finishes (save() or cancelEdit() clears modtoolsediting).
+    mockModtoolsediting.value = false
+    await nextTick()
+    await flushPromises()
+
+    // The deferred refresh is now applied, same as a parked modal refresh is
+    // applied as soon as the modal closes.
+    expect(mockFetchMessagesMT).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Edit a pending message in ModTools, save it, and it could vanish from the Pending list. It wasn't lost — a page reload brought it back — but the moderator had no way to know that, so the natural reading was that saving had eaten the message.

The Pending list refreshes itself when the work counts change. That refresh clears the list and refetches it, so it already knew to wait while a dialog was open. It didn't know about editing in place, which happens on the page itself rather than in a dialog. So if the counts happened to change while someone was mid-edit, the list reloaded underneath them and the message they had just saved dropped out of view.

ModTools already tracks in-place editing, and the work-count poll already respects it. It simply wasn't wired into the refresh. Now it is: a refresh arriving during an edit is parked, and applied as soon as the edit finishes — exactly how it already handles a refresh arriving while a dialog is open.

## Code Quality Review

- The parking mechanism, the flag and the "apply it once you're done" pattern all existed. This adds the one missing connection between them rather than a new mechanism.
- Renamed `aModalIsOpen()` to `refreshMustWait()`, since it now answers a broader question and the old name would have been actively misleading.
- Every other mod action (approve, reject, hold, release, spam) already defers refreshes properly. In-place edit was the one that didn't, which is why it was the one that lost messages.
- Same class of bug as the rejection-reason dialog fix (Discourse #9737 and #9946) — that one was fixed for dialogs only.
- One other place checks for an open dialog the same way (`chats/review.vue`). It has no concept of in-place editing, so there's nothing to connect there.

## Future Improvements

Deferral is opt-in: each new mutating action has to remember to participate, and this bug is what happens when one doesn't. Having the refresh ask "is anything in progress?" rather than each action announcing itself would make the next one safe by default.

## Test Plan

New test: `iznik-nuxt3/tests/unit/composables/useModMessages.editingAutoRefresh.spec.js`.

It fails without the fix, with the refresh firing immediately mid-edit:

```
× defers the refresh while a message is being edited in place and applies it once editing finishes
  AssertionError: expected "spy" to not be called at all, but actually been called 1 times
```

With the fix it passes. Ran alongside the existing suites that cover the same code — the dialog-deferral tests, `useModMessages`, `useModMe` and `ModMessage` — 145 tests, all passing, so approve/reject/hold and the existing dialog behaviour are unaffected.

Reported at https://discourse.ilovefreegle.org/t/10001/2