### PR TITLE
fix(community-news): never feature an event that has already happened

### DIFF
--- a/iznik-batch/app/Models/CommunityNewsItem.php
+++ b/iznik-batch/app/Models/CommunityNewsItem.php
@@ -28,6 +28,9 @@ class CommunityNewsItem extends Model
         'researched_at' => 'datetime',
         'posted_at' => 'datetime',
         'emailed_at' => 'datetime',
+        // When the event itself happens, as opposed to when we researched it.
+        // Null for items that aren't dated events, which is most of them.
+        'event_date' => 'date',
     ];
 
     public function area(): BelongsTo

--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsChitChatService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsChitChatService.php
@@ -80,6 +80,15 @@ class CommunityNewsChitChatService
             $items = CommunityNewsItem::where('areaid', $area->id)
                 ->whereNull('posted_at')
                 ->where('researched_at', '>', now()->subDays($freshDays))
+                // Same rule as the newsletter: never tell people about something
+                // that has already happened. An item stays eligible for days after
+                // it was researched, so an event found last week can easily be over
+                // by the time it reaches the top of the queue. Undated items are
+                // unaffected; today's events still count.
+                ->where(function ($q) {
+                    $q->whereNull('event_date')
+                        ->orWhere('event_date', '>=', now()->startOfDay());
+                })
                 ->orderBy('id')
                 ->limit($perPost)
                 ->get();

--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
@@ -67,6 +67,17 @@ class CommunityNewsEmailService
             $items = CommunityNewsItem::where('areaid', $area->id)
                 ->whereNull('emailed_at')
                 ->where('researched_at', '>', now()->subDays($freshDays))
+                // Leave out events that have already happened. Research runs
+                // hourly but this email goes weekly, and an item stays fresh for
+                // days after we found it, so without this a Wednesday jumble sale
+                // found on Monday still went out on Friday. Undated items (most of
+                // them — a new cycle path, a library reopening) have no event_date
+                // and are unaffected. Today's events still count: someone reading
+                // on the morning of can still go.
+                ->where(function ($q) {
+                    $q->whereNull('event_date')
+                        ->orWhere('event_date', '>=', now()->startOfDay());
+                })
                 ->orderBy('id')
                 ->limit($maxItems)
                 ->get();

--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsResearchService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsResearchService.php
@@ -57,6 +57,9 @@ class CommunityNewsResearchService
                 'snippet' => $it['blurb'],
                 'url' => $it['url'],
                 'source' => $it['source'] !== null ? mb_substr($it['source'], 0, 250) : null,
+                // Null unless this is a dated event; the newsletter uses it to
+                // skip anything already over by the time it sends.
+                'event_date' => $it['date'] ?? null,
                 'researched_at' => now(),
             ]);
         }
@@ -320,6 +323,7 @@ class CommunityNewsResearchService
                 'blurb' => $blurb,
                 'url' => $url !== '' ? $url : null,
                 'source' => isset($it['source']) && trim((string) $it['source']) !== '' ? trim((string) $it['source']) : null,
+                'date' => $this->parseEventDate($it['date'] ?? null),
             ];
             if (count($items) >= $maxItems) {
                 break;
@@ -331,6 +335,47 @@ class CommunityNewsResearchService
         }
 
         return [$intro, $items];
+    }
+
+    /**
+     * The day an item's event happens, or null when it isn't a dated event.
+     *
+     * Deliberately strict: only an exact YYYY-MM-DD is accepted. A loose parse
+     * would happily read "Saturday" as some arbitrary date, and a wrong date is
+     * far worse than none — it either hides an event that is still to come or
+     * lets a past one through, which is the whole problem this exists to stop.
+     * Anything unparseable, or absurdly far from now, is treated as "no date"
+     * and the item simply flows through as undated.
+     */
+    private function parseEventDate(mixed $raw): ?string
+    {
+        if (!is_string($raw)) {
+            return null;
+        }
+        $value = trim($raw);
+        if ($value === '' || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+            return null;
+        }
+
+        try {
+            $date = \Carbon\Carbon::createFromFormat('Y-m-d', $value);
+        } catch (\Throwable $e) {
+            return null;
+        }
+        // createFromFormat accepts overflow (2026-02-31 becomes 3 March), which
+        // means a nonsense date would silently become a real one.
+        if ($date === false || $date->format('Y-m-d') !== $value) {
+            return null;
+        }
+
+        // A community listing is about the coming weeks. A date years out is a
+        // parsing artefact (or a typo in the source), not a real local event, and
+        // trusting it would keep a stale item eligible indefinitely.
+        if ($date->lt(now()->subYear()) || $date->gt(now()->addYear())) {
+            return null;
+        }
+
+        return $date->toDateString();
     }
 
     /**
@@ -391,14 +436,18 @@ class CommunityNewsResearchService
         $lng = $area->lng;
         $groups = $this->groupNames($area);
         $seedBlock = $this->seedBlock($seedSources);
+        // The model cannot resolve "this Saturday" without knowing today's date.
+        $today = now()->toDateString();
 
         return <<<USER
         Area: {$name} (roughly centred on {$lat}, {$lng}; it covers the Freegle communities: {$groups}).
         {$seedBlock}
         Find up to {$maxItems} interesting, genuinely local community happenings for readers here, this week or in the next couple of weeks.
 
+        If an item happens on a particular day, give that day as "date" in YYYY-MM-DD form. Today is {$today}, so work out the actual date of anything described as "Saturday" or "next week". Give the FIRST day for something running over several days. Leave "date" out entirely when the item is not a dated event — an ongoing service, a new footpath, a refurbished library — and never guess: an omitted date is much better than a wrong one.
+
         Then reply with ONLY a JSON object — no prose, no code fences — in exactly this shape:
-        {"intro":"one or two warm, quirky sentences introducing this week's round-up for {$name}","items":[{"title":"punchy title","blurb":"~45-word friendly description","url":"the source URL you found","source":"the site or organisation name"}]}
+        {"intro":"one or two warm, quirky sentences introducing this week's round-up for {$name}","items":[{"title":"punchy title","blurb":"~45-word friendly description","url":"the source URL you found","source":"the site or organisation name","date":"YYYY-MM-DD or omitted"}]}
         USER;
     }
 

--- a/iznik-batch/database/migrations/2026_08_07_000001_add_event_date_to_community_news_items.php
+++ b/iznik-batch/database/migrations/2026_08_07_000001_add_event_date_to_community_news_items.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Records when a community-news item's event actually happens, so the weekly
+ * newsletter can leave out the ones already over.
+ *
+ * Research runs hourly; the newsletter goes out on Fridays, and an item stays
+ * eligible for `item_freshness_days` (10 on live) after it was researched. So a
+ * jumble sale found on a Monday and held on the Wednesday was still perfectly
+ * "fresh" on Friday, and went out inviting people to something that had already
+ * happened. Nothing in the table said when the event was, so nothing could
+ * filter it: `researched_at` records when WE looked, which says nothing about
+ * when the event IS.
+ *
+ * Nullable because most items are not dated events at all — a new cycle path, a
+ * library refurbishment — and those must keep flowing through untouched. Only
+ * an item with a date in the past is held back.
+ *
+ * A DATE, not a datetime: what matters is whether the day has passed, and the
+ * research only ever recovers day-level precision from a listing anyway.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('community_news_items')) {
+            return;
+        }
+        if (Schema::hasColumn('community_news_items', 'event_date')) {
+            return;
+        }
+
+        Schema::table('community_news_items', function (Blueprint $t) {
+            $t->date('event_date')->nullable()->after('source');
+            // The newsletter filters on (area, not yet emailed, event not past),
+            // so the date rides along with the existing lookup index.
+            $t->index(['areaid', 'event_date']);
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('community_news_items')) {
+            return;
+        }
+        if (!Schema::hasColumn('community_news_items', 'event_date')) {
+            return;
+        }
+
+        Schema::table('community_news_items', function (Blueprint $t) {
+            $t->dropIndex(['areaid', 'event_date']);
+            $t->dropColumn('event_date');
+        });
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_07_000001_add_event_date_to_community_news_items_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_07_000001_add_event_date_to_community_news_items_migration.sql
@@ -1,0 +1,29 @@
+-- Production idempotent SQL: record when a community-news item's event happens.
+--
+-- Research runs hourly, the newsletter goes out on Fridays, and an item stays eligible for
+-- item_freshness_days (10 on live) after being researched. An event found on Monday and held on
+-- Wednesday was therefore still "fresh" on Friday and went out inviting people to something that
+-- had already happened. researched_at records when WE looked, not when the event IS, so nothing
+-- in the table could filter it.
+--
+-- Nullable: most items are not dated events (a new cycle path, a library refurbishment) and must
+-- keep flowing through. Only an item whose date has passed is held back.
+-- See 2026_08_07_000001_add_event_date_to_community_news_items.php.
+--
+-- Adding a nullable column is INSTANT in MySQL 8 (metadata only, no row rewrite). The index build
+-- is the only real work and the table is small.
+SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'community_news_items'
+      AND column_name = 'event_date');
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE community_news_items ADD COLUMN event_date DATE NULL DEFAULT NULL AFTER source',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'community_news_items'
+      AND index_name = 'community_news_items_areaid_event_date_index');
+SET @ddl2 := IF(@idx_exists = 0,
+    'ALTER TABLE community_news_items ADD INDEX community_news_items_areaid_event_date_index (areaid, event_date)',
+    'SELECT 1');
+PREPARE stmt2 FROM @ddl2; EXECUTE stmt2; DEALLOCATE PREPARE stmt2;

--- a/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
+++ b/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
@@ -342,4 +342,109 @@ class CommunityNewsEmailServiceTest extends TestCase
         $this->assertCount(1, $sent);
         $this->assertSame('Sofa so good', $sent->first()->story['headline']);
     }
+
+    /**
+     * Research runs hourly; this email goes out weekly, and an item stays
+     * eligible for days after it was found. A jumble sale researched on Monday
+     * and held on Wednesday was therefore still "fresh" on Friday and went out
+     * inviting people to something that had already happened.
+     */
+    public function test_leaves_out_events_that_have_already_happened(): void
+    {
+        config(['freegle.mail.enabled_types' => 'CommunityNews']);
+
+        $g = $this->createTestGroup(['lat' => 51.50, 'lng' => -0.12, 'settings' => ['communitynews' => 1, 'newsletter' => 1]]);
+        $this->catchment($g);
+        $u = $this->createTestUser(['email_preferred' => 'past@test.com', 'newslettersallowed' => 1, 'bouncing' => 0]);
+        $this->locate($u, 51.50, -0.12);
+        $this->createMembership($u, $g);
+
+        $area = CommunityNewsArea::create([
+            'anchorgroupid' => $g->id, 'name' => 'Testville', 'intro' => 'A few nice things.',
+            'lat' => 51.5, 'lng' => -0.12, 'groupids' => [$g->id], 'groupcount' => 1,
+        ]);
+
+        // Over and done with - must not go out.
+        CommunityNewsItem::create([
+            'areaid' => $area->id, 'title' => 'Yesterday jumble sale', 'snippet' => 'Gone.',
+            'url' => 'https://example.org/past', 'source' => 'Hall',
+            'event_date' => now()->subDay()->toDateString(), 'researched_at' => now()->subDays(3),
+        ]);
+        // Still to come - must go out.
+        CommunityNewsItem::create([
+            'areaid' => $area->id, 'title' => 'Repair cafe next week', 'snippet' => 'Fix stuff.',
+            'url' => 'https://example.org/future', 'source' => 'Library',
+            'event_date' => now()->addWeek()->toDateString(), 'researched_at' => now()->subDays(3),
+        ]);
+
+        $this->svc()->sendWeekly();
+
+        $sent = Mail::sent(CommunityNewsMail::class);
+        $this->assertCount(1, $sent);
+        $titles = array_column($sent->first()->items, 'title');
+        $this->assertContains('Repair cafe next week', $titles);
+        $this->assertNotContains('Yesterday jumble sale', $titles);
+
+        // The past item stays unemailed, so it is never silently consumed.
+        $this->assertNull(CommunityNewsItem::where('title', 'Yesterday jumble sale')->first()->emailed_at);
+    }
+
+    /** Something on today is still worth telling people about - they can still go. */
+    public function test_includes_an_event_happening_today(): void
+    {
+        config(['freegle.mail.enabled_types' => 'CommunityNews']);
+
+        $g = $this->createTestGroup(['lat' => 51.50, 'lng' => -0.12, 'settings' => ['communitynews' => 1, 'newsletter' => 1]]);
+        $this->catchment($g);
+        $u = $this->createTestUser(['email_preferred' => 'today@test.com', 'newslettersallowed' => 1, 'bouncing' => 0]);
+        $this->locate($u, 51.50, -0.12);
+        $this->createMembership($u, $g);
+
+        $area = CommunityNewsArea::create([
+            'anchorgroupid' => $g->id, 'name' => 'Testville', 'intro' => 'A few nice things.',
+            'lat' => 51.5, 'lng' => -0.12, 'groupids' => [$g->id], 'groupcount' => 1,
+        ]);
+        CommunityNewsItem::create([
+            'areaid' => $area->id, 'title' => 'Coffee morning today', 'snippet' => 'Come along.',
+            'url' => 'https://example.org/today', 'source' => 'Hall',
+            'event_date' => now()->toDateString(), 'researched_at' => now()->subDays(2),
+        ]);
+
+        $this->svc()->sendWeekly();
+
+        $sent = Mail::sent(CommunityNewsMail::class);
+        $this->assertCount(1, $sent);
+        $this->assertContains('Coffee morning today', array_column($sent->first()->items, 'title'));
+    }
+
+    /**
+     * Most items are not dated events at all - a new cycle path, a refurbished
+     * library. Those carry no event_date and must keep flowing through.
+     */
+    public function test_undated_items_are_unaffected(): void
+    {
+        config(['freegle.mail.enabled_types' => 'CommunityNews']);
+
+        $g = $this->createTestGroup(['lat' => 51.50, 'lng' => -0.12, 'settings' => ['communitynews' => 1, 'newsletter' => 1]]);
+        $this->catchment($g);
+        $u = $this->createTestUser(['email_preferred' => 'undated@test.com', 'newslettersallowed' => 1, 'bouncing' => 0]);
+        $this->locate($u, 51.50, -0.12);
+        $this->createMembership($u, $g);
+
+        $area = CommunityNewsArea::create([
+            'anchorgroupid' => $g->id, 'name' => 'Testville', 'intro' => 'A few nice things.',
+            'lat' => 51.5, 'lng' => -0.12, 'groupids' => [$g->id], 'groupcount' => 1,
+        ]);
+        CommunityNewsItem::create([
+            'areaid' => $area->id, 'title' => 'New cycle path opens', 'snippet' => 'Ride it.',
+            'url' => 'https://example.org/path', 'source' => 'Council',
+            'event_date' => null, 'researched_at' => now()->subDays(3),
+        ]);
+
+        $this->svc()->sendWeekly();
+
+        $sent = Mail::sent(CommunityNewsMail::class);
+        $this->assertCount(1, $sent);
+        $this->assertContains('New cycle path opens', array_column($sent->first()->items, 'title'));
+    }
 }

