### PR TITLE
feat(rippling): split held replies into first-reply and additional

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
@@ -127,6 +127,9 @@
               {{ pct(s1.held_replies_pct) }}
             </div>
             <div class="sub">of replies held (waiting for reach)</div>
+            <div v-if="heldFirstVsAdditional" class="sub muted">
+              {{ heldFirstVsAdditional }}
+            </div>
             <div v-if="heldSourceBreakdown" class="sub muted">
               held now by source: {{ heldSourceBreakdown }}
             </div>
@@ -139,8 +142,8 @@
       <p class="text-muted small mb-2">
         Each headline number over time, by the day the post entered rippling.
         Figures use fixed windows (replies within 36h, taken within 14 days) so
-        every day is measured the same way — a dashed tail marks days too
-        recent for the window to have finished, not a real decline.
+        every day is measured the same way — a dashed tail marks days too recent
+        for the window to have finished, not a real decline.
       </p>
       <div class="kpi-grid trends">
         <div v-for="t in trendCharts" :key="t.title" class="panel">
@@ -533,6 +536,25 @@ let metricsWindow = null
 const stratumLabel = computed(() =>
   stratum.value === 'all' ? 'all-density' : stratum.value
 )
+
+/*
+ * Held replies split by whether the post already had a reply from someone else at the moment
+ * this one was held. The two are not equally costly: holding the only reply a post has leaves
+ * the offerer staring at silence, while holding a later one just defers a choice they can
+ * already make. Since first replies started going through, "first" should be close to zero —
+ * a stubborn count there says the first-reply path is still holding somebody up.
+ */
+const heldFirstVsAdditional = computed(() => {
+  const s = s1.value
+  if (!s || !s.held_replies) return null
+  const additional = Number(s.held_replies_additional || 0)
+  const first = Number(s.held_replies_first || 0)
+  if (!additional && !first) return null
+  return (
+    `of which ${additional.toLocaleString()} additional ` +
+    `(post already had a reply) · ${first.toLocaleString()} first reply`
+  )
+})
 
 // Currently-held replies broken down by origin channel (email / tn / web), for the friction
 // panel - shows how many replies the new web reply-hold is capturing vs the email/TN path.

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
@@ -68,6 +68,10 @@ const FULL = {
     mean_freeglers_reached: 3261,
     held_replies: 1344,
     held_replies_pct: 10.8,
+    held_replies_first: 96,
+    held_replies_first_pct: 0.8,
+    held_replies_additional: 1248,
+    held_replies_additional_pct: 10.0,
     reply_drive_min: {
       mean_min: 17.2,
       ci_half_min: 0.85,
@@ -257,6 +261,38 @@ describe('ModSysAdminRipplingAnalytics', () => {
     expect(html).toContain('17.2') // reply drive-time
     expect(html).toContain('10.8%') // held-reply friction KPI
     expect(html).toContain('of replies held')
+    wrapper.unmount()
+  })
+
+  // Holding the only reply a post has leaves the offerer looking at silence; holding a
+  // later one just defers a choice they can already make. Since first replies started
+  // going through, the split says whether any are still being held up.
+  it('splits held replies into additional and first-reply cases', async () => {
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
+    const wrapper = mountComponent()
+    await flushPromises()
+    const html = wrapper.html()
+    expect(html).toContain('1,248 additional')
+    expect(html).toContain('post already had a reply')
+    expect(html).toContain('96 first reply')
+    wrapper.unmount()
+  })
+
+  it('omits the split when nothing is being held', async () => {
+    mockFetchAnalytics.mockResolvedValue(
+      fastOf({
+        ...FULL,
+        section1: {
+          ...FULL.section1,
+          held_replies: 0,
+          held_replies_first: 0,
+          held_replies_additional: 0,
+        },
+      })
+    )
+    const wrapper = mountComponent()
+    await flushPromises()
+    expect(wrapper.html()).not.toContain('post already had a reply')
     wrapper.unmount()
   })
 

--- a/iznik-server-go/rippling/analytics.go
+++ b/iznik-server-go/rippling/analytics.go
@@ -419,6 +419,15 @@ type Section1KPI struct {
 	// had not yet rippled to the replier's location).
 	HeldReplies    int     `json:"held_replies"`
 	HeldRepliesPct float64 `json:"held_replies_pct"`
+	// Split of the above by whether the post ALREADY had a reply from someone else when this
+	// one was held. The two cost the offerer very different things: holding the only reply a
+	// post has leaves it looking ignored, while holding a later one just defers a choice the
+	// offerer already has. Since the first-reply-through change they should be almost entirely
+	// "additional" — a non-trivial "first" count means first replies are still being held.
+	HeldRepliesFirst         int     `json:"held_replies_first"`
+	HeldRepliesFirstPct      float64 `json:"held_replies_first_pct"`
+	HeldRepliesAdditional    int     `json:"held_replies_additional"`
+	HeldRepliesAdditionalPct float64 `json:"held_replies_additional_pct"`
 }
 
 // Analytics is the on-the-fly sysadmin rippling analytics endpoint. Support/Admin only.
@@ -506,20 +515,41 @@ func Analytics(c *fiber.Ctx) error {
 	// stratumSQL toggle as 2def63211a50 above - 4 possible rendered forms,
 	// all proven by the retired ormharness (shapes.json /
 	// TestTier3Shapes_62cea0b491c9, removed in d22ba1d6c).
-	var held int
+	var heldTotal, heldAdditional int
 	go func() {
 		defer wg.Done()
+		// "Additional" means another member had already replied to the post when
+		// this reply was held, so the offerer had something to act on regardless.
+		// Judged at the moment of holding (c2.date < hr.created_at) rather than by
+		// what the post has now: a reply that arrived later cannot have made this
+		// hold harmless at the time. The replier's own message is excluded by id,
+		// and their other messages by userid, so a member replying twice does not
+		// count as company for themselves.
+		//
 		// WHERE built as a single string for ONE Where() call: GORM's
 		// clause.Where wraps any fragment containing "AND"/"OR" in an extra
 		// paren pair once there is more than one Where expression to
 		// combine (clause/where.go buildExprs), which would diverge from
 		// the golden.
-		db.Table("rippling_held_replies hr").
-			Select("COUNT(*)").
+		row := db.Table("rippling_held_replies hr").
+			Select("COUNT(*) AS total, "+
+				"COALESCE(SUM(CASE WHEN EXISTS("+
+				"SELECT 1 FROM chat_messages c2 "+
+				"WHERE c2.refmsgid = hr.msgid AND c2.type = 'Interested' "+
+				"AND c2.id <> hr.chatmsgid AND c2.userid <> hr.replieruserid "+
+				"AND c2.date < hr.created_at"+
+				") THEN 1 ELSE 0 END), 0) AS additional").
 			Joins("JOIN rippling_reach rr ON rr.msgid = hr.msgid AND rr.total_freeglers > 0"+stratumSQL).
 			Joins("JOIN messages m ON m.id = hr.msgid AND m.type = 'Offer'").
 			Where("hr.created_at >= ? AND hr.created_at < ? AND EXISTS(SELECT 1 FROM messages_groups mgr WHERE mgr.msgid = hr.msgid AND mgr.rippled_in = 1 AND mgr.deleted = 0)", start, end).
-			Scan(&held)
+			Row()
+		// Read the two aggregates positionally. Scan() into a struct silently left
+		// both at zero here — the aggregates carry no model to map onto — and a
+		// zeroed KPI looks exactly like "nothing was held", so the failure would
+		// have been invisible on the dashboard.
+		if row != nil {
+			_ = row.Scan(&heldTotal, &heldAdditional)
+		}
 	}()
 
 	// The drive-time figures (the Section 1 overall mean, the Section 3 rippled-out mean, the
@@ -557,9 +587,16 @@ func Analytics(c *fiber.Ctx) error {
 		kpi.TakenPct = float64(agg.Taken) / float64(agg.Posts) * 100
 		kpi.MeanReplies = float64(agg.TotalReplies) / float64(agg.Posts)
 	}
-	kpi.HeldReplies = held
+	kpi.HeldReplies = heldTotal
+	// Whatever is not "additional" is a reply held while the post had nothing else
+	// on it. Derived by subtraction so the two always sum to the total shown above,
+	// rather than being counted separately and drifting apart.
+	kpi.HeldRepliesAdditional = heldAdditional
+	kpi.HeldRepliesFirst = heldTotal - heldAdditional
 	if agg.TotalReplies > 0 {
-		kpi.HeldRepliesPct = float64(held) / float64(agg.TotalReplies) * 100
+		kpi.HeldRepliesPct = float64(heldTotal) / float64(agg.TotalReplies) * 100
+		kpi.HeldRepliesFirstPct = float64(kpi.HeldRepliesFirst) / float64(agg.TotalReplies) * 100
+		kpi.HeldRepliesAdditionalPct = float64(kpi.HeldRepliesAdditional) / float64(agg.TotalReplies) * 100
 	}
 
 	trend := fiber.Map{

--- a/iznik-server-go/test/rippling_held_split_test.go
+++ b/iznik-server-go/test/rippling_held_split_test.go
@@ -1,0 +1,211 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// The sysadmin "% of replies held (waiting for reach)" figure lumps together two situations
+// that cost the offerer very different things. Holding the ONLY reply a post has leaves them
+// looking at silence. Holding a LATER one merely defers a choice they can already make.
+//
+// Since first replies started going through, the held count should be almost entirely
+// "additional"; a stubborn "first" count means first replies are still being held up. The
+// dashboard can only show that if the endpoint splits them.
+//
+// A small square around (51.5, -0.1) in EPSG:3857, used as the reach polygon.
+const heldSplitTick = "POLYGON((-11150 6712000,-11050 6712000,-11050 6712100,-11150 6712100,-11150 6712000))"
+
+// seedHeldSplitPost creates a rippled-out Offer inside the analytics window and returns its id.
+func seedHeldSplitPost(t *testing.T, posterID, groupID uint64, subject string) uint64 {
+	t.Helper()
+	db := database.DBConn
+
+	msgID := CreateTestMessage(t, posterID, groupID, subject, 51.5, -0.1)
+
+	// The analytics query only counts holds on posts that actually rippled out.
+	db.Exec("UPDATE messages_groups SET rippled_in = 1, deleted = 0 WHERE msgid = ?", msgID)
+
+	// total_freeglers must be > 0 to join, and < 1700 to fall in the 'rural' stratum the
+	// test asks for — keeping the fixture away from whatever else lives in the window.
+	db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", msgID)
+	res := db.Exec("INSERT INTO rippling_reach "+
+		"(msgid, lat, lng, polygon, outer_bound, arrival, mode, tick, total_ticks, total_freeglers, "+
+		" max_drive_min, schedule, next_expansion_at, status, created_at, updated_at) "+
+		"VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), ST_Envelope(ST_GeomFromText(?, 3857)), "+
+		" NOW(), 'drive', 1, 3, 100, 30, NULL, NOW(), 'expanding', NOW(), NOW())",
+		msgID, heldSplitTick, heldSplitTick)
+	if res.Error != nil {
+		t.Fatalf("could not seed reach: %v", res.Error)
+	}
+	return msgID
+}
+
+// replyInRoom inserts an 'Interested' reply on msgID from userID, offset minutes before now
+// (0 = now), and returns the chat message id. Every step is checked: a silently failed fixture
+// shows up as an unexplained zero in the KPI, which says nothing about what actually broke.
+func replyInRoom(t *testing.T, chatID, msgID, userID uint64, minutesAgo int) uint64 {
+	t.Helper()
+	db := database.DBConn
+
+	res := db.Exec(
+		"INSERT INTO chat_messages (chatid, userid, message, type, date, refmsgid, "+
+			"reviewrequired, reviewrejected, processingrequired, processingsuccessful) "+
+			"VALUES (?, ?, 'Can I collect this please?', 'Interested', NOW() - INTERVAL ? MINUTE, ?, 0, 0, 0, 1)",
+		chatID, userID, minutesAgo, msgID,
+	)
+	if res.Error != nil {
+		t.Fatalf("could not create reply chat message: %v", res.Error)
+	}
+	var chatMsgID uint64
+	db.Raw("SELECT id FROM chat_messages WHERE chatid = ? ORDER BY id DESC LIMIT 1", chatID).Scan(&chatMsgID)
+	if chatMsgID == 0 {
+		t.Fatal("reply chat message created but id not found")
+	}
+	return chatMsgID
+}
+
+// heldMinutesAgo backdates the held reply. The analytics window ends at time.Now() formatted
+// to WHOLE SECONDS and the bound is exclusive, so a fixture stamped in the same second as the
+// request falls outside it and the KPI reads zero — indistinguishable from "nothing held".
+// Five minutes is also closer to life: a hold is never simultaneous with someone opening the
+// dashboard.
+const heldMinutesAgo = 5
+
+// holdReply files a held reply from replierID against msgID and returns the chat message id.
+// Pass an existing chatID to reuse a room — chat_rooms is unique on (user1, user2, chattype),
+// so a second CreateTestChatRoom for the same pair fails.
+func holdReply(t *testing.T, chatID, msgID, replierID uint64) uint64 {
+	t.Helper()
+	db := database.DBConn
+
+	chatMsgID := replyInRoom(t, chatID, msgID, replierID, heldMinutesAgo)
+
+	res := db.Exec("INSERT INTO rippling_held_replies (chatid, chatmsgid, msgid, replieruserid, status, created_at) "+
+		"VALUES (?, ?, ?, ?, 'held', NOW() - INTERVAL ? MINUTE)",
+		chatID, chatMsgID, msgID, replierID, heldMinutesAgo)
+	if res.Error != nil {
+		t.Fatalf("could not file the held reply: %v", res.Error)
+	}
+
+	// Prove the fixture is visible to the analytics query's own predicates — INCLUDING the
+	// window — before trusting any number that comes back from it. Leaving the window out
+	// of this check is what let a windowing mismatch masquerade as a zero KPI.
+	var visible int
+	db.Raw("SELECT COUNT(*) FROM rippling_held_replies hr "+
+		"JOIN rippling_reach rr ON rr.msgid = hr.msgid AND rr.total_freeglers > 0 AND rr.total_freeglers < 1700 "+
+		"JOIN messages m ON m.id = hr.msgid AND m.type = 'Offer' "+
+		"WHERE hr.chatmsgid = ? AND hr.created_at >= NOW() - INTERVAL 30 DAY AND hr.created_at < NOW() "+
+		"AND EXISTS(SELECT 1 FROM messages_groups mgr "+
+		"WHERE mgr.msgid = hr.msgid AND mgr.rippled_in = 1 AND mgr.deleted = 0)", chatMsgID).Scan(&visible)
+	if visible != 1 {
+		t.Fatalf("held reply %d is not visible to the analytics predicates (got %d) — fixture setup is wrong, "+
+			"so any KPI assertion below would be meaningless", chatMsgID, visible)
+	}
+	return chatMsgID
+}
+
+func TestRipplingAnalytics_HeldRepliesSplitFirstVsAdditional(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("heldsplit")
+
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	replierA := CreateTestUser(t, prefix+"_replierA", "User")
+	replierB := CreateTestUser(t, prefix+"_replierB", "User")
+	otherID := CreateTestUser(t, prefix+"_other", "User")
+	for _, u := range []uint64{posterID, replierA, replierB, otherID} {
+		CreateTestMembership(t, u, groupID, "Member")
+	}
+
+	// Post 1: its held reply is the only reply on the post — a FIRST reply held.
+	lonely := seedHeldSplitPost(t, posterID, groupID, "OFFER: lonely held reply")
+	roomA := CreateTestChatRoom(t, replierA, &posterID, nil, "User2User")
+	lonelyMsg := holdReply(t, roomA, lonely, replierA)
+
+	// Post 2: someone else already replied an hour earlier — an ADDITIONAL reply held.
+	crowded := seedHeldSplitPost(t, posterID, groupID, "OFFER: crowded held reply")
+	roomOther := CreateTestChatRoom(t, otherID, &posterID, nil, "User2User")
+	replyInRoom(t, roomOther, crowded, otherID, heldMinutesAgo+60)
+	roomB := CreateTestChatRoom(t, replierB, &posterID, nil, "User2User")
+	crowdedMsg := holdReply(t, roomB, crowded, replierB)
+
+	defer func() {
+		db.Exec("DELETE FROM rippling_held_replies WHERE chatmsgid IN (?, ?)", lonelyMsg, crowdedMsg)
+		db.Exec("DELETE FROM rippling_reach WHERE msgid IN (?, ?)", lonely, crowded)
+	}()
+
+	url := fmt.Sprintf("/api/rippling/analytics?jwt=%s&stratum=rural", token)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil), 30000)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body map[string]interface{}
+	json.Unmarshal(rsp(resp), &body)
+	s1, ok := body["section1"].(map[string]interface{})
+	assert.True(t, ok, "section1 KPI block present")
+
+	total := s1["held_replies"]
+	first := s1["held_replies_first"]
+	additional := s1["held_replies_additional"]
+	assert.NotNil(t, total, "held_replies still reported")
+	assert.NotNil(t, first, "held replies split out a first-reply count")
+	assert.NotNil(t, additional, "held replies split out an additional-reply count")
+
+	// Other fixtures may share the window, so assert the relationships rather than
+	// exact totals: both of ours are counted, each on the correct side, and the two
+	// halves always reconstruct the headline number.
+	assert.Equal(t, total, first.(float64)+additional.(float64),
+		"first + additional must reconstruct the headline held count")
+	assert.GreaterOrEqual(t, first.(float64), float64(1), "the lonely hold counts as a first reply")
+	assert.GreaterOrEqual(t, additional.(float64), float64(1), "the crowded hold counts as additional")
+
+	// And the percentages must be reported on the same basis as the headline one.
+	assert.NotNil(t, s1["held_replies_first_pct"], "first-reply share reported")
+	assert.NotNil(t, s1["held_replies_additional_pct"], "additional-reply share reported")
+}
+
+// A reply from the SAME member does not make their own held reply "additional" — a person
+// replying twice is still a post with only one interested party, which is the thing the
+// split is trying to measure.
+func TestRipplingAnalytics_OwnEarlierReplyIsNotCompany(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("heldsplitown")
+
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	replierID := CreateTestUser(t, prefix+"_replier", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, replierID, groupID, "Member")
+
+	msgID := seedHeldSplitPost(t, posterID, groupID, "OFFER: same replier twice")
+	// Both replies are from the SAME member, so they share one chat room.
+	room := CreateTestChatRoom(t, replierID, &posterID, nil, "User2User")
+	replyInRoom(t, room, msgID, replierID, heldMinutesAgo+60)
+	heldMsg := holdReply(t, room, msgID, replierID)
+
+	defer func() {
+		db.Exec("DELETE FROM rippling_held_replies WHERE chatmsgid = ?", heldMsg)
+		db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", msgID)
+	}()
+
+	url := fmt.Sprintf("/api/rippling/analytics?jwt=%s&stratum=rural", token)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", url, nil), 30000)
+	var body map[string]interface{}
+	json.Unmarshal(rsp(resp), &body)
+	s1 := body["section1"].(map[string]interface{})
+
+	assert.GreaterOrEqual(t, s1["held_replies_first"].(float64), float64(1),
+		"a member's own earlier reply must not count as another reply")
+}


### PR DESCRIPTION
## Summary

The sysadmin rippling panel showed a single "% of replies held (waiting for reach)" figure. It covers two situations that cost the offerer very different things:

- **First reply held** — the post has nothing else on it, so the offerer is looking at silence.
- **Additional reply held** — someone else has already replied, so the offerer has something to act on and the hold merely defers a further choice.

`section1` now reports `held_replies_first` / `held_replies_additional` and their percentages alongside the existing `held_replies`, and the panel shows them under the headline figure:

> of which 1,248 additional (post already had a reply) · 96 first reply

Now that first replies pass through, the expectation is that held replies are almost entirely additional. A non-trivial first-reply count is the signal that some first replies are still being held.

## Code Quality Review

- Classification is made **at the moment of holding** (`c2.date < hr.created_at`), not from the post's current state. A reply that arrived later cannot retroactively have made an earlier hold harmless, so judging by what the post looks like now would understate the first-reply case.
- A member's own earlier reply does not count as company: the replier's own message is excluded by id and their other messages by userid, so someone replying twice still reads as a post with one interested party.
- `first` is derived by subtracting `additional` from the total, so the two halves always reconstruct the headline number instead of being counted separately and drifting apart.
- Both counts come from the existing single query — one added `SUM(CASE WHEN EXISTS(...))`, no extra round trip, and the `WHERE` stays a single string per the GORM paren-wrapping note already in that block.
- `COALESCE(SUM(...), 0)` keeps the additional count at 0 rather than NULL when no rows match.
- Read with `Row().Scan` rather than `Scan` into a struct. GORM leaves a struct's fields at zero for a multi-aggregate select and returns no error, and these goroutines ignore errors by design, so the KPI would have read zero — indistinguishable on the dashboard from "nothing was held".

## Future Improvements

- The split is computed over the window but not carried into the per-day trend series; a first-reply-held trend would show whether the first-reply path is regressing rather than only its current level.
- `held_replies_pct` uses all replies as the denominator. A first-reply-held rate per *post* would answer "how often is a post left looking ignored" more directly than a share of replies.

## Test Plan

- Go suite: **3903 passed, 0 failed**. Two new tests in `test/rippling_held_split_test.go`: one seeds a post whose only reply is held plus a second post where another member replied an hour earlier, asserting each lands on the correct side and that first + additional reconstruct the total; the other asserts a member's own earlier reply does not make their held reply "additional". Assertions are relational rather than absolute so other fixtures sharing the window cannot make them flaky.
- Vitest: **14,882 passed**. Two new cases in `ModSysAdminRipplingAnalytics.spec.js` cover the split rendering and its omission when nothing is held.
- `gofmt` clean; `eslint --fix` run on the changed frontend files.

The fixtures assert they are visible to the analytics query's own predicates — window included — before any KPI assertion runs. Without that, a setup problem surfaces as a zero KPI, which is indistinguishable from a genuine "nothing held" and says nothing about what actually broke. The window bound in particular is exclusive and formatted to whole seconds, so a fixture stamped in the same second as the request falls outside it; the held reply is backdated five minutes, which is also closer to life.

Two local-environment notes for anyone running the Go suite on this branch, neither requiring a code change:

- `iznik-server-go/firstreply/` is a new directory and the container file-sync only updates files in directories that already exist, so `/app/firstreply` is absent until the container is rebuilt and the whole suite fails to compile — reported as `0✓ 0✗`, which reads as "no tests ran" rather than a failure. `docker cp iznik-server-go/firstreply freegle-apiv2:/app/firstreply` unblocks it.
- `2026_08_06_000001_create_users_searches_embeddings_table` needs applying, or `TestSearchMatchesHoldTheEmailThreshold` fails on a missing table. `./scripts/setup-test-database.sh` runs the migrations and re-clones the Go test schema.
