### PR TITLE
fix(notifications): count only what the bell shows, and badge the back button where it doesn't

### DIFF
--- a/iznik-batch/app/Services/NotificationChaseUpService.php
+++ b/iznik-batch/app/Services/NotificationChaseUpService.php
@@ -40,8 +40,11 @@ class NotificationChaseUpService
 
     /**
      * Spam-user collection types — notifications from these users are excluded.
+     *
+     * Public: also reused by PushNotificationService::consumerUnreadCounts() so the
+     * push-computed app badge excludes the same senders as the in-app bell/chaseup mail.
      */
-    private const SPAM_COLLECTIONS = ['Spammer', 'PendingAdd'];
+    public const SPAM_COLLECTIONS = ['Spammer', 'PendingAdd'];
 
     /**
      * Send chaseup emails for unmailed, unseen notifications.

--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -38,6 +38,12 @@ class PushNotificationService
     // previous day's tray entry rather than stacking a new one.
     private const NEW_POSTS_NOT_ID = '200000001';
 
+    // Mirrors iznik-server-go utils.NOTIFICATION_AGE: the in-app notification
+    // bell/list (notification.Count()/List()) never returns rows older than this,
+    // so a member can never mark them seen once they age out. A notification the
+    // badge counts but the bell can't show would be a permanent phantom blob.
+    private const NOTIFICATION_VISIBLE_DAYS = 90;
+
     private $messaging = null;
 
     /** Whether we've already alerted that FCM is unavailable (avoids per-push spam). */
@@ -301,9 +307,21 @@ class PushNotificationService
      */
     public function consumerUnreadCounts(int $userId): array
     {
+        // Only count notifications the member can actually see and clear in the
+        // app: within the bell's visibility window, and not from a spam/pending-add
+        // sender (mirrors iznik-server-go notification.Count()'s LEFT JOIN spam_users
+        // and NotificationChaseUpService's chaseup-mail exclusion). Discourse #9953:
+        // an old or spam-hidden unseen notification can never be marked seen, so
+        // without this bound it inflates the app-icon badge forever.
         $notifcount = (int) DB::table('users_notifications')
-            ->where('touser', $userId)
-            ->where('seen', 0)
+            ->leftJoin('spam_users', function ($join) {
+                $join->on('spam_users.userid', '=', 'users_notifications.fromuser')
+                    ->whereIn('spam_users.collection', NotificationChaseUpService::SPAM_COLLECTIONS);
+            })
+            ->where('users_notifications.touser', $userId)
+            ->where('users_notifications.seen', 0)
+            ->where('users_notifications.timestamp', '>=', now()->subDays(self::NOTIFICATION_VISIBLE_DAYS))
+            ->whereNull('spam_users.userid')
             ->count();
 
         // Unseen chats: User2User/User2Mod rooms where a message from someone
@@ -344,10 +362,20 @@ class PushNotificationService
             $threadId = 'chats';
             $category = 'CHAT_MESSAGE';
         } elseif ($notifcount > 0) {
+            // Same visibility bound as consumerUnreadCounts(): the highest-id unseen
+            // row could otherwise be a spam-sender notification even though it's
+            // excluded from $notifcount, showing its content instead of a real one.
             $latest = DB::table('users_notifications')
-                ->where('touser', $userId)
-                ->where('seen', 0)
-                ->orderByDesc('id')
+                ->leftJoin('spam_users', function ($join) {
+                    $join->on('spam_users.userid', '=', 'users_notifications.fromuser')
+                        ->whereIn('spam_users.collection', NotificationChaseUpService::SPAM_COLLECTIONS);
+                })
+                ->where('users_notifications.touser', $userId)
+                ->where('users_notifications.seen', 0)
+                ->where('users_notifications.timestamp', '>=', now()->subDays(self::NOTIFICATION_VISIBLE_DAYS))
+                ->whereNull('spam_users.userid')
+                ->select('users_notifications.*')
+                ->orderByDesc('users_notifications.id')
                 ->first();
 
             $title = ($latest->title ?? '') ?: 'You have a new notification';

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -1360,4 +1360,123 @@ class PushNotificationServiceTest extends TestCase
         $this->assertSame('/microvolunteering/message/123', $payload['route'],
             'Relative notification URLs must be passed through unchanged');
     }
+
+    // -----------------------------------------------------------------------
+    // consumerUnreadCounts() notification visibility (Discourse #9953)
+    //
+    // The app-icon badge is driven by consumerUnreadCounts()'s notifcount. The
+    // in-app bell/list (iznik-server-go notification.Count()/List()) only ever
+    // shows unseen notifications within a 90-day window and hides ones from a
+    // spam/pending-add sender. A notification invisible in the bell can never
+    // be marked seen there, so if the badge counts it anyway it becomes a
+    // permanent phantom blob - exactly Diz's report: "a permanent notification
+    // blob... and I don't [have any replies]".
+    // -----------------------------------------------------------------------
+
+    /**
+     * Sanity check: a recent, non-spam unseen notification does count, so the
+     * exclusion tests below aren't vacuously true.
+     */
+    public function test_consumerUnreadCounts_counts_recent_unseen_notification(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        DB::table('users_notifications')->insert([
+            'fromuser' => $sender->id,
+            'touser' => $user->id,
+            'type' => 'Exhort',
+            'seen' => 0,
+            'timestamp' => now()->subDays(1),
+        ]);
+
+        [, $notifcount] = $this->service->consumerUnreadCounts($user->id);
+
+        $this->assertEquals(1, $notifcount, 'A recent unseen notification must count towards the badge');
+    }
+
+    /**
+     * A notification older than the in-app bell's 90-day window can never be
+     * marked seen there (NotificationOne.vue's markSeen() only fires for a
+     * notification actually rendered in the list), so it must not permanently
+     * inflate the app-icon badge.
+     */
+    public function test_consumerUnreadCounts_excludes_notification_older_than_bell_window(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        DB::table('users_notifications')->insert([
+            'fromuser' => $sender->id,
+            'touser' => $user->id,
+            'type' => 'Exhort',
+            'seen' => 0,
+            'timestamp' => now()->subDays(200),
+        ]);
+
+        [, $notifcount] = $this->service->consumerUnreadCounts($user->id);
+
+        $this->assertEquals(0, $notifcount,
+            'A notification the member can never see in the bell must not inflate the badge (Discourse #9953)');
+    }
+
+    /**
+     * Notifications from a spam/pending-add sender are hidden from the in-app
+     * bell (notification.Count()/List() LEFT JOIN spam_users) and from the
+     * chaseup mailer (NotificationChaseUpService::SPAM_COLLECTIONS) - the
+     * push-computed badge must exclude them too.
+     */
+    public function test_consumerUnreadCounts_excludes_notification_from_spam_sender(): void
+    {
+        $user = $this->createTestUser();
+        $spammer = $this->createTestUser();
+
+        DB::table('spam_users')->insert([
+            'userid' => $spammer->id,
+            'byuserid' => $user->id,
+            'collection' => 'Spammer',
+        ]);
+
+        DB::table('users_notifications')->insert([
+            'fromuser' => $spammer->id,
+            'touser' => $user->id,
+            'type' => 'CommentOnYourPost',
+            'seen' => 0,
+            'timestamp' => now(),
+        ]);
+
+        [, $notifcount] = $this->service->consumerUnreadCounts($user->id);
+
+        $this->assertEquals(0, $notifcount,
+            'A notification from a spam-flagged sender must not inflate the badge (Discourse #9953)');
+    }
+
+    /**
+     * A Whitelisted spam_users row must not exclude the sender's notifications -
+     * only Spammer/PendingAdd hide a notification from the bell.
+     */
+    public function test_consumerUnreadCounts_does_not_exclude_whitelisted_sender(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        DB::table('spam_users')->insert([
+            'userid' => $sender->id,
+            'byuserid' => $user->id,
+            'collection' => 'Whitelisted',
+        ]);
+
+        DB::table('users_notifications')->insert([
+            'fromuser' => $sender->id,
+            'touser' => $user->id,
+            'type' => 'CommentOnYourPost',
+            'seen' => 0,
+            'timestamp' => now(),
+        ]);
+
+        [, $notifcount] = $this->service->consumerUnreadCounts($user->id);
+
+        $this->assertEquals(1, $notifcount,
+            'Whitelisted is not a spam collection and must not exclude the notification');
+    }
 }