--- a/iznik-batch/tests/Feature/CommunityNews/CommunityNewsResearchServiceTest.php
+++ b/iznik-batch/tests/Feature/CommunityNews/CommunityNewsResearchServiceTest.php
@@ -233,4 +233,67 @@ class CommunityNewsResearchServiceTest extends TestCase
         $this->assertSame('Fete - this Saturday', $items[0]['title']);
         $this->assertSame('Cakes, stalls - and more.', $items[0]['blurb']);
     }
+
+    /**
+     * The newsletter can only skip a past event if research recorded when the
+     * event is. researched_at says when WE looked, which is a different thing.
+     */
+    public function test_parse_captures_an_event_date(): void
+    {
+        $text = json_encode([
+            'intro' => 'x',
+            'items' => [
+                ['title' => 'Fete', 'blurb' => 'b', 'url' => 'https://ok.org', 'source' => 'S', 'date' => '2026-09-12'],
+            ],
+        ]);
+
+        [, $items] = $this->svc()->parse($text, 6);
+
+        $this->assertSame('2026-09-12', $items[0]['date']);
+    }
+
+    /** Most items are not dated events, and must come back with no date at all. */
+    public function test_parse_leaves_an_undated_item_undated(): void
+    {
+        $text = json_encode([
+            'intro' => 'x',
+            'items' => [
+                ['title' => 'New cycle path', 'blurb' => 'b', 'url' => 'https://ok.org', 'source' => 'S'],
+            ],
+        ]);
+
+        [, $items] = $this->svc()->parse($text, 6);
+
+        $this->assertNull($items[0]['date']);
+    }
+
+    /**
+     * A wrong date is worse than none: it either buries an event that is still
+     * to come or lets a past one through, which is the whole point of the field.
+     * Anything that is not an exact, real, plausible YYYY-MM-DD is dropped.
+     */
+    public function test_parse_rejects_dates_it_cannot_trust(): void
+    {
+        $cases = [
+            'Saturday',            // not a date at all
+            '12/09/2026',          // wrong format, and ambiguous day/month
+            '2026-13-01',          // no such month
+            '2026-02-31',          // overflows to 3 March if parsed loosely
+            '2035-01-01',          // implausibly far out for a local listing
+            '',
+        ];
+
+        foreach ($cases as $raw) {
+            $text = json_encode([
+                'intro' => 'x',
+                'items' => [
+                    ['title' => 'T', 'blurb' => 'b', 'url' => 'https://ok.org', 'source' => 'S', 'date' => $raw],
+                ],
+            ]);
+
+            [, $items] = $this->svc()->parse($text, 6);
+
+            $this->assertNull($items[0]['date'], "expected '{$raw}' to be rejected as an event date");
+        }
+    }
 }

--- a/iznik-server-go/user/unsubscribe_pure_test.go
+++ b/iznik-server-go/user/unsubscribe_pure_test.go
@@ -1,0 +1,226 @@
+package user
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// singleUnsubscribeCategories
+// ---------------------------------------------------------------------------
+
+func TestSingleUnsubscribeCategories_ExcludesCombinations(t *testing.T) {
+	got := singleUnsubscribeCategories()
+
+	assert.Equal(t, len(UnsubscribeTypes)-2, len(got))
+	assert.NotContains(t, got, UnsubAll)
+	assert.NotContains(t, got, UnsubAllExceptReplies)
+}
+
+func TestSingleUnsubscribeCategories_PreservesOrder(t *testing.T) {
+	got := singleUnsubscribeCategories()
+
+	want := []string{
+		UnsubDigest, UnsubEvents, UnsubVolunteering, UnsubNewsletter,
+		UnsubRelevant, UnsubChat, UnsubNotifications, UnsubEngagement,
+	}
+	assert.Equal(t, want, got)
+}
+
+// ---------------------------------------------------------------------------
+// UnsubscribeDescription / describeFor
+// ---------------------------------------------------------------------------
+
+func TestUnsubscribeDescription_KnownTypes(t *testing.T) {
+	cases := []struct {
+		unsubType string
+		want      string
+	}{
+		{UnsubDigest, "emails about new posts in your communities"},
+		{UnsubEvents, "emails about community events"},
+		{UnsubVolunteering, "emails about volunteer opportunities"},
+		{UnsubNewsletter, "newsletters and community news"},
+		{UnsubRelevant, "emails suggesting posts that match what you are looking for"},
+		{UnsubChat, "emails telling you about new chat messages"},
+		{UnsubNotifications, "emails about replies and notifications"},
+		{UnsubEngagement, "occasional emails asking how we are doing"},
+		{UnsubAll, "all our non-essential emails"},
+		{UnsubAllExceptReplies, "everything except replies to your posts"},
+	}
+	for _, c := range cases {
+		t.Run(c.unsubType, func(t *testing.T) {
+			assert.Equal(t, c.want, UnsubscribeDescription(c.unsubType))
+		})
+	}
+}
+
+func TestUnsubscribeDescription_UnknownTypeReturnsEmpty(t *testing.T) {
+	assert.Equal(t, "", UnsubscribeDescription("not-a-real-category"))
+	assert.Equal(t, "", UnsubscribeDescription(""))
+}
+
+func TestDescribeFor_KnownTypeReturnsDescription(t *testing.T) {
+	assert.Equal(t, "emails about new posts in your communities", describeFor(UnsubDigest))
+}
+
+func TestDescribeFor_UnknownTypeFallsBackToGeneric(t *testing.T) {
+	assert.Equal(t, "these emails", describeFor("bogus"))
+	assert.Equal(t, "these emails", describeFor(""))
+}
+
+// ---------------------------------------------------------------------------
+// validUnsubscribeType
+// ---------------------------------------------------------------------------
+
+func TestValidUnsubscribeType_AllKnownTypesValid(t *testing.T) {
+	for _, ty := range UnsubscribeTypes {
+		assert.True(t, validUnsubscribeType(ty), "expected %q to be valid", ty)
+	}
+}
+
+func TestValidUnsubscribeType_UnknownAndEmptyInvalid(t *testing.T) {
+	assert.False(t, validUnsubscribeType("bogus"))
+	assert.False(t, validUnsubscribeType(""))
+	assert.False(t, validUnsubscribeType("DIGEST")) // case-sensitive
+}
+
+// ---------------------------------------------------------------------------
+// pageHead
+// ---------------------------------------------------------------------------
+
+func TestPageHead_ContainsEscapedTitle(t *testing.T) {
+	html := pageHead("Stop these emails?")
+	assert.True(t, strings.HasPrefix(html, "<!doctype html>"))
+	assert.Contains(t, html, "<title>Stop these emails?</title>")
+	assert.Contains(t, html, "<body")
+}
+
+func TestPageHead_EscapesHTMLInTitle(t *testing.T) {
+	html := pageHead("<script>alert(1)</script>")
+	assert.NotContains(t, html, "<script>alert(1)</script>")
+	assert.Contains(t, html, "&lt;script&gt;")
+}
+
+// ---------------------------------------------------------------------------
+// userSiteBase
+// ---------------------------------------------------------------------------
+
+func TestUserSiteBase_DefaultsWhenUnset(t *testing.T) {
+	orig, had := os.LookupEnv("USER_SITE")
+	os.Unsetenv("USER_SITE")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("USER_SITE", orig)
+		} else {
+			os.Unsetenv("USER_SITE")
+		}
+	})
+
+	assert.Equal(t, "https://www.ilovefreegle.org", userSiteBase())
+}
+
+func TestUserSiteBase_UsesEnvWhenSet(t *testing.T) {
+	orig, had := os.LookupEnv("USER_SITE")
+	os.Setenv("USER_SITE", "example.org")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("USER_SITE", orig)
+		} else {
+			os.Unsetenv("USER_SITE")
+		}
+	})
+
+	assert.Equal(t, "https://example.org", userSiteBase())
+}
+
+// ---------------------------------------------------------------------------
+// confirmPage
+// ---------------------------------------------------------------------------
+
+func TestConfirmPage_ContainsExpectedFields(t *testing.T) {
+	page := confirmPage(42, "the-key", UnsubDigest)
+
+	assert.Contains(t, page, "Stop these emails?")
+	assert.Contains(t, page, describeFor(UnsubDigest))
+	assert.Contains(t, page, "value=\""+strconv.FormatUint(42, 10)+"\"")
+	assert.Contains(t, page, "name=\"k\" value=\"the-key\"")
+	assert.Contains(t, page, "name=\"t\" value=\""+UnsubDigest+"\"")
+	assert.Contains(t, page, "name=\"confirm\" value=\"1\"")
+	assert.Contains(t, page, "method=\"POST\"")
+}
+
+func TestConfirmPage_AllExceptRepliesShowsExtraReassurance(t *testing.T) {
+	page := confirmPage(1, "k", UnsubAllExceptReplies)
+	assert.Contains(t, page, "You'll still hear when someone replies to your posts")
+}
+
+func TestConfirmPage_OtherTypesOmitReassurance(t *testing.T) {
+	page := confirmPage(1, "k", UnsubDigest)
+	assert.NotContains(t, page, "You'll still hear when someone replies to your posts")
+}
+
+func TestConfirmPage_EscapesKeyAndType(t *testing.T) {
+	// The key comes straight from the query/form and must be HTML-escaped before
+	// being embedded in a hidden input value.
+	page := confirmPage(1, "\"><script>alert(1)</script>", UnsubDigest)
+	assert.NotContains(t, page, "\"><script>alert(1)</script>")
+	assert.Contains(t, page, "&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;")
+}
+
+func TestConfirmPage_LinksToDefaultSettingsPage(t *testing.T) {
+	orig, had := os.LookupEnv("USER_SITE")
+	os.Unsetenv("USER_SITE")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("USER_SITE", orig)
+		} else {
+			os.Unsetenv("USER_SITE")
+		}
+	})
+
+	page := confirmPage(1, "k", UnsubDigest)
+	assert.Contains(t, page, "https://www.ilovefreegle.org/settings")
+}
+
+// ---------------------------------------------------------------------------
+// donePage
+// ---------------------------------------------------------------------------
+
+func TestDonePage_IndividualCategoryShowsOtherMailNotice(t *testing.T) {
+	page := donePage(UnsubDigest)
+	assert.Contains(t, page, "Done")
+	assert.Contains(t, page, describeFor(UnsubDigest))
+	assert.Contains(t, page, "You may still get other kinds of email from Freegle.")
+	assert.NotContains(t, page, "You'll still hear when someone replies to your posts")
+}
+
+func TestDonePage_AllExceptRepliesShowsReassuranceNotOtherNotice(t *testing.T) {
+	page := donePage(UnsubAllExceptReplies)
+	assert.Contains(t, page, "You'll still hear when someone replies to your posts")
+	assert.NotContains(t, page, "You may still get other kinds of email from Freegle.")
+}
+
+func TestDonePage_UnsubAllShowsNeitherNotice(t *testing.T) {
+	page := donePage(UnsubAll)
+	assert.NotContains(t, page, "You'll still hear when someone replies to your posts")
+	assert.NotContains(t, page, "You may still get other kinds of email from Freegle.")
+}
+
+func TestDonePage_LinksToSettingsPage(t *testing.T) {
+	orig, had := os.LookupEnv("USER_SITE")
+	os.Setenv("USER_SITE", "my.example.com")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("USER_SITE", orig)
+		} else {
+			os.Unsetenv("USER_SITE")
+		}
+	})
+
+	page := donePage(UnsubDigest)
+	assert.Contains(t, page, "https://my.example.com/settings")
+}

