### PR TITLE
fix(chat): restore unread-first sort of ModTools chat list

### DIFF
--- a/iznik-nuxt3/modtools/pages/chats/[[id]].vue
+++ b/iznik-nuxt3/modtools/pages/chats/[[id]].vue
@@ -233,8 +233,18 @@ function scanChats(closed, chatList) {
     })
   }
 
-  // Sort by most recent first.
+  // Sort unread chats to the top, then by most recent first. Skip the
+  // unseen-first pass while actively searching, since search results can
+  // carry stale unseen counts and shouldn't be reordered by them (#356).
   result.sort((a, b) => {
+    if (!search.value) {
+      if (a.unseen === 0 && b.unseen > 0) {
+        return 1
+      } else if (a.unseen > 0 && b.unseen === 0) {
+        return -1
+      }
+    }
+
     if (a.lastdate && b.lastdate) {
       return dayjs(b.lastdate).diff(dayjs(a.lastdate))
     } else if (a.lastdate) {

--- a/iznik-nuxt3/tests/unit/pages/modtools/chats.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/chats.spec.js
@@ -228,6 +228,55 @@ describe('chats/[[id]].vue page', () => {
       expect(filtered).toHaveLength(1)
       expect(filtered[0].name).toBe('Test Chat')
     })
+
+    it('scanChats sorts unread chats to the top when not searching (Discourse 10013)', () => {
+      const wrapper = mountComponent()
+      const chats = [
+        {
+          id: 1,
+          name: 'Read chat, newer',
+          status: 'Active',
+          unseen: 0,
+          lastdate: '2026-08-05T00:00:00Z',
+        },
+        {
+          id: 2,
+          name: 'Unread chat, older',
+          status: 'Active',
+          unseen: 3,
+          lastdate: '2026-08-01T00:00:00Z',
+        },
+      ]
+      const sorted = wrapper.vm.scanChats(false, chats)
+      expect(sorted[0].id).toBe(2)
+    })
+
+    it('scanChats does not reorder by unseen while actively searching', () => {
+      const wrapper = mountComponent()
+      wrapper.vm.search = 'test'
+      const chats = [
+        {
+          id: 1,
+          name: 'Read chat matching test',
+          status: 'Active',
+          unseen: 0,
+          lastdate: '2026-08-05T00:00:00Z',
+          search: true,
+        },
+        {
+          id: 2,
+          name: 'Unread chat matching test',
+          status: 'Active',
+          unseen: 3,
+          lastdate: '2026-08-01T00:00:00Z',
+          search: true,
+        },
+      ]
+      const sorted = wrapper.vm.scanChats(false, chats)
+      // Date order preserved (id 1 is more recent) - unseen must not push
+      // stale search matches to the top of the results.
+      expect(sorted[0].id).toBe(1)
+    })
   })
 
   describe('session expiry on chat load (Discourse 9881)', () => {


### PR DESCRIPTION
No prior attempt found for this area.

## Root Cause
Commit `b9690464c` ("MT chat search requires >2 chars, sort by date not unseen", #356) removed the unseen-first comparator from `scanChats()` in `modtools/pages/chats/[[id]].vue` entirely, as a side effect of fixing an unrelated search-debounce bug (the search watch had no minimum-length guard). The commit's stated goal was to stop stale search results with stale unseen counts jumping to the top - but it removed unseen-first ordering unconditionally, so it also stopped working during normal (non-search) browsing, which was never the intent.

The Go API (`iznik-server-go/chat/chatroom.go`, `listChats()`) has never ordered by unseen server-side - it only computes `Unseen` for the badge/count and orders by `latestmessage DESC`. So the client-side comparator in `scanChats()` is the sole place this can be fixed.

## Evidence
Failing test before fix (`scanChats sorts unread chats to the top when not searching`):
```
FAIL  tests/unit/pages/modtools/chats.spec.js > ... > scanChats sorts unread chats to the top when not searching (Discourse 10013)
AssertionError: expected 1 to be 2 // Object.is equality
 ❯ tests/unit/pages/modtools/chats.spec.js:251:28
    249|       ]
    250|       const sorted = wrapper.vm.scanChats(false, chats)
    251|       expect(sorted[0].id).toBe(2)
       |                            ^
 Test Files  1 failed (1)
      Tests  1 failed | 14 passed (15)
```
An unread chat (`unseen: 3`) with an older `lastdate` stayed behind a read chat with a newer `lastdate` - i.e. no unread-first ordering at all, matching the member's report.

## Fix
Restored the unseen-first branch in the sort comparator in `scanChats()`, but guarded it with `if (!search.value)` so it only applies during normal browsing - preserving the original #356 fix (search results aren't reordered by stale unseen counts).

## Other Call Sites
`grep -rn "unseen" pages/chats stores/chat.js modtools/pages/chats` shows no other list-sort call site with this pattern. The member-facing Freegle inbox (`pages/chats/[[id]].vue`) has an identical date-only comparator (also stripped of unseen-first ordering by the same commit), but the reported symptom is specifically ModTools ("mod tools messages are no longer filtering unread messages to the top"), so it's out of scope for this PR.

## Test
File: `iznik-nuxt3/tests/unit/pages/modtools/chats.spec.js`
Command: `npx vitest run tests/unit/pages/modtools/chats.spec.js`
Proves fail-before (unread chat not sorted to top, 1 failed / 14 passed) / pass-after (unread chat first; all 15 tests in the file pass, including the search-guard test confirming date order is preserved and not reordered by stale unseen counts while searching).

## Discourse
https://discourse.ilovefreegle.org/t/10013/1