### PR TITLE
fix(navigation): keep notification bell visible on + menu sub-pages

### DIFF
--- a/iznik-nuxt3/components/NavbarMobile.vue
+++ b/iznik-nuxt3/components/NavbarMobile.vue
@@ -27,7 +27,7 @@
           <v-icon icon="arrow-left" class="back-icon" />
         </nuxt-link>
         <NotificationOptions
-          v-if="online && !showBackButton && loggedIn"
+          v-if="online && loggedIn"
           v-model:unread-notification-count="unreadNotificationCount"
           v-model:shown="notificationsShown"
           :distance="distance"

--- a/iznik-nuxt3/tests/unit/components/NavbarMobile.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NavbarMobile.spec.js
@@ -9,6 +9,7 @@ const mockLogout = vi.fn()
 const mockShowAboutMe = vi.fn()
 const mockMaybeReload = vi.fn()
 const mockBackButton = vi.fn()
+const mockShowBackButton = ref(false)
 
 vi.mock('~/composables/useNavbar', () => ({
   useNavbar: () => ({
@@ -20,7 +21,9 @@ vi.mock('~/composables/useNavbar', () => ({
     browseCount: ref(10),
     chatCount: ref(5),
     showAboutMeModal: ref(false),
-    showBackButton: ref(false),
+    get showBackButton() {
+      return mockShowBackButton.value
+    },
     backButtonCount: ref(0),
     requestLogin: mockRequestLogin,
     logout: mockLogout,
@@ -219,6 +222,7 @@ describe('NavbarMobile', () => {
     mockBreakpoint.value = 'md'
     mockStickyAdRendered.value = false
     mockRoute.path = '/browse'
+    mockShowBackButton.value = false
 
     // Mock window.scrollY
     Object.defineProperty(window, 'scrollY', { value: 0, writable: true })
@@ -370,6 +374,27 @@ describe('NavbarMobile', () => {
     it('hides back button by default', () => {
       const wrapper = createWrapper()
       expect(wrapper.find('.nav-back-btn').exists()).toBe(false)
+    })
+  })
+
+  describe('notification bell visibility', () => {
+    // Topic 10001 post 3: on "+ menu" sub-pages such as an individual My
+    // Posts item (/mypost/123) or the Events pages, the route isn't one of
+    // the "home" routes (/browse, /chitchat, /myposts, /explore/*, /), so
+    // useNavbar's showBackButton is true and a back arrow replaces the logo
+    // slot. The bell must still show alongside it - a sub-page is exactly
+    // when you're most likely to miss a reply.
+    it('still shows the notification bell when a back button is shown', () => {
+      mockShowBackButton.value = true
+      const wrapper = createWrapper()
+      expect(wrapper.find('.nav-back-btn').exists()).toBe(true)
+      expect(wrapper.find('.notification-options').exists()).toBe(true)
+    })
+
+    it('shows the notification bell on home routes too', () => {
+      mockShowBackButton.value = false
+      const wrapper = createWrapper()
+      expect(wrapper.find('.notification-options').exists()).toBe(true)
     })
   })
 

--- a/iznik-server-go/session/oauth_urls_pure_test.go
+++ b/iznik-server-go/session/oauth_urls_pure_test.go
@@ -1,0 +1,187 @@
+package session
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Endpoint getters — pure env-var-with-default lookups, no network involved.
+// ---------------------------------------------------------------------------
+
+func TestGetAppleJWKSURL(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("APPLE_JWKS_URL", "")
+		assert.Equal(t, "https://appleid.apple.com/auth/keys", getAppleJWKSURL())
+	})
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv("APPLE_JWKS_URL", "https://example.test/apple-jwks")
+		assert.Equal(t, "https://example.test/apple-jwks", getAppleJWKSURL())
+	})
+}
+
+func TestGetFacebookGraphURL(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("FACEBOOK_GRAPH_URL", "")
+		assert.Equal(t, "https://graph.facebook.com", getFacebookGraphURL())
+	})
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv("FACEBOOK_GRAPH_URL", "https://example.test/graph")
+		assert.Equal(t, "https://example.test/graph", getFacebookGraphURL())
+	})
+}
+
+func TestGetFacebookJWKSURL(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("FACEBOOK_JWKS_URL", "")
+		assert.Equal(t, "https://limited.facebook.com/.well-known/oauth/openid/jwks/", getFacebookJWKSURL())
+	})
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv("FACEBOOK_JWKS_URL", "https://example.test/fb-jwks")
+		assert.Equal(t, "https://example.test/fb-jwks", getFacebookJWKSURL())
+	})
+}
+
+func TestGetGoogleTokenInfoURL(t *testing.T) {
+	t.Run("default when both unset", func(t *testing.T) {
+		t.Setenv("GOOGLE_TOKENINFO_URL", "")
+		saved := googleTokenInfoURL
+		googleTokenInfoURL = ""
+		defer func() { googleTokenInfoURL = saved }()
+		assert.Equal(t, "https://oauth2.googleapis.com/tokeninfo", getGoogleTokenInfoURL())
+	})
+	t.Run("package var used when env unset", func(t *testing.T) {
+		t.Setenv("GOOGLE_TOKENINFO_URL", "")
+		saved := googleTokenInfoURL
+		googleTokenInfoURL = "https://example.test/pkgvar"
+		defer func() { googleTokenInfoURL = saved }()
+		assert.Equal(t, "https://example.test/pkgvar", getGoogleTokenInfoURL())
+	})
+	t.Run("env takes priority over package var", func(t *testing.T) {
+		t.Setenv("GOOGLE_TOKENINFO_URL", "https://example.test/envvar")
+		saved := googleTokenInfoURL
+		googleTokenInfoURL = "https://example.test/pkgvar"
+		defer func() { googleTokenInfoURL = saved }()
+		assert.Equal(t, "https://example.test/envvar", getGoogleTokenInfoURL())
+	})
+}
+
+// ---------------------------------------------------------------------------
+// parseJWKS — pure JSON/base64/RSA-assembly parsing, no network.
+// ---------------------------------------------------------------------------
+
+func makeJWK(t *testing.T, kid string) jwksKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 512) // small key: fast, fine for parse-only tests
+	assert.NoError(t, err)
+	nBytes := key.PublicKey.N.Bytes()
+	eBytes := []byte{byte(key.PublicKey.E >> 16), byte(key.PublicKey.E >> 8), byte(key.PublicKey.E)}
+	// Trim leading zero bytes from the exponent encoding, mirroring real JWKS output.
+	for len(eBytes) > 1 && eBytes[0] == 0 {
+		eBytes = eBytes[1:]
+	}
+	return jwksKey{
+		Kty: "RSA",
+		Kid: kid,
+		Use: "sig",
+		N:   base64.RawURLEncoding.EncodeToString(nBytes),
+		E:   base64.RawURLEncoding.EncodeToString(eBytes),
+		Alg: "RS256",
+	}
+}
+
+func TestParseJWKS(t *testing.T) {
+	t.Run("single valid RSA key", func(t *testing.T) {
+		k := makeJWK(t, "key-1")
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{k}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.NoError(t, err)
+		assert.Len(t, keys, 1)
+		assert.Contains(t, keys, "key-1")
+		assert.NotNil(t, keys["key-1"])
+	})
+
+	t.Run("multiple valid RSA keys", func(t *testing.T) {
+		k1 := makeJWK(t, "key-1")
+		k2 := makeJWK(t, "key-2")
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{k1, k2}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.NoError(t, err)
+		assert.Len(t, keys, 2)
+		assert.Contains(t, keys, "key-1")
+		assert.Contains(t, keys, "key-2")
+	})
+
+	t.Run("non-RSA key type is skipped", func(t *testing.T) {
+		rsaKey := makeJWK(t, "rsa-key")
+		ecKey := jwksKey{Kty: "EC", Kid: "ec-key", N: "irrelevant", E: "irrelevant"}
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{ecKey, rsaKey}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.NoError(t, err)
+		assert.Len(t, keys, 1)
+		assert.Contains(t, keys, "rsa-key")
+		assert.NotContains(t, keys, "ec-key")
+	})
+
+	t.Run("malformed JSON returns error", func(t *testing.T) {
+		keys, err := parseJWKS([]byte("not json"))
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("empty keys array returns no RSA keys error", func(t *testing.T) {
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("only non-RSA keys returns no RSA keys error", func(t *testing.T) {
+		ecKey := jwksKey{Kty: "EC", Kid: "ec-key", N: "irrelevant", E: "irrelevant"}
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{ecKey}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("invalid base64 modulus returns error", func(t *testing.T) {
+		k := jwksKey{Kty: "RSA", Kid: "bad-n", N: "not-valid-base64!!!", E: "AQAB"}
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{k}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("invalid base64 exponent returns error", func(t *testing.T) {
+		k := jwksKey{Kty: "RSA", Kid: "bad-e", N: base64.RawURLEncoding.EncodeToString([]byte{1, 2, 3}), E: "not-valid-base64!!!"}
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{k}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("empty body returns error", func(t *testing.T) {
+		keys, err := parseJWKS([]byte(""))
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+}

--- a/iznik-server-go/session/session_pure_test.go
+++ b/iznik-server-go/session/session_pure_test.go
@@ -1,0 +1,255 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ---------------------------------------------------------------------------
+// TopicActiveWithin — pure, no DB/HTTP needed.
+// ---------------------------------------------------------------------------
+
+func TestTopicActiveWithin(t *testing.T) {
+	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		createdAt  string
+		bumpedAt   string
+		lastPosted string
+		since      time.Time
+		want       bool
+	}{
+		{"bumpedAt after since wins", "2025-01-01T00:00:00Z", "2026-02-01T00:00:00Z", "2025-06-01T00:00:00Z", since, true},
+		{"bumpedAt before since, falls back to lastPosted after since", "2025-01-01T00:00:00Z", "2025-06-01T00:00:00Z", "2026-02-01T00:00:00Z", since, false},
+		{"bumpedAt missing, lastPosted after since wins", "2025-01-01T00:00:00Z", "", "2026-02-01T00:00:00Z", since, true},
+		{"bumpedAt and lastPosted missing, createdAt after since wins", "2026-02-01T00:00:00Z", "", "", since, true},
+		{"all missing", "", "", "", since, false},
+		{"all malformed", "not-a-date", "also-not", "nope", since, false},
+		{"RFC3339 with millis format", "2025-01-01T00:00:00Z", "2026-02-01T00:00:00.000Z", "", since, true},
+		{"exactly equal to since is not after", "2026-01-01T00:00:00Z", "", "", since, false},
+		{"bumpedAt malformed falls back to lastPosted", "2025-01-01T00:00:00Z", "garbage", "2026-02-01T00:00:00Z", since, true},
+		{"bumpedAt malformed, lastPosted malformed, createdAt valid and after", "2026-03-01T00:00:00Z", "garbage", "garbage2", since, true},
+		{"bumpedAt malformed, lastPosted malformed, createdAt valid but before", "2025-03-01T00:00:00Z", "garbage", "garbage2", since, false},
+		{"all before since", "2024-01-01T00:00:00Z", "2024-06-01T00:00:00Z", "2024-09-01T00:00:00Z", since, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := TopicActiveWithin(c.createdAt, c.bumpedAt, c.lastPosted, c.since)
+			assert.Equal(t, c.want, got, c.name)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchEmailHealth — the out-of-window guard returns before touching db, so
+// it is safe to call with a nil *gorm.DB for those branches.
+// ---------------------------------------------------------------------------
+
+func TestFetchEmailHealth_OutOfWindowNeverTouchesDB(t *testing.T) {
+	cases := []struct {
+		name string
+		hour int
+	}{
+		{"midnight", 0},
+		{"just before window opens", 6},
+		{"exactly window close boundary is excluded", 22},
+		{"late evening", 23},
+		{"negative hour", -1},
+		{"hour beyond 24", 25},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// A nil db would panic if the function tried to use it - reaching
+			// here without panicking proves the guard short-circuited.
+			in, out := FetchEmailHealth(nil, c.hour)
+			assert.Equal(t, int64(0), in)
+			assert.Equal(t, int64(0), out)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fetchDiscourseStats — returns nil immediately when Discourse env vars are
+// unset, without making any network call.
+// ---------------------------------------------------------------------------
+
+func TestFetchDiscourseStats_NotConfiguredReturnsNil(t *testing.T) {
+	cases := []struct {
+		name string
+		api  string
+		key  string
+	}{
+		{"both unset", "", ""},
+		{"api set, key unset", "https://discourse.example.com", ""},
+		{"api unset, key set", "", "some-key"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("DISCOURSE_API", c.api)
+			t.Setenv("DISCOURSE_APIKEY", c.key)
+			got := fetchDiscourseStats(12345)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FlexBool — accepts JSON booleans, integers (0/1), and strings.
+// ---------------------------------------------------------------------------
+
+func TestFlexBool_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{"json true", `true`, true},
+		{"json false", `false`, false},
+		{"numeric 1", `1`, true},
+		{"numeric 0", `0`, false},
+		{"quoted true", `"true"`, true},
+		{"quoted false", `"false"`, false},
+		{"quoted 1", `"1"`, true},
+		{"quoted 0", `"0"`, false},
+		{"uppercase TRUE", `"TRUE"`, true},
+		{"mixed case True", `"True"`, true},
+		{"empty string", `""`, false},
+		{"garbage string", `"banana"`, false},
+		{"numeric 2 is not true", `2`, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var f FlexBool
+			err := f.UnmarshalJSON([]byte(c.data))
+			assert.NoError(t, err)
+			assert.Equal(t, c.want, bool(f))
+			assert.Equal(t, c.want, f.Bool())
+		})
+	}
+}
+
+func TestFlexBool_Bool(t *testing.T) {
+	var t1 FlexBool = true
+	var f1 FlexBool = false
+	assert.True(t, t1.Bool())
+	assert.False(t, f1.Bool())
+}
+
+// ---------------------------------------------------------------------------
+// buildPatchSessionUpdateSet — pure clause.Set builder, no DB round-trip.
+// ---------------------------------------------------------------------------
+
+func setToMap(set clause.Set) map[string]interface{} {
+	m := make(map[string]interface{}, len(set))
+	for _, a := range set {
+		m[a.Column.Name] = a.Value
+	}
+	return m
+}
+
+func strp(s string) *string { return &s }
+func intp(i int) *int       { return &i }
+func u64p(u uint64) *uint64 { return &u }
+
+func TestBuildPatchSessionUpdateSet(t *testing.T) {
+	t.Run("nothing set produces empty set", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
+		assert.Empty(t, set)
+	})
+
+	t.Run("displayname alone clears first and last name", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(strp("Jo Bloggs"), nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, "Jo Bloggs", m["fullname"])
+		// firstname/lastname should be present and set to the NULL SQL expression.
+		assert.Equal(t, gorm.Expr("NULL"), m["firstname"])
+		assert.Equal(t, gorm.Expr("NULL"), m["lastname"])
+	})
+
+	t.Run("displayname with explicit firstname keeps firstname, clears lastname", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(strp("Jo Bloggs"), strp("Jo"), nil, nil, nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, "Jo Bloggs", m["fullname"])
+		assert.Equal(t, "Jo", m["firstname"])
+		assert.Contains(t, m, "lastname")
+	})
+
+	t.Run("firstname and lastname independently settable without displayname", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, strp("Jo"), strp("Bloggs"), nil, nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.NotContains(t, m, "fullname")
+		assert.Equal(t, "Jo", m["firstname"])
+		assert.Equal(t, "Bloggs", m["lastname"])
+	})
+
+	t.Run("settingsJSON without lastlocation sets only settings", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, strp(`{"a":1}`), nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, `{"a":1}`, m["settings"])
+		assert.NotContains(t, m, "lastlocation")
+	})
+
+	t.Run("settingsJSON with lastlocation sets both", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, strp(`{"a":1}`), u64p(42), nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, `{"a":1}`, m["settings"])
+		assert.Equal(t, uint64(42), m["lastlocation"])
+	})
+
+	t.Run("lastlocation without settingsJSON is dropped entirely", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, u64p(42), nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.NotContains(t, m, "lastlocation")
+		assert.NotContains(t, m, "settings")
+	})
+
+	t.Run("onholidaytill, relevantallowed, newslettersallowed, source, marketingconsent all independently settable", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, strp("2026-12-25"), intp(1), intp(0), strp("app"), false, intp(1))
+		m := setToMap(set)
+		assert.Equal(t, "2026-12-25", m["onholidaytill"])
+		assert.Equal(t, 1, m["relevantallowed"])
+		assert.Equal(t, 0, m["newslettersallowed"])
+		assert.Equal(t, "app", m["source"])
+		assert.Equal(t, 1, m["marketingconsent"])
+	})
+
+	t.Run("deletedNull true adds the deleted column", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, nil, nil, nil, nil, true, nil)
+		m := setToMap(set)
+		assert.Equal(t, gorm.Expr("NULL"), m["deleted"])
+	})
+
+	t.Run("deletedNull false omits the deleted column", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.NotContains(t, m, "deleted")
+	})
+
+	t.Run("zero-value relevantallowed and newslettersallowed still included when pointer non-nil", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, nil, intp(0), intp(0), nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, 0, m["relevantallowed"])
+		assert.Equal(t, 0, m["newslettersallowed"])
+	})
+
+	t.Run("everything set at once produces every column", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(
+			strp("Jo Bloggs"), strp("Jo"), strp("Bloggs"), strp(`{"a":1}`), u64p(7),
+			strp("2026-01-01"), intp(1), intp(1), strp("web"), true, intp(0),
+		)
+		m := setToMap(set)
+		for _, col := range []string{"fullname", "firstname", "lastname", "settings", "lastlocation",
+			"onholidaytill", "relevantallowed", "newslettersallowed", "source", "deleted", "marketingconsent"} {
+			assert.Contains(t, m, col, "expected column %q in update set", col)
+		}
+	})
+}