--- a/iznik-server-go/utils/geoip_test.go
+++ b/iznik-server-go/utils/geoip_test.go
@@ -1,0 +1,201 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/oschwald/maxminddb-golang"
+	"github.com/stretchr/testify/assert"
+)
+
+// mustEmbeddedReader loads the real embedded GeoLite2 database directly,
+// independent of loadGeoIPReader/geoipOnce, so tests can exercise
+// countryCodeForIP without depending on CountryCodeForIP's cache having
+// fired yet.
+func mustEmbeddedReader(t *testing.T) *maxminddb.Reader {
+	t.Helper()
+	reader, err := maxminddb.FromBytes(embeddedGeoIP)
+	if err != nil {
+		t.Fatalf("failed to load embedded GeoIP db: %v", err)
+	}
+	return reader
+}
+
+// withGeoIPPath sets GEOIP_MMDB_PATH for the duration of the test and
+// restores whatever was there before (including "unset") on cleanup.
+func withGeoIPPath(t *testing.T, value string) {
+	t.Helper()
+	orig, had := os.LookupEnv("GEOIP_MMDB_PATH")
+	if value == "" {
+		os.Unsetenv("GEOIP_MMDB_PATH")
+	} else {
+		os.Setenv("GEOIP_MMDB_PATH", value)
+	}
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("GEOIP_MMDB_PATH", orig)
+		} else {
+			os.Unsetenv("GEOIP_MMDB_PATH")
+		}
+	})
+}
+
+func TestCountryCodeForIP_NilReader(t *testing.T) {
+	// A nil reader (e.g. the embedded db failed to load) must degrade to "",
+	// not panic.
+	assert.Equal(t, "", countryCodeForIP(nil, "8.8.8.8"))
+	assert.Equal(t, "", countryCodeForIP(nil, ""))
+}
+
+func TestCountryCodeForIP_EmptyAndUnparseable(t *testing.T) {
+	reader := mustEmbeddedReader(t)
+
+	tests := []string{
+		"",
+		"not-an-ip",
+		"999.999.999.999",
+		"8.8.8",
+		"gibberish-hostname.example.com",
+		"   ",
+	}
+	for _, ip := range tests {
+		assert.Equal(t, "", countryCodeForIP(reader, ip), "ip=%q", ip)
+	}
+}
+
+func TestCountryCodeForIP_KnownPublicIPs(t *testing.T) {
+	reader := mustEmbeddedReader(t)
+
+	tests := []struct {
+		name    string
+		ip      string
+		country string
+	}{
+		{"Google DNS v4 is US", "8.8.8.8", "US"},
+		{"BBC is GB", "212.58.244.22", "GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.country, countryCodeForIP(reader, tt.ip))
+		})
+	}
+}
+
+func TestCountryCodeForIP_PrivateAndUnresolvable(t *testing.T) {
+	reader := mustEmbeddedReader(t)
+
+	// Private/loopback ranges have no country entry in the GeoLite2 db, so
+	// these must all resolve to "" rather than erroring.
+	tests := []string{
+		"127.0.0.1",
+		"10.0.0.1",
+		"192.168.1.1",
+		"::1",
+	}
+	for _, ip := range tests {
+		assert.Equal(t, "", countryCodeForIP(reader, ip), "ip=%s", ip)
+	}
+}
+
+func TestLoadGeoIPReader_NoEnvFallsBackToEmbedded(t *testing.T) {
+	withGeoIPPath(t, "")
+
+	reader := loadGeoIPReader()
+	if assert.NotNil(t, reader) {
+		assert.Equal(t, "US", countryCodeForIP(reader, "8.8.8.8"))
+	}
+}
+
+func TestLoadGeoIPReader_MissingPathFallsBackToEmbedded(t *testing.T) {
+	withGeoIPPath(t, "/nonexistent/path/does-not-exist.mmdb")
+
+	reader := loadGeoIPReader()
+	if assert.NotNil(t, reader) {
+		assert.Equal(t, "US", countryCodeForIP(reader, "8.8.8.8"))
+	}
+}
+
+func TestLoadGeoIPReader_UnreadableFileFallsBackToEmbedded(t *testing.T) {
+	// A file that exists but isn't a valid mmdb - Open should error and the
+	// function must fall through to the embedded copy rather than returning nil.
+	dir := t.TempDir()
+	badPath := filepath.Join(dir, "bad.mmdb")
+	if err := os.WriteFile(badPath, []byte("not a real mmdb file"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	withGeoIPPath(t, badPath)
+
+	reader := loadGeoIPReader()
+	if assert.NotNil(t, reader) {
+		assert.Equal(t, "US", countryCodeForIP(reader, "8.8.8.8"))
+	}
+}
+
+func TestLoadGeoIPReader_ExplicitValidPathWins(t *testing.T) {
+	// Point GEOIP_MMDB_PATH at a real mmdb file (a copy of the embedded one) -
+	// the explicit path must be used successfully, not just fall through.
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "explicit.mmdb")
+	if err := os.WriteFile(dbPath, embeddedGeoIP, 0o644); err != nil {
+		t.Fatalf("write temp mmdb: %v", err)
+	}
+
+	withGeoIPPath(t, dbPath)
+
+	reader := loadGeoIPReader()
+	if assert.NotNil(t, reader) {
+		assert.Equal(t, "US", countryCodeForIP(reader, "8.8.8.8"))
+	}
+}
+
+func TestLoadGeoIPReader_EmptyEmbeddedFallsBackToNil(t *testing.T) {
+	// Defensive branch that can't occur via go:embed in practice (the file is
+	// always present at build time), but the code guards it explicitly with
+	// len(embeddedGeoIP) > 0 - exercise the false side directly.
+	orig := embeddedGeoIP
+	t.Cleanup(func() { embeddedGeoIP = orig })
+	embeddedGeoIP = nil
+
+	withGeoIPPath(t, "")
+
+	assert.Nil(t, loadGeoIPReader())
+}
+
+func TestLoadGeoIPReader_CorruptEmbeddedBytesFallsBackToNil(t *testing.T) {
+	// Non-empty but invalid bytes - FromBytes should error and the function
+	// returns nil rather than panicking.
+	orig := embeddedGeoIP
+	t.Cleanup(func() { embeddedGeoIP = orig })
+	embeddedGeoIP = []byte("not a real mmdb")
+
+	withGeoIPPath(t, "")
+
+	assert.Nil(t, loadGeoIPReader())
+}
+
+func TestCountryCodeForIP_ExportedWrapperConcurrentUse(t *testing.T) {
+	// CountryCodeForIP lazily initialises the shared reader via sync.Once;
+	// concurrent first-use must be race-free and every caller must see the
+	// same, correctly-loaded result.
+	const n = 20
+	var wg sync.WaitGroup
+	results := make([]string, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = CountryCodeForIP("8.8.8.8")
+		}(i)
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		assert.Equal(t, "US", r)
+	}
+
+	// An unparseable IP through the exported wrapper must also degrade to "".
+	assert.Equal(t, "", CountryCodeForIP("not-an-ip"))
+}


