### PR TITLE
feat(partners): tell TN when a user is forgotten or purged

### DIFF
--- a/docs/developers/reference/trashnothing.md
+++ b/docs/developers/reference/trashnothing.md
@@ -1,3 +1,12 @@
+---
+last_reviewed: 2026-08-08
+owner: Freegle dev team
+covers:
+  - iznik-server-go/changes/**
+  - iznik-batch/app/Console/Commands/TrashNothing/**
+  - iznik-batch/app/Models/UserDeletion.php
+---
+
 # TrashNothing Integration Documentation
 
 This document describes how Freegle integrates with TrashNothing (TN), including technical details, user experience differences, synchronization mechanisms, and areas for improvement.
@@ -94,6 +103,42 @@ Syncs:
 - Username changes
 - Location updates
 - Account removal notifications
+
+### Changes Feed (TN pulls from Freegle)
+
+The traffic above goes TN to Freegle. The other direction is a single polling endpoint,
+`GET /api/changes?partner={key}&since={timestamp}` (Go, `iznik-server-go/changes/`),
+authenticated with a row in `partners_keys`. It answers "what has moved since?" with
+three arrays: `messages`, `users` and `ratings`. `since` defaults to an hour ago.
+
+Each entry in `users` carries a `type`:
+
+| type | Means | What the partner should do |
+|------|-------|----------------------------|
+| `Modified` | The user's profile has changed (`users.lastupdated` moved) | Re-read the user |
+| `Deleted` | The user has been forgotten or hard-deleted | Delete their copy - the `id` is all they get |
+
+`Deleted` entries are read from `users_deletions`, a tombstone table written by every
+path that destroys a user:
+
+- `UserManagementService::forgetUser()` - the GDPR wipe, reached from the 14-day limbo
+  expiry (`processForgets`), the inactive-user sweep, and support purges queued as
+  `user_forget` background tasks.
+- `User::forget()` - the Eloquent equivalent, used by the TN sync when TN tells us one
+  of their accounts has gone.
+- `UserManagementService::deleteFullyForgottenUsers()` and `deleteYahooGroupsUsers()` -
+  the hard deletes, where the `users` row itself goes.
+
+The tombstone exists precisely because `users` entries are otherwise derived from
+`users.lastupdated`, which needs a row to read. Without it a purged member simply stops
+appearing in the feed, and the partner keeps a copy of someone who asked to be gone.
+Rows have no foreign key to `users` for the same reason, and are pruned after
+`UserManagementService::DELETION_RETENTION_DAYS` (90 days), far longer than any partner
+catch-up window.
+
+Deletions are appended after the modified users, so a partner applying the array in
+order ends on the deletion rather than resurrecting a user who was also edited inside
+the same window.
 
 ### LoveJunk Offer Syndication
 

--- a/iznik-batch/app/Console/Commands/User/CleanupUsersCommand.php
+++ b/iznik-batch/app/Console/Commands/User/CleanupUsersCommand.php
@@ -44,6 +44,7 @@ class CleanupUsersCommand extends Command
                     [$prefix . 'Forget inactive users', number_format($stats['inactive_users_forgotten'])],
                     [$prefix . 'Process GDPR forgets', number_format($stats['gdpr_forgets_processed'])],
                     [$prefix . 'Delete fully forgotten users', number_format($stats['forgotten_users_deleted'])],
+                    [$prefix . 'Prune old deletion records', number_format($stats['deletion_records_pruned'])],
                 ]
             );
 

--- a/iznik-batch/app/Models/User.php
+++ b/iznik-batch/app/Models/User.php
@@ -1764,6 +1764,12 @@ class User extends Model implements Auditable
         if (!$dryRun) {
             $log->save();
         }
+
+        // --- Tell partners, who mirror our users and can only find out by polling ---
+        Logger::info("TN-SYNC-TRACE [WRITE] table=users_deletions op=insert set=userid={$this->id},type=Forgotten");
+        if (!$dryRun) {
+            UserDeletion::record($this->id, UserDeletion::TYPE_FORGOTTEN, $reason);
+        }
     }
 
     /**

--- a/iznik-batch/app/Models/UserDeletion.php
+++ b/iznik-batch/app/Models/UserDeletion.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A tombstone for a user we have destroyed, so partners can destroy their copy.
+ *
+ * Partners (TrashNothing) poll /api/changes for everything that has moved since a
+ * timestamp. Users are reported from users.lastupdated, which only works while the
+ * row exists - so without this table a forgotten-then-purged member just stops
+ * appearing, and the partner keeps a copy of someone who asked to be gone.
+ *
+ * Written wherever we forget or hard-delete a user; read by the Go /api/changes
+ * handler, which reports each row as a user change of type Deleted carrying only
+ * the Freegle user id.
+ *
+ * Not Auditable, unlike most of our models: the rows are themselves an append-only
+ * record of one event each, so auditing them would just duplicate every insert.
+ *
+ * @see ../../database/migrations/2026_08_08_000001_create_users_deletions_table.php
+ * @property int $id
+ * @property int $userid id in the users table - no FK, the row outlives the user
+ * @property \Illuminate\Support\Carbon $timestamp
+ * @property string $type Forgotten|Purged
+ * @property string|null $reason
+ * @mixin \Eloquent
+ */
+class UserDeletion extends Model
+{
+    public const TYPE_FORGOTTEN = 'Forgotten';
+    public const TYPE_PURGED = 'Purged';
+
+    protected $table = 'users_deletions';
+    protected $guarded = ['id'];
+    public $timestamps = false;
+
+    protected $casts = [
+        'timestamp' => 'datetime',
+    ];
+
+    /**
+     * Record that a user has been destroyed.
+     *
+     * Called from every path that wipes or removes a user. Deliberately tolerant:
+     * losing a tombstone must never be the thing that aborts a GDPR erasure, so a
+     * failure here is logged and swallowed.
+     */
+    public static function record(int $userId, string $type, ?string $reason = NULL): void
+    {
+        try {
+            self::create([
+                'userid' => $userId,
+                'timestamp' => now(),
+                'type' => $type,
+                'reason' => $reason,
+            ]);
+        } catch (\Throwable $e) {
+            \Illuminate\Support\Facades\Log::error("Failed to record deletion of user #{$userId}: " . $e->getMessage());
+        }
+    }
+}