--- a/iznik-nuxt3/composables/useNavbar.js
+++ b/iznik-nuxt3/composables/useNavbar.js
@@ -152,7 +152,13 @@ export function useNavbar() {
       return chatCount.value - chat?.unseen
     }
 
-    return 0
+    // Everywhere else the back button REPLACES the notification bell - NavbarMobile
+    // only renders NotificationOptions when there's no back button. So on any
+    // sub-page (an individual post, an event, Volunteering) a notification arriving
+    // has nowhere to show itself, and you'd only find it by happening to navigate
+    // back. Put the count on the back button instead: it's the way back to the bell,
+    // so the badge is both the news and the route to it.
+    return Math.min(99, notificationStore.count || 0)
   })
 
   const newsCount = computed(() => {

--- a/iznik-nuxt3/tests/unit/components/NavbarMobile.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NavbarMobile.spec.js
@@ -10,6 +10,11 @@ const mockShowAboutMe = vi.fn()
 const mockMaybeReload = vi.fn()
 const mockBackButton = vi.fn()
 
+// Varied per test: the back button replaces the bell, so these two together
+// decide whether an unread notification is visible at all on a sub-page.
+const mockShowBackButton = ref(false)
+const mockBackButtonCount = ref(0)
+
 vi.mock('~/composables/useNavbar', () => ({
   useNavbar: () => ({
     online: ref(true),
@@ -20,8 +25,8 @@ vi.mock('~/composables/useNavbar', () => ({
     browseCount: ref(10),
     chatCount: ref(5),
     showAboutMeModal: ref(false),
-    showBackButton: ref(false),
-    backButtonCount: ref(0),
+    showBackButton: mockShowBackButton,
+    backButtonCount: mockBackButtonCount,
     requestLogin: mockRequestLogin,
     logout: mockLogout,
     showAboutMe: mockShowAboutMe,
@@ -139,8 +144,13 @@ vi.mock('vue', async (importOriginal) => {
 })
 
 describe('NavbarMobile', () => {
+  // Wrappers are shared-ref driven, so one left mounted after its test will try
+  // to re-render when the next test resets those refs - patching a torn-down
+  // tree throws inside Vue rather than in any test. Unmount them all instead.
+  const wrappers = []
+
   function createWrapper(props = {}) {
-    return mount(NavbarMobile, {
+    const wrapper = mount(NavbarMobile, {
       global: {
         stubs: {
           'b-navbar': {
@@ -149,8 +159,11 @@ describe('NavbarMobile', () => {
             props: ['type', 'fixed'],
           },
           'b-badge': {
-            template:
-              '<span class="b-badge" :class="variant">{{ $slots.default?.() }}</span>',
+            // Render the slot, don't interpolate it: {{ $slots.default?.() }}
+            // stringifies VNodes, and a VNode is circular, so any badge with
+            // content threw "Converting circular structure to JSON" instead of
+            // showing its count.
+            template: '<span class="b-badge" :class="variant"><slot /></span>',
             props: ['variant'],
           },
           'b-dropdown': {
@@ -206,6 +219,9 @@ describe('NavbarMobile', () => {
       },
       ...props,
     })
+
+    wrappers.push(wrapper)
+    return wrapper
   }
 
   beforeEach(() => {
@@ -219,6 +235,8 @@ describe('NavbarMobile', () => {
     mockBreakpoint.value = 'md'
     mockStickyAdRendered.value = false
     mockRoute.path = '/browse'
+    mockShowBackButton.value = false
+    mockBackButtonCount.value = 0
 
     // Mock window.scrollY
     Object.defineProperty(window, 'scrollY', { value: 0, writable: true })
@@ -229,6 +247,9 @@ describe('NavbarMobile', () => {
   })
 
   afterEach(() => {
+    while (wrappers.length) {
+      wrappers.pop().unmount()
+    }
     vi.restoreAllMocks()
   })
 
@@ -370,6 +391,36 @@ describe('NavbarMobile', () => {
     it('hides back button by default', () => {
       const wrapper = createWrapper()
       expect(wrapper.find('.nav-back-btn').exists()).toBe(false)
+    })
+
+    it('badges the back button with unread notifications, since the bell is gone', () => {
+      // A sub-page shows the back button INSTEAD of the bell, so this badge is
+      // the only sign a notification arrived - and the button carrying it is
+      // the way back to reading it.
+      mockShowBackButton.value = true
+      mockBackButtonCount.value = 4
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('.nav-back-btn').exists()).toBe(true)
+      expect(wrapper.find('.back-badge').text()).toBe('4')
+      expect(wrapper.find('.notification-options').exists()).toBe(false)
+    })
+
+    it('leaves the back button bare when nothing is unread', () => {
+      mockShowBackButton.value = true
+      mockBackButtonCount.value = 0
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('.nav-back-btn').exists()).toBe(true)
+      expect(wrapper.find('.back-badge').exists()).toBe(false)
+    })
+
+    it('shows the bell, not a back-button badge, on a home route', () => {
+      mockShowBackButton.value = false
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('.notification-options').exists()).toBe(true)
+      expect(wrapper.find('.back-badge').exists()).toBe(false)
     })
   })
 

--- a/iznik-nuxt3/tests/unit/composables/useNavbarBackButtonCount.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useNavbarBackButtonCount.spec.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+
+import { useNavbar } from '~/composables/useNavbar'
+
+// On mobile the back button REPLACES the notification bell: NavbarMobile renders
+// NotificationOptions only when showBackButton is false. So on every sub-page -
+// an individual post, an event, Volunteering - an arriving notification has
+// nowhere to show itself, and the member has no reason to go back and look.
+// The badge on the back button is that reason.
+
+const mockNotificationStore = {
+  count: 0,
+  fetchCount: vi.fn(),
+  fetchList: vi.fn(),
+}
+const mockChatStore = { unreadCount: 0, byChatId: vi.fn(() => null) }
+
+vi.mock('~/stores/misc', () => ({
+  useMiscStore: () => ({ online: true, get: () => null }),
+}))
+vi.mock('~/stores/newsfeed', () => ({
+  useNewsfeedStore: () => ({ count: 0, fetchCount: vi.fn() }),
+}))
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({
+    count: 0,
+    activePostsCounter: 0,
+    fetchCount: vi.fn(),
+    fetchActivePostCount: vi.fn(),
+  }),
+}))
+vi.mock('~/stores/notification', () => ({
+  useNotificationStore: () => mockNotificationStore,
+}))
+vi.mock('~/stores/chat', () => ({ useChatStore: () => mockChatStore }))
+// Logged out, so useNavbar's onMounted getCounts() short-circuits and no store
+// fetching happens - this spec is about the computed, not the fetching.
+vi.mock('~/stores/auth', () => ({ useAuthStore: () => ({ user: null }) }))
+vi.mock('~/stores/communityevent', () => ({
+  useCommunityEventStore: () => ({ list: [], fetchList: vi.fn() }),
+}))
+vi.mock('~/stores/volunteering', () => ({
+  useVolunteeringStore: () => ({ list: [], fetchList: vi.fn() }),
+}))
+vi.mock('~/stores/mobile', () => ({
+  useMobileStore: () => ({ isApp: false, setBadgeCount: vi.fn() }),
+}))
+vi.mock('~/composables/useMe', () => ({ fetchMe: vi.fn() }))
+vi.mock('~/composables/useStaleBuild', () => ({
+  classifyStaleBuild: () => ({ stale: false }),
+}))
+
+function countOn(path) {
+  globalThis.useRoute = () => ({ path, params: {}, query: {}, fullPath: path })
+  globalThis.useRouter = () => ({
+    push: vi.fn(),
+    currentRoute: { value: { path } },
+  })
+
+  const Harness = defineComponent({
+    setup() {
+      const { backButtonCount } = useNavbar()
+      return { backButtonCount }
+    },
+    template: '<span>{{ backButtonCount }}</span>',
+  })
+
+  return mount(Harness).vm.backButtonCount
+}
+
+describe('backButtonCount surfaces unread notifications where the bell is hidden', () => {
+  beforeEach(() => {
+    mockNotificationStore.count = 0
+    mockChatStore.unreadCount = 0
+    mockChatStore.byChatId = vi.fn(() => null)
+  })
+
+  afterEach(() => {
+    delete globalThis.useRoute
+    delete globalThis.useRouter
+    vi.clearAllMocks()
+  })
+
+  it('shows the unread notification count on a sub-page, where the bell is not rendered', () => {
+    mockNotificationStore.count = 4
+    expect(countOn('/mypost/123')).toBe(4)
+  })
+
+  it('shows it on the other sub-pages reached from the + menu', () => {
+    mockNotificationStore.count = 2
+    expect(countOn('/communityevents')).toBe(2)
+    expect(countOn('/volunteerings')).toBe(2)
+    expect(countOn('/chats')).toBe(2)
+  })
+
+  it('shows nothing when there are no unread notifications, so no empty badge appears', () => {
+    mockNotificationStore.count = 0
+    expect(countOn('/mypost/123')).toBe(0)
+  })
+
+  it('tolerates a count the store has not fetched yet', () => {
+    mockNotificationStore.count = undefined
+    expect(countOn('/mypost/123')).toBe(0)
+  })
+
+  it('caps at 99, matching the other navbar counts', () => {
+    mockNotificationStore.count = 250
+    expect(countOn('/mypost/123')).toBe(99)
+  })
+
+  it('leaves a specific chat showing the OTHER unread chats, not notifications', () => {
+    // In a chat the whole navbar goes; the badge stands in for the chats you
+    // can no longer see, and must not be hijacked by the notification count.
+    mockNotificationStore.count = 7
+    mockChatStore.unreadCount = 5
+    mockChatStore.byChatId = vi.fn(() => ({ unseen: 2 }))
+    expect(countOn('/chats/123')).toBe(3)
+  })
+})

--- a/iznik-server-go/embedding/store_gaps_test.go
+++ b/iznik-server-go/embedding/store_gaps_test.go
@@ -1,0 +1,169 @@
+package embedding
+
+import (
+	"testing"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// FindByMsgid / Evict - pure in-memory Store operations, no DB required.
+// ---------------------------------------------------------------------------
+
+func TestStoreFindByMsgid(t *testing.T) {
+	v1 := makeVec(1.0)
+	v2 := makeVec(2.0)
+	s := &Store{entries: []Entry{
+		{Msgid: 1, Subject: "first", SubjectVec: v1},
+		{Msgid: 2, Subject: "second", SubjectVec: v2},
+	}}
+
+	tests := []struct {
+		name      string
+		msgid     uint64
+		wantFound bool
+		wantSubj  string
+	}{
+		{"found first entry", 1, true, "first"},
+		{"found second entry", 2, true, "second"},
+		{"missing msgid not found", 999, false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, found := s.FindByMsgid(tt.msgid)
+			assert.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
+				assert.Equal(t, tt.wantSubj, entry.Subject)
+			}
+		})
+	}
+}
+
+func TestStoreFindByMsgid_EmptyStore(t *testing.T) {
+	s := &Store{}
+	_, found := s.FindByMsgid(1)
+	assert.False(t, found)
+}
+
+func TestStoreEvict(t *testing.T) {
+	v := makeVec(1.0)
+	s := &Store{entries: []Entry{
+		{Msgid: 1, SubjectVec: v},
+		{Msgid: 2, SubjectVec: v},
+		{Msgid: 3, SubjectVec: v},
+	}}
+
+	// Evict the middle entry - the others must survive, in order.
+	removed := s.Evict(2)
+	assert.True(t, removed)
+	assert.Equal(t, 2, s.Count())
+	_, found := s.FindByMsgid(2)
+	assert.False(t, found)
+	e1, ok1 := s.FindByMsgid(1)
+	assert.True(t, ok1)
+	assert.Equal(t, uint64(1), e1.Msgid)
+	e3, ok3 := s.FindByMsgid(3)
+	assert.True(t, ok3)
+	assert.Equal(t, uint64(3), e3.Msgid)
+}
+
+func TestStoreEvict_NotFound(t *testing.T) {
+	v := makeVec(1.0)
+	s := &Store{entries: []Entry{{Msgid: 1, SubjectVec: v}}}
+
+	removed := s.Evict(999)
+	assert.False(t, removed)
+	assert.Equal(t, 1, s.Count())
+}
+
+func TestStoreEvict_EmptyStore(t *testing.T) {
+	s := &Store{}
+	assert.False(t, s.Evict(1))
+}
+
+func TestStoreEvict_LastRemainingEntry(t *testing.T) {
+	v := makeVec(1.0)
+	s := &Store{entries: []Entry{{Msgid: 1, SubjectVec: v}}}
+
+	removed := s.Evict(1)
+	assert.True(t, removed)
+	assert.Equal(t, 0, s.Count())
+}
+
+// ---------------------------------------------------------------------------
+// Refresh - the db==nil guard (distinct from Load's, only reached when the
+// store is already non-empty so the Count()==0 fallback to Load isn't taken).
+// ---------------------------------------------------------------------------
+
+func TestStoreRefresh_WithoutDB(t *testing.T) {
+	orig := database.DBConn
+	database.DBConn = nil
+	defer func() { database.DBConn = orig }()
+
+	v := makeVec(1.0)
+	s := &Store{entries: []Entry{{Msgid: 1, SubjectVec: v}}}
+
+	err := s.Refresh()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not initialized")
+	// The store must be left untouched on failure.
+	assert.Equal(t, 1, s.Count())
+}
+
+func TestStoreRefresh_EmptyStoreFallsBackToLoad(t *testing.T) {
+	// Count()==0 makes Refresh delegate to Load, which fails fast with DBConn
+	// nil - proving the fallback branch is taken (not the id-diff branch).
+	orig := database.DBConn
+	database.DBConn = nil
+	defer func() { database.DBConn = orig }()
+
+	s := &Store{}
+	err := s.Refresh()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not initialized")
+}
+
+// ---------------------------------------------------------------------------
+// StartRefresh - kicks off an initial Load and a background ticker. With
+// DBConn nil the initial Load fails fast (logged, not fatal) and the ticker
+// interval is set far beyond the test's lifetime so it never fires.
+// ---------------------------------------------------------------------------
+
+func TestStartRefresh_InitialLoadFailureDoesNotPanic(t *testing.T) {
+	orig := database.DBConn
+	database.DBConn = nil
+	defer func() { database.DBConn = orig }()
+
+	assert.NotPanics(t, func() {
+		StartRefresh(time.Hour)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// fetchEntries - the db==nil guard, reached directly (Load/Refresh both call
+// through it, but this exercises the guard without going through either).
+// ---------------------------------------------------------------------------
+
+func TestFetchEntries_WithoutDB(t *testing.T) {
+	orig := database.DBConn
+	database.DBConn = nil
+	defer func() { database.DBConn = orig }()
+
+	entries, err := fetchEntries("")
+	assert.Nil(t, entries)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not initialized")
+}
+
+func TestFetchEntries_WithoutDB_WithExtraWhere(t *testing.T) {
+	orig := database.DBConn
+	database.DBConn = nil
+	defer func() { database.DBConn = orig }()
+
+	entries, err := fetchEntries(" AND me.msgid IN (?)", []uint64{1, 2})
+	assert.Nil(t, entries)
+	assert.Error(t, err)
+}

--- a/iznik-server-go/isochrone/mapbox_http_test.go
+++ b/iznik-server-go/isochrone/mapbox_http_test.go
@@ -1,0 +1,100 @@
+package isochrone
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// FetchIsochroneWKT HTTP paths - mapbox_test.go already covers the pure
+// conversion helpers (polygonToWKT, geojsonGeometryToWKT,
+// FetchIsochroneWKTFromGeoJSON) and the no-token short-circuit. These tests
+// use the shared fakeRoundTripper (defined in routing_test.go) to drive
+// FetchIsochroneWKT's own HTTP success/error branches without any network
+// access.
+// ---------------------------------------------------------------------------
+
+func TestFetchIsochroneWKT_NetworkError(t *testing.T) {
+	withEnv(t, "MAPBOX_KEY", "test-token")
+	withFakeTransport(t, &fakeRoundTripper{err: errors.New("dial tcp: connection refused")})
+	assert.Equal(t, "", FetchIsochroneWKT("Walk", -0.1, 51.5, 10))
+}
+
+func TestFetchIsochroneWKT_ReadBodyError(t *testing.T) {
+	withEnv(t, "MAPBOX_KEY", "test-token")
+	withFakeTransport(t, &fakeRoundTripper{resp: &http.Response{
+		StatusCode: 200,
+		Body:       errReadCloser{},
+		Header:     make(http.Header),
+	}})
+	assert.Equal(t, "", FetchIsochroneWKT("Walk", -0.1, 51.5, 10))
+}
+
+func TestFetchIsochroneWKT_NonOKStatus(t *testing.T) {
+	withEnv(t, "MAPBOX_KEY", "test-token")
+	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(429, "rate limited")})
+	assert.Equal(t, "", FetchIsochroneWKT("Walk", -0.1, 51.5, 10))
+}
+
+func TestFetchIsochroneWKT_NonOKStatusLongBody(t *testing.T) {
+	withEnv(t, "MAPBOX_KEY", "test-token")
+	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(500, strings.Repeat("y", 1000))})
+	assert.Equal(t, "", FetchIsochroneWKT("Walk", -0.1, 51.5, 10))
+}
+
+func TestFetchIsochroneWKT_BadJSON(t *testing.T) {
+	withEnv(t, "MAPBOX_KEY", "test-token")
+	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(200, "not json")})
+	assert.Equal(t, "", FetchIsochroneWKT("Walk", -0.1, 51.5, 10))
+}
+
+func TestFetchIsochroneWKT_NoFeaturesInResponse(t *testing.T) {
+	withEnv(t, "MAPBOX_KEY", "test-token")
+	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(200, `{"features":[]}`)})
+	assert.Equal(t, "", FetchIsochroneWKT("Walk", -0.1, 51.5, 10))
+}
+
+func TestFetchIsochroneWKT_SuccessPolygon(t *testing.T) {
+	withEnv(t, "MAPBOX_KEY", "test-token")
+	body := `{"features":[{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-0.1,51.5],[-0.2,51.5],[-0.2,51.6],[-0.1,51.5]]]}}]}`
+	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(200, body)})
+
+	wkt := FetchIsochroneWKT("Walk", -0.1, 51.5, 10)
+	assert.True(t, strings.HasPrefix(wkt, "POLYGON("))
+	assert.Contains(t, wkt, "-0.100000 51.500000")
+}
+
+func TestFetchIsochroneWKT_TransportProfileMapping(t *testing.T) {
+	tests := []struct{ transport, profile string }{
+		{"Walk", "walking"},
+		{"Cycle", "cycling"},
+		{"Drive", "driving"},
+		{"Teleport", "driving"}, // unknown transport falls back to "driving"
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.transport, func(t *testing.T) {
+			withEnv(t, "MAPBOX_KEY", "test-token")
+			rt := &fakeRoundTripper{resp: fakeResponse(200, `{"features":[]}`)}
+			withFakeTransport(t, rt)
+
+			FetchIsochroneWKT(tt.transport, -0.1, 51.5, 10)
+			assert.Contains(t, rt.lastURL, "/mapbox/"+tt.profile+"/")
+			assert.Contains(t, rt.lastURL, "access_token=test-token")
+		})
+	}
+}
+
+func TestFetchIsochroneWKT_URLIncludesParams(t *testing.T) {
+	withEnv(t, "MAPBOX_KEY", "test-token")
+	rt := &fakeRoundTripper{resp: fakeResponse(200, `{"features":[]}`)}
+	withFakeTransport(t, rt)
+
+	FetchIsochroneWKT("Walk", -0.1, 51.5, 12)
+	assert.Contains(t, rt.lastURL, "contours_minutes=12")
+	assert.Contains(t, rt.lastURL, "-0.100000,51.500000")
+}

--- a/iznik-server-go/isochrone/routing_test.go
+++ b/iznik-server-go/isochrone/routing_test.go
@@ -1,0 +1,248 @@
+package isochrone
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Shared test doubles for isochroneHTTPClient - both mapbox.go and routing.go
+// call through this shared client, so overriding its Transport lets these
+// pure unit tests exercise every HTTP success/error branch with no network
+// access and no external routing/Mapbox server.
+// ---------------------------------------------------------------------------
+
+type fakeRoundTripper struct {
+	resp    *http.Response
+	err     error
+	lastURL string
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.lastURL = req.URL.String()
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.resp, nil
+}
+
+func withFakeTransport(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	orig := isochroneHTTPClient.Transport
+	isochroneHTTPClient.Transport = rt
+	t.Cleanup(func() { isochroneHTTPClient.Transport = orig })
+}
+
+func fakeResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+// errReadCloser fails every Read, so the io.ReadAll error path is reachable
+// without a real broken connection.
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("simulated read failure") }
+func (errReadCloser) Close() error              { return nil }
+
+func withEnv(t *testing.T, key, val string) {
+	t.Helper()
+	orig, had := os.LookupEnv(key)
+	os.Setenv(key, val)
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(key, orig)
+		} else {
+			os.Unsetenv(key)
+		}
+	})
+}
+
+func clearEnv(t *testing.T, key string) {
+	t.Helper()
+	orig, had := os.LookupEnv(key)
+	os.Unsetenv(key)
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(key, orig)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// FetchIsochroneWKTFromRoutingServer
+// ---------------------------------------------------------------------------
+
+func TestFetchIsochroneWKTFromRoutingServer_NoURLConfigured(t *testing.T) {
+	clearEnv(t, "SPATIAL_SERVER_URL")
+	clearEnv(t, "ROUTING_SERVER_URL")
+	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
+}
+
+func TestFetchIsochroneWKTFromRoutingServer_FallsBackToLegacyEnvVar(t *testing.T) {
+	// SPATIAL_SERVER_URL unset, ROUTING_SERVER_URL set - the base must come
+	// from the legacy var rather than short-circuiting to "".
+	clearEnv(t, "SPATIAL_SERVER_URL")
+	withEnv(t, "ROUTING_SERVER_URL", "http://legacy.invalid")
+	rt := &fakeRoundTripper{resp: fakeResponse(200, routingResponseJSON())}
+	withFakeTransport(t, rt)
+
+	wkt := FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15)
+	assert.True(t, strings.HasPrefix(wkt, "POLYGON(("))
+	assert.True(t, strings.HasPrefix(rt.lastURL, "http://legacy.invalid/v1/isochrone"))
+}
+
+func TestFetchIsochroneWKTFromRoutingServer_NetworkError(t *testing.T) {
+	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withFakeTransport(t, &fakeRoundTripper{err: errors.New("connection refused")})
+	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
+}
+
+func TestFetchIsochroneWKTFromRoutingServer_ReadBodyError(t *testing.T) {
+	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withFakeTransport(t, &fakeRoundTripper{resp: &http.Response{
+		StatusCode: 200,
+		Body:       errReadCloser{},
+		Header:     make(http.Header),
+	}})
+	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
+}
+
+func TestFetchIsochroneWKTFromRoutingServer_NonOKStatus(t *testing.T) {
+	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(500, "internal error")})
+	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
+}
+
+func TestFetchIsochroneWKTFromRoutingServer_NonOKStatusLongBody(t *testing.T) {
+	// The error-logging path truncates the body to 500 bytes - exercise it
+	// with a body long enough to require the truncation.
+	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	longBody := strings.Repeat("x", 1000)
+	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(503, longBody)})
+	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
+}
+
+func TestFetchIsochroneWKTFromRoutingServer_BadJSON(t *testing.T) {
+	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(200, "not json")})
+	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
+}
+
+func routingResponseJSON() string {
+	return `{
+		"walk": {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-0.1,51.5],[-0.2,51.5],[-0.2,51.6],[-0.1,51.5]]]}},
+		"cycle": {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-0.3,51.5],[-0.4,51.5],[-0.4,51.6],[-0.3,51.5]]]}},
+		"drive": {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-0.5,51.5],[-0.6,51.5],[-0.6,51.6],[-0.5,51.5]]]}}
+	}`
+}
+
+func TestFetchIsochroneWKTFromRoutingServer_TransportSelection(t *testing.T) {
+	tests := []struct {
+		name       string
+		transport  string
+		wantPoint  string
+	}{
+		{"walk maps to walk polygon", "Walk", "-0.100000 51.500000"},
+		{"cycle maps to cycle polygon", "Cycle", "-0.300000 51.500000"},
+		{"drive maps to drive polygon", "Drive", "-0.500000 51.500000"},
+		{"unknown transport defaults to drive polygon", "Teleport", "-0.500000 51.500000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+			withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(200, routingResponseJSON())})
+
+			wkt := FetchIsochroneWKTFromRoutingServer(tt.transport, 51.5, -0.1, 15)
+			assert.True(t, strings.HasPrefix(wkt, "POLYGON(("))
+			assert.Contains(t, wkt, tt.wantPoint)
+		})
+	}
+}
+
+func TestFetchIsochroneWKTFromRoutingServer_URLIncludesParams(t *testing.T) {
+	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	rt := &fakeRoundTripper{resp: fakeResponse(200, routingResponseJSON())}
+	withFakeTransport(t, rt)
+
+	FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15)
+	assert.Contains(t, rt.lastURL, "lat=51.500000")
+	assert.Contains(t, rt.lastURL, "lng=-0.100000")
+	assert.Contains(t, rt.lastURL, "minutes=15")
+}
+
+// ---------------------------------------------------------------------------
+// routingPolygonToWKT
+// ---------------------------------------------------------------------------
+
+func TestRoutingPolygonToWKT(t *testing.T) {
+	tests := []struct {
+		name string
+		poly routingPolygon
+		want string
+	}{
+		{
+			name: "wrong geometry type returns empty",
+			poly: routingPolygon{Geometry: routingGeometry{Type: "Point"}},
+			want: "",
+		},
+		{
+			name: "empty coordinates returns empty",
+			poly: routingPolygon{Geometry: routingGeometry{Type: "Polygon"}},
+			want: "",
+		},
+		{
+			name: "too few points in ring returns empty",
+			poly: routingPolygon{Geometry: routingGeometry{
+				Type:        "Polygon",
+				Coordinates: [][][2]float64{{{0, 0}, {1, 1}}},
+			}},
+			want: "",
+		},
+		{
+			name: "zero-length ring returns empty",
+			poly: routingPolygon{Geometry: routingGeometry{
+				Type:        "Polygon",
+				Coordinates: [][][2]float64{{}},
+			}},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, routingPolygonToWKT(tt.poly))
+		})
+	}
+}
+
+func TestRoutingPolygonToWKT_Valid(t *testing.T) {
+	poly := routingPolygon{Geometry: routingGeometry{
+		Type:        "Polygon",
+		Coordinates: [][][2]float64{{{0, 0}, {1, 0}, {1, 1}, {0, 0}}},
+	}}
+	wkt := routingPolygonToWKT(poly)
+	assert.True(t, strings.HasPrefix(wkt, "POLYGON(("))
+	assert.True(t, strings.HasSuffix(wkt, "))"))
+	assert.Contains(t, wkt, "0.000000 0.000000")
+	assert.Contains(t, wkt, "1.000000 0.000000")
+	assert.Contains(t, wkt, "1.000000 1.000000")
+}
+
+func TestRoutingTransportMap(t *testing.T) {
+	assert.Equal(t, "walk", routingTransport["Walk"])
+	assert.Equal(t, "cycle", routingTransport["Cycle"])
+	assert.Equal(t, "drive", routingTransport["Drive"])
+	_, ok := routingTransport["Teleport"]
+	assert.False(t, ok)
+}