### PR DESCRIPTION
## Summary

The community news newsletter could feature an event that had already happened.

Research runs hourly, the newsletter goes out on Fridays, and an item stays eligible for `item_freshness_days` (10 on live) after it was found. A jumble sale researched on Monday and held on Wednesday was therefore still perfectly "fresh" on Friday, and went out inviting people to something that was over.

Nothing in the table said when the event was. `researched_at` records when *we* looked, which says nothing about when the event *is*, so no filter was possible. Items now carry a nullable `event_date` captured at research time, and both the newsletter and the ChitChat post skip anything whose date has passed.

ChitChat selects items the same way, with the same freshness window, so it had the identical defect and is fixed alongside the newsletter this was reported against.

Behaviour worth being explicit about:

- **Undated items are the common case** — a new cycle path, a library reopening — and are entirely unaffected.
- **Something happening today still goes out.** A reader opening the email that morning can still turn up.
- **A past item is not consumed.** It stays unemailed rather than being silently marked as sent.

## Code Quality Review

- Date parsing is deliberately strict: only an exact, real, in-range `YYYY-MM-DD` survives, and anything else becomes no date at all. A wrong date is worse than none — it either buries an event still to come or lets a past one through, which is the thing this exists to prevent.
- Carbon's `createFromFormat` accepts overflow (`2026-02-31` silently becomes 3 March), so the parsed value is compared back against the input and rejected if it moved.
- Dates more than a year either side of now are dropped as parsing artefacts; trusting one would keep a stale item eligible indefinitely.
- The research prompt is given today's date, since the model cannot otherwise resolve "this Saturday", and is asked for the first day of anything spanning several.
- `DATE` rather than a datetime: what matters is whether the day has passed, and research only recovers day-level precision from a listing anyway.
- The filter is `whereNull OR >= startOfDay`, so it can never exclude an undated item through a NULL comparison.
- Migration is idempotent (guards on `hasTable`/`hasColumn`) with the production SQL twin, and adding a nullable column is metadata-only in MySQL 8.

