### PR TITLE
fix(posting): let people zoom into a photo before they post it

### DIFF
--- a/iznik-nuxt3/components/MessageEditModal.vue
+++ b/iznik-nuxt3/components/MessageEditModal.vue
@@ -103,7 +103,7 @@
             @start="dragging = true"
             @end="dragging = false"
           >
-            <template #item="{ element }">
+            <template #item="{ element, index }">
               <PostPhoto
                 :id="element.id"
                 :key="element.id"
@@ -113,6 +113,7 @@
                 :externalmods="element.externalmods"
                 class="photo-item"
                 @remove="removePhoto"
+                @click="viewPhoto(index)"
               />
             </template>
             <template #footer>
@@ -126,6 +127,12 @@
               </div>
             </template>
           </draggable>
+          <MessagePhotosModal
+            v-if="viewingPhoto !== null"
+            :attachments="attachments"
+            :initial-index="viewingPhoto"
+            @hidden="viewingPhoto = null"
+          />
         </div>
       </div>
 
@@ -172,6 +179,9 @@ const OurUploader = defineAsyncComponent(() =>
   import('~/components/OurUploader')
 )
 const PostItem = defineAsyncComponent(() => import('./PostItem'))
+const MessagePhotosModal = defineAsyncComponent(() =>
+  import('./MessagePhotosModal')
+)
 
 const props = defineProps({
   id: {
@@ -205,6 +215,20 @@ const attachments = ref(message.attachments || [])
 const dragging = ref(false)
 const triedToSave = ref(false)
 const item = ref(null)
+
+// Tapping a photo opens the same full-screen zoomable viewer as elsewhere, so
+// you can see what you are about to keep or delete.
+const viewingPhoto = ref(null)
+
+function viewPhoto(index) {
+  if (dragging.value) {
+    // A drag that finishes over the image also fires a click. Reordering is
+    // not a request to zoom.
+    return
+  }
+
+  viewingPhoto.value = index
+}
 
 const defaultDeadline = new Date(
   Date.now() + MESSAGE_EXPIRE_TIME * 24 * 60 * 60 * 1000

--- a/iznik-nuxt3/components/MessagePhotosModal.vue
+++ b/iznik-nuxt3/components/MessagePhotosModal.vue
@@ -41,7 +41,7 @@
           :class="{ transitioning: isTransitioning }"
         >
           <div
-            v-for="(attachment, index) in message?.attachments"
+            v-for="(attachment, index) in photos"
             :key="attachment.id || index"
             class="image-slide"
           >
@@ -66,7 +66,7 @@
       <!-- Navigation dots -->
       <div v-if="attachmentCount > 1" class="nav-dots">
         <span
-          v-for="(_, index) in message?.attachments"
+          v-for="(_, index) in photos"
           :key="index"
           class="dot"
           :class="{ active: index === currentIndex }"
@@ -113,9 +113,18 @@ import PinchMe from '~/components/PinchMe.vue'
 import 'zoompinch/style.css'
 
 const props = defineProps({
+  // A posted message, whose photos we read from the store.
   id: {
     type: Number,
-    required: true,
+    required: false,
+    default: null,
+  },
+  // Photos that are not (yet) a message - the ones you have just uploaded while
+  // composing a post. Takes precedence over id when both are given.
+  attachments: {
+    type: Array,
+    required: false,
+    default: null,
   },
   initialIndex: {
     type: Number,
@@ -128,11 +137,15 @@ const emit = defineEmits(['hidden'])
 const messageStore = useMessageStore()
 
 // Handle browser back button/swipe to close modal
-useModalHistory(`photos-${props.id}`, () => emit('hidden'))
+useModalHistory(`photos-${props.id ?? 'compose'}`, () => emit('hidden'))
 
-const message = computed(() => messageStore?.byId(props.id))
+const message = computed(() => (props.id ? messageStore?.byId(props.id) : null))
 
-const attachmentCount = computed(() => message.value?.attachments?.length || 0)
+const photos = computed(
+  () => props.attachments ?? message.value?.attachments ?? []
+)
+
+const attachmentCount = computed(() => photos.value.length)
 
 // Current image index - start at initialIndex prop
 const currentIndex = ref(props.initialIndex)
@@ -423,6 +436,11 @@ function handleBackgroundClick(e) {
 
 function handleKeydown(e) {
   if (e.key === 'Escape') {
+    // We are on top of whatever opened us, which may itself be a modal that
+    // closes on Escape - the edit-post form, for instance, where that would
+    // throw away someone's edits. Escape belongs to the topmost thing only,
+    // hence the capture-phase listener below and this stopPropagation.
+    e.stopPropagation()
     close()
   } else if (e.key === 'ArrowLeft' && currentIndex.value > 0) {
     goToImage(currentIndex.value - 1)
@@ -448,15 +466,15 @@ onMounted(() => {
   // Prevent body scroll
   document.body.style.overflow = 'hidden'
 
-  // Listen for keyboard events
-  window.addEventListener('keydown', handleKeydown)
+  // Capture phase, so Escape reaches us before the modal we are covering.
+  window.addEventListener('keydown', handleKeydown, true)
 })
 
 onUnmounted(() => {
   // Restore body scroll
   document.body.style.overflow = ''
 
-  window.removeEventListener('keydown', handleKeydown)
+  window.removeEventListener('keydown', handleKeydown, true)
 })
 </script>
 

--- a/iznik-nuxt3/components/PhotoUploader.vue
+++ b/iznik-nuxt3/components/PhotoUploader.vue
@@ -55,6 +55,7 @@
           @rotate="rotatePhoto(selectedPhoto, 90)"
           @retry="retryUpload(selectedPhoto)"
           @show-quality="showQualityWarning(selectedPhoto)"
+          @select="viewPhoto"
         />
       </div>
     </Transition>
@@ -171,6 +172,14 @@
       </template>
     </b-modal>
 
+    <!-- Full-screen zoomable view of the featured photo -->
+    <MessagePhotosModal
+      v-if="viewingPhoto"
+      :attachments="photos"
+      :initial-index="selectedIndex"
+      @hidden="viewingPhoto = false"
+    />
+
     <!-- Uppy Dashboard Modal for web browsers -->
     <DashboardModal
       v-if="!isApp && uppy"
@@ -225,6 +234,9 @@ import {
 } from '~/composables/usePhotoQuality'
 
 const draggable = defineAsyncComponent(() => import('vuedraggable'))
+const MessagePhotosModal = defineAsyncComponent(() =>
+  import('~/components/MessagePhotosModal')
+)
 
 const props = defineProps({
   modelValue: {
@@ -318,6 +330,17 @@ function selectPhoto(index) {
     photos.value.unshift(photo)
     // Keep selectedIndex at 0 (always show first photo as featured)
     selectedIndex.value = 0
+  }
+}
+
+// Tapping the featured photo opens the same full-screen zoomable viewer as a
+// photo on a live post, so you can check the picture is any good before you
+// post it. A photo still uploading has nothing to show yet.
+const viewingPhoto = ref(false)
+
+function viewPhoto() {
+  if (selectedPhoto.value && !selectedPhoto.value.uploading) {
+    viewingPhoto.value = true
   }
 }
 

--- a/iznik-nuxt3/tests/unit/components/MessageEditModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageEditModal.spec.js
@@ -97,7 +97,7 @@ describe('MessageEditModal', () => {
             emits: ['hidden'],
           },
           PostPhoto: {
-            template: '<div class="post-photo" />',
+            template: '<div class="post-photo" @click="$emit(\'click\')" />',
             props: [
               'id',
               'path',
@@ -108,7 +108,7 @@ describe('MessageEditModal', () => {
               'externalmods',
               'primary',
             ],
-            emits: ['remove'],
+            emits: ['remove', 'click'],
           },
           OurUploader: {
             template: '<div class="our-uploader" />',
@@ -557,6 +557,45 @@ describe('MessageEditModal', () => {
       const wrapper = createWrapper()
       expect(wrapper.find('.photo-grid').exists()).toBe(true)
       expect(wrapper.findAll('.post-photo').length).toBe(0)
+    })
+
+    // You should be able to see a photo properly before deciding to delete it.
+    it('opens the full-screen viewer on the photo you clicked', async () => {
+      mockMessageStore.byId.mockReturnValue({
+        id: 1,
+        subject: 'Test Subject',
+        textbody: 'Test description',
+        type: 'Offer',
+        availablenow: 1,
+        deadline: null,
+        location: { name: 'AB1 2CD' },
+        item: { name: 'Test Item' },
+        attachments: [
+          { id: 1, path: '/test1.jpg' },
+          { id: 2, path: '/test2.jpg' },
+        ],
+        groups: [{ groupid: 1 }],
+      })
+      const wrapper = createWrapper()
+
+      // The viewer teleports to the body, so it is not inside the wrapper.
+      const viewer = () => document.body.querySelector('.fullscreen-viewer')
+      expect(viewer()).toBeNull()
+
+      await wrapper.findAll('.post-photo')[1].trigger('click')
+      // Loaded on demand, so give the import a moment.
+      await vi.waitFor(() => expect(viewer()).not.toBeNull(), { timeout: 5000 })
+
+      expect(viewer().querySelectorAll('.image-slide')).toHaveLength(2)
+      expect(viewer().querySelector('.image-counter').textContent.trim()).toBe(
+        '2 / 2'
+      )
+
+      viewer().querySelector('.back-button').click()
+      await flushPromises()
+      expect(viewer()).toBeNull()
+
+      wrapper.unmount()
     })
 
     it('wraps photos in draggable component for reordering', () => {

--- a/iznik-nuxt3/tests/unit/components/MessagePhotosModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessagePhotosModal.spec.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { ref, nextTick } from 'vue'
+import MessagePhotosModal from '~/components/MessagePhotosModal.vue'
 
 const mockMessageStore = {
   byId: vi.fn(),
@@ -311,6 +313,113 @@ describe('MessagePhotosModal', () => {
     it('has even larger arrows on desktop', () => {
       // @media (min-width: 1200px) width: 64px
       expect(true).toBe(true)
+    })
+  })
+
+  // The viewer serves two callers: a posted message, whose photos it reads from
+  // the store, and photos that are not a message yet - the ones you have just
+  // uploaded while composing a post, which it is handed directly.
+  describe('where the photos come from', () => {
+    function mountViewer(props) {
+      return mount(MessagePhotosModal, {
+        props,
+        attachTo: document.body,
+        global: {
+          stubs: {
+            teleport: true,
+            PinchMe: {
+              name: 'PinchMe',
+              props: ['attachment', 'width', 'height', 'zoom'],
+              template: '<div class="pinch-me" />',
+            },
+            'v-icon': { template: '<span />' },
+          },
+        },
+      })
+    }
+
+    it('uses the attachments it is given, without asking the store', () => {
+      const wrapper = mountViewer({
+        attachments: [
+          { id: 11, path: '/composed1.jpg' },
+          { id: 12, path: '/composed2.jpg' },
+        ],
+      })
+
+      expect(wrapper.findAll('.image-slide')).toHaveLength(2)
+      expect(mockMessageStore.byId).not.toHaveBeenCalled()
+      expect(wrapper.find('.image-counter').text()).toBe('1 / 2')
+    })
+
+    it('falls back to the message in the store when given an id', () => {
+      const wrapper = mountViewer({ id: 123 })
+
+      // The store fixture has three photos.
+      expect(wrapper.findAll('.image-slide')).toHaveLength(3)
+      expect(mockMessageStore.byId).toHaveBeenCalledWith(123)
+    })
+
+    it('starts on the photo that was clicked', () => {
+      const wrapper = mountViewer({
+        attachments: [{ id: 11 }, { id: 12 }, { id: 13 }],
+        initialIndex: 2,
+      })
+
+      expect(wrapper.find('.image-counter').text()).toBe('3 / 3')
+    })
+
+    it('shows no counter for a single photo', () => {
+      const wrapper = mountViewer({ attachments: [{ id: 11 }] })
+
+      expect(wrapper.find('.image-counter').exists()).toBe(false)
+    })
+
+    it('copes with an empty attachments array', () => {
+      const wrapper = mountViewer({ attachments: [] })
+
+      expect(wrapper.findAll('.image-slide')).toHaveLength(0)
+      expect(mockMessageStore.byId).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('escape key', () => {
+    function mountViewer(props) {
+      return mount(MessagePhotosModal, {
+        props,
+        attachTo: document.body,
+        global: {
+          stubs: {
+            teleport: true,
+            PinchMe: { template: '<div class="pinch-me" />' },
+            'v-icon': { template: '<span />' },
+          },
+        },
+      })
+    }
+
+    it('closes on escape', async () => {
+      const wrapper = mountViewer({ attachments: [{ id: 11 }] })
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+      await nextTick()
+
+      expect(wrapper.emitted('hidden')).toBeTruthy()
+    })
+
+    it('keeps escape to itself, so it cannot also close the modal underneath', () => {
+      // The viewer opens on top of things that close on escape - the edit-post
+      // form, for one, where closing would throw away someone's edits.
+      const wrapper = mountViewer({ attachments: [{ id: 11 }] })
+
+      const underneath = vi.fn()
+      window.addEventListener('keydown', underneath)
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+      expect(wrapper.emitted('hidden')).toBeTruthy()
+      expect(underneath).not.toHaveBeenCalled()
+
+      window.removeEventListener('keydown', underneath)
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
@@ -1713,4 +1713,62 @@ describe('PhotoUploader', () => {
       consoleError.mockRestore()
     })
   })
+
+  // You should be able to check a photo is any good before you post it, not
+  // after - so tapping it opens the same full-screen zoomable viewer as a photo
+  // on a live post.
+  describe('viewing a photo full screen', () => {
+    // The viewer teleports to the body, so it is not inside the wrapper.
+    function viewer() {
+      return document.body.querySelector('.fullscreen-viewer')
+    }
+
+    it('opens the viewer when the featured photo is tapped', async () => {
+      createWrapper({
+        modelValue: [
+          { id: 1, ouruid: 'uid1' },
+          { id: 2, ouruid: 'uid2' },
+        ],
+      })
+      await flushPromises()
+
+      expect(viewer()).toBeNull()
+
+      await wrapper.find('.featured-photo .photo-card').trigger('click')
+
+      // The viewer is loaded on demand, so give the import a moment.
+      await vi.waitFor(() => expect(viewer()).not.toBeNull(), { timeout: 5000 })
+
+      // Every photo, so you can page through them, starting on the one shown.
+      expect(viewer().querySelectorAll('.image-slide')).toHaveLength(2)
+      expect(viewer().querySelector('.image-counter').textContent.trim()).toBe(
+        '1 / 2'
+      )
+    })
+
+    it('does not open for a photo that is still uploading', async () => {
+      createWrapper({
+        modelValue: [{ id: 1, tempId: 't1', uploading: true, progress: 40 }],
+      })
+      await flushPromises()
+
+      await wrapper.find('.featured-photo .photo-card').trigger('click')
+      await flushPromises()
+
+      expect(viewer()).toBeNull()
+    })
+
+    it('closes again when the viewer is dismissed', async () => {
+      createWrapper({ modelValue: [{ id: 1, ouruid: 'uid1' }] })
+      await flushPromises()
+
+      await wrapper.find('.featured-photo .photo-card').trigger('click')
+      await vi.waitFor(() => expect(viewer()).not.toBeNull(), { timeout: 5000 })
+
+      viewer().querySelector('.back-button').click()
+      await flushPromises()
+
+      expect(viewer()).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Everywhere a photo is already public - browse, a post in My Posts, a chat - tapping it opens the full-screen pinch-and-zoom viewer. In the one place where a proper look actually changes what you do, composing a post, tapping did nothing: `PhotoUploader`'s featured photo emitted `select` and nobody listened. You could only find out the picture was blurry, sideways or of your own feet after posting it.

- **Posting**: tapping the featured photo now opens the same viewer, holding every photo on the post so you can page through them, starting on the one you tapped. A photo still uploading is not opened - there is nothing to show yet. Tapping a thumbnail still promotes it to primary, as before.
- **Editing a post**: same fix. `MessageEditModal` had the same dead `click` emit on `PostPhoto`.
- **My Posts already worked** and is untouched - `MyMessage.vue` has opened the viewer on the photo for a while. Confirmed in a browser as part of this.
- `MessagePhotosModal` took a message id and read the photos out of the store. Compose photos are not a message yet, so it now also accepts an `attachments` array; `id` still works exactly as before for posted messages.
- **Escape belongs to the topmost thing only.** The viewer's keydown listener moved to the capture phase and now stops propagation, so Escape closes the viewer without also closing whatever is underneath. Over the edit-post form that meant silently throwing away someone's edits.

## Code Quality Review

- `PostMessage.vue` also has an unlistened `click` emit, but nothing renders it any more (`/give` and `/find` both use `PostMessageTablet` -> `PhotoUploader`), so it is left alone rather than grown.
- Both new click handlers ignore the click when a drag is in progress: a drag that ends over an image also fires a click, and reordering photos is not a request to zoom.
- The viewer is loaded with `defineAsyncComponent`, so the compose and edit screens do not pay for zoompinch unless someone opens a photo.

## Future Improvements

- The desktop zoom slider is hidden behind `@media (hover: hover) and (pointer: fine)`, so it does not appear on touch laptops. Pre-existing, and pinch/wheel zoom still works there.
- In the edit form, a photo whose image fails to load renders nothing at all (`OurUploadedImage` hides itself on error), so there is no target to tap. Pre-existing, and arguably right, but an explicit broken-photo placeholder would be kinder.

## Test Plan

- Verified in Chrome against the local dev site: uploaded two photos on `/give`, tapped the featured one, got the full-screen viewer with a `1 / 2` counter; the dots move between photos; the back button closes it and returns to the compose form; tapping a thumbnail still promotes it rather than zooming. Also opened the viewer on a My Posts photo.
- New unit tests: the viewer uses the attachments it is given without touching the store, still falls back to the store when given an id, starts on the photo that was clicked, copes with an empty array, and keeps Escape to itself so a listener underneath is not called.
- New unit tests for the posting flow: tapping the featured photo opens the viewer with every photo, a still-uploading photo does not open it, and dismissing closes it. Same for the edit form, which opens on the photo that was clicked.
- Full Vitest suite green: 708 files, 14982 passed, 3 skipped (pre-existing).
