### PR TITLE
feat(modtools): show which community a chat's post is on, in chat review

### DIFF
--- a/iznik-nuxt3/modtools/components/ModChatReview.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReview.vue
@@ -153,9 +153,9 @@
                act (the other member is on a group you mod), which is a
                different thing - a mod of many communities was having to open
                each chat to work out whether the post was theirs to handle. -->
-          <span v-if="message.refmsggroup">
+          <span v-if="message.refmsggroups?.length">
             <v-icon icon="signpost-2" /> Post is on
-            {{ message.refmsggroup.namedisplay }}
+            {{ postGroupNames(message) }}
           </span>
           <span>
             <v-icon icon="hashtag" class="text-muted" scale="0.75" />{{
@@ -472,6 +472,17 @@ const reviewreason = computed(() => {
 
   return ret
 })
+
+// The communities the post is on, origin first as the server orders them, then
+// the ones it rippled to. Comma-separated, the way group lists read elsewhere -
+// a moderator is scanning for whether ANY of these is theirs, so the names have
+// to be there rather than hidden behind a count.
+function postGroupNames(message) {
+  return (message?.refmsggroups ?? [])
+    .map((g) => g.namedisplay)
+    .filter(Boolean)
+    .join(', ')
+}
 
 function reload() {
   emit('reload')

--- a/iznik-nuxt3/modtools/components/ModChatReview.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReview.vue
@@ -149,6 +149,14 @@
               </b-button>
             </span>
           </span>
+          <!-- Which community the POST is on. The line above says why you can
+               act (the other member is on a group you mod), which is a
+               different thing - a mod of many communities was having to open
+               each chat to work out whether the post was theirs to handle. -->
+          <span v-if="message.refmsggroup">
+            <v-icon icon="signpost-2" /> Post is on
+            {{ message.refmsggroup.namedisplay }}
+          </span>
           <span>
             <v-icon icon="hashtag" class="text-muted" scale="0.75" />{{
               message.id

--- a/iznik-nuxt3/tests/e2e/test-modtools-chat-review.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-modtools-chat-review.spec.js
@@ -1,0 +1,203 @@
+// @ts-check
+/**
+ * Tests for the ModTools Chat Review page (modtools/pages/chats/review.vue)
+ * and its collapsible help panel (modtools/components/ModHelpChatReview.vue).
+ *
+ * The review queue itself is populated asynchronously - a message only shows
+ * up here after chats:process-incoming (run on a schedule) flags it via a
+ * content check - so the seeded test database never has anything pending
+ * review. These tests cover the parts of the page that are always reachable
+ * regardless of queue contents: the empty-queue state, getting to the page
+ * via the sidebar nav link (as opposed to a direct URL, which exercises a
+ * different code path in ModMenuItemLeft's click handler), and the help
+ * panel toggle, none of which had any e2e coverage before.
+ */
+
+const { test, expect } = require('./fixtures')
+const { timeouts, environment } = require('./config')
+const { loginViaModTools } = require('./utils/user')
+
+const MODTOOLS_URL = environment.modtoolsBaseUrl
+
+// Helper: dismiss any overlay modals that block interaction.
+async function dismissAllModals(page) {
+  await page.evaluate(() => {
+    document
+      .querySelectorAll('.modal.show, .modal[style*="display: block"]')
+      .forEach((el) => {
+        el.classList.remove('show')
+        el.style.display = 'none'
+      })
+    document.querySelectorAll('.modal-backdrop').forEach((el) => el.remove())
+    document.body.classList.remove('modal-open')
+    document.body.style.removeProperty('overflow')
+    document.body.style.removeProperty('padding-right')
+  })
+}
+
+// Helper: check page for common error indicators.
+async function assertNoErrors(page) {
+  const body = await page.textContent('body')
+  expect(body).not.toContain('something went wrong')
+  expect(body).not.toContain('Oh dear')
+  expect(body).not.toContain('undefined is not an object')
+  expect(body).not.toContain('Cannot read properties of undefined')
+}
+
+// Helper: navigate to the Chat Review page directly and wait for the initial
+// review-queue fetch to settle.
+async function gotoChatReview(page) {
+  const errors = []
+  page.on('pageerror', (error) => {
+    errors.push(error.message)
+  })
+
+  await page
+    .goto(`${MODTOOLS_URL}/chats/review`, {
+      timeout: timeouts.navigation.initial,
+      waitUntil: 'domcontentloaded',
+    })
+    .catch((e) => {
+      if (!e.message.includes('ERR_ABORTED')) throw e
+    })
+
+  await page
+    .waitForURL(`${MODTOOLS_URL}/chats/review**`, {
+      timeout: timeouts.navigation.slowPage,
+    })
+    .catch(() => {})
+
+  // Wait for the loading spinner(s) to disappear - confirms the onMounted
+  // fetchReviewChatsMT call has completed.
+  const spinner = page.locator('.spinner-border').first()
+  if (
+    await spinner
+      .isVisible({ timeout: timeouts.ui.appearance })
+      .catch(() => false)
+  ) {
+    await expect(spinner).not.toBeVisible({
+      timeout: timeouts.navigation.slowPage,
+    })
+  }
+
+  await dismissAllModals(page)
+  return errors
+}
+
+test.describe('ModTools Chat Review', () => {
+  test('empty review queue shows no messages, no errors, and no Delete All button', async ({
+    page,
+    testEnv,
+  }) => {
+    await loginViaModTools(page, testEnv.mod.email)
+    const errors = await gotoChatReview(page)
+
+    // The fixtures never seed a chat_messages row with reviewrequired=1, so
+    // the queue is reliably empty - no ModChatReview card should render, and
+    // the "Delete All" bulk-action button (which only shows for >1 visible
+    // message) must stay hidden rather than throwing on an empty list.
+    await expect(page.getByRole('button', { name: 'Delete All' })).toHaveCount(
+      0
+    )
+    await expect(
+      page.getByRole('button', { name: 'Approve - Not Spam' })
+    ).toHaveCount(0)
+
+    await assertNoErrors(page)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('help panel is collapsed by default, expands with full guidance, and collapses again', async ({
+    page,
+    testEnv,
+  }) => {
+    await loginViaModTools(page, testEnv.mod.email)
+    await gotoChatReview(page)
+
+    const helpToggle = page.getByRole('button', { name: 'Help', exact: true })
+    const hideHelpButton = page.getByRole('button', { name: 'Hide Help' })
+    const guidanceText = page.getByText(/worry words/i)
+    const wikiLink = page.getByRole('link', { name: 'the wiki' })
+
+    // Collapsed by default (ModHelpChatReview calls hide() on mount).
+    await expect(helpToggle).toBeVisible({ timeout: timeouts.ui.appearance })
+    await expect(hideHelpButton).toHaveCount(0)
+    await expect(guidanceText).toHaveCount(0)
+
+    // Expand.
+    await helpToggle.click()
+    await expect(hideHelpButton).toBeVisible({
+      timeout: timeouts.ui.appearance,
+    })
+    await expect(guidanceText).toBeVisible()
+    await expect(page.getByText(/Quicker Chat Review/i).first()).toBeVisible()
+    await expect(page.getByText(/Add Moderator message/i)).toBeVisible()
+    await expect(wikiLink).toHaveAttribute(
+      'href',
+      'https://wiki.ilovefreegle.org/Spammers#Chat_Review'
+    )
+    await expect(helpToggle).toHaveCount(0)
+
+    // Collapse again.
+    await hideHelpButton.click()
+    await expect(helpToggle).toBeVisible({ timeout: timeouts.ui.appearance })
+    await expect(hideHelpButton).toHaveCount(0)
+    await expect(guidanceText).toHaveCount(0)
+
+    await assertNoErrors(page)
+  })
+
+  test('sidebar nav link reaches Chat Review, marks it active, and re-clicking the active link does not navigate away', async ({
+    page,
+    testEnv,
+  }) => {
+    await loginViaModTools(page, testEnv.mod.email)
+
+    const errors = []
+    page.on('pageerror', (error) => {
+      errors.push(error.message)
+    })
+
+    // Start somewhere else in ModTools so the nav click is a real route
+    // change (router.push branch of ModMenuItemLeft's click handler).
+    await page
+      .goto(`${MODTOOLS_URL}/chats`, {
+        timeout: timeouts.navigation.initial,
+        waitUntil: 'domcontentloaded',
+      })
+      .catch((e) => {
+        if (!e.message.includes('ERR_ABORTED')) throw e
+      })
+    await dismissAllModals(page)
+
+    const chatReviewLink = page.getByRole('link', {
+      name: 'Chat Review',
+      exact: true,
+    })
+    await chatReviewLink.waitFor({
+      state: 'visible',
+      timeout: timeouts.ui.appearance,
+    })
+    await chatReviewLink.click()
+
+    await page.waitForURL(`${MODTOOLS_URL}/chats/review**`, {
+      timeout: timeouts.navigation.default,
+    })
+
+    // The nav item's wrapping div (ModMenuItemLeft's root, class "ps-1")
+    // picks up an "active" class once the route matches its link (getClass
+    // computed).
+    const navItem = page.locator('div.ps-1', { has: chatReviewLink })
+    await expect(navItem).toHaveClass(/active/)
+
+    // Clicking the link again while already on that route takes the
+    // "click on current route" branch (checkWork, no router.push) rather
+    // than navigating away.
+    await chatReviewLink.click()
+    await expect(page).toHaveURL(/\/chats\/review\/?(\?.*)?$/)
+
+    await dismissAllModals(page)
+    await assertNoErrors(page)
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/message.coverage.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/message.coverage.spec.js
@@ -1,0 +1,1275 @@
+/**
+ * Broad coverage pass over stores/message.js actions/getters that
+ * message.spec.js and message.heldByOtherMod.spec.js don't touch: the
+ * fetch()/processMessageBatch()/fetchMultiple() batching pipeline,
+ * handleFetchError(), fetchInBounds/search/similar/matches/fetchMyGroups/
+ * fetchByUser, bulkInterest(State), Helper actions, update(), remove/clear,
+ * the promise/renege/addBy/removeBy/intend family, markSeen()'s 401 swallow,
+ * fetchMT/fetchReach/updateMT, delete/approveedits/revertedits/backToPending,
+ * approve/reject's fromuser re-fetch, reply/spam/move, searchMember, and the
+ * remaining getters.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+import { useMessageStore } from '~/stores/message'
+import { useAuthStore } from '~/stores/auth'
+import { APIError } from '~/api/APIErrors'
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const mockApiFetch = vi.fn()
+const mockFetchByUser = vi.fn()
+const mockSave = vi.fn()
+const mockFetch = vi.fn()
+const mockSearch = vi.fn()
+const mockSimilar = vi.fn()
+const mockMatches = vi.fn()
+const mockInbounds = vi.fn()
+const mockMygroups = vi.fn()
+const mockFetchMessages = vi.fn()
+const mockView = vi.fn()
+const mockMarkSeen = vi.fn()
+const mockCount = vi.fn()
+const mockNearbyMarkSeen = vi.fn()
+const mockHold = vi.fn()
+const mockRelease = vi.fn()
+const mockFetchMT = vi.fn()
+const mockBulkInterest = vi.fn()
+const mockBulkInterestState = vi.fn()
+const mockGetHelper = vi.fn()
+const mockHelper = vi.fn()
+const mockUpdate = vi.fn()
+const mockAddBy = vi.fn()
+const mockRemoveBy = vi.fn()
+const mockIntend = vi.fn()
+const mockReach = vi.fn()
+const mockDelete = vi.fn()
+const mockApprove = vi.fn()
+const mockReject = vi.fn()
+const mockReply = vi.fn()
+const mockSpam = vi.fn()
+const mockApproveEdits = vi.fn()
+const mockRevertEdits = vi.fn()
+const mockGroupFetchBatch = vi.fn()
+const mockUserFetch = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    message: {
+      fetch: mockApiFetch,
+      fetchByUser: mockFetchByUser,
+      save: mockSave,
+      inbounds: mockInbounds,
+      search: mockSearch,
+      similar: mockSimilar,
+      matches: mockMatches,
+      mygroups: mockMygroups,
+      fetchMessages: mockFetchMessages,
+      view: mockView,
+      markSeen: mockMarkSeen,
+      count: mockCount,
+      hold: mockHold,
+      release: mockRelease,
+      fetchMT: mockFetchMT,
+      bulkInterest: mockBulkInterest,
+      bulkInterestState: mockBulkInterestState,
+      getHelper: mockGetHelper,
+      helper: mockHelper,
+      update: mockUpdate,
+      addBy: mockAddBy,
+      removeBy: mockRemoveBy,
+      intend: mockIntend,
+      reach: mockReach,
+      delete: mockDelete,
+      approve: mockApprove,
+      reject: mockReject,
+      reply: mockReply,
+      spam: mockSpam,
+      approveEdits: mockApproveEdits,
+      revertEdits: mockRevertEdits,
+    },
+  }),
+}))
+
+vi.mock('~/stores/auth', () => ({
+  useAuthStore: vi.fn(),
+}))
+
+vi.mock('~/stores/group', () => ({
+  useGroupStore: () => ({ fetchBatch: mockGroupFetchBatch }),
+}))
+
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => ({ fetch: mockUserFetch }),
+}))
+
+const mockNearbyStore = { markSeen: mockNearbyMarkSeen, messageList: [] }
+vi.mock('~/stores/nearby', () => ({
+  useNearbyStore: () => mockNearbyStore,
+}))
+
+const mockMiscStore = { modtools: false }
+vi.mock('~/stores/misc', () => ({
+  useMiscStore: () => mockMiscStore,
+}))
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+  useAuthStore.mockReturnValue({ user: { id: 1 } })
+  mockNearbyStore.messageList = []
+})
+
+describe('message store - fetch() cache/batch behaviour', () => {
+  it('returns the cached message immediately without hitting the batch pipeline', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[5] = { id: 5, addedToCache: Math.round(Date.now() / 1000) }
+
+    const result = await store.fetch(5)
+
+    expect(result).toBe(store.list[5])
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  // TODO: latent bug - fetch() correctly identifies an expired-but-unforced
+  // cache entry as needing a refresh and routes it into the batch, but
+  // fetchMultiple() re-derives its own "needs fetching" filter from
+  // `force || !this.list[id]` alone (it isn't told which ids were expired
+  // vs merely missing). Since the id IS cached and force is false, it never
+  // makes the API call - the stale entry is silently kept forever and the
+  // 10-minute refetch documented at stores/message.js:64-68 never fires.
+  it.skip('re-fetches when the cached entry expired more than 10 minutes ago', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[6] = {
+      id: 6,
+      addedToCache: Math.round(Date.now() / 1000) - 601,
+    }
+    mockApiFetch.mockResolvedValue([{ id: 6, subject: 'fresh' }])
+
+    const p = store.fetch(6)
+    await wait(70)
+    await p
+
+    expect(mockApiFetch).toHaveBeenCalledWith('6', false)
+    expect(store.list[6].subject).toBe('fresh')
+  })
+
+  it('bypasses a fresh cache entry when force is true', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[7] = { id: 7, addedToCache: Math.round(Date.now() / 1000) }
+    mockApiFetch.mockResolvedValue([{ id: 7, subject: 'forced' }])
+
+    const p = store.fetch(7, true)
+    await wait(70)
+    await p
+
+    expect(mockApiFetch).toHaveBeenCalledWith('7', false)
+  })
+
+  it('awaits an in-flight fetch for the same id and returns the cached value', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[8] = { id: 8, subject: 'settled' }
+    store.fetching[8] = Promise.resolve()
+
+    const result = await store.fetch(8)
+
+    expect(result).toEqual({ id: 8, subject: 'settled' })
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('swallows a 404 from an in-flight fetch via handleFetchError', async () => {
+    const store = useMessageStore()
+    store.init({})
+    // Deliberately not cached: fetch()'s early "already have it" return only
+    // triggers when this.list[id] is set, so leaving it empty is what routes
+    // this call through the "already fetching" branch being tested here.
+    store.fetching[9] = Promise.reject(
+      new APIError({ response: { status: 404 } }, 'gone')
+    )
+
+    const result = await store.fetch(9)
+
+    expect(result).toBeUndefined()
+    expect(store.list[9]).toBeUndefined()
+  })
+
+  it('propagates a non-404 error from an in-flight fetch', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.fetching[10] = Promise.reject(new Error('boom'))
+
+    await expect(store.fetch(10)).rejects.toThrow('boom')
+  })
+
+  it('batches concurrent fetch() calls for different ids into one API call', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockResolvedValue([
+      { id: 20, subject: 'a' },
+      { id: 21, subject: 'b' },
+    ])
+
+    const p1 = store.fetch(20)
+    const p2 = store.fetch(21)
+    await wait(70)
+    const [r1, r2] = await Promise.all([p1, p2])
+
+    expect(mockApiFetch).toHaveBeenCalledTimes(1)
+    expect(mockApiFetch).toHaveBeenCalledWith('20,21', false)
+    expect(r1.subject).toBe('a')
+    expect(r2.subject).toBe('b')
+  })
+})
+
+describe('message store - handleFetchError()', () => {
+  it('removes a 404d message from list and the current user byUserList', () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[30] = { id: 30 }
+    store.byUserList[1] = [{ id: 30 }, { id: 31 }]
+
+    store.handleFetchError(30, new APIError({ response: { status: 404 } }, 'x'))
+
+    expect(store.list[30]).toBeUndefined()
+    expect(store.byUserList[1]).toEqual([{ id: 31 }])
+  })
+
+  it('does not touch byUserList when there is no logged in user', () => {
+    useAuthStore.mockReturnValue({ user: null })
+    const store = useMessageStore()
+    store.init({})
+    store.list[30] = { id: 30 }
+
+    store.handleFetchError(30, new APIError({ response: { status: 404 } }, 'x'))
+
+    expect(store.list[30]).toBeUndefined()
+  })
+
+  it('rethrows a non-404 APIError', () => {
+    const store = useMessageStore()
+    store.init({})
+
+    expect(() =>
+      store.handleFetchError(30, new APIError({ response: { status: 500 } }, 'x'))
+    ).toThrow()
+  })
+
+  it('rethrows an error that is not an APIError at all', () => {
+    const store = useMessageStore()
+    store.init({})
+
+    expect(() => store.handleFetchError(30, new Error('plain'))).toThrow(
+      'plain'
+    )
+  })
+})
+
+describe('message store - processMessageBatch()', () => {
+  it('does nothing when there are no pending fetches', async () => {
+    const store = useMessageStore()
+    store.init({})
+
+    await store.processMessageBatch()
+
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('skips ids that are already cached and not forced, but still resolves them', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[40] = { id: 40, addedToCache: Math.round(Date.now() / 1000) }
+    let resolved
+    store.pendingFetches = [
+      {
+        id: 40,
+        force: false,
+        resolve: (v) => (resolved = v),
+        reject: () => {},
+      },
+    ]
+
+    await store.processMessageBatch()
+
+    expect(mockApiFetch).not.toHaveBeenCalled()
+    expect(resolved).toBe(store.list[40])
+  })
+
+  it('logs and swallows an error from fetchMultiple', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockRejectedValue(new Error('down'))
+    let resolved = 'not-called'
+    store.pendingFetches = [
+      {
+        id: 41,
+        force: false,
+        resolve: (v) => (resolved = v),
+        reject: () => {},
+      },
+    ]
+
+    await expect(store.processMessageBatch()).resolves.toBeUndefined()
+    expect(resolved).toBeUndefined()
+  })
+})
+
+describe('message store - fetchMultiple()', () => {
+  it('skips ids already cached and not forced, and never calls the API', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[50] = { id: 50 }
+
+    await store.fetchMultiple([50], false)
+
+    expect(mockApiFetch).not.toHaveBeenCalled()
+    expect(mockGroupFetchBatch).not.toHaveBeenCalled()
+  })
+
+  it('re-fetches an already cached id when force is true', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[51] = { id: 51, subject: 'stale' }
+    mockApiFetch.mockResolvedValue([{ id: 51, subject: 'new' }])
+
+    await store.fetchMultiple([51], true)
+
+    expect(mockApiFetch).toHaveBeenCalledWith('51', false)
+    expect(store.list[51].subject).toBe('new')
+  })
+
+  it('splits more than 19 ids into multiple chunks', async () => {
+    const store = useMessageStore()
+    store.init({})
+    const ids = Array.from({ length: 20 }, (_, i) => 100 + i)
+    mockApiFetch.mockImplementation((joined) =>
+      Promise.resolve(
+        joined.split(',').map((id) => ({ id: parseInt(id), subject: 'x' }))
+      )
+    )
+
+    await store.fetchMultiple(ids, false)
+
+    expect(mockApiFetch).toHaveBeenCalledTimes(2)
+    expect(store.list[100]).toBeDefined()
+    expect(store.list[119]).toBeDefined()
+  })
+
+  it('stores a single object response keyed by its own id', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockResolvedValue({ id: 60, subject: 'solo' })
+
+    await store.fetchMultiple([60], false)
+
+    expect(store.list[60].subject).toBe('solo')
+    expect(store.list[60].addedToCache).toBeDefined()
+  })
+
+  it('logs and does not throw for an unexpected response shape', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockResolvedValue('unexpected-string')
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(store.fetchMultiple([61], false)).resolves.toBeUndefined()
+
+    expect(errSpy).toHaveBeenCalledWith('Failed to fetch', 'unexpected-string')
+    errSpy.mockRestore()
+  })
+
+  it('swallows a 404 from the batch API call', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockRejectedValue(
+      new APIError({ response: { status: 404 } }, 'gone')
+    )
+
+    await expect(store.fetchMultiple([62], false)).resolves.toBeUndefined()
+    expect(store.fetching[62]).toBeNull()
+  })
+
+  it('rethrows a non-404 error from the batch API call', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockRejectedValue(new Error('server exploded'))
+
+    await expect(store.fetchMultiple([63], false)).rejects.toThrow(
+      'server exploded'
+    )
+    // finally block still ran and cleared the fetching flag
+    expect(store.fetching[63]).toBeNull()
+  })
+
+  it('batch-fetches the groups referenced by the newly fetched messages', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockResolvedValue([
+      { id: 70, groups: [{ groupid: 200 }, { groupid: 201 }] },
+      { id: 71, groups: [{ groupid: 201 }] },
+    ])
+
+    await store.fetchMultiple([70, 71], false)
+
+    expect(mockGroupFetchBatch).toHaveBeenCalledWith([200, 201])
+  })
+
+  it('does not call fetchBatch when no groups are referenced', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockResolvedValue([{ id: 72 }])
+
+    await store.fetchMultiple([72], false)
+
+    expect(mockGroupFetchBatch).not.toHaveBeenCalled()
+  })
+})
+
+describe('message store - fetchInBounds()', () => {
+  it('fetches and caches by composite key', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockInbounds.mockResolvedValue([{ id: 1 }])
+
+    const result = await store.fetchInBounds(1, 2, 3, 4, 5, 10, true)
+
+    expect(result).toEqual([{ id: 1 }])
+    expect(store.bounds['1:2:3:4:5']).toEqual([{ id: 1 }])
+  })
+
+  it('returns the cached value without calling the API again', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.bounds['1:2:3:4:5'] = [{ id: 'cached' }]
+
+    const result = await store.fetchInBounds(1, 2, 3, 4, 5, 10, true)
+
+    expect(result).toEqual([{ id: 'cached' }])
+    expect(mockInbounds).not.toHaveBeenCalled()
+  })
+
+  it('does not use the cache when cache=false', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.bounds['1:2:3:4:5'] = [{ id: 'cached' }]
+    mockInbounds.mockResolvedValue([{ id: 'fresh' }])
+
+    const result = await store.fetchInBounds(1, 2, 3, 4, 5, 10, false)
+
+    expect(result).toEqual([{ id: 'fresh' }])
+  })
+})
+
+describe('message store - search/similar/matches passthroughs', () => {
+  it('search() clears the store then delegates to the API', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.count = 99
+    mockSearch.mockResolvedValue(['result'])
+
+    const result = await store.search({ search: 'sofa' })
+
+    expect(store.count).toBe(0)
+    expect(mockSearch).toHaveBeenCalledWith({ search: 'sofa' })
+    expect(result).toEqual(['result'])
+  })
+
+  it('similar() forwards id and limit', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockSimilar.mockResolvedValue([{ id: 5 }])
+
+    const result = await store.similar(123, 4)
+
+    expect(mockSimilar).toHaveBeenCalledWith(123, 4)
+    expect(result).toEqual([{ id: 5 }])
+  })
+
+  it('matches() forwards query/lat/lng/limit', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockMatches.mockResolvedValue([{ id: 6 }])
+
+    const result = await store.matches('chair', 1.1, 2.2, 3)
+
+    expect(mockMatches).toHaveBeenCalledWith('chair', 1.1, 2.2, 3)
+    expect(result).toEqual([{ id: 6 }])
+  })
+})
+
+describe('message store - fetchMyGroups()', () => {
+  it('stores the combined feed when no gid is given', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockMygroups.mockResolvedValue([{ id: 1 }, { id: 2 }])
+
+    const result = await store.fetchMyGroups()
+
+    expect(store.myGroupsList).toEqual([{ id: 1 }, { id: 2 }])
+    expect(result).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('does not overwrite myGroupsList for a single-group fetch', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.myGroupsList = [{ id: 'existing' }]
+    mockMygroups.mockResolvedValue([{ id: 99 }])
+
+    await store.fetchMyGroups(5)
+
+    expect(store.myGroupsList).toEqual([{ id: 'existing' }])
+  })
+
+  it('a concurrent call awaits the in-flight fetch instead of firing a second request', async () => {
+    const store = useMessageStore()
+    store.init({})
+    let resolveApi
+    mockMygroups.mockReturnValue(
+      new Promise((resolve) => {
+        resolveApi = resolve
+      })
+    )
+
+    const p1 = store.fetchMyGroups()
+    const p2 = store.fetchMyGroups()
+    resolveApi([{ id: 1 }])
+    const [r1, r2] = await Promise.all([p1, p2])
+
+    expect(mockMygroups).toHaveBeenCalledTimes(1)
+    expect(r1).toEqual([{ id: 1 }])
+    expect(r2).toEqual([{ id: 1 }])
+  })
+})
+
+describe('message store - fetchByUser()', () => {
+  it('awaits the server for a fresh (non-active) request and marks own messages seen', async () => {
+    useAuthStore.mockReturnValue({ user: { id: 1 } })
+    const store = useMessageStore()
+    store.init({})
+    mockFetchByUser.mockResolvedValue([{ id: 1, unseen: true }])
+
+    const result = await store.fetchByUser(1, false, false)
+
+    expect(result[0].unseen).toBe(false)
+    expect(store.byUserList[1]).toEqual(result)
+  })
+
+  it('defaults to an empty array when the API returns something non-array', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFetchByUser.mockResolvedValue(null)
+
+    const result = await store.fetchByUser(1, false, false)
+
+    expect(result).toEqual([])
+  })
+
+  it('returns the cache immediately for active messages and refreshes in the background', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.byUserList[1] = [{ id: 1, unseen: true }]
+    let resolveApi
+    mockFetchByUser.mockReturnValue(
+      new Promise((resolve) => {
+        resolveApi = resolve
+      })
+    )
+
+    const result = await store.fetchByUser(1, true, false)
+    expect(result).toEqual([{ id: 1, unseen: true }])
+
+    resolveApi([{ id: 1, unseen: true }])
+    await wait(10)
+    expect(store.byUserList[1][0].unseen).toBe(false)
+  })
+
+  it('force=true always awaits the server even when cached', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.byUserList[1] = [{ id: 'stale' }]
+    mockFetchByUser.mockResolvedValue([{ id: 'fresh' }])
+
+    const result = await store.fetchByUser(1, true, true)
+
+    // userid (1) matches the mocked logged-in user, so isOwnMessages forces
+    // unseen=false on every returned message.
+    expect(result).toEqual([{ id: 'fresh', unseen: false }])
+  })
+
+  it("does not mark unseen=false for someone else's messages", async () => {
+    useAuthStore.mockReturnValue({ user: { id: 999 } })
+    const store = useMessageStore()
+    store.init({})
+    mockFetchByUser.mockResolvedValue([{ id: 1, unseen: true }])
+
+    const result = await store.fetchByUser(1, false, false)
+
+    expect(result[0].unseen).toBe(true)
+  })
+})
+
+describe('message store - bulkInterest()/bulkInterestState()', () => {
+  it('bulkInterest posts then refetches the message', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockBulkInterest.mockResolvedValue({ ret: 0 })
+    mockApiFetch.mockResolvedValue([{ id: 80, subject: 'refetched' }])
+
+    const dataPromise = store.bulkInterest(80, [{ bulkitemid: 1 }], 5, 'note')
+    await wait(70)
+    const data = await dataPromise
+
+    expect(mockBulkInterest).toHaveBeenCalledWith(
+      80,
+      [{ bulkitemid: 1 }],
+      5,
+      'note'
+    )
+    expect(data).toEqual({ ret: 0 })
+    expect(store.list[80].subject).toBe('refetched')
+  })
+
+  it('bulkInterestState posts then refetches the message', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockBulkInterestState.mockResolvedValue({ ret: 0 })
+    mockApiFetch.mockResolvedValue([{ id: 81, subject: 'refetched' }])
+
+    const dataPromise = store.bulkInterestState(81, 2, 9, 'Collected')
+    await wait(70)
+    await dataPromise
+
+    expect(mockBulkInterestState).toHaveBeenCalledWith(81, 2, 9, 'Collected')
+    expect(store.list[81].subject).toBe('refetched')
+  })
+})
+
+describe('message store - Freegle Helper actions', () => {
+  it('fetchHelper stores the result keyed by msgid', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockGetHelper.mockResolvedValue({ batch: {} })
+
+    const result = await store.fetchHelper(900)
+
+    expect(mockGetHelper).toHaveBeenCalledWith(900, false)
+    expect(store.helper[900]).toEqual({ batch: {} })
+    expect(result).toEqual({ batch: {} })
+  })
+
+  it('helperSetStatus posts the status and omits automode when absent', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockGetHelper.mockResolvedValue({ status: 'Paused' })
+
+    await store.helperSetStatus(901, 'Paused')
+
+    expect(mockHelper).toHaveBeenCalledWith({
+      action: 'SetStatus',
+      msgid: 901,
+      status: 'Paused',
+    })
+  })
+
+  it('helperSetStatus includes automode when given', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockGetHelper.mockResolvedValue({})
+
+    await store.helperSetStatus(901, 'Running', 'automatic')
+
+    expect(mockHelper).toHaveBeenCalledWith({
+      action: 'SetStatus',
+      msgid: 901,
+      status: 'Running',
+      automode: 'automatic',
+    })
+  })
+
+  it('helperResolveProposal resolves, refetches the message and the helper state', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockResolvedValue([{ id: 902, subject: 'x' }])
+    mockGetHelper.mockResolvedValue({ proposals: [] })
+
+    const p = store.helperResolveProposal(902, 55, 'send', 'hi')
+    await wait(70)
+    const result = await p
+
+    expect(mockHelper).toHaveBeenCalledWith({
+      action: 'ResolveProposal',
+      proposalid: 55,
+      decision: 'send',
+      text: 'hi',
+    })
+    expect(store.list[902].subject).toBe('x')
+    expect(result).toEqual({ proposals: [] })
+  })
+
+  it('helperResolveProposal omits text when null', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApiFetch.mockResolvedValue([{ id: 903 }])
+    mockGetHelper.mockResolvedValue({})
+
+    const p = store.helperResolveProposal(903, 56, 'dismiss', null)
+    await wait(70)
+    await p
+
+    expect(mockHelper).toHaveBeenCalledWith({
+      action: 'ResolveProposal',
+      proposalid: 56,
+      decision: 'dismiss',
+    })
+  })
+})
+
+describe('message store - update()', () => {
+  it('removes the message from list and byUserList when the server reports deleted', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[100] = { id: 100 }
+    store.byUserList[1] = [{ id: 100 }]
+    mockUpdate.mockResolvedValue({ deleted: true })
+
+    const data = await store.update({ id: 100 })
+
+    expect(data).toEqual({ deleted: true })
+    expect(store.list[100]).toBeUndefined()
+    expect(store.byUserList[1]).toEqual([])
+  })
+
+  it('refetches and syncs byUserList on a normal update', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.byUserList[1] = [{ id: 101, hasoutcome: false }]
+    mockUpdate.mockResolvedValue({ id: 101 })
+    mockApiFetch.mockResolvedValue([{ id: 101, subject: 'updated' }])
+
+    const p = store.update({ id: 101 })
+    await wait(70)
+    await p
+
+    expect(store.byUserList[1][0].subject).toBe('updated')
+  })
+
+  it('sets hasoutcome on the matching byUserList entry for an Outcome action', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.byUserList[1] = [{ id: 102, hasoutcome: false }]
+    mockUpdate.mockResolvedValue({ id: 102 })
+    mockApiFetch.mockResolvedValue([{ id: 102, subject: 'given away' }])
+
+    const p = store.update({ id: 102, action: 'Outcome' })
+    await wait(70)
+    await p
+
+    expect(store.byUserList[1][0].hasoutcome).toBe(true)
+  })
+
+  it('does not throw when the message is not present in byUserList', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.byUserList[1] = [{ id: 999 }]
+    mockUpdate.mockResolvedValue({ id: 103 })
+    mockApiFetch.mockResolvedValue([{ id: 103 }])
+
+    const p = store.update({ id: 103 })
+    await wait(70)
+    await expect(p).resolves.toEqual({ id: 103 })
+  })
+})
+
+describe('message store - remove()/clear()/clearContext()', () => {
+  it('remove() deletes the parsed id from list', () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[110] = { id: 110 }
+
+    store.remove({ id: '110' })
+
+    expect(store.list[110]).toBeUndefined()
+  })
+
+  it('clear() resets state and clears the ModTools context', () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[1] = { id: 1 }
+    store.context = { some: 'context' }
+
+    store.clear()
+
+    expect(store.list).toEqual({})
+    expect(store.context).toBeNull()
+  })
+
+  it('clearContext() only clears the context', () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[1] = { id: 1 }
+    store.context = { some: 'context' }
+
+    store.clearContext()
+
+    expect(store.context).toBeNull()
+    expect(store.list[1]).toBeDefined()
+  })
+})
+
+describe.each([
+  ['promise', mockUpdate, { action: 'Promise' }],
+  ['renege', mockUpdate, { action: 'Renege' }],
+])('message store - %s()', (method, mockFn, extra) => {
+  it(`calls the API with the right action and refetches`, async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFn.mockResolvedValue({})
+    mockApiFetch.mockResolvedValue([{ id: 120 }])
+
+    const p = store[method](120, 55)
+    await wait(70)
+    await p
+
+    expect(mockFn).toHaveBeenCalledWith({ id: 120, userid: 55, ...extra })
+    expect(mockApiFetch).toHaveBeenCalledWith('120', false)
+  })
+})
+
+describe('message store - addBy()/removeBy()/intend()', () => {
+  it('addBy calls the API and refetches', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockAddBy.mockResolvedValue({})
+    mockApiFetch.mockResolvedValue([{ id: 130 }])
+
+    const p = store.addBy(130, 7, 2)
+    await wait(70)
+    await p
+
+    expect(mockAddBy).toHaveBeenCalledWith(130, 7, 2)
+    expect(mockApiFetch).toHaveBeenCalledWith('130', false)
+  })
+
+  it('removeBy calls the API and refetches', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockRemoveBy.mockResolvedValue({})
+    mockApiFetch.mockResolvedValue([{ id: 131 }])
+
+    const p = store.removeBy(131, 8)
+    await wait(70)
+    await p
+
+    expect(mockRemoveBy).toHaveBeenCalledWith(131, 8)
+  })
+
+  it('intend calls the API without refetching', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockIntend.mockResolvedValue({})
+
+    await store.intend(132, 'Taken')
+
+    expect(mockIntend).toHaveBeenCalledWith(132, 'Taken')
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('message store - markSeen() error handling', () => {
+  beforeEach(() => {
+    mockCount.mockResolvedValue({ count: 0 })
+  })
+
+  it('silently swallows a 401 (expired session)', async () => {
+    const store = useMessageStore()
+    store.init({})
+    const err = new Error('unauthorized')
+    err.response = { status: 401 }
+    mockMarkSeen.mockRejectedValue(err)
+
+    await expect(store.markSeen([1])).resolves.toBeUndefined()
+    expect(mockNearbyMarkSeen).not.toHaveBeenCalled()
+  })
+
+  it('rethrows any other error', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockMarkSeen.mockRejectedValue(new Error('server error'))
+
+    await expect(store.markSeen([1])).rejects.toThrow('server error')
+  })
+})
+
+describe('message store - fetchMessagesMT()', () => {
+  beforeEach(() => {
+    mockMiscStore.modtools = true
+  })
+
+  it('returns early when there are no messages', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFetchMessages.mockResolvedValue({ messages: [] })
+
+    const result = await store.fetchMessagesMT({ groupid: 1 })
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns early when messages is missing entirely', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFetchMessages.mockResolvedValue({})
+
+    const result = await store.fetchMessagesMT({ groupid: 1 })
+
+    expect(result).toBeUndefined()
+  })
+
+  it('does not overwrite context for a Draft collection fetch', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.context = 'existing-context'
+    mockFetchMessages.mockResolvedValue({
+      messages: [1],
+      context: { Date: 1 },
+    })
+    store.fetchMT = vi.fn().mockResolvedValue({ id: 1 })
+
+    await store.fetchMessagesMT({ collection: 'Draft', context: null })
+
+    expect(store.context).toBe('existing-context')
+  })
+
+  it('defaults a missing subject to an empty string and logs individual fetch failures', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFetchMessages.mockResolvedValue({ messages: [1, 2] })
+    store.fetchMT = vi.fn().mockImplementation(({ id }) => {
+      if (id === 1) throw new Error('missing')
+      return { id: 2 }
+    })
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const ids = await store.fetchMessagesMT({ collection: 'Approved' })
+
+    expect(ids).toEqual([1, 2])
+    expect(store.list[2].subject).toBe('')
+    expect(store.list[1]).toBeUndefined()
+    logSpy.mockRestore()
+  })
+})
+
+describe('message store - fetchMT()/fetchReach()/updateMT()', () => {
+  it('fetchMT defaults a missing subject to an empty string', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFetchMT.mockResolvedValue({ id: 1 })
+
+    const result = await store.fetchMT({ id: 1 })
+
+    expect(result.subject).toBe('')
+  })
+
+  it('fetchMT leaves an existing subject untouched', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFetchMT.mockResolvedValue({ id: 1, subject: 'Sofa' })
+
+    const result = await store.fetchMT({ id: 1 })
+
+    expect(result.subject).toBe('Sofa')
+  })
+
+  it('fetchMT returns falsy responses untouched', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFetchMT.mockResolvedValue(null)
+
+    const result = await store.fetchMT({ id: 1 })
+
+    expect(result).toBeNull()
+  })
+
+  it('fetchReach forwards to the API', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockReach.mockResolvedValue({ pct: 50 })
+
+    const result = await store.fetchReach(5, false)
+
+    expect(mockReach).toHaveBeenCalledWith(5, false)
+    expect(result).toEqual({ pct: 50 })
+  })
+
+  it('updateMT forwards to the API', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockUpdate.mockResolvedValue({ ok: true })
+
+    const result = await store.updateMT({ id: 1, action: 'Approve' })
+
+    expect(mockUpdate).toHaveBeenCalledWith({ id: 1, action: 'Approve' })
+    expect(result).toEqual({ ok: true })
+  })
+})
+
+describe('message store - delete/approveedits/revertedits/backToPending', () => {
+  it('delete() calls the API then removes the message from list', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[200] = { id: 200 }
+    mockDelete.mockResolvedValue({})
+
+    await store.delete({
+      id: 200,
+      groupid: 9,
+      subject: 's',
+      stdmsgid: 1,
+      body: 'b',
+    })
+
+    expect(mockDelete).toHaveBeenCalledWith(200, 9, 's', 1, 'b')
+    expect(store.list[200]).toBeUndefined()
+  })
+
+  it('approveedits() calls the API then removes the message', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[201] = { id: 201 }
+    mockApproveEdits.mockResolvedValue({})
+
+    await store.approveedits({ id: 201 })
+
+    expect(mockApproveEdits).toHaveBeenCalledWith(201)
+    expect(store.list[201]).toBeUndefined()
+  })
+
+  it('revertedits() calls the API then removes the message', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[202] = { id: 202 }
+    mockRevertEdits.mockResolvedValue({})
+
+    await store.revertedits({ id: 202 })
+
+    expect(mockRevertEdits).toHaveBeenCalledWith(202)
+    expect(store.list[202]).toBeUndefined()
+  })
+
+  it('backToPending() posts the action then removes the message', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[203] = { id: 203 }
+    mockUpdate.mockResolvedValue({})
+
+    await store.backToPending(203, 44)
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      id: 203,
+      groupid: 44,
+      action: 'BackToPending',
+    })
+    expect(store.list[203]).toBeUndefined()
+  })
+})
+
+describe('message store - approve()/reject() re-fetch the sender', () => {
+  it('approve() refetches the sender by numeric fromuser id', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[300] = { id: 300, fromuser: 42 }
+    mockApprove.mockResolvedValue({})
+    mockFetchMT.mockResolvedValue({ id: 300, groups: [] })
+
+    await store.approve(300, 1, 's', 2, 'b')
+
+    expect(mockApprove).toHaveBeenCalledWith(300, 1, 's', 2, 'b')
+    expect(mockUserFetch).toHaveBeenCalledWith(42, true)
+  })
+
+  it('approve() refetches the sender by object fromuser.id', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[301] = { id: 301, fromuser: { id: 43 } }
+    mockApprove.mockResolvedValue({})
+    mockFetchMT.mockResolvedValue({ id: 301, groups: [] })
+
+    await store.approve(301, 1)
+
+    expect(mockUserFetch).toHaveBeenCalledWith(43, true)
+  })
+
+  it('approve() does not refetch a sender when the message has none cached', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockApprove.mockResolvedValue({})
+    mockFetchMT.mockResolvedValue({ id: 302, groups: [] })
+
+    await store.approve(302, 1)
+
+    expect(mockUserFetch).not.toHaveBeenCalled()
+  })
+
+  it('reject() refetches the sender the same way', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[303] = { id: 303, fromuser: 44 }
+    mockReject.mockResolvedValue({})
+    mockFetchMT.mockResolvedValue({ id: 303, groups: [] })
+
+    await store.reject(303, 1, 's', 2, 'b')
+
+    expect(mockReject).toHaveBeenCalledWith(303, 1, 's', 2, 'b')
+    expect(mockUserFetch).toHaveBeenCalledWith(44, true)
+  })
+})
+
+describe('message store - reply()/spam()/move()', () => {
+  it('reply() posts without removing the message from list', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[400] = { id: 400 }
+    mockReply.mockResolvedValue({})
+
+    await store.reply({ id: 400, groupid: 1, subject: 's', stdmsgid: 2, body: 'b' })
+
+    expect(mockReply).toHaveBeenCalledWith(400, 1, 's', 2, 'b')
+    expect(store.list[400]).toBeDefined()
+  })
+
+  it('spam() removes the message from list', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list[401] = { id: 401 }
+    mockSpam.mockResolvedValue({})
+
+    await store.spam({ id: 401, groupid: 1 })
+
+    expect(mockSpam).toHaveBeenCalledWith(401, 1)
+    expect(store.list[401]).toBeUndefined()
+  })
+
+  it('move() updates then refetches the message', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockUpdate.mockResolvedValue({})
+    mockFetchMT.mockResolvedValue({ id: 402, subject: 'moved' })
+
+    await store.move({ id: 402, groupid: 7 })
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      id: 402,
+      groupid: 7,
+      action: 'Move',
+    })
+    expect(store.list[402].subject).toBe('moved')
+  })
+})
+
+describe('message store - searchMember()', () => {
+  it('clears the store then fetches full details for each matched id', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.count = 5
+    mockFetchMessages.mockResolvedValue({ messages: [500, 501] })
+    store.fetchMT = vi.fn().mockImplementation(({ id }) => ({ id }))
+
+    await store.searchMember('bob', 9)
+
+    expect(mockFetchMessages).toHaveBeenCalledWith({
+      subaction: 'searchmemb',
+      search: 'bob',
+      groupid: 9,
+    })
+    expect(store.count).toBe(0)
+    expect(store.list[500]).toBeDefined()
+    expect(store.list[501]).toBeDefined()
+  })
+
+  it('returns early when there are no matches', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFetchMessages.mockResolvedValue({ messages: [] })
+    store.fetchMT = vi.fn()
+
+    await store.searchMember('nobody', 9)
+
+    expect(store.fetchMT).not.toHaveBeenCalled()
+  })
+
+  it('logs and continues when an individual fetch fails', async () => {
+    const store = useMessageStore()
+    store.init({})
+    mockFetchMessages.mockResolvedValue({ messages: [502, 503] })
+    store.fetchMT = vi.fn().mockImplementation(({ id }) => {
+      if (id === 502) throw new Error('gone')
+      return { id }
+    })
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await store.searchMember('x', 9)
+
+    expect(store.list[502]).toBeUndefined()
+    expect(store.list[503]).toBeDefined()
+    logSpy.mockRestore()
+  })
+})
+
+describe('message store - remaining getters', () => {
+  it('helperById returns the helper state for a msgid', () => {
+    const store = useMessageStore()
+    store.init({})
+    store.helper[900] = { batch: {} }
+
+    expect(store.helperById(900)).toEqual({ batch: {} })
+  })
+
+  // TODO: latent bug - the inBounds getter is `(state) => (...) => key in
+  // this.bounds ? ... `, but the returned closure is an arrow function so
+  // `this` is never rebound to the store; it resolves to whatever `this` is
+  // in the module's lexical scope (undefined in strict ESM), so any real
+  // call throws "Cannot use 'in' operator ... in undefined" instead of
+  // reading state.bounds. Nothing in the app currently calls .inBounds(),
+  // which is presumably why this has gone unnoticed.
+  it.skip('inBounds returns the cached array for a matching key', () => {
+    const store = useMessageStore()
+    store.init({})
+    store.bounds['1:2:3:4:5'] = [{ id: 1 }]
+
+    expect(store.inBounds(1, 2, 3, 4, 5)).toEqual([{ id: 1 }])
+  })
+
+  it.skip('inBounds returns an empty array when the key is not cached', () => {
+    const store = useMessageStore()
+    store.init({})
+
+    expect(store.inBounds(1, 2, 3, 4, 5)).toEqual([])
+  })
+
+  it('all returns every cached message', () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list = { 1: { id: 1 }, 2: { id: 2 } }
+
+    expect(store.all).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('byUser returns the cached list for a userid', () => {
+    const store = useMessageStore()
+    store.init({})
+    store.byUserList[9] = [{ id: 1 }]
+
+    expect(store.byUser(9)).toEqual([{ id: 1 }])
+  })
+
+  it('byUser returns an empty array for an unknown userid', () => {
+    const store = useMessageStore()
+    store.init({})
+
+    expect(store.byUser(999)).toEqual([])
+  })
+})

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -1582,7 +1582,7 @@ func getReviewQueue(c *fiber.Ctx, myid uint64) error {
 		Nameshort string `gorm:"column:nameshort"`
 		Namefull  string `gorm:"column:namefull"`
 	}
-	refGroups := make(map[uint64]fiber.Map)
+	refGroups := make(map[uint64][]fiber.Map)
 	if len(refmsgids) > 0 {
 		var refRows []refGroupRow
 		db.Table("messages_groups mg").
@@ -1591,21 +1591,23 @@ func getReviewQueue(c *fiber.Ctx, myid uint64) error {
 			Where("mg.msgid IN ? AND mg.deleted = 0", refmsgids).
 			Order("mg.msgid, mg.rippled_in, mg.arrival").
 			Scan(&refRows)
+		// ALL the communities the post is on, not just the first. A rippled post
+		// is genuinely on several, and a moderator deciding whether a chat is
+		// theirs needs to see whether ANY of them is one of theirs - showing only
+		// the origin hides exactly the case where it is theirs by ripple. The
+		// ORDER carries the meaning instead: origin first (the query sorts on
+		// rippled_in, then arrival), so the community that knows the post reads
+		// first, the way group lists are shown elsewhere.
 		for _, r := range refRows {
-			if _, done := refGroups[r.Msgid]; done {
-				// Already have this post's origin - later rows are groups it
-				// rippled to.
-				continue
-			}
 			namedisplay := r.Namefull
 			if namedisplay == "" {
 				namedisplay = r.Nameshort
 			}
-			refGroups[r.Msgid] = fiber.Map{
+			refGroups[r.Msgid] = append(refGroups[r.Msgid], fiber.Map{
 				"id":          r.ID,
 				"nameshort":   r.Nameshort,
 				"namedisplay": namedisplay,
-			}
+			})
 		}
 	}
 
@@ -1666,11 +1668,12 @@ func getReviewQueue(c *fiber.Ctx, myid uint64) error {
 			msg["msgid"] = *m.Msgid
 		}
 
-		// The community the post itself is on, so a moderator can see at a
-		// glance whether a chat is theirs to handle (Discourse #10004).
+		// The communities the post itself is on, so a moderator can see at a
+		// glance whether a chat is theirs to handle (Discourse #10004). Origin
+		// first; a rippled post lists every community it reached.
 		if m.Refmsgid != nil {
-			if g, ok := refGroups[*m.Refmsgid]; ok {
-				msg["refmsggroup"] = g
+			if g, ok := refGroups[*m.Refmsgid]; ok && len(g) > 0 {
+				msg["refmsggroups"] = g
 			}
 		}
 

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -1556,6 +1556,59 @@ func getReviewQueue(c *fiber.Ctx, myid uint64) error {
 		}
 	}
 
+	// The community the post being discussed actually lives on.
+	//
+	// The `groupid` on each row is the group through which the MODERATOR can act
+	// - the one the other member belongs to. That is not the same thing as where
+	// the post is, and moderators of many communities were having to click into
+	// each chat to work out whether it was theirs to handle: Discourse #10004,
+	// "I usually prefer to leave that for the mods on the group for the post.
+	// But I need to do a lot of clicking to work that out."
+	//
+	// Ordered rippled_in first so a rippled post reports the community it
+	// STARTED on rather than one it spread to - that origin group's moderators
+	// are the ones who know the post.
+	refmsgids := make([]uint64, 0, len(msgs))
+	seenRef := make(map[uint64]bool)
+	for _, m := range msgs {
+		if m.Refmsgid != nil && *m.Refmsgid > 0 && !seenRef[*m.Refmsgid] {
+			seenRef[*m.Refmsgid] = true
+			refmsgids = append(refmsgids, *m.Refmsgid)
+		}
+	}
+	type refGroupRow struct {
+		Msgid     uint64 `gorm:"column:msgid"`
+		ID        uint64 `gorm:"column:id"`
+		Nameshort string `gorm:"column:nameshort"`
+		Namefull  string `gorm:"column:namefull"`
+	}
+	refGroups := make(map[uint64]fiber.Map)
+	if len(refmsgids) > 0 {
+		var refRows []refGroupRow
+		db.Table("messages_groups mg").
+			Select("mg.msgid, g.id, g.nameshort, COALESCE(g.namefull, '') AS namefull").
+			Joins("INNER JOIN `groups` g ON g.id = mg.groupid").
+			Where("mg.msgid IN ? AND mg.deleted = 0", refmsgids).
+			Order("mg.msgid, mg.rippled_in, mg.arrival").
+			Scan(&refRows)
+		for _, r := range refRows {
+			if _, done := refGroups[r.Msgid]; done {
+				// Already have this post's origin - later rows are groups it
+				// rippled to.
+				continue
+			}
+			namedisplay := r.Namefull
+			if namedisplay == "" {
+				namedisplay = r.Nameshort
+			}
+			refGroups[r.Msgid] = fiber.Map{
+				"id":          r.ID,
+				"nameshort":   r.Nameshort,
+				"namedisplay": namedisplay,
+			}
+		}
+	}
+
 	// Build response with inline chatroom info.
 	result := make([]fiber.Map, 0, len(msgs))
 	for _, m := range msgs {
@@ -1611,6 +1664,14 @@ func getReviewQueue(c *fiber.Ctx, myid uint64) error {
 		// Add msgid if the message came via email.
 		if m.Msgid != nil {
 			msg["msgid"] = *m.Msgid
+		}
+
+		// The community the post itself is on, so a moderator can see at a
+		// glance whether a chat is theirs to handle (Discourse #10004).
+		if m.Refmsgid != nil {
+			if g, ok := refGroups[*m.Refmsgid]; ok {
+				msg["refmsggroup"] = g
+			}
 		}
 
 		// Add held info if message is held by a moderator.

--- a/iznik-server-go/test/chatreview_postgroup_test.go
+++ b/iznik-server-go/test/chatreview_postgroup_test.go
@@ -1,0 +1,133 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// The chat review queue tells a moderator which group lets them ACT on a chat -
+// the group the other member belongs to. It never said which community the POST
+// is on, and those are routinely different. A moderator of many communities had
+// to open each chat to work out whether it was theirs to handle:
+//
+//	"the problem chat might refer to an item that isn't on any of my groups and
+//	 I usually prefer to leave that for the mods on the group for the post. But
+//	 I need to do a lot of clicking to work that out." - Discourse #10004
+//
+// So each reviewable message that refers to a post now carries refmsggroup.
+func TestChatReview_CarriesTheGroupThePostIsOn(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("reviewpostgroup")
+
+	// The moderator's own group, and a DIFFERENT community hosting the post.
+	modGroup := CreateTestGroup(t, prefix+"_mod")
+	postGroup := CreateTestGroup(t, prefix+"_post")
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, modGroup, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	// The replier is on the moderator's group - that is what puts this chat in
+	// their queue at all.
+	replierID := CreateTestUser(t, prefix+"_replier", "User")
+	CreateTestMembership(t, replierID, modGroup, "Member")
+
+	// The post lives on the OTHER community.
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, postGroup, "Member")
+	msgID := CreateTestMessage(t, posterID, postGroup, "OFFER: sofa (review group test)", 51.5, -0.1)
+
+	chatID := CreateTestChatRoom(t, posterID, &replierID, nil, "User2User")
+	res := db.Exec(
+		"INSERT INTO chat_messages (chatid, userid, message, type, date, refmsgid, "+
+			"reviewrequired, reviewrejected, processingrequired, processingsuccessful) "+
+			"VALUES (?, ?, 'Is this still available?', 'Default', NOW(), ?, 1, 0, 0, 1)",
+		chatID, posterID, msgID,
+	)
+	if res.Error != nil {
+		t.Fatalf("could not create the reviewable message: %v", res.Error)
+	}
+	var chatMsgID uint64
+	db.Raw("SELECT id FROM chat_messages WHERE chatid = ? ORDER BY id DESC LIMIT 1", chatID).Scan(&chatMsgID)
+	if chatMsgID == 0 {
+		t.Fatal("reviewable message created but id not found")
+	}
+	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", chatMsgID)
+
+	resp, err := getApp().Test(httptest.NewRequest("GET",
+		fmt.Sprintf("/api/chatmessages?jwt=%s", token), nil), 20000)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body map[string]interface{}
+	json.Unmarshal(rsp(resp), &body)
+	msgs, _ := body["chatmessages"].([]interface{})
+
+	var mine map[string]interface{}
+	for _, raw := range msgs {
+		if m, ok := raw.(map[string]interface{}); ok {
+			if id, ok := m["id"].(float64); ok && uint64(id) == chatMsgID {
+				mine = m
+			}
+		}
+	}
+	if mine == nil {
+		t.Fatalf("message %d not in the review queue - the fixture is wrong, so the "+
+			"assertion below would prove nothing", chatMsgID)
+	}
+
+	group, ok := mine["refmsggroup"].(map[string]interface{})
+	assert.True(t, ok, "a reviewable message about a post carries the post's group")
+	if ok {
+		assert.Equal(t, float64(postGroup), group["id"],
+			"reports the community the POST is on, not the one that grants the mod their buttons")
+		assert.NotEmpty(t, group["namedisplay"], "carries a name the UI can show")
+	}
+}
+
+// A chat with no post behind it - a direct message rather than a reply to an
+// offer - has no group to report, and must not invent one.
+func TestChatReview_NoPostMeansNoGroup(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("reviewnopost")
+
+	modGroup := CreateTestGroup(t, prefix+"_mod")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, modGroup, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	senderID := CreateTestUser(t, prefix+"_sender", "User")
+	recipientID := CreateTestUser(t, prefix+"_recipient", "User")
+	CreateTestMembership(t, recipientID, modGroup, "Member")
+
+	chatID := CreateTestChatRoom(t, senderID, &recipientID, nil, "User2User")
+	db.Exec(
+		"INSERT INTO chat_messages (chatid, userid, message, type, date, "+
+			"reviewrequired, reviewrejected, processingrequired, processingsuccessful) "+
+			"VALUES (?, ?, 'Hello there', 'Default', NOW(), 1, 0, 0, 1)",
+		chatID, senderID,
+	)
+	var chatMsgID uint64
+	db.Raw("SELECT id FROM chat_messages WHERE chatid = ? ORDER BY id DESC LIMIT 1", chatID).Scan(&chatMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", chatMsgID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		fmt.Sprintf("/api/chatmessages?jwt=%s", token), nil), 20000)
+	var body map[string]interface{}
+	json.Unmarshal(rsp(resp), &body)
+	msgs, _ := body["chatmessages"].([]interface{})
+
+	for _, raw := range msgs {
+		if m, ok := raw.(map[string]interface{}); ok {
+			if id, ok := m["id"].(float64); ok && uint64(id) == chatMsgID {
+				_, present := m["refmsggroup"]
+				assert.False(t, present, "a chat about no post carries no post group")
+			}
+		}
+	}
+}

--- a/iznik-server-go/test/chatreview_postgroup_test.go
+++ b/iznik-server-go/test/chatreview_postgroup_test.go
@@ -19,7 +19,8 @@ import (
 //	 I usually prefer to leave that for the mods on the group for the post. But
 //	 I need to do a lot of clicking to work that out." - Discourse #10004
 //
-// So each reviewable message that refers to a post now carries refmsggroup.
+// So each reviewable message that refers to a post now carries refmsggroups -
+// every community the post is on, origin first.
 func TestChatReview_CarriesTheGroupThePostIsOn(t *testing.T) {
 	db := database.DBConn
 	prefix := uniquePrefix("reviewpostgroup")
@@ -81,12 +82,13 @@ func TestChatReview_CarriesTheGroupThePostIsOn(t *testing.T) {
 			"assertion below would prove nothing", chatMsgID)
 	}
 
-	group, ok := mine["refmsggroup"].(map[string]interface{})
-	assert.True(t, ok, "a reviewable message about a post carries the post's group")
-	if ok {
-		assert.Equal(t, float64(postGroup), group["id"],
-			"reports the community the POST is on, not the one that grants the mod their buttons")
-		assert.NotEmpty(t, group["namedisplay"], "carries a name the UI can show")
+	groups, ok := mine["refmsggroups"].([]interface{})
+	assert.True(t, ok, "a reviewable message about a post carries the post's groups")
+	if ok && assert.NotEmpty(t, groups, "at least the community it was posted to") {
+		first, _ := groups[0].(map[string]interface{})
+		assert.Equal(t, float64(postGroup), first["id"],
+			"origin community first, not the one that grants the mod their buttons")
+		assert.NotEmpty(t, first["namedisplay"], "carries a name the UI can show")
 	}
 }
 
@@ -125,9 +127,99 @@ func TestChatReview_NoPostMeansNoGroup(t *testing.T) {
 	for _, raw := range msgs {
 		if m, ok := raw.(map[string]interface{}); ok {
 			if id, ok := m["id"].(float64); ok && uint64(id) == chatMsgID {
-				_, present := m["refmsggroup"]
+				_, present := m["refmsggroups"]
 				assert.False(t, present, "a chat about no post carries no post group")
 			}
 		}
+	}
+}
+
+// A rippled post is on more than one community, and the moderator scanning the
+// queue needs to see all of them: the whole question is "is any of these mine?",
+// and reporting only the origin hides exactly the case where it is theirs
+// because the post rippled to them.
+//
+// Origin first, then where it spread - the community that knows the post reads
+// first, and the UI joins the names with commas.
+func TestChatReview_RippledPostListsEveryCommunityOriginFirst(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("reviewrippled")
+
+	modGroup := CreateTestGroup(t, prefix+"_mod")
+	originGroup := CreateTestGroup(t, prefix+"_origin")
+	rippledGroup := CreateTestGroup(t, prefix+"_rippled")
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, modGroup, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	replierID := CreateTestUser(t, prefix+"_replier", "User")
+	CreateTestMembership(t, replierID, modGroup, "Member")
+
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, originGroup, "Member")
+	msgID := CreateTestMessage(t, posterID, originGroup, "OFFER: bookcase (rippled review test)", 51.5, -0.1)
+
+	// The same post, reached by rippling. rippled_in sorts after the origin's
+	// NULL, which is what makes the ordering meaningful rather than incidental.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, collection, arrival, rippled_in, deleted) "+
+		"VALUES (?, ?, 'Approved', NOW(), 1, 0)", msgID, rippledGroup)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, rippledGroup)
+
+	chatID := CreateTestChatRoom(t, posterID, &replierID, nil, "User2User")
+	db.Exec(
+		"INSERT INTO chat_messages (chatid, userid, message, type, date, refmsgid, "+
+			"reviewrequired, reviewrejected, processingrequired, processingsuccessful) "+
+			"VALUES (?, ?, 'Still going?', 'Default', NOW(), ?, 1, 0, 0, 1)",
+		chatID, posterID, msgID,
+	)
+	var chatMsgID uint64
+	db.Raw("SELECT id FROM chat_messages WHERE chatid = ? ORDER BY id DESC LIMIT 1", chatID).Scan(&chatMsgID)
+	if chatMsgID == 0 {
+		t.Fatal("reviewable message created but id not found")
+	}
+	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", chatMsgID)
+
+	resp, err := getApp().Test(httptest.NewRequest("GET",
+		fmt.Sprintf("/api/chatmessages?jwt=%s", token), nil), 20000)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body map[string]interface{}
+	json.Unmarshal(rsp(resp), &body)
+	msgs, _ := body["chatmessages"].([]interface{})
+
+	var mine map[string]interface{}
+	for _, raw := range msgs {
+		if m, ok := raw.(map[string]interface{}); ok {
+			if id, ok := m["id"].(float64); ok && uint64(id) == chatMsgID {
+				mine = m
+			}
+		}
+	}
+	if mine == nil {
+		t.Fatalf("message %d not in the review queue - the fixture is wrong, so the "+
+			"assertion below would prove nothing", chatMsgID)
+	}
+
+	groups, ok := mine["refmsggroups"].([]interface{})
+	assert.True(t, ok, "a rippled post carries its communities")
+	if !ok {
+		return
+	}
+
+	ids := make([]float64, 0, len(groups))
+	for _, g := range groups {
+		if m, ok := g.(map[string]interface{}); ok {
+			if id, ok := m["id"].(float64); ok {
+				ids = append(ids, id)
+			}
+		}
+	}
+
+	assert.Len(t, ids, 2, "both the origin and the community it rippled to")
+	if len(ids) == 2 {
+		assert.Equal(t, float64(originGroup), ids[0], "origin first")
+		assert.Equal(t, float64(rippledGroup), ids[1], "then where it spread")
 	}
 }

--- a/iznik-server-go/test/firstreply_test.go
+++ b/iznik-server-go/test/firstreply_test.go
@@ -169,9 +169,36 @@ func TestFirstReplyPassthrough_RespectsTheRolloutPercentage(t *testing.T) {
 	t.Setenv("FIRSTREPLY_ROLLOUT_PERCENT", "100")
 	assert.True(t, firstreply.ShouldPassThrough(db, msgID, 0.8, 51.9))
 
-	// A partial rollout agrees with msgid % 100, the same bucket the batch app uses.
+	// A partial rollout agrees with the SHARED bucket, not with msgid % 100.
+	//
+	// This used to assert msgid % 100 < 50. Bucketing moved to
+	// CRC32(msgid|firstreply) % 100 in d4a069215 so the arms do not collide with
+	// other experiments split on the same id, and the assertion was left behind.
+	// The two expressions agree for about half of all ids, so the test passed or
+	// failed on whichever auto-increment id the fixture happened to get - a coin
+	// flip that looked like flakiness rather than a stale assertion.
 	t.Setenv("FIRSTREPLY_ROLLOUT_PERCENT", "50")
-	assert.Equal(t, msgID%100 < 50, firstreply.ShouldPassThrough(db, msgID, 0.8, 51.9))
+	assert.Equal(t, firstreply.RolloutBucket(msgID) < 50,
+		firstreply.ShouldPassThrough(db, msgID, 0.8, 51.9))
+}
+
+// The bucket is a CROSS-STACK contract: Laravel's Rollout::includes uses
+// crc32($msgid . '|firstreply') % 100 and MySQL's CRC32() is the same
+// polynomial. If Go's expression drifts, a post lands in the trial for an
+// emailed reply and out of it for an in-app one, and the arms quietly stop
+// meaning anything - which no test comparing Go against Go would notice.
+//
+// So pin known values. These were computed independently of the Go code.
+func TestRolloutBucketMatchesTheOtherStacks(t *testing.T) {
+	for msgid, want := range map[uint64]int{
+		1:      69,
+		2:      93,
+		12345:  36,
+		999999: 99,
+	} {
+		assert.Equal(t, want, firstreply.RolloutBucket(msgid),
+			"bucket for msgid %d must match crc32('%d|firstreply') %% 100", msgid, msgid)
+	}
 }
 
 // The sysadmin metrics endpoint must actually answer, against the real schema.


### PR DESCRIPTION
## Problem

Chat review tells a moderator which community lets them act on a chat - the community the other member belongs to. It never said which community the *post* is on, and for a moderator of many communities those are routinely different. So working out whether a chat was theirs to handle meant opening it:

> the problem chat might refer to an item that isn't on any of my groups and I usually prefer to leave that for the mods on the group for the post. But I need to do a lot of clicking to work that out.
> - Carol1, [#10004](https://discourse.ilovefreegle.org/t/chat-review-which-group/10004)

Jax ("I struggle with this too") and Emma ("I also prefer to leave it to the Mods on its home group") said the same.

## What this does

Each reviewable message that refers to a post carries `refmsggroups`: every community the post is on, each with `id`, `nameshort` and `namedisplay`, ordered `rippled_in, arrival` so the origin community comes first. The card renders them comma-separated as **Post is on \<communities\>**, alongside the existing line. The two answer different questions - why you *can* act, and whether you *should* - so both earn their place.

Every community rather than just the origin: a rippled post is genuinely on several, and the moderator is scanning for whether *any* of them is theirs. Showing only the origin would hide exactly the case where the chat *is* theirs, because the post rippled to them. The ordering carries the origin instead, so the community that knows the post reads first.

- One batched query for the whole page, keyed on the distinct `refmsgid`s already in the result set - no per-row lookup, and no change to the review query itself (a UNION with four bound group-id lists, best left alone).
- `namedisplay` follows the existing convention: `namefull`, falling back to `nameshort`.
- Deleted `messages_groups` rows are excluded, so a post removed from a community is not reported as being on it.
- The field is omitted rather than nulled when a chat has no post behind it, so the UI's `v-if` needs no special case.

## First-reply bucket assertion

`TestFirstReplyPassthrough_RespectsTheRolloutPercentage` asserted `msgid % 100`, but first-reply bucketing is `CRC32(msgid|firstreply) % 100`, so the arms don't collide with other experiments split on the same id. The two expressions agree for roughly half of all ids, so the test passed or failed on whichever auto-increment id the fixture happened to get - a coin flip that read as flakiness. It now pins the bucket against values computed independently of the Go code: the expression is a cross-stack contract with Laravel's `Rollout::includes`, and drift there would put a post in the trial for an emailed reply and out of it for an in-app one, which no Go-vs-Go comparison would catch.

## Tests

`iznik-server-go/test/chatreview_postgroup_test.go`:
- A chat whose post lives on a different community from the one granting the moderator their buttons reports the post's community, not that one - asserting the actual bug needs the two to differ.
- A rippled post lists every community it reached, origin first.
- A chat with no post behind it reports no community rather than inventing one.
- The fixture check fails loudly if the message never reaches the review queue, so a broken fixture can't masquerade as a pass.

`iznik-nuxt3/tests/unit/stores/message.coverage.spec.js` covers `stores/message.js` - the fetch/batch pipeline, `fetchByUser`, Freegle Helper actions, the update/delete/approve/reject family, `searchMember` and the remaining getters. Two cases are `.skip`ped with TODOs for latent bugs they expose, left alone here:
- `fetch()` correctly flags an expired-but-unforced cache entry as needing a refresh, but `fetchMultiple()` re-derives its own filter from `force || !this.list[id]` alone, so it never calls the API and a stale entry is kept indefinitely.
- The `inBounds` getter's returned closure reads `this.bounds` inside nested arrow functions, so `this` is never rebound to the store and any real call throws. Nothing currently calls it.

`iznik-nuxt3/tests/e2e/test-modtools-chat-review.spec.js` covers the ModTools Chat Review page (`/chats/review`), which previously had only a "loads without errors" smoke assertion. It exercises what is reachable regardless of queue contents (the queue is populated asynchronously by `chats:process-incoming`, so a seeded database has nothing pending): the empty-queue state, the sidebar nav link reaching Chat Review and a second click on the already-active link taking the check-for-new-work branch, and the `ModHelpChatReview` panel expanding and collapsing.

Go and vitest suites pass; `gofmt` clean.

The label's wording and placement have not been seen on a real screen.

## Discourse

https://discourse.ilovefreegle.org/t/chat-review-which-group/10004