--- a/iznik-batch/app/Services/UserManagementService.php
+++ b/iznik-batch/app/Services/UserManagementService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Helpers\MailHelper;
 use App\Models\Message;
 use App\Models\User;
+use App\Models\UserDeletion;
 use App\Models\UserEmail;
 use App\Traits\ChunkedProcessing;
 use Illuminate\Support\Facades\DB;
@@ -18,6 +19,15 @@ class UserManagementService
      * Chunk size for batch operations.
      */
     protected int $chunkSize = 1000;
+
+    /**
+     * How long we keep a users_deletions tombstone.
+     *
+     * Partners poll /api/changes for what has moved since a timestamp, typically
+     * every few minutes. Three months is far longer than any sane catch-up window
+     * after an outage, and keeps the table small enough to stay uninteresting.
+     */
+    public const DELETION_RETENTION_DAYS = 90;
 
     private LokiService $lokiService;
 
@@ -168,6 +178,7 @@ class UserManagementService
      *   2. Forget inactive users (no memberships, no activity in 6 months, no logs in 90 days)
      *   3. Process GDPR forgets (users deleted > 14 days ago)
      *   4. Hard-delete fully forgotten users with no remaining messages
+     *   5. Prune deletion tombstones older than any partner would poll for
      *
      * @param  bool  $dryRun  If true, count what would be affected but don't modify data.
      * @param  int|null  $limit  Max users to process per phase. Each forget is ~20 DB
@@ -181,12 +192,14 @@ class UserManagementService
             'inactive_users_forgotten' => 0,
             'gdpr_forgets_processed' => 0,
             'forgotten_users_deleted' => 0,
+            'deletion_records_pruned' => 0,
         ];
 
         $stats['yahoo_users_deleted'] = $this->deleteYahooGroupsUsers($dryRun);
         $stats['inactive_users_forgotten'] = $this->forgetInactiveUsers($dryRun, $limit);
         $stats['gdpr_forgets_processed'] = $this->processForgets($dryRun, $limit);
         $stats['forgotten_users_deleted'] = $this->deleteFullyForgottenUsers($dryRun, $limit);
+        $stats['deletion_records_pruned'] = $this->pruneDeletions($dryRun);
 
         Log::info('User cleanup completed', $stats);
 
@@ -218,6 +231,8 @@ class UserManagementService
 
                 // Hard delete the user.
                 DB::table('users')->where('id', $userId)->delete();
+
+                UserDeletion::record($userId, UserDeletion::TYPE_PURGED, 'Yahoo Groups user');
             }
         }
 
@@ -425,6 +440,9 @@ class UserManagementService
             'text' => $reason,
             'timestamp' => now(),
         ]);