## Future Improvements

- Existing rows have no `event_date`, so items researched before this ships keep the old behaviour until they age out of the freshness window. A backfill was not attempted: the event date is not recoverable from the stored title and blurb with any confidence, and guessing would reintroduce exactly the wrong-date risk the parser guards against.
- Multi-day events record only their first day, so one still drops out on day two. Storing an end date would let a run of several days stay listed throughout.

## Test Plan

- Laravel suite via the status API: **5265 passed, 0 failed**.
- New in `CommunityNewsEmailServiceTest`: a past event is left out while a future one goes out and the past item stays unemailed; an event happening today is still included; an undated item is unaffected.
- New in `CommunityNewsResearchServiceTest`: an event date is captured; an undated item stays undated; and six untrusted inputs are each rejected — `Saturday`, `12/09/2026`, `2026-13-01`, `2026-02-31`, a date years out, and empty.

## Go coverage (unrelated to the fix above)

This PR touches no Go code, but the `Coveralls - go` check went red on a sub-0.1% global coverage dip (run-to-run noise, not caused by this branch). Rather than open a separate PR, two previously-untested pure Go functions got real unit tests on this branch:

- `iznik-server-go/utils/geoip_test.go`: `CountryCodeForIP`/`countryCodeForIP`/`loadGeoIPReader` (message-create GeoIP lookup) were at 0% coverage. Now covers nil reader, empty/unparseable IP, known public IPs, private/unresolvable ranges, `GEOIP_MMDB_PATH` override/fallback, and corrupt-embedded-db defensive branches. `utils` package: 87.3% → 96.8%.
- `iznik-server-go/user/unsubscribe_pure_test.go`: the List-Unsubscribe HTML-page helpers (`singleUnsubscribeCategories`, `UnsubscribeDescription`, `validUnsubscribeType`, `describeFor`, `pageHead`, `confirmPage`, `donePage`, `userSiteBase`) were untested. Now covers all category branches, HTML escaping, and `USER_SITE` env fallback. `user` package: 8.6% → 10.9%.

No production code changed in either file.