### PR TITLE
DO NOT MERGE: posting-status replica-lag diagnosis disproven (#10008 fixed by #1275)

### DIFF
--- a/iznik-server-go/user/membership_readsplit_test.go
+++ b/iznik-server-go/user/membership_readsplit_test.go
@@ -1,0 +1,44 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/freegle/iznik-server-go/database"
+)
+
+func init() {
+	database.InitDatabase()
+}
+
+// TestMembershipsPinsModtoolsReadsToWriter guards against Discourse #10008
+// post 2: a mod flips a member's ourPostingStatus (Can't Post -> Moderated)
+// via PatchMemberships (a write), then ModTools re-fetches that member
+// (GET /user/:id?modtools=true) to refresh the Approve-button gate on a
+// pending message. That re-fetch went through GetMemberships(id), a plain
+// SELECT that the DB read/write split can route to a replica which hasn't
+// applied the write yet (Galera apply-lag) - so the Approve button stayed
+// hidden until the replica caught up, exactly the "it corrected itself
+// after a delay" symptom the reporter described. Replica lag can't be
+// simulated on the single test DB (see test/insert_id_test.go), so this
+// asserts the routing decision directly: dbForMemberships must pin the
+// modtools read to the writer, and must NOT pin the plain read used by
+// high-frequency "my groups" checks (volunteering, community events, "who
+// am I") - pinning those to the writer would defeat the point of the
+// read/write split.
+func TestMembershipsPinsModtoolsReadsToWriter(t *testing.T) {
+	const writeMarker = "gorm:db_resolver:write"
+
+	db := database.DBConn
+	require.NotNil(t, db)
+
+	pinned := dbForMemberships(db, true)
+	_, ok := pinned.Statement.Settings.Load(writeMarker)
+	assert.True(t, ok, "the modtools re-fetch after a posting-status change must be pinned to the writer")
+
+	unpinned := dbForMemberships(db, false)
+	_, ok = unpinned.Statement.Settings.Load(writeMarker)
+	assert.False(t, ok, "the plain 'my groups' read must not be pinned to the writer")
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+	"gorm.io/plugin/dbresolver"
 )
 
 type Aboutme struct {
@@ -396,9 +397,38 @@ func GetExpectedReplies(id uint64) []uint64 {
 	return expectedReplies
 }
 
-func GetMemberships(id uint64) []Membership {
-	db := database.DBConn
+// dbForMemberships returns the db handle a memberships read should go
+// through. modtools=true is the ModTools single-member re-fetch that runs
+// right after a mod may have just changed the member's ourPostingStatus via
+// PatchMemberships (e.g. Can't Post -> Moderated) - ModMessage.vue's
+// membership computed reads exactly this value to gate the Approve button
+// on a pending message. Under the DB read/write split a plain SELECT here
+// can land on a replica that hasn't applied that write yet (Galera
+// apply-lag), so the button stays hidden until the replica catches up
+// (Discourse #10008 post 2). Pin that path to the writer, matching the same
+// read-your-writes fix already applied elsewhere (PR #905). Plain
+// GetMemberships(id) stays unpinned - it also backs "my groups" checks on
+// every page load (volunteering, community events, "who am I"), which are
+// high-frequency and not read-your-writes sensitive; pinning those to the
+// writer would defeat the point of the read/write split.
+func dbForMemberships(db *gorm.DB, modtools bool) *gorm.DB {
+	if modtools {
+		return db.Clauses(dbresolver.Write)
+	}
+	return db
+}
 
+func GetMemberships(id uint64) []Membership {
+	return getMemberships(dbForMemberships(database.DBConn, false), id)
+}
+
+// GetMembershipsForModtools is GetMemberships pinned to the writer - see
+// dbForMemberships.
+func GetMembershipsForModtools(id uint64) []Membership {
+	return getMemberships(dbForMemberships(database.DBConn, true), id)
+}
+
+func getMemberships(db *gorm.DB, id uint64) []Membership {
 	var memberships []Membership
 	db.Table("memberships").
 		Select("memberships.id, added, role, groupid, emailfrequency, eventsallowed, volunteeringallowed, ourPostingStatus, microvolunteering AS microvolunteeringallowed, nameshort, namefull, groups.type, ST_AsText(ST_ENVELOPE(polyindex)) AS bbox").
@@ -1292,12 +1322,14 @@ func enrichUserForModtools(u *User, id uint64, myid uint64, modtools bool) {
 	var modmails uint64
 	var wg sync.WaitGroup
 
-	// Fetch memberships for authenticated requests only.
+	// Fetch memberships for authenticated requests only. Pinned to the writer
+	// (see dbForMemberships) - this is the modtools re-fetch that runs right
+	// after a mod may have just changed the member's ourPostingStatus.
 	if myid > 0 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			memberships = GetMemberships(id)
+			memberships = GetMembershipsForModtools(id)
 		}()
 	}
 


### PR DESCRIPTION
## This must not merge as it stands

The diagnosis behind this branch (a modtools membership read hitting a replica that had not applied the just-committed posting-status write) is wrong, and the reporter's own timeline disproves it.

## Why replica lag is not the cause

Discourse [#10008](https://discourse.ilovefreegle.org/t/10008): reported at 23:24, corrected at 04:28 the next morning - five hours. The database is a Galera synchronous multi-master cluster, which certifies a transaction across nodes before commit returns, so apply lag is measured in milliseconds. A five-hour recovery is off by six orders of magnitude. The reporter also retried within that window ("I've tried changing settings to moderated but it's not sticking"), and lag would have resolved between attempts.

The test on this branch asserts the routing decision - that the query is pinned to the writer - so it passes whether or not lag was ever involved. It cannot fail for the reason the fix claims to address.

## What actually caused it

\#1275, already merged. `memberStore.updateMembership()` PATCHed the membership but never invalidated the cached `userStore` entry, so `ModMessage.vue`'s `membership` computed kept returning `ourpostingstatus: 'PROHIBITED'` and `:cantpost` kept hiding the Approve button. The cached snapshot in the mod's open tab stayed stale until a fresh page load - which is what five hours and an overnight gap look like. The reporter confirmed on post 4: "It did work eventually."

There is no second fault on the read path. Pinning `GET /user/:id?modtools=true` to the writer would take a chunk of modtools read traffic off the replicas permanently in exchange for nothing.

## Observation on the same path, not a fix for this report

`userStore.fetchMT()` (`iznik-nuxt3/stores/user.js`) returns the in-flight result when a fetch for the same id is already running, without honouring `force`:

```js
if (id && this.fetching[id]) {
  await this.fetching[id]
  return this.list[id]
}
```

The non-modtools branch of `fetch()` handles this correctly ("Only return early if not forcing - otherwise continue to queue refresh"), so the two disagree. #1275's fix runs through `fetchMT` with `force = true`, so a concurrent fetch for the same user would make that fix silently no-op. It has not been shown that a concurrent fetch occurs on the pending-message page at the moment the posting status changes, so this is not offered as the cause of #10008.

## Discourse

https://discourse.ilovefreegle.org/t/10008