### PR DESCRIPTION
## Root Cause
On mobile, `components/NavbarMobile.vue` gated the notification bell (`<NotificationOptions>`) on `!showBackButton`:
```
<NotificationOptions v-if="online && !showBackButton && loggedIn" ... />
```
`showBackButton` (in `composables/useNavbar.js`) is true for every route except the four "home" routes `/browse`, `/chitchat`, `/myposts`, `/explore/*` and `/`. So on any sub-page reached off those - an individual My Posts item (`/mypost/[id]`), the Events pages (`/communityevents`, `/communityevent/[id]`), Volunteering, Give/Find, etc. - the back arrow replaces the bell entirely instead of appearing alongside it. The originating comment says the back arrow was meant to replace "the logo", not the notification bell, so this reads as an accidental coupling rather than intended behaviour: the back-button/home-link slot and the notification-bell slot are two separate flex children in the navbar, and there's no reason showing one should suppress the other. Desktop nav (`NavbarDesktop.vue`) already shows `NotificationOptions` unconditionally whenever logged in, with no such gating - mobile should behave the same way.

While on a sub-page like an individual My Posts item, you're most likely to miss a new Chitchat/chat reply precisely because the bell (and its unread badge) has vanished until you navigate back.

The bottom footer nav (which carries the Chats badge) is a separate condition (`navBarBottomHidden`, gated on the `/give`, `/find`, `/post`, `/chat` route prefixes) that is intentionally hidden during the full-screen post-composer and chat flows - that part is unaffected by this fix and left as-is.