--- a/iznik-server-go/isochrone/score_gaps_test.go
+++ b/iznik-server-go/isochrone/score_gaps_test.go
@@ -1,0 +1,29 @@
+package isochrone
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// ReachRadiusMetres - edge cases not covered by score_test.go: a ring vertex
+// with too few fields, and a ring vertex whose fields don't parse as floats.
+// Both must be skipped rather than aborting the whole scan.
+// ---------------------------------------------------------------------------
+
+func TestReachRadiusMetres_SkipsMalformedVertices(t *testing.T) {
+	// First vertex has only one field (skipped by the len(parts)<2 guard),
+	// second vertex has non-numeric fields (skipped by the ParseFloat guard),
+	// third vertex is the only valid one, 1 degree of longitude from the origin.
+	wkt := "POLYGON((5, abc def, 1 0))"
+	got := ReachRadiusMetres(0, 0, wkt, 30000)
+	want := HaversineMetres(0, 0, 0, 1)
+	approxScore(t, "malformed vertices skipped, valid vertex used", got, want, 1)
+}
+
+func TestReachRadiusMetres_AllVerticesMalformedFallsBackToDefault(t *testing.T) {
+	// Every vertex is unparseable, so maxDist never rises above 0 and the
+	// function must fall back to defaultM.
+	wkt := "POLYGON((abc def, ghi, 5))"
+	got := ReachRadiusMetres(51.5, -0.1, wkt, 9999)
+	approxScore(t, "all vertices malformed -> default", got, 9999, 1e-9)
+}

