### PR TITLE
fix(file-sync): sync a whole new directory, not just files in existing ones

### DIFF
--- a/file-sync.sh
+++ b/file-sync.sh
@@ -404,6 +404,23 @@ inotifywait -m -r -e modify,create,move,close_write,delete \
             ;;
     esac
 
+    # A brand-new DIRECTORY: queue everything inside it.
+    #
+    # inotifywait -r only holds watches on directories that existed when it
+    # started. When a whole tree appears at once - a git checkout or a branch
+    # switch bringing in a new package - the files land before a watch exists on
+    # their parent, so they are never seen and never sync. The container then
+    # runs without them, which for Go means the entire suite fails to COMPILE
+    # and reports "0 passed, 0 failed", i.e. it reads as "no tests ran" rather
+    # than as a missing file (iznik-server-go/firstreply did exactly this).
+    # Walking the new directory here closes that gap for the common case.
+    if [[ "$events" == *ISDIR* && -d "$full_path" ]]; then
+        while IFS= read -r newfile; do
+            [[ -f "$newfile" ]] && queue_sync "$newfile"
+        done < <(find "$full_path" -type f 2>/dev/null)
+        continue
+    fi
+
     # Only process regular files - queue them for sync after settling
     if [[ -f "$full_path" ]]; then
         queue_sync "$full_path"


### PR DESCRIPTION
## Summary

A new source directory never reaches the containers, so the code inside it silently isn't there.

`inotifywait -r` sets its watches when it starts and only holds them on directories that existed at that moment. When a whole tree appears at once — a git checkout, a branch switch bringing in a new package — the files land before any watch exists on their parent. The create events are never seen, nothing is queued, and the container keeps running without them.

What makes this worth fixing rather than remembering is the failure it produces. Go can't compile a package it can't find, so one missing directory fails the **entire** suite at build time and the runner reports:

```
Tests failed (0✓ 0✗)
```

That reads as "no tests ran" — a hung runner, a broken database, a bad command. It does not read as "one directory is missing". `iznik-server-go/firstreply` did this twice today and both times the first guess was wrong.

A directory-create event now walks the new directory and queues every file inside it.

## Code Quality Review

- Handled where the existing code already branches on `ISDIR` for deletes, so directory events were being inspected anyway — this adds the create side of the same distinction.
- Reuses `queue_sync`, so new files settle, route and get filtered exactly like any other. No second copy path to keep in step.
- `continue`s afterwards rather than falling through to the regular-file branch, which would never match a directory anyway.
- `find` failures are swallowed: a directory that vanishes between the event and the walk (a checkout being undone) should sync nothing, not error.
- Bind-mounted trees are unaffected — `get_container_info` still declines to target them, so `iznik-batch` can't be touched by this path.

## Future Improvements

This closes the common case, not the general one: a directory created *inside* another brand-new directory in the same instant can still be missed, since the walk happens once per event. A periodic reconciliation sweep would close it properly, at the cost of a recurring full-tree comparison. Worth doing only if this recurs.

Separately, `0✓ 0✗` deserves to be reported as an error rather than a test result. A build failure and a run with no tests in it are different things, and the runner currently renders them identically — which is why this cost time twice.

## Test Plan

Shell script with no unit-test harness, so verified by reasoning and syntax check rather than automation, and I'd flag that as the weak point of this change:

- `bash -n file-sync.sh` clean.
- The path it fixes was reproduced twice today: `firstreply/` absent from `freegle-apiv2` after a branch switch, Go suite failing to compile, resolved by hand with `docker cp`.
- The guard is narrow — it only adds behaviour on `ISDIR` create events, which previously fell through to the regular-file check and did nothing.