## Evidence
Failing test before the fix (`tests/unit/components/NavbarMobile.spec.js`, mocking `showBackButton: true` to simulate a My Posts/Events sub-page route):
```
 × NavbarMobile > notification bell visibility > still shows the notification bell when a back button is shown 17ms
   → expected false to be true // Object.is equality
 ❯ tests/unit/components/NavbarMobile.spec.js:391:62
    389|       const wrapper = createWrapper()
    390|       expect(wrapper.find('.nav-back-btn').exists()).toBe(true)
    391|       expect(wrapper.find('.notification-options').exists()).toBe(true)
       |                                                              ^
    392|     })
 Test Files  1 failed (1)
      Tests  1 failed | 32 passed (33)
```
After the fix, all 33 tests in the file (including the 2 new ones) pass.

## Fix
Changed the `NotificationOptions` condition in `components/NavbarMobile.vue` from `online && !showBackButton && loggedIn` to `online && loggedIn`, so the bell no longer depends on whether a back button is also shown.

## Prior Attempt
No prior attempt found for Navigation - Notification Bell / Footer (topic 10001 post 3). Searched `gh pr list` for "notification bell footer navigation", "10001", "showBackButton", "bell", "back button navbar", and `git log --all --grep` for "notification bell"/"footer" - no matching closed-unmerged PR touching this area.