--- a/iznik-server-go/session/oauth_urls_pure_test.go
+++ b/iznik-server-go/session/oauth_urls_pure_test.go
@@ -1,0 +1,187 @@
+package session
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Endpoint getters — pure env-var-with-default lookups, no network involved.
+// ---------------------------------------------------------------------------
+
+func TestGetAppleJWKSURL(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("APPLE_JWKS_URL", "")
+		assert.Equal(t, "https://appleid.apple.com/auth/keys", getAppleJWKSURL())
+	})
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv("APPLE_JWKS_URL", "https://example.test/apple-jwks")
+		assert.Equal(t, "https://example.test/apple-jwks", getAppleJWKSURL())
+	})
+}
+
+func TestGetFacebookGraphURL(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("FACEBOOK_GRAPH_URL", "")
+		assert.Equal(t, "https://graph.facebook.com", getFacebookGraphURL())
+	})
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv("FACEBOOK_GRAPH_URL", "https://example.test/graph")
+		assert.Equal(t, "https://example.test/graph", getFacebookGraphURL())
+	})
+}
+
+func TestGetFacebookJWKSURL(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("FACEBOOK_JWKS_URL", "")
+		assert.Equal(t, "https://limited.facebook.com/.well-known/oauth/openid/jwks/", getFacebookJWKSURL())
+	})
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv("FACEBOOK_JWKS_URL", "https://example.test/fb-jwks")
+		assert.Equal(t, "https://example.test/fb-jwks", getFacebookJWKSURL())
+	})
+}
+
+func TestGetGoogleTokenInfoURL(t *testing.T) {
+	t.Run("default when both unset", func(t *testing.T) {
+		t.Setenv("GOOGLE_TOKENINFO_URL", "")
+		saved := googleTokenInfoURL
+		googleTokenInfoURL = ""
+		defer func() { googleTokenInfoURL = saved }()
+		assert.Equal(t, "https://oauth2.googleapis.com/tokeninfo", getGoogleTokenInfoURL())
+	})
+	t.Run("package var used when env unset", func(t *testing.T) {
+		t.Setenv("GOOGLE_TOKENINFO_URL", "")
+		saved := googleTokenInfoURL
+		googleTokenInfoURL = "https://example.test/pkgvar"
+		defer func() { googleTokenInfoURL = saved }()
+		assert.Equal(t, "https://example.test/pkgvar", getGoogleTokenInfoURL())
+	})
+	t.Run("env takes priority over package var", func(t *testing.T) {
+		t.Setenv("GOOGLE_TOKENINFO_URL", "https://example.test/envvar")
+		saved := googleTokenInfoURL
+		googleTokenInfoURL = "https://example.test/pkgvar"
+		defer func() { googleTokenInfoURL = saved }()
+		assert.Equal(t, "https://example.test/envvar", getGoogleTokenInfoURL())
+	})
+}
+
+// ---------------------------------------------------------------------------
+// parseJWKS — pure JSON/base64/RSA-assembly parsing, no network.
+// ---------------------------------------------------------------------------
+
+func makeJWK(t *testing.T, kid string) jwksKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 512) // small key: fast, fine for parse-only tests
+	assert.NoError(t, err)
+	nBytes := key.PublicKey.N.Bytes()
+	eBytes := []byte{byte(key.PublicKey.E >> 16), byte(key.PublicKey.E >> 8), byte(key.PublicKey.E)}
+	// Trim leading zero bytes from the exponent encoding, mirroring real JWKS output.
+	for len(eBytes) > 1 && eBytes[0] == 0 {
+		eBytes = eBytes[1:]
+	}
+	return jwksKey{
+		Kty: "RSA",
+		Kid: kid,
+		Use: "sig",
+		N:   base64.RawURLEncoding.EncodeToString(nBytes),
+		E:   base64.RawURLEncoding.EncodeToString(eBytes),
+		Alg: "RS256",
+	}
+}
+
+func TestParseJWKS(t *testing.T) {
+	t.Run("single valid RSA key", func(t *testing.T) {
+		k := makeJWK(t, "key-1")
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{k}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.NoError(t, err)
+		assert.Len(t, keys, 1)
+		assert.Contains(t, keys, "key-1")
+		assert.NotNil(t, keys["key-1"])
+	})
+
+	t.Run("multiple valid RSA keys", func(t *testing.T) {
+		k1 := makeJWK(t, "key-1")
+		k2 := makeJWK(t, "key-2")
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{k1, k2}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.NoError(t, err)
+		assert.Len(t, keys, 2)
+		assert.Contains(t, keys, "key-1")
+		assert.Contains(t, keys, "key-2")
+	})
+
+	t.Run("non-RSA key type is skipped", func(t *testing.T) {
+		rsaKey := makeJWK(t, "rsa-key")
+		ecKey := jwksKey{Kty: "EC", Kid: "ec-key", N: "irrelevant", E: "irrelevant"}
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{ecKey, rsaKey}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.NoError(t, err)
+		assert.Len(t, keys, 1)
+		assert.Contains(t, keys, "rsa-key")
+		assert.NotContains(t, keys, "ec-key")
+	})
+
+	t.Run("malformed JSON returns error", func(t *testing.T) {
+		keys, err := parseJWKS([]byte("not json"))
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("empty keys array returns no RSA keys error", func(t *testing.T) {
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("only non-RSA keys returns no RSA keys error", func(t *testing.T) {
+		ecKey := jwksKey{Kty: "EC", Kid: "ec-key", N: "irrelevant", E: "irrelevant"}
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{ecKey}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("invalid base64 modulus returns error", func(t *testing.T) {
+		k := jwksKey{Kty: "RSA", Kid: "bad-n", N: "not-valid-base64!!!", E: "AQAB"}
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{k}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("invalid base64 exponent returns error", func(t *testing.T) {
+		k := jwksKey{Kty: "RSA", Kid: "bad-e", N: base64.RawURLEncoding.EncodeToString([]byte{1, 2, 3}), E: "not-valid-base64!!!"}
+		body, err := json.Marshal(jwksResponse{Keys: []jwksKey{k}})
+		assert.NoError(t, err)
+
+		keys, err := parseJWKS(body)
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("empty body returns error", func(t *testing.T) {
+		keys, err := parseJWKS([]byte(""))
+		assert.Error(t, err)
+		assert.Nil(t, keys)
+	})
+}

--- a/iznik-server-go/session/session_pure_test.go
+++ b/iznik-server-go/session/session_pure_test.go
@@ -1,0 +1,255 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ---------------------------------------------------------------------------
+// TopicActiveWithin — pure, no DB/HTTP needed.
+// ---------------------------------------------------------------------------
+
+func TestTopicActiveWithin(t *testing.T) {
+	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		createdAt  string
+		bumpedAt   string
+		lastPosted string
+		since      time.Time
+		want       bool
+	}{
+		{"bumpedAt after since wins", "2025-01-01T00:00:00Z", "2026-02-01T00:00:00Z", "2025-06-01T00:00:00Z", since, true},
+		{"bumpedAt before since, falls back to lastPosted after since", "2025-01-01T00:00:00Z", "2025-06-01T00:00:00Z", "2026-02-01T00:00:00Z", since, false},
+		{"bumpedAt missing, lastPosted after since wins", "2025-01-01T00:00:00Z", "", "2026-02-01T00:00:00Z", since, true},
+		{"bumpedAt and lastPosted missing, createdAt after since wins", "2026-02-01T00:00:00Z", "", "", since, true},
+		{"all missing", "", "", "", since, false},
+		{"all malformed", "not-a-date", "also-not", "nope", since, false},
+		{"RFC3339 with millis format", "2025-01-01T00:00:00Z", "2026-02-01T00:00:00.000Z", "", since, true},
+		{"exactly equal to since is not after", "2026-01-01T00:00:00Z", "", "", since, false},
+		{"bumpedAt malformed falls back to lastPosted", "2025-01-01T00:00:00Z", "garbage", "2026-02-01T00:00:00Z", since, true},
+		{"bumpedAt malformed, lastPosted malformed, createdAt valid and after", "2026-03-01T00:00:00Z", "garbage", "garbage2", since, true},
+		{"bumpedAt malformed, lastPosted malformed, createdAt valid but before", "2025-03-01T00:00:00Z", "garbage", "garbage2", since, false},
+		{"all before since", "2024-01-01T00:00:00Z", "2024-06-01T00:00:00Z", "2024-09-01T00:00:00Z", since, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := TopicActiveWithin(c.createdAt, c.bumpedAt, c.lastPosted, c.since)
+			assert.Equal(t, c.want, got, c.name)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchEmailHealth — the out-of-window guard returns before touching db, so
+// it is safe to call with a nil *gorm.DB for those branches.
+// ---------------------------------------------------------------------------
+
+func TestFetchEmailHealth_OutOfWindowNeverTouchesDB(t *testing.T) {
+	cases := []struct {
+		name string
+		hour int
+	}{
+		{"midnight", 0},
+		{"just before window opens", 6},
+		{"exactly window close boundary is excluded", 22},
+		{"late evening", 23},
+		{"negative hour", -1},
+		{"hour beyond 24", 25},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// A nil db would panic if the function tried to use it - reaching
+			// here without panicking proves the guard short-circuited.
+			in, out := FetchEmailHealth(nil, c.hour)
+			assert.Equal(t, int64(0), in)
+			assert.Equal(t, int64(0), out)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fetchDiscourseStats — returns nil immediately when Discourse env vars are
+// unset, without making any network call.
+// ---------------------------------------------------------------------------
+
+func TestFetchDiscourseStats_NotConfiguredReturnsNil(t *testing.T) {
+	cases := []struct {
+		name string
+		api  string
+		key  string
+	}{
+		{"both unset", "", ""},
+		{"api set, key unset", "https://discourse.example.com", ""},
+		{"api unset, key set", "", "some-key"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("DISCOURSE_API", c.api)
+			t.Setenv("DISCOURSE_APIKEY", c.key)
+			got := fetchDiscourseStats(12345)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FlexBool — accepts JSON booleans, integers (0/1), and strings.
+// ---------------------------------------------------------------------------
+
+func TestFlexBool_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{"json true", `true`, true},
+		{"json false", `false`, false},
+		{"numeric 1", `1`, true},
+		{"numeric 0", `0`, false},
+		{"quoted true", `"true"`, true},
+		{"quoted false", `"false"`, false},
+		{"quoted 1", `"1"`, true},
+		{"quoted 0", `"0"`, false},
+		{"uppercase TRUE", `"TRUE"`, true},
+		{"mixed case True", `"True"`, true},
+		{"empty string", `""`, false},
+		{"garbage string", `"banana"`, false},
+		{"numeric 2 is not true", `2`, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var f FlexBool
+			err := f.UnmarshalJSON([]byte(c.data))
+			assert.NoError(t, err)
+			assert.Equal(t, c.want, bool(f))
+			assert.Equal(t, c.want, f.Bool())
+		})
+	}
+}
+
+func TestFlexBool_Bool(t *testing.T) {
+	var t1 FlexBool = true
+	var f1 FlexBool = false
+	assert.True(t, t1.Bool())
+	assert.False(t, f1.Bool())
+}
+
+// ---------------------------------------------------------------------------
+// buildPatchSessionUpdateSet — pure clause.Set builder, no DB round-trip.
+// ---------------------------------------------------------------------------
+
+func setToMap(set clause.Set) map[string]interface{} {
+	m := make(map[string]interface{}, len(set))
+	for _, a := range set {
+		m[a.Column.Name] = a.Value
+	}
+	return m
+}
+
+func strp(s string) *string { return &s }
+func intp(i int) *int       { return &i }
+func u64p(u uint64) *uint64 { return &u }
+
+func TestBuildPatchSessionUpdateSet(t *testing.T) {
+	t.Run("nothing set produces empty set", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
+		assert.Empty(t, set)
+	})
+
+	t.Run("displayname alone clears first and last name", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(strp("Jo Bloggs"), nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, "Jo Bloggs", m["fullname"])
+		// firstname/lastname should be present and set to the NULL SQL expression.
+		assert.Equal(t, gorm.Expr("NULL"), m["firstname"])
+		assert.Equal(t, gorm.Expr("NULL"), m["lastname"])
+	})
+
+	t.Run("displayname with explicit firstname keeps firstname, clears lastname", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(strp("Jo Bloggs"), strp("Jo"), nil, nil, nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, "Jo Bloggs", m["fullname"])
+		assert.Equal(t, "Jo", m["firstname"])
+		assert.Contains(t, m, "lastname")
+	})
+
+	t.Run("firstname and lastname independently settable without displayname", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, strp("Jo"), strp("Bloggs"), nil, nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.NotContains(t, m, "fullname")
+		assert.Equal(t, "Jo", m["firstname"])
+		assert.Equal(t, "Bloggs", m["lastname"])
+	})
+
+	t.Run("settingsJSON without lastlocation sets only settings", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, strp(`{"a":1}`), nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, `{"a":1}`, m["settings"])
+		assert.NotContains(t, m, "lastlocation")
+	})
+
+	t.Run("settingsJSON with lastlocation sets both", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, strp(`{"a":1}`), u64p(42), nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, `{"a":1}`, m["settings"])
+		assert.Equal(t, uint64(42), m["lastlocation"])
+	})
+
+	t.Run("lastlocation without settingsJSON is dropped entirely", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, u64p(42), nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.NotContains(t, m, "lastlocation")
+		assert.NotContains(t, m, "settings")
+	})
+
+	t.Run("onholidaytill, relevantallowed, newslettersallowed, source, marketingconsent all independently settable", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, strp("2026-12-25"), intp(1), intp(0), strp("app"), false, intp(1))
+		m := setToMap(set)
+		assert.Equal(t, "2026-12-25", m["onholidaytill"])
+		assert.Equal(t, 1, m["relevantallowed"])
+		assert.Equal(t, 0, m["newslettersallowed"])
+		assert.Equal(t, "app", m["source"])
+		assert.Equal(t, 1, m["marketingconsent"])
+	})
+
+	t.Run("deletedNull true adds the deleted column", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, nil, nil, nil, nil, true, nil)
+		m := setToMap(set)
+		assert.Equal(t, gorm.Expr("NULL"), m["deleted"])
+	})
+
+	t.Run("deletedNull false omits the deleted column", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, nil, nil, nil, nil, false, nil)
+		m := setToMap(set)
+		assert.NotContains(t, m, "deleted")
+	})
+
+	t.Run("zero-value relevantallowed and newslettersallowed still included when pointer non-nil", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(nil, nil, nil, nil, nil, nil, intp(0), intp(0), nil, false, nil)
+		m := setToMap(set)
+		assert.Equal(t, 0, m["relevantallowed"])
+		assert.Equal(t, 0, m["newslettersallowed"])
+	})
+
+	t.Run("everything set at once produces every column", func(t *testing.T) {
+		set := buildPatchSessionUpdateSet(
+			strp("Jo Bloggs"), strp("Jo"), strp("Bloggs"), strp(`{"a":1}`), u64p(7),
+			strp("2026-01-01"), intp(1), intp(1), strp("web"), true, intp(0),
+		)
+		m := setToMap(set)
+		for _, col := range []string{"fullname", "firstname", "lastname", "settings", "lastlocation",
+			"onholidaytill", "relevantallowed", "newslettersallowed", "source", "deleted", "marketingconsent"} {
+			assert.Contains(t, m, col, "expected column %q in update set", col)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Two halves of the same thing: a member is told they have notifications they cannot see, and is not told about ones they can.

**The app icon over-counts.** `PushNotificationService::consumerUnreadCounts()` counts every unseen `users_notifications` row - no age bound, no spam-sender exclusion. The bell the member actually opens only ever returns rows inside a 90-day window and excludes notifications from a spam or pending-add sender. `NotificationOne.vue`'s `markSeen()` can only fire for something rendered in that list, so anything outside either bound can never be marked seen and the icon badge counts it forever. Diz on [#9953](https://discourse.ilovefreegle.org/t/9953/1): "a permanent notification blob... and I don't [have any replies]."

**Sub-pages hide the bell.** On mobile the back button *replaces* the notification bell - `NavbarMobile` renders `NotificationOptions` only when there is no back button. So on any page reached off a home route (an individual post, Community Events, Volunteering, Give/Find) a notification that arrives has nowhere to show itself, and nothing prompts the member to go back and look. That is the reporting on [#10001](https://discourse.ilovefreegle.org/t/10001/3).

## What this does

**Batch (`iznik-batch`).** `consumerUnreadCounts()` and the sibling `$latest` lookup in `buildUserNotificationPayload()` apply both of the bell's visibility clauses: `timestamp >= now - 90 days`, and a `LEFT JOIN spam_users ... WHERE spam_users.userid IS NULL` over the Spammer/PendingAdd collections. The spam exclusion reuses `NotificationChaseUpService::SPAM_COLLECTIONS` (now `public`) rather than restating the literal. The icon badge and the bell therefore count the same rows, and a notification the member cannot reach can no longer stick on the icon forever.

**Frontend (`iznik-nuxt3`).** The back button already carries a badge - `useNavbar`'s `backButtonCount` - but it only counted the *other* unread chats while inside a specific chat, and was zero everywhere else. It now carries the unread notification count on the pages where the bell is not rendered. The bell keeps its existing gating: where there is a back button there is no bell, and the badge on the back button is both the news and the way to it, since that control is what takes you back.

Capped at 99, matching `browseCount` and `chatCount`, so a long-dormant account cannot render a four-digit number into a small circle. A specific chat keeps its existing meaning - the navbar is gone entirely there, and the count stands in for the chats you can no longer see.

### Community Events, one unread notification

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/back-button-notification-badge/before-no-badge.png" width="320"> | <img src="https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/back-button-notification-badge/after-badge.png" width="320"> |

Same page, same account, same single unread notification. `pr-assets/back-button-notification-badge` holds only these two images and can be deleted after merge.

## Tests

- `iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php`: `consumerUnreadCounts()` sanity count, age exclusion, spam-sender exclusion, and a negative control so a `Whitelisted` `spam_users` row is not over-excluded.
- `iznik-nuxt3/tests/unit/composables/useNavbarBackButtonCount.spec.js`: the count appears on sub-pages and on the pages reached from the + menu, is absent when nothing is unread, tolerates a count not yet fetched, caps at 99, and leaves a specific chat reporting other unread chats rather than notifications.
- `iznik-nuxt3/tests/unit/components/NavbarMobile.spec.js`: the badge renders on the back button with the bell absent, the button stays bare when nothing is unread, and a home route still shows the bell and no back-button badge.
- Go tests added for previously untested pure helpers in `isochrone`, `utils/geoip`, `embedding` and `session`. No production Go code is touched; these lift the suite clear of the coverage-delta noise floor that flags frontend-and-PHP branches red.

Full unit and Laravel suites pass.

## Notes

The bottom footer nav is a separate condition (`navBarBottomHidden`, gated on the `/give`, `/find`, `/post`, `/chat` prefixes) that intentionally hides during the full-screen composer and chat flows. It is unaffected.

## Discourse

- https://discourse.ilovefreegle.org/t/9953/1
- https://discourse.ilovefreegle.org/t/10001/3