+
+        // Tell partners, who mirror our users and can only find out by polling.
+        UserDeletion::record($userId, UserDeletion::TYPE_FORGOTTEN, $reason);
     }
 
     /**
@@ -460,6 +478,8 @@ class UserManagementService
                 // Hard delete the user.
                 DB::table('users')->where('id', $user->id)->delete();
 
+                UserDeletion::record($user->id, UserDeletion::TYPE_PURGED, 'Fully forgotten');
+
                 $processed++;
                 if ($processed % 1000 === 0) {
                     Log::info("Deleted {$processed} / {$count} fully forgotten users");
@@ -468,6 +488,24 @@ class UserManagementService
         }
 
         return $count;
+    }
+
+    /**
+     * Drop deletion tombstones that no partner could still be asking about.
+     *
+     * @return int Rows removed (or that would be removed, on a dry run).
+     */
+    public function pruneDeletions(bool $dryRun = FALSE): int
+    {
+        $cutoff = now()->subDays(self::DELETION_RETENTION_DAYS);
+
+        $query = UserDeletion::where('timestamp', '<', $cutoff);
+
+        if ($dryRun) {
+            return $query->count();
+        }
+
+        return $query->delete();
     }
 
     /**

--- a/iznik-batch/database/migrations/2026_08_08_000001_create_users_deletions_table.php
+++ b/iznik-batch/database/migrations/2026_08_08_000001_create_users_deletions_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * users_deletions - a tombstone per user we have destroyed.
+ *
+ * Partners (TrashNothing) mirror our users, and learn about our changes by polling
+ * /api/changes for everything that has moved since a timestamp. Users are reported
+ * from users.lastupdated, which only works while there is a row to read: once we
+ * forget someone (their personal data is wiped) and later hard-delete them, they
+ * simply stop appearing, and the partner keeps a copy of a member who asked to be
+ * gone. This table is the record that outlives them, so the deletion is a change
+ * the partner can see.
+ *
+ * Deliberately NO foreign key to users: the whole point is that the row survives
+ * `DELETE FROM users`. userid is not unique either - forget-then-purge is two real
+ * events, and reporting both is harmless because removal is idempotent.
+ *
+ * Rows are pruned once they are older than any sane partner polling window (see
+ * UserManagementService::pruneDeletions).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('users_deletions')) {
+            return;
+        }
+
+        Schema::create('users_deletions', function (Blueprint $t) {
+            $t->bigIncrements('id');
+
+            // The Freegle user id - all a partner needs to remove their copy.
+            $t->unsignedBigInteger('userid')->index('users_deletions_userid');
+
+            // Polled by range, so this is the index that matters.
+            $t->timestamp('timestamp')->useCurrent()->index('users_deletions_timestamp');
+
+            // 'Forgotten' = personal data wiped, row still present.
+            // 'Purged'    = the users row itself has now gone.
+            // Ours for debugging; partners are told only that the user is gone.
+            $t->enum('type', ['Forgotten', 'Purged'])->default('Forgotten');
+
+            // Why, e.g. 'Grace period', 'Inactive', 'TN account removed'.
+            $t->string('reason', 255)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users_deletions');
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_08_000001_create_users_deletions_table_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_08_000001_create_users_deletions_table_migration.sql
@@ -1,0 +1,18 @@
+-- Production idempotent SQL: users_deletions.
+--
+-- A tombstone per user we have destroyed, so that partners polling /api/changes learn
+-- about deletions. Users are otherwise reported from users.lastupdated, which stops
+-- working the moment the row is hard-deleted - the member vanishes from the feed and
+-- the partner keeps a copy of someone who asked to be gone.
+--
+-- No foreign key to users, deliberately: the row must survive DELETE FROM users.
+CREATE TABLE IF NOT EXISTS users_deletions (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    userid BIGINT UNSIGNED NOT NULL,
+    timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    type ENUM('Forgotten', 'Purged') NOT NULL DEFAULT 'Forgotten',
+    reason VARCHAR(255) NULL,
+    PRIMARY KEY (id),
+    KEY users_deletions_userid (userid),
+    KEY users_deletions_timestamp (timestamp)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/iznik-batch/tests/Unit/Models/UserForgetTest.php
+++ b/iznik-batch/tests/Unit/Models/UserForgetTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Models;
 
 use App\Models\User;
+use App\Models\UserDeletion;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -180,6 +181,30 @@ class UserForgetTest extends TestCase
 
         $this->assertNotNull($log);
         $this->assertEquals('GDPR request', $log->text);
+    }
+
+    public function test_forget_records_deletion_for_partners(): void
+    {
+        // Partners mirror our users and only learn about changes by polling, so a
+        // forget has to leave a tombstone they can see.
+        $user = $this->createTestUser();
+
+        $user->forget('TN account removed');
+
+        $this->assertDatabaseHas('users_deletions', [
+            'userid' => $user->id,
+            'type' => UserDeletion::TYPE_FORGOTTEN,
+            'reason' => 'TN account removed',
+        ]);
+    }
+
+    public function test_forget_dry_run_records_nothing(): void
+    {
+        $user = $this->createTestUser();
+
+        $user->forget('TN account removed', TRUE);
+
+        $this->assertDatabaseMissing('users_deletions', ['userid' => $user->id]);
     }
 
     public function test_forget_clears_message_content(): void

--- a/iznik-batch/tests/Unit/Services/UserManagementServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UserManagementServiceTest.php
@@ -6,6 +6,7 @@ use App\Models\ChatMessage;
 use App\Models\ChatRoom;
 use App\Models\Membership;
 use App\Models\User;
+use App\Models\UserDeletion;
 use App\Models\UserEmail;
 use App\Services\LokiService;
 use App\Services\UserManagementService;
@@ -61,6 +62,7 @@ class UserManagementServiceTest extends TestCase
         $this->assertArrayHasKey('inactive_users_forgotten', $stats);
         $this->assertArrayHasKey('gdpr_forgets_processed', $stats);
         $this->assertArrayHasKey('forgotten_users_deleted', $stats);
+        $this->assertArrayHasKey('deletion_records_pruned', $stats);
     }
 
     public function test_merge_duplicates_with_no_duplicates(): void
@@ -307,6 +309,21 @@ class UserManagementServiceTest extends TestCase
         ]);
     }
 
+    public function test_forget_user_records_deletion_for_partners(): void
+    {
+        // Partners mirror our users and only learn about changes by polling, so a
+        // forget has to leave a tombstone they can see.
+        $user = $this->createTestUser();
+
+        $this->service->forgetUser($user->id, 'Test reason');
+
+        $this->assertDatabaseHas('users_deletions', [
+            'userid' => $user->id,
+            'type' => UserDeletion::TYPE_FORGOTTEN,
+            'reason' => 'Test reason',
+        ]);
+    }
+
     public function test_delete_fully_forgotten_users(): void
     {
         // Create a forgotten user with no messages.
@@ -344,6 +361,104 @@ class UserManagementServiceTest extends TestCase
 
         // User should NOT be deleted because they still have messages.
         $this->assertDatabaseHas('users', ['id' => $user->id]);
+    }
+
+    public function test_delete_fully_forgotten_users_records_purge(): void
+    {
+        // The users row goes for good here, so the tombstone is the only trace
+        // left for a partner to act on.
+        $user = User::create([
+            'firstname' => NULL,
+            'lastname' => NULL,
+            'fullname' => 'Deleted User #997',
+            'added' => now()->subYears(2),
+            'lastaccess' => now()->subYears(1),
+            'forgotten' => now()->subDays(30),
+        ]);
+
+        $this->service->deleteFullyForgottenUsers();
+
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+        $this->assertDatabaseHas('users_deletions', [
+            'userid' => $user->id,
+            'type' => UserDeletion::TYPE_PURGED,
+        ]);
+    }
+
+    public function test_delete_fully_forgotten_users_dry_run_records_nothing(): void
+    {
+        $user = User::create([
+            'firstname' => NULL,
+            'lastname' => NULL,
+            'fullname' => 'Deleted User #996',
+            'added' => now()->subYears(2),
+            'lastaccess' => now()->subYears(1),
+            'forgotten' => now()->subDays(30),
+        ]);
+
+        $this->service->deleteFullyForgottenUsers(TRUE);
+
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+        $this->assertDatabaseMissing('users_deletions', ['userid' => $user->id]);
+    }
+
+    public function test_delete_yahoo_groups_users_records_purge(): void
+    {
+        $user = User::create([
+            'firstname' => 'Yahoo',
+            'lastname' => 'Purged',
+            'fullname' => 'Yahoo Purged',
+            'added' => now()->subYears(2),
+            'lastaccess' => now()->subYears(1),
+        ]);
+
+        DB::table('users_emails')->insert([
+            'userid' => $user->id,
+            'email' => 'purgedgroup@yahoogroups.com',
+            'added' => now()->subYears(2),
+        ]);
+
+        $this->service->deleteYahooGroupsUsers();
+
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+        $this->assertDatabaseHas('users_deletions', [
+            'userid' => $user->id,
+            'type' => UserDeletion::TYPE_PURGED,
+        ]);
+    }
+
+    public function test_prune_deletions_removes_records_older_than_retention(): void
+    {
+        $stale = UserDeletion::create([
+            'userid' => 999001,
+            'timestamp' => now()->subDays(UserManagementService::DELETION_RETENTION_DAYS + 1),
+            'type' => UserDeletion::TYPE_FORGOTTEN,
+        ]);
+
+        $fresh = UserDeletion::create([
+            'userid' => 999002,
+            'timestamp' => now()->subDays(1),
+            'type' => UserDeletion::TYPE_FORGOTTEN,
+        ]);
+
+        $pruned = $this->service->pruneDeletions();
+
+        $this->assertGreaterThanOrEqual(1, $pruned);
+        $this->assertDatabaseMissing('users_deletions', ['id' => $stale->id]);
+        $this->assertDatabaseHas('users_deletions', ['id' => $fresh->id]);
+    }
+
+    public function test_prune_deletions_dry_run_keeps_records(): void
+    {
+        $stale = UserDeletion::create([
+            'userid' => 999003,
+            'timestamp' => now()->subDays(UserManagementService::DELETION_RETENTION_DAYS + 1),
+            'type' => UserDeletion::TYPE_FORGOTTEN,
+        ]);
+
+        $this->service->pruneDeletions(TRUE);
+
+        $this->assertDatabaseHas('users_deletions', ['id' => $stale->id]);
     }
 
     public function test_merge_users_for_email_with_single_user(): void

--- a/iznik-server-go/changes/changes.go
+++ b/iznik-server-go/changes/changes.go
@@ -15,10 +15,22 @@ type MessageChange struct {
 	Type      string `json:"type"`
 }
 
+// UserChange is one user a partner should re-read - or, when Type is
+// UserChangeDeleted, stop holding altogether.
 type UserChange struct {
 	ID          uint64  `json:"id"`
 	LastUpdated *string `json:"lastupdated" gorm:"column:lastupdated"`
+	Type        string  `json:"type"`
 }
+
+const (
+	// UserChangeModified - the user's profile has changed; re-read it.
+	UserChangeModified = "Modified"
+
+	// UserChangeDeleted - the user has been forgotten or purged. Delete your
+	// copy: the id is all you get, because everything else about them is gone.
+	UserChangeDeleted = "Deleted"
+)
 
 type Rating struct {
 	ID         uint64  `json:"id"`
@@ -49,7 +61,7 @@ type ChangesResponse struct {
 // GetChanges returns message changes, user changes, and optionally ratings since a given time.
 // Requires partner key authentication via the partner query parameter.
 // @Summary Get changes since a timestamp
-// @Description Returns message changes (deleted, edited, promised, reneged, outcomes, approved/reposted), user changes, and ratings since a given time. Requires partner key authentication.
+// @Description Returns message changes (deleted, edited, promised, reneged, outcomes, approved/reposted), user changes (type Modified for a profile to re-read, type Deleted for a user who has been forgotten or purged and should be removed), and ratings since a given time. Requires partner key authentication.
 // @Tags changes
 // @Produce json
 // @Param since query string false "ISO8601 or MySQL datetime timestamp (defaults to 1 hour ago)" example("2026-03-04T12:00:00Z")
@@ -97,10 +109,11 @@ func GetChanges(c *fiber.Ctx) error {
 	// Fetch message changes, user changes, and ratings in parallel.
 	var messages []MessageChange
 	var users []UserChange
+	var deletions []UserChange
 	var ratings []Rating
 	var wg sync.WaitGroup
 
-	wg.Add(3)
+	wg.Add(4)
 
 	go func() {
 		defer wg.Done()
@@ -127,7 +140,17 @@ func GetChanges(c *fiber.Ctx) error {
 
 	go func() {
 		defer wg.Done()
-		db.Table("users").Select("id, lastupdated").Where("lastupdated IS NOT NULL AND lastupdated >= ?", mysqlTime).Scan(&users)
+		db.Table("users").Select("id, lastupdated, ? AS `type`", UserChangeModified).
+			Where("lastupdated IS NOT NULL AND lastupdated >= ?", mysqlTime).Scan(&users)
+	}()
+
+	go func() {
+		defer wg.Done()
+		// Users we have destroyed. Read from a tombstone table rather than from
+		// users, because the point at which a partner most needs to know is the
+		// point at which the row itself has gone.
+		db.Table("users_deletions").Select("userid AS id, timestamp AS lastupdated, ? AS `type`", UserChangeDeleted).
+			Where("timestamp >= ?", mysqlTime).Scan(&deletions)
 	}()
 
 	go func() {
@@ -139,6 +162,11 @@ func GetChanges(c *fiber.Ctx) error {
 	}()
 
 	wg.Wait()
+
+	// Deletions go last so that a partner applying the list in order finishes on
+	// the deletion, rather than resurrecting someone whose profile also changed
+	// within the window.
+	users = append(users, deletions...)
 
 	// Format timestamps to ISO8601.
 	for i := range messages {

--- a/iznik-server-go/changes/changes_test.go
+++ b/iznik-server-go/changes/changes_test.go
@@ -78,6 +78,36 @@ func TestUserChange_NonNilLastUpdatedMarshal(t *testing.T) {
 	assert.Equal(t, val, m["lastupdated"])
 }
 
+func TestUserChange_TypeIsAlwaysPresent(t *testing.T) {
+	// Partners branch on type, so the key must be in the JSON even if we ever
+	// forget to set it.
+	b, err := json.Marshal(UserChange{ID: 7})
+	assert.NoError(t, err)
+
+	var m map[string]interface{}
+	assert.NoError(t, json.Unmarshal(b, &m))
+	_, present := m["type"]
+	assert.True(t, present, "type key must always be present in the JSON object")
+}
+
+func TestUserChange_DeletedTypeMarshal(t *testing.T) {
+	ts := "2026-03-15T14:30:00Z"
+	b, err := json.Marshal(UserChange{ID: 8, LastUpdated: &ts, Type: UserChangeDeleted})
+	assert.NoError(t, err)
+
+	var m map[string]interface{}
+	assert.NoError(t, json.Unmarshal(b, &m))
+	assert.Equal(t, float64(8), m["id"], "the id is all a partner needs to remove their copy")
+	assert.Equal(t, "Deleted", m["type"])
+}
+
+func TestUserChangeTypeValues(t *testing.T) {
+	// These strings are part of the partner API contract — changing them breaks
+	// TrashNothing's handling silently.
+	assert.Equal(t, "Modified", UserChangeModified)
+	assert.Equal(t, "Deleted", UserChangeDeleted)
+}
+
 // ---------------------------------------------------------------------------
 // Rating JSON marshaling
 // ---------------------------------------------------------------------------

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -440,7 +440,7 @@ func SetupRoutes(app *fiber.App) {
 		// Changes
 		// @Router /changes [get]
 		// @Summary Get changes since timestamp
-		// @Description Returns message changes, user changes, and ratings since a given time. Requires partner key.
+		// @Description Returns message changes, user changes (Modified or Deleted), and ratings since a given time. Requires partner key.
 		// @Tags changes
 		// @Produce json
 		// @Param since query string false "ISO8601 timestamp (defaults to 1 hour ago)"

--- a/iznik-server-go/swagger/swagger.go
+++ b/iznik-server-go/swagger/swagger.go
@@ -877,7 +877,11 @@ type postChatMessageModerationParams struct {
 // Get changes since timestamp
 //
 // Returns message changes (deleted, edited, promised, reneged, outcomes, approved/reposted),
-// user changes, and ratings since a given time. Requires partner key authentication.
+// user changes and ratings since a given time. Requires partner key authentication.
+//
+// Each user change carries a type: Modified means the profile has changed and should be
+// re-read; Deleted means the user has been forgotten or purged and their copy should be
+// removed, for which the id is all that is supplied.
 //
 // Parameters:
 //   + name: since

--- a/iznik-server-go/swagger/swagger.json
+++ b/iznik-server-go/swagger/swagger.json
@@ -10607,6 +10607,10 @@
         "lastupdated": {
           "type": "string",
           "x-go-name": "LastUpdated"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
         }
       },
       "x-go-package": "github.com/freegle/iznik-server-go/changes"

--- a/iznik-server-go/test/changes_test.go
+++ b/iznik-server-go/test/changes_test.go
@@ -217,6 +217,143 @@ func TestChangesUserLastUpdatedNotEmpty(t *testing.T) {
 	assert.True(t, found, "Expected user in changes")
 }
 
+func TestChangesUserChangeHasModifiedType(t *testing.T) {
+	// A user whose profile has moved is reported as Modified, so a partner can
+	// tell it apart from a user who has been deleted.
+	prefix := uniquePrefix("changes_mod_type")
+	db := database.DBConn
+
+	partnerKey := prefix + "_key"
+	db.Exec("INSERT INTO partners_keys (partner, `key`) VALUES (?, ?)", prefix+"_partner", partnerKey)
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	userID := CreateTestUser(t, prefix, "User")
+	defer db.Exec("DELETE FROM users WHERE id = ?", userID)
+
+	db.Exec("UPDATE users SET lastupdated = NOW() WHERE id = ?", userID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/changes?partner=%s", partnerKey), nil)
+	resp, err := getApp().Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	changes := result["changes"].(map[string]interface{})
+	users := changes["users"].([]interface{})
+
+	found := false
+	for _, u := range users {
+		user := u.(map[string]interface{})
+		if uint64(user["id"].(float64)) == userID {
+			assert.Equal(t, "Modified", user["type"], "an updated user must be reported as Modified")
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected user in changes")
+}
+
+func TestChangesUserDeleted(t *testing.T) {
+	// A forgotten or purged user must be reported so the partner can remove
+	// their copy — the id is all they need.
+	prefix := uniquePrefix("changes_del")
+	db := database.DBConn
+
+	partnerKey := prefix + "_key"
+	db.Exec("INSERT INTO partners_keys (partner, `key`) VALUES (?, ?)", prefix+"_partner", partnerKey)
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	userID := CreateTestUser(t, prefix, "User")
+
+	// The user is gone entirely — as they would be after a purge. The tombstone
+	// is the only thing left, and it must still produce a change.
+	db.Exec("DELETE FROM users WHERE id = ?", userID)
+	db.Exec("INSERT INTO users_deletions (userid, timestamp, type, reason) VALUES (?, NOW(), 'Purged', 'Test')", userID)
+	defer db.Exec("DELETE FROM users_deletions WHERE userid = ?", userID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/changes?partner=%s", partnerKey), nil)
+	resp, err := getApp().Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	changes := result["changes"].(map[string]interface{})
+	users := changes["users"].([]interface{})
+
+	found := false
+	for _, u := range users {
+		user := u.(map[string]interface{})
+		if uint64(user["id"].(float64)) == userID {
+			assert.Equal(t, "Deleted", user["type"], "a destroyed user must be reported as Deleted")
+			lu, ok := user["lastupdated"].(string)
+			assert.True(t, ok, "deleted users must carry a timestamp")
+			assert.Contains(t, lu, "T", "lastupdated should be ISO8601 format")
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected deleted user in changes")
+}
+
+func TestChangesUserDeletedRespectsSince(t *testing.T) {
+	// Old tombstones must not be replayed to a partner that has already caught up.
+	prefix := uniquePrefix("changes_del_since")
+	db := database.DBConn
+
+	partnerKey := prefix + "_key"
+	db.Exec("INSERT INTO partners_keys (partner, `key`) VALUES (?, ?)", prefix+"_partner", partnerKey)
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	userID := CreateTestUser(t, prefix, "User")
+	defer db.Exec("DELETE FROM users WHERE id = ?", userID)
+
+	db.Exec("INSERT INTO users_deletions (userid, timestamp, type, reason) VALUES (?, DATE_SUB(NOW(), INTERVAL 2 DAY), 'Forgotten', 'Test')", userID)
+	defer db.Exec("DELETE FROM users_deletions WHERE userid = ?", userID)
+
+	// Default window is the last hour, so a two-day-old deletion is not in it.
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/changes?partner=%s", partnerKey), nil)
+	resp, err := getApp().Test(req, -1)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	changes := result["changes"].(map[string]interface{})
+	users := changes["users"].([]interface{})
+
+	for _, u := range users {
+		user := u.(map[string]interface{})
+		if uint64(user["id"].(float64)) == userID {
+			assert.NotEqual(t, "Deleted", user["type"], "a deletion older than since must not be reported")
+		}
+	}
+
+	// Widen the window and it should appear.
+	since := time.Now().Add(-72 * time.Hour).Format(time.RFC3339)
+	req = httptest.NewRequest("GET", fmt.Sprintf("/api/changes?partner=%s&since=%s", partnerKey, since), nil)
+	resp, err = getApp().Test(req, -1)
+	require.NoError(t, err)
+
+	json2.Unmarshal(rsp(resp), &result)
+	changes = result["changes"].(map[string]interface{})
+	users = changes["users"].([]interface{})
+
+	found := false
+	for _, u := range users {
+		user := u.(map[string]interface{})
+		if uint64(user["id"].(float64)) == userID && user["type"] == "Deleted" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected deletion within the since window")
+}
+
 func TestChangesRatingHasIdAndTnRatingId(t *testing.T) {
 	// Ratings must include id and tn_rating_id fields.
 	prefix := uniquePrefix("changes_rid")


### PR DESCRIPTION
## Summary

- `GET /api/changes` reports users from `users.lastupdated`, which needs a row to read. A member who is forgotten after the 14-day limbo, and later hard-deleted, simply stops appearing in the feed - so TrashNothing keeps a copy of someone who asked to be gone.
- New `users_deletions` tombstone table, written by every path that destroys a user: `UserManagementService::forgetUser()` (limbo expiry, inactive sweep, support purge via the `user_forget` background task), `User::forget()` (used by the TN sync), and both hard deletes (`deleteFullyForgottenUsers()`, `deleteYahooGroupsUsers()`). No foreign key to `users`, deliberately - the row has to outlive the row it is about.
- `changes.users` entries now carry a `type`: `Modified` for a profile to re-read, `Deleted` for a user to remove. A `Deleted` entry needs nothing but the Freegle user id, which is all we have left of them.
- Deletions are appended after the modified users, so a partner applying the array in order ends on the deletion rather than resurrecting someone who was also edited inside the same window.
- Tombstones are pruned after 90 days (`UserManagementService::DELETION_RETENTION_DAYS`) as a fifth phase of the daily `users:cleanup`, far longer than any partner catch-up window.
- Partner-facing behaviour is documented in `docs/developers/reference/trashnothing.md`, which now also declares `covers:` front matter so the page cannot go stale silently.

## What a partner sees

```
GET /api/changes?partner={key}&since=2026-08-08T09:00:00Z
```

```json
{
  "ret": 0,
  "status": "Success",
  "changes": {
    "messages": [
      {
        "id": 987654,
        "timestamp": "2026-08-08T09:12:30Z",
        "type": "Taken"
      }
    ],
    "users": [
      {
        "id": 12345,
        "lastupdated": "2026-08-08T09:14:02Z",
        "type": "Modified"
      },
      {
        "id": 67890,
        "lastupdated": "2026-08-08T09:31:47Z",
        "type": "Deleted"
      }
    ],
    "ratings": [
      {
        "id": 555,
        "rater": 12345,
        "ratee": 22222,
        "rating": "Up",
        "timestamp": "2026-08-08T09:20:11Z",
        "visible": 1,
        "tn_rating_id": null,
        "comment": null,
        "reason": null
      }
    ]
  }
}
```

User 12345 has edited their profile: re-read them. User 67890 is gone: delete
your copy. There is nothing else to give you about 67890 - `lastupdated` is when
we destroyed them, and the id is all that survives.

`type` is new on the `users` entries. Everything else is unchanged, so a partner
that ignores the field behaves exactly as it does today.

## Code Quality Review

- **A failed tombstone must not abort a GDPR erasure.** `UserDeletion::record()` logs and swallows, so the wipe always completes even if this write fails.
- **No foreign key, on purpose.** `ON DELETE CASCADE` would delete the tombstone at exactly the moment it becomes the only record that the user existed.
- **`userid` is not unique.** Forget-then-purge is two real events; reporting both is harmless because removal is idempotent.
- **Deploy order is safe either way.** If the Go API ships before the migration runs, the `users_deletions` query errors, `deletions` stays empty and the endpoint still serves messages, users and ratings. It starts reporting deletions as soon as the migration lands.
- Existing `changes.users` consumers see one extra JSON key, which is additive.

## Future Improvements

- Account merges hard-delete the merged-away user (`user.go` `DeleteUser`). That id is deliberately **not** reported as `Deleted`: a partner should re-point at the surviving user rather than remove the record. If TN wants to act on it, that wants its own `Merged` type carrying both ids.
- `RestoreUserCommand` un-forgets a user but tells no partner. In practice `forget()` has already cleared `tnuserid`, so TN could not relink anyway.

## Test Plan

- Go: full suite green locally (3946 tests).
- Laravel: full suite green locally (5355 tests).
- New Go tests (`test/changes_test.go`): a purged user (row deleted, tombstone only) appears with `type: Deleted` and an ISO8601 timestamp; an updated user appears as `Modified`; a two-day-old deletion is outside the default one-hour window and inside a 72-hour one.
- New Go unit tests (`changes/changes_test.go`): `type` is always present in the JSON, a `Deleted` entry marshals with the id, and the two type strings are pinned because they are part of the partner contract.
- New Laravel tests: `forgetUser()` and `User::forget()` each record a `Forgotten` tombstone; both hard deletes record `Purged`; dry runs record nothing; prune drops rows past the retention window and keeps fresh ones.