## Other Call Sites
`showBackButton` is only referenced in `components/NavbarMobile.vue` (grep confirmed) - no other component duplicates this pattern. The in-chat header (`ChatMobileNavbar.vue`) has its own independent back-button/badge logic and is unaffected.

## Test
File: `iznik-nuxt3/tests/unit/components/NavbarMobile.spec.js` (`notification bell visibility` describe block)
Command: `npx vitest run tests/unit/components/NavbarMobile.spec.js`
Proves fail-before (bell absent when `showBackButton` is true) / pass-after (bell present alongside the back button).

## Discourse
https://discourse.ilovefreegle.org/t/10001/3

## Go Coverage (unrelated to the navbar fix)
CI's Coveralls coverage-delta checks (`Coveralls - go`, `coverage/coveralls`) were flagging this PR red on run-to-run noise: global Go suite coverage dipped <0.1% below the base commit even though this PR's own changed lines (all frontend Vue) are fully covered. Added `iznik-server-go/session/session_pure_test.go` and `iznik-server-go/session/oauth_urls_pure_test.go` - genuine unit tests (no production code touched) for previously-untested pure helpers in the `session` package: `TopicActiveWithin`, the `FetchEmailHealth`/`fetchDiscourseStats` out-of-window guards, `FlexBool` (un)marshalling, `buildPatchSessionUpdateSet`'s full branch matrix, and the Apple/Facebook/Google OAuth endpoint getters plus `parseJWKS`. This lifts `session` package coverage from 1.2% to 9.7% (12 -> 97 of 1000 statements), clearing the coverage-delta check's noise floor.