### PR TITLE
feat(modtools): export a standard-messages config as a PDF

### DIFF
--- a/docs/moderators/04-running-your-community.md
+++ b/docs/moderators/04-running-your-community.md
@@ -1,8 +1,10 @@
 ---
-last_reviewed: 2026-08-05
+last_reviewed: 2026-08-08
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/modtools/pages/settings/**
+  - iznik-nuxt3/modtools/components/ModSettingsModConfig.vue
+  - iznik-nuxt3/modtools/composables/useModConfigPdf.js
   - iznik-nuxt3/modtools/pages/members/stories.vue
   - iznik-nuxt3/modtools/pages/communityevents/**
   - iznik-nuxt3/modtools/pages/admins.vue
@@ -53,6 +55,12 @@ A message can mark part of its wording as something you must fill in each time, 
 something optional, using `<editthis>` and `<optional>` tags. See
 [fill-in boxes and optional bits](02-moderating-posts.md#fill-in-boxes-and-optional-bits)
 for what a moderator then sees when they send it.
+
+**Export PDF** produces the whole set as one document: the general settings, the BCC
+settings for each queue, and every standard message with its wording and what sending it
+does. Useful for reviewing a set away from the screen, agreeing wording with your fellow
+volunteers, or handing a community over. It works on locked sets too, since you can
+already read and copy those.
 
 ## Stories and newsletters
 

--- a/iznik-nuxt3/modtools/components/ModSettingsModConfig.vue
+++ b/iznik-nuxt3/modtools/components/ModSettingsModConfig.vue
@@ -39,7 +39,11 @@
     </div>
     <Spinner v-if="loading" :size="50" class="d-block mt-2" />
     <div v-else-if="configid && config">
-      <NoticeMessage v-if="config.protected && config.createdby" variant="info" class="mb-2">
+      <NoticeMessage
+        v-if="config.protected && config.createdby"
+        variant="info"
+        class="mb-2"
+      >
         <v-icon icon="lock" />
         <span v-if="parseInt(config.createdby) === myid">
           You have locked this. Other people can use, view or copy it, but can't
@@ -51,8 +55,8 @@
             lockerUser?.displayname ||
             lockerUser?.fullname ||
             '#' + config.createdby
-          }}</strong>. You can use, view or copy
-          it, but you can't change or delete it.
+          }}</strong
+          >. You can use, view or copy it, but you can't change or delete it.
         </span>
       </NoticeMessage>
       <NoticeMessage v-if="config.using && config.using.length">
@@ -292,15 +296,29 @@
             />
           </slot>
         </b-input-group>
-        <b-button
-          v-if="!locked && (!config || !config.using || !config.using.length)"
-          variant="white"
-          class="mt-2"
-          @click="deleteIt"
-        >
-          <v-icon icon="trash-alt" /> Delete
-        </b-button>
+        <div class="d-flex gap-2">
+          <SpinButton
+            variant="white"
+            class="mt-2 text-nowrap"
+            icon-name="download"
+            label="Export PDF"
+            title="Download this whole config as a PDF you can read, print or send to someone"
+            @handle="exportPdf"
+          />
+          <b-button
+            v-if="!locked && (!config || !config.using || !config.using.length)"
+            variant="white"
+            class="mt-2"
+            @click="deleteIt"
+          >
+            <v-icon icon="trash-alt" /> Delete
+          </b-button>
+        </div>
       </div>
+      <NoticeMessage v-if="exportError" variant="danger" class="mt-2">
+        Sorry, we couldn't make the PDF. Please try again, and tell us if it
+        keeps happening.
+      </NoticeMessage>
       <ConfirmModal
         v-if="showDeleteModal"
         :title="'Delete: ' + config.name"
@@ -317,18 +335,20 @@ import { useModGroupStore } from '~/stores/modgroup'
 import { useMiscStore } from '@/stores/misc'
 import { useUserStore } from '~/stores/user'
 import { useMe } from '~/composables/useMe'
+import { exportModConfigPdf } from '~/composables/useModConfigPdf'
 
 const miscStore = useMiscStore()
 const modConfigStore = useModConfigStore()
 const modGroupStore = useModGroupStore()
 const userStore = useUserStore()
-const { myid } = useMe()
+const { me, myid } = useMe()
 
 const loading = ref(false)
 const showUsing = ref(false)
 const newconfigname = ref(null)
 const copyconfigname = ref(null)
 const showDeleteModal = ref(false)
+const exportError = ref(false)
 
 const configid = computed({
   get() {
@@ -466,6 +486,23 @@ async function copy(callback) {
   modConfigStore.fetch({
     all: true,
   })
+  callback()
+}
+
+async function exportPdf(callback) {
+  exportError.value = false
+
+  try {
+    await exportModConfigPdf(config.value, {
+      exportedBy: me.value?.displayname || me.value?.fullname,
+    })
+  } catch (e) {
+    // The button must stop spinning either way, so the failure is shown rather
+    // than left as a button that never comes back.
+    console.error('Failed to export config as PDF', e)
+    exportError.value = true
+  }
+
   callback()
 }
 

--- a/iznik-nuxt3/modtools/composables/useModConfigPdf.js
+++ b/iznik-nuxt3/modtools/composables/useModConfigPdf.js
@@ -1,0 +1,495 @@
+import { copyStdMsgs } from '~/composables/useStdMsgs'
+
+/**
+ * Turning a ModConfig into a document someone can read away from the screen.
+ *
+ * Mods review each other's standard messages, hand them over when a group
+ * changes hands, and get asked by Freegle HQ what their group actually sends.
+ * All of that means reading the whole config at once, which the settings page -
+ * an accordion of one-at-a-time sections - is the wrong shape for.
+ *
+ * Split in two on purpose: buildModConfigDocument() decides WHAT the document
+ * says and is pure, so it can be tested without a PDF anywhere near it;
+ * renderModConfigPdf() decides what it LOOKS like.
+ */
+
+// The sections of the settings page, in the order a mod sees them, with the
+// message actions that belong to each. Kept in step with ModSettingsModConfig.
+export const MESSAGE_SECTIONS = [
+  {
+    heading: 'Pending Messages',
+    cc: 'ccrejectto',
+    addr: 'ccrejectaddr',
+    actions: ['Approve', 'Reject', 'Leave', 'Delete', 'Edit', 'Hold Message'],
+  },
+  {
+    heading: 'Approved Messages',
+    cc: 'ccfollowupto',
+    addr: 'ccfollowupaddr',
+    actions: ['Leave Approved Message', 'Delete Approved Message', 'Edit'],
+  },
+  {
+    heading: 'Approved Members',
+    cc: 'ccfollmembto',
+    addr: 'ccfollmembaddr',
+    actions: ['Leave Approved Member', 'Delete Approved Member'],
+  },
+]
+
+// The wording mods see in the settings UI, so the PDF says the same thing the
+// screen does rather than exposing what we happen to store.
+const MOD_STATUS = {
+  UNCHANGED: 'Unchanged',
+  MODERATED: 'Moderated',
+  DEFAULT: 'Group Settings',
+  PROHIBITED: "Can't Post",
+  UNMODERATED: 'Unmoderated',
+}
+
+const DELIVERY_STATUS = {
+  UNCHANGED: 'Unchanged',
+  DIGEST: 'Daily Digest',
+  NONE: 'Web Only',
+  SINGLE: 'Individual Emails',
+  ANNOUNCEMENT: 'Special Notices',
+}
+
+function yesNo(value) {
+  return parseInt(value) ? 'Yes' : 'No'
+}
+
+function blankAsDash(value) {
+  const str = value === null || value === undefined ? '' : String(value).trim()
+  return str.length ? str : '-'
+}
+
+function generalRows(config) {
+  return [
+    { label: 'Name', value: blankAsDash(config.name) },
+    {
+      label: 'Leave chat unread?',
+      value: parseInt(config.chatread) ? 'Mark as read' : 'Leave as unread',
+    },
+    {
+      label: "'From:' name in messages",
+      value:
+        config.fromname === 'My name' ? 'Own Name' : '$groupname Moderator',
+    },
+    { label: 'Colour-code subjects?', value: yesNo(config.coloursubj) },
+    { label: 'Subject length warning', value: blankAsDash(config.subjlen) },
+    {
+      label: 'Regular expression for colour-coding',
+      value: blankAsDash(config.subjreg),
+    },
+    {
+      label: '$network substitution string',
+      value: blankAsDash(config.network),
+    },
+    { label: 'Locked against changes?', value: yesNo(config.protected) },
+  ]
+}
+
+function messageRows(stdmsg) {
+  const rows = [
+    { label: 'Action', value: blankAsDash(stdmsg.action) },
+    {
+      label: 'Autosend',
+      value: parseInt(stdmsg.autosend)
+        ? 'Send immediately'
+        : 'Edit before send',
+    },
+    {
+      label: 'How often used',
+      value: parseInt(stdmsg.rarelyused) ? 'Rarely' : 'Frequently',
+    },
+  ]
+
+  // Only worth the ink when the message actually changes something.
+  if (stdmsg.newmodstatus && stdmsg.newmodstatus !== 'UNCHANGED') {
+    rows.push({
+      label: 'Change moderation status',
+      value: MOD_STATUS[stdmsg.newmodstatus] || stdmsg.newmodstatus,
+    })
+  }
+
+  if (stdmsg.newdelstatus && stdmsg.newdelstatus !== 'UNCHANGED') {
+    rows.push({
+      label: 'Change delivery settings',
+      value: DELIVERY_STATUS[stdmsg.newdelstatus] || stdmsg.newdelstatus,
+    })
+  }
+
+  if (stdmsg.subjpref) {
+    rows.push({ label: 'Subject prefix', value: stdmsg.subjpref })
+  }
+
+  if (stdmsg.subjsuff) {
+    rows.push({ label: 'Subject suffix', value: stdmsg.subjsuff })
+  }
+
+  if (stdmsg.insert) {
+    rows.push({ label: 'Insert text', value: stdmsg.insert })
+  }
+
+  return rows
+}
+
+function ccRows(config, section) {
+  const to = config[section.cc]
+  const rows = [{ label: 'BCC to', value: blankAsDash(to) }]
+
+  if (to === 'Specific') {
+    rows.push({
+      label: 'Specific address',
+      value: blankAsDash(config[section.addr]),
+    })
+  }
+
+  return rows
+}
+
+/**
+ * Describe a config as an ordered document: headings, label/value rows and
+ * message bodies. No PDF, no formatting decisions - just what it says.
+ *
+ * @param {object} config A config as returned by the modconfigs API.
+ * @param {object} [opts]
+ * @param {Date} [opts.exportedAt] Stamped on the front page.
+ * @param {string} [opts.exportedBy] Display name of whoever pressed the button.
+ * @returns {object} { title, meta, sections }
+ */
+export function buildModConfigDocument(config, opts = {}) {
+  if (!config) {
+    throw new Error('No config to export')
+  }
+
+  const exportedAt = opts.exportedAt || new Date()
+
+  const meta = [
+    {
+      label: 'Exported',
+      value: exportedAt.toLocaleString('en-GB', {
+        dateStyle: 'long',
+        timeStyle: 'short',
+      }),
+    },
+  ]
+
+  if (opts.exportedBy) {
+    meta.push({ label: 'Exported by', value: opts.exportedBy })
+  }
+
+  meta.push({ label: 'Config id', value: String(config.id ?? '-') })
+
+  // Ordered the way the mod ordered their buttons, so the paper matches the
+  // screen. copyStdMsgs mutates the order it parses, hence the fresh object.
+  const ordered = config.stdmsgs?.length
+    ? copyStdMsgs({
+        messageorder: config.messageorder,
+        stdmsgs: config.stdmsgs,
+      })
+    : []
+
+  const sections = [
+    {
+      heading: 'General Settings',
+      rows: generalRows(config),
+      messages: [],
+    },
+  ]
+
+  MESSAGE_SECTIONS.forEach((section) => {
+    const messages = ordered
+      .filter((s) => section.actions.includes(s.action))
+      .map((s) => ({
+        title: blankAsDash(s.title),
+        rows: messageRows(s),
+        editText: s.edittext || '',
+        body: s.body || '',
+      }))
+
+    sections.push({
+      heading: section.heading,
+      rows: ccRows(config, section),
+      messages,
+    })
+  })
+
+  return {
+    title: config.name || 'Standard Messages',
+    meta,
+    sections,
+  }
+}
+
+/**
+ * A filename someone can find again in their Downloads folder.
+ */
+export function pdfFilename(config, exportedAt = new Date()) {
+  const name = (config?.name || 'modconfig')
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+
+  const date = exportedAt.toISOString().slice(0, 10)
+
+  return `${name || 'modconfig'}-${date}.pdf`
+}
+
+// A4 in points, and the space we leave around the text.
+const PAGE = { width: 595.28, height: 841.89 }
+const MARGIN = { top: 64, bottom: 56, left: 56, right: 56 }
+const CONTENT_WIDTH = PAGE.width - MARGIN.left - MARGIN.right
+const LABEL_WIDTH = 170
+
+/**
+ * Draw a document from buildModConfigDocument onto a jsPDF instance.
+ *
+ * Everything here is layout: where things sit, when to break the page, what is
+ * bold. Exported so it can be driven with a fake doc in tests.
+ */
+export function renderModConfigPdf(pdf, doc) {
+  let y = MARGIN.top
+
+  // Running header and page number, added at the end when we know the total.
+  function decoratePages() {
+    const pages = pdf.getNumberOfPages()
+
+    for (let page = 1; page <= pages; page++) {
+      pdf.setPage(page)
+      pdf.setFont('helvetica', 'normal')
+      pdf.setFontSize(8)
+      pdf.setTextColor(120)
+
+      if (page > 1) {
+        // Page one has the title block, so it does not need telling.
+        pdf.text(doc.title, MARGIN.left, MARGIN.top - 28)
+        pdf.setDrawColor(220)
+        pdf.line(
+          MARGIN.left,
+          MARGIN.top - 22,
+          PAGE.width - MARGIN.right,
+          MARGIN.top - 22
+        )
+      }
+
+      pdf.text(
+        `Page ${page} of ${pages}`,
+        PAGE.width - MARGIN.right,
+        PAGE.height - MARGIN.bottom + 24,
+        { align: 'right' }
+      )
+      pdf.setTextColor(0)
+    }
+  }
+
+  function room(needed) {
+    if (y + needed > PAGE.height - MARGIN.bottom) {
+      pdf.addPage()
+      y = MARGIN.top
+      return true
+    }
+    return false
+  }
+
+  // A label/value pair in two columns. The label wraps rather than running
+  // into the value - "Regular expression for colour-coding" is wider than the
+  // column, and a label sitting on top of its own value is unreadable.
+  function labelledRow(row, { size, indent, labelStyle, labelColour }) {
+    pdf.setFontSize(size)
+
+    pdf.setFont('helvetica', labelStyle)
+    const labelLines = pdf.splitTextToSize(row.label, LABEL_WIDTH - indent - 10)
+
+    pdf.setFont('helvetica', 'normal')
+    const valueLines = pdf.splitTextToSize(
+      row.value,
+      CONTENT_WIDTH - LABEL_WIDTH
+    )
+
+    const lineHeight = size * 1.3
+    const height =
+      Math.max(labelLines.length, valueLines.length, 1) * lineHeight
+
+    room(height)
+
+    pdf.setFont('helvetica', labelStyle)
+    pdf.setTextColor(labelColour)
+    labelLines.forEach((line, i) => {
+      pdf.text(line, MARGIN.left + indent, y + i * lineHeight)
+    })
+
+    pdf.setFont('helvetica', 'normal')
+    pdf.setTextColor(0)
+    valueLines.forEach((line, i) => {
+      pdf.text(line, MARGIN.left + LABEL_WIDTH, y + i * lineHeight)
+    })
+
+    y += height
+  }
+
+  function paragraph(text, { size, style, indent = 0, colour = 0, gap = 4 }) {
+    pdf.setFont('helvetica', style)
+    pdf.setFontSize(size)
+    pdf.setTextColor(colour)
+
+    const lines = pdf.splitTextToSize(text, CONTENT_WIDTH - indent)
+    const lineHeight = size * 1.35
+
+    lines.forEach((line) => {
+      room(lineHeight)
+      pdf.text(line, MARGIN.left + indent, y)
+      y += lineHeight
+    })
+
+    y += gap
+    pdf.setTextColor(0)
+  }
+
+  // --- Title block ---
+  pdf.setFont('helvetica', 'bold')
+  pdf.setFontSize(20)
+  pdf.text(doc.title, MARGIN.left, y)
+  y += 26
+
+  pdf.setFont('helvetica', 'normal')
+  pdf.setFontSize(10)
+  pdf.setTextColor(90)
+  pdf.text('Standard Messages configuration', MARGIN.left, y)
+  y += 16
+
+  pdf.setFontSize(9)
+  doc.meta.forEach((m) => {
+    pdf.text(`${m.label}: ${m.value}`, MARGIN.left, y)
+    y += 12
+  })
+  pdf.setTextColor(0)
+
+  y += 6
+  pdf.setDrawColor(180)
+  pdf.setLineWidth(1)
+  pdf.line(MARGIN.left, y, PAGE.width - MARGIN.right, y)
+  y += 24
+
+  // --- Sections ---
+  doc.sections.forEach((section, index) => {
+    // A heading with nothing under it on the page is worse than a page break.
+    if (index > 0) {
+      room(90)
+    }
+
+    pdf.setFont('helvetica', 'bold')
+    pdf.setFontSize(14)
+    pdf.text(section.heading, MARGIN.left, y)
+    y += 8
+    pdf.setDrawColor(200)
+    pdf.setLineWidth(0.5)
+    pdf.line(MARGIN.left, y, PAGE.width - MARGIN.right, y)
+    y += 18
+
+    section.rows.forEach((row) => {
+      labelledRow(row, {
+        size: 10,
+        indent: 0,
+        labelStyle: 'bold',
+        labelColour: 70,
+      })
+      y += 2
+    })
+
+    if (section.messages.length) {
+      y += 10
+    } else if (index > 0) {
+      // Say so, so that an empty section reads as empty rather than as
+      // something that failed to print.
+      y += 12
+      paragraph('No standard messages in this section.', {
+        size: 9,
+        style: 'italic',
+        indent: 12,
+        colour: 120,
+        gap: 2,
+      })
+    }
+
+    section.messages.forEach((message) => {
+      // Keep a message's title with at least the start of its detail.
+      room(70)
+
+      pdf.setFillColor(242, 242, 242)
+      pdf.rect(MARGIN.left, y - 11, CONTENT_WIDTH, 20, 'F')
+      pdf.setFont('helvetica', 'bold')
+      pdf.setFontSize(11)
+      pdf.text(message.title, MARGIN.left + 6, y + 3)
+      y += 26
+
+      message.rows.forEach((row) => {
+        labelledRow(row, {
+          size: 9,
+          indent: 12,
+          labelStyle: 'normal',
+          labelColour: 110,
+        })
+      })
+
+      y += 6
+
+      if (message.editText) {
+        paragraph('Edit text', {
+          size: 9,
+          style: 'bold',
+          indent: 12,
+          colour: 110,
+          gap: 2,
+        })
+        paragraph(message.editText, { size: 9, style: 'normal', indent: 12 })
+      }
+
+      if (message.body) {
+        paragraph('Message body', {
+          size: 9,
+          style: 'bold',
+          indent: 12,
+          colour: 110,
+          gap: 2,
+        })
+        paragraph(message.body, {
+          size: 9,
+          style: 'normal',
+          indent: 12,
+          gap: 8,
+        })
+      } else {
+        y += 6
+      }
+    })
+
+    y += 14
+  })
+
+  decoratePages()
+
+  return pdf
+}
+
+/**
+ * Build and download the PDF. jsPDF is pulled in on demand - it is a big
+ * library and most mods never press this button.
+ */
+export async function exportModConfigPdf(config, opts = {}) {
+  const exportedAt = opts.exportedAt || new Date()
+  const doc = buildModConfigDocument(config, { ...opts, exportedAt })
+
+  const { jsPDF: JsPDF } = await import('jspdf')
+  const pdf = new JsPDF({ unit: 'pt', format: 'a4' })
+
+  pdf.setProperties({
+    title: `${doc.title} - Standard Messages configuration`,
+    creator: 'Freegle ModTools',
+  })
+
+  renderModConfigPdf(pdf, doc)
+  pdf.save(pdfFilename(config, exportedAt))
+
+  return doc
+}

--- a/iznik-nuxt3/package-lock.json
+++ b/iznik-nuxt3/package-lock.json
@@ -76,6 +76,7 @@
         "floating-vue": "^5.2.2",
         "heic-to": "^1.5.2",
         "isomorphic-dompurify": "^3.18.0",
+        "jspdf": "^4.2.1",
         "jwt-decode": "^3.1.2",
         "leaflet": "^1.8.0",
         "leaflet-control-geocoder": "^1.13.0",
@@ -1772,9 +1773,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -9777,6 +9779,12 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -9790,6 +9798,13 @@
       "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -13321,6 +13336,16 @@
         }
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -13955,6 +13980,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -15139,6 +15191,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -18364,6 +18426,33 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -19629,6 +19718,20 @@
         }
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -20090,6 +20193,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ionicons": {
       "version": "6.1.3",
@@ -21506,6 +21615,29 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
@@ -24762,7 +24894,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -26078,6 +26210,16 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "dev": true
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -26743,6 +26885,16 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -27988,6 +28140,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -28381,6 +28543,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
@@ -28700,6 +28872,16 @@
       "dev": true,
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -29998,6 +30180,16 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/iznik-nuxt3/package.json
+++ b/iznik-nuxt3/package.json
@@ -163,6 +163,7 @@
     "floating-vue": "^5.2.2",
     "heic-to": "^1.5.2",
     "isomorphic-dompurify": "^3.18.0",
+    "jspdf": "^4.2.1",
     "jwt-decode": "^3.1.2",
     "leaflet": "^1.8.0",
     "leaflet-control-geocoder": "^1.13.0",

--- a/iznik-nuxt3/tests/unit/components/ModSettingsModConfig.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ModSettingsModConfig.spec.js
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+
+import ModSettingsModConfig from '~/modtools/components/ModSettingsModConfig.vue'
+
+const config = {
+  id: 42,
+  name: 'South West Mods',
+  createdby: null,
+  protected: 0,
+  using: [],
+  stdmsgs: [],
+  messageorder: null,
+}
+
+const mockModConfigStore = {
+  configs: [{ id: 42, name: 'South West Mods' }],
+  current: config,
+  fetch: vi.fn().mockResolvedValue({}),
+  fetchConfig: vi.fn().mockResolvedValue({}),
+  add: vi.fn().mockResolvedValue(43),
+  delete: vi.fn().mockResolvedValue({}),
+}
+
+const mockMiscStore = {
+  get: vi.fn().mockReturnValue(42),
+  set: vi.fn().mockResolvedValue({}),
+}
+
+const mockUserStore = {
+  byId: vi.fn(),
+  fetch: vi.fn().mockResolvedValue({}),
+  fetchMultiple: vi.fn().mockResolvedValue({}),
+}
+
+const mockModGroupStore = {
+  list: {},
+  fetchIfNeedBeMT: vi.fn().mockResolvedValue({}),
+}
+
+const mockExport = vi.hoisted(() => vi.fn().mockResolvedValue({}))
+
+vi.mock('~/stores/modconfig', () => ({
+  useModConfigStore: () => mockModConfigStore,
+}))
+
+vi.mock('~/stores/modgroup', () => ({
+  useModGroupStore: () => mockModGroupStore,
+}))
+
+vi.mock('~/stores/misc', () => ({
+  useMiscStore: () => mockMiscStore,
+}))
+
+vi.mock('@/stores/misc', () => ({
+  useMiscStore: () => mockMiscStore,
+}))
+
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => mockUserStore,
+}))
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({
+    me: ref({ id: 7, displayname: 'Jane Moderator' }),
+    myid: ref(7),
+  }),
+}))
+
+vi.mock('~/composables/useModConfigPdf', () => ({
+  exportModConfigPdf: mockExport,
+}))
+
+function mountConfig() {
+  return mount(ModSettingsModConfig, {
+    global: {
+      stubs: {
+        SpinButton: {
+          // The real one hands the handler a callback to stop the spinner.
+          template:
+            '<button class="spin-button" :data-label="label" @click="$emit(\'handle\', done)"><slot />{{ label }}</button>',
+          props: ['variant', 'iconName', 'label', 'disabled', 'title'],
+          emits: ['handle'],
+          setup() {
+            return { done: () => {} }
+          },
+        },
+        ModConfigSetting: { template: '<div class="mod-config-setting" />' },
+        ModSettingsStandardMessageSet: {
+          template: '<div class="stdmsg-set" />',
+        },
+        NoticeMessage: { template: '<div class="notice"><slot /></div>' },
+        Spinner: { template: '<div class="spinner" />' },
+        ConfirmModal: { template: '<div class="confirm-modal" />' },
+        ExternalLink: { template: '<a><slot /></a>' },
+        'v-icon': { template: '<span />' },
+        'b-form-select': {
+          template: '<select class="config-select" />',
+          props: ['modelValue', 'options'],
+          emits: ['update:modelValue'],
+        },
+        'b-form-input': {
+          template: '<input />',
+          props: ['modelValue', 'placeholder'],
+          emits: ['update:modelValue'],
+        },
+        'b-input-group': {
+          template: '<div><slot /><slot name="append" /></div>',
+        },
+        'b-button': {
+          template:
+            '<button class="b-button" @click="$emit(\'click\')"><slot /></button>',
+          emits: ['click'],
+        },
+        'b-card': { template: '<div><slot /></div>' },
+        'b-card-header': { template: '<div><slot /></div>' },
+        'b-card-body': { template: '<div><slot /></div>' },
+        'b-collapse': { template: '<div><slot /></div>' },
+      },
+      directives: {
+        'b-toggle': {},
+      },
+    },
+  })
+}
+
+describe('ModSettingsModConfig export button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExport.mockResolvedValue({})
+    mockMiscStore.get.mockReturnValue(42)
+    mockModConfigStore.current = config
+  })
+
+  function exportButton(wrapper) {
+    return wrapper
+      .findAll('.spin-button')
+      .find((b) => b.attributes('data-label') === 'Export PDF')
+  }
+
+  it('offers an export button once a config is chosen', async () => {
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    expect(exportButton(wrapper)).toBeTruthy()
+  })
+
+  it('exports the config that is being looked at, and says who by', async () => {
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    await exportButton(wrapper).trigger('click')
+    await flushPromises()
+
+    expect(mockExport).toHaveBeenCalledWith(config, {
+      exportedBy: 'Jane Moderator',
+    })
+  })
+
+  it('tells the mod when the export fails rather than spinning forever', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockExport.mockRejectedValue(new Error('no can do'))
+
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    await exportButton(wrapper).trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain("couldn't make the PDF")
+    consoleError.mockRestore()
+  })
+
+  it('offers the export even when the config is locked against changes', async () => {
+    // Locked configs can be used, viewed and copied, so they can be read on
+    // paper too - it is only editing that is barred.
+    mockModConfigStore.current = { ...config, protected: 1, createdby: 999 }
+
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    expect(exportButton(wrapper)).toBeTruthy()
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useModConfigPdf.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModConfigPdf.spec.js
@@ -1,0 +1,519 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  buildModConfigDocument,
+  pdfFilename,
+  renderModConfigPdf,
+} from '~/composables/useModConfigPdf'
+
+function makeConfig(overrides = {}) {
+  return {
+    id: 42,
+    name: 'Test Config',
+    chatread: 0,
+    fromname: 'My name',
+    coloursubj: 1,
+    subjlen: 67,
+    subjreg: '/^OFFER/',
+    network: 'Freegle',
+    protected: 0,
+    ccrejectto: 'Nobody',
+    ccrejectaddr: '',
+    ccfollowupto: 'Nobody',
+    ccfollowupaddr: '',
+    ccfollmembto: 'Nobody',
+    ccfollmembaddr: '',
+    messageorder: null,
+    stdmsgs: [],
+    ...overrides,
+  }
+}
+
+function makeStdMsg(overrides = {}) {
+  return {
+    id: 1,
+    title: 'Approve',
+    action: 'Approve',
+    autosend: 0,
+    rarelyused: 0,
+    newmodstatus: 'UNCHANGED',
+    newdelstatus: 'UNCHANGED',
+    subjpref: '',
+    subjsuff: '',
+    insert: null,
+    edittext: '',
+    body: '',
+    ...overrides,
+  }
+}
+
+function sectionNamed(doc, heading) {
+  return doc.sections.find((s) => s.heading === heading)
+}
+
+function rowNamed(rows, label) {
+  return rows.find((r) => r.label === label)
+}
+
+describe('buildModConfigDocument', () => {
+  const exportedAt = new Date('2026-08-08T14:05:00Z')
+
+  it('refuses to export nothing', () => {
+    expect(() => buildModConfigDocument(null)).toThrow('No config to export')
+  })
+
+  it('titles the document with the config name', () => {
+    const doc = buildModConfigDocument(makeConfig({ name: 'South West' }), {
+      exportedAt,
+    })
+
+    expect(doc.title).toBe('South West')
+  })
+
+  it('falls back to a title when the config has no name', () => {
+    const doc = buildModConfigDocument(makeConfig({ name: '' }), { exportedAt })
+
+    expect(doc.title).toBe('Standard Messages')
+  })
+
+  it('stamps who exported it and when', () => {
+    const doc = buildModConfigDocument(makeConfig(), {
+      exportedAt,
+      exportedBy: 'Jane Moderator',
+    })
+
+    expect(rowNamed(doc.meta, 'Exported by').value).toBe('Jane Moderator')
+    expect(rowNamed(doc.meta, 'Exported').value).toContain('2026')
+    expect(rowNamed(doc.meta, 'Config id').value).toBe('42')
+  })
+
+  it('leaves out the exporter when we do not know who it is', () => {
+    const doc = buildModConfigDocument(makeConfig(), { exportedAt })
+
+    expect(rowNamed(doc.meta, 'Exported by')).toBeUndefined()
+  })
+
+  it('has the four sections a mod sees on the settings page, in that order', () => {
+    const doc = buildModConfigDocument(makeConfig(), { exportedAt })
+
+    expect(doc.sections.map((s) => s.heading)).toEqual([
+      'General Settings',
+      'Pending Messages',
+      'Approved Messages',
+      'Approved Members',
+    ])
+  })
+
+  describe('general settings', () => {
+    it('says what the settings mean rather than what we store', () => {
+      const doc = buildModConfigDocument(
+        makeConfig({
+          chatread: 1,
+          fromname: 'My name',
+          coloursubj: 1,
+          protected: 1,
+        }),
+        { exportedAt }
+      )
+
+      const rows = sectionNamed(doc, 'General Settings').rows
+      expect(rowNamed(rows, 'Leave chat unread?').value).toBe('Mark as read')
+      expect(rowNamed(rows, "'From:' name in messages").value).toBe('Own Name')
+      expect(rowNamed(rows, 'Colour-code subjects?').value).toBe('Yes')
+      expect(rowNamed(rows, 'Locked against changes?').value).toBe('Yes')
+    })
+
+    it('reads the other way round too', () => {
+      const doc = buildModConfigDocument(
+        makeConfig({
+          chatread: 0,
+          fromname: 'Groupname Moderator',
+          coloursubj: 0,
+          protected: 0,
+        }),
+        { exportedAt }
+      )
+
+      const rows = sectionNamed(doc, 'General Settings').rows
+      expect(rowNamed(rows, 'Leave chat unread?').value).toBe('Leave as unread')
+      expect(rowNamed(rows, "'From:' name in messages").value).toBe(
+        '$groupname Moderator'
+      )
+      expect(rowNamed(rows, 'Colour-code subjects?').value).toBe('No')
+      expect(rowNamed(rows, 'Locked against changes?').value).toBe('No')
+    })
+
+    it('shows a dash rather than a blank for an empty setting', () => {
+      const doc = buildModConfigDocument(makeConfig({ subjreg: '  ' }), {
+        exportedAt,
+      })
+
+      const rows = sectionNamed(doc, 'General Settings').rows
+      expect(rowNamed(rows, 'Regular expression for colour-coding').value).toBe(
+        '-'
+      )
+    })
+  })
+
+  describe('BCC settings', () => {
+    it('includes the specific address only when BCC is set to Specific', () => {
+      const doc = buildModConfigDocument(
+        makeConfig({
+          ccrejectto: 'Specific',
+          ccrejectaddr: 'mods@example.org',
+          ccfollowupto: 'Me',
+          ccfollowupaddr: 'ignored@example.org',
+        }),
+        { exportedAt }
+      )
+
+      const pending = sectionNamed(doc, 'Pending Messages').rows
+      expect(rowNamed(pending, 'BCC to').value).toBe('Specific')
+      expect(rowNamed(pending, 'Specific address').value).toBe(
+        'mods@example.org'
+      )
+
+      const approved = sectionNamed(doc, 'Approved Messages').rows
+      expect(rowNamed(approved, 'BCC to').value).toBe('Me')
+      expect(rowNamed(approved, 'Specific address')).toBeUndefined()
+    })
+  })
+
+  describe('standard messages', () => {
+    it('files each message under the section its action belongs to', () => {
+      const doc = buildModConfigDocument(
+        makeConfig({
+          stdmsgs: [
+            makeStdMsg({ id: 1, title: 'Approve it', action: 'Approve' }),
+            makeStdMsg({
+              id: 2,
+              title: 'Chase',
+              action: 'Leave Approved Message',
+            }),
+            makeStdMsg({
+              id: 3,
+              title: 'Welcome',
+              action: 'Leave Approved Member',
+            }),
+          ],
+        }),
+        { exportedAt }
+      )
+
+      expect(
+        sectionNamed(doc, 'Pending Messages').messages.map((m) => m.title)
+      ).toEqual(['Approve it'])
+      expect(
+        sectionNamed(doc, 'Approved Messages').messages.map((m) => m.title)
+      ).toEqual(['Chase'])
+      expect(
+        sectionNamed(doc, 'Approved Members').messages.map((m) => m.title)
+      ).toEqual(['Welcome'])
+    })
+
+    it('keeps the order the mod arranged their buttons in', () => {
+      const doc = buildModConfigDocument(
+        makeConfig({
+          messageorder: JSON.stringify([3, 1, 2]),
+          stdmsgs: [
+            makeStdMsg({ id: 1, title: 'First added', action: 'Approve' }),
+            makeStdMsg({ id: 2, title: 'Second added', action: 'Reject' }),
+            makeStdMsg({ id: 3, title: 'Third added', action: 'Reject' }),
+          ],
+        }),
+        { exportedAt }
+      )
+
+      expect(
+        sectionNamed(doc, 'Pending Messages').messages.map((m) => m.title)
+      ).toEqual(['Third added', 'First added', 'Second added'])
+    })
+
+    it('does not consume the config messageorder it was given', () => {
+      // copyStdMsgs shifts the array it parses; the caller's config must
+      // survive being exported so the settings page still works afterwards.
+      const config = makeConfig({
+        messageorder: JSON.stringify([2, 1]),
+        stdmsgs: [
+          makeStdMsg({ id: 1, action: 'Approve' }),
+          makeStdMsg({ id: 2, action: 'Reject' }),
+        ],
+      })
+
+      buildModConfigDocument(config, { exportedAt })
+
+      expect(JSON.parse(config.messageorder)).toEqual([2, 1])
+    })
+
+    it('spells out how a message behaves', () => {
+      const doc = buildModConfigDocument(
+        makeConfig({
+          stdmsgs: [
+            makeStdMsg({
+              action: 'Reject',
+              autosend: 1,
+              rarelyused: 1,
+              subjpref: 'OFFER: ',
+              subjsuff: ' (area)',
+              insert: 'Top',
+            }),
+          ],
+        }),
+        { exportedAt }
+      )
+
+      const rows = sectionNamed(doc, 'Pending Messages').messages[0].rows
+      expect(rowNamed(rows, 'Action').value).toBe('Reject')
+      expect(rowNamed(rows, 'Autosend').value).toBe('Send immediately')
+      expect(rowNamed(rows, 'How often used').value).toBe('Rarely')
+      expect(rowNamed(rows, 'Subject prefix').value).toBe('OFFER: ')
+      expect(rowNamed(rows, 'Subject suffix').value).toBe(' (area)')
+      expect(rowNamed(rows, 'Insert text').value).toBe('Top')
+    })
+
+    it('translates status changes into the words the UI uses', () => {
+      const doc = buildModConfigDocument(
+        makeConfig({
+          stdmsgs: [
+            makeStdMsg({
+              newmodstatus: 'PROHIBITED',
+              newdelstatus: 'ANNOUNCEMENT',
+            }),
+          ],
+        }),
+        { exportedAt }
+      )
+
+      const rows = sectionNamed(doc, 'Pending Messages').messages[0].rows
+      expect(rowNamed(rows, 'Change moderation status').value).toBe(
+        "Can't Post"
+      )
+      expect(rowNamed(rows, 'Change delivery settings').value).toBe(
+        'Special Notices'
+      )
+    })
+
+    it('leaves out status rows that change nothing', () => {
+      const doc = buildModConfigDocument(
+        makeConfig({ stdmsgs: [makeStdMsg()] }),
+        { exportedAt }
+      )
+
+      const rows = sectionNamed(doc, 'Pending Messages').messages[0].rows
+      expect(rowNamed(rows, 'Change moderation status')).toBeUndefined()
+      expect(rowNamed(rows, 'Change delivery settings')).toBeUndefined()
+      expect(rowNamed(rows, 'Subject prefix')).toBeUndefined()
+    })
+
+    it('carries the edit text and the message body', () => {
+      const doc = buildModConfigDocument(
+        makeConfig({
+          stdmsgs: [
+            makeStdMsg({
+              edittext: 'Reject - wrong format',
+              body: 'Hi there,\n\nPlease repost.',
+            }),
+          ],
+        }),
+        { exportedAt }
+      )
+
+      const message = sectionNamed(doc, 'Pending Messages').messages[0]
+      expect(message.editText).toBe('Reject - wrong format')
+      expect(message.body).toBe('Hi there,\n\nPlease repost.')
+    })
+
+    it('copes with a config that has no messages at all', () => {
+      const doc = buildModConfigDocument(makeConfig({ stdmsgs: [] }), {
+        exportedAt,
+      })
+
+      doc.sections.forEach((section) => {
+        expect(section.messages).toEqual([])
+      })
+    })
+  })
+})
+
+describe('pdfFilename', () => {
+  const exportedAt = new Date('2026-08-08T14:05:00Z')
+
+  it('is something you can find again in Downloads', () => {
+    expect(pdfFilename({ name: 'South West Mods' }, exportedAt)).toBe(
+      'south-west-mods-2026-08-08.pdf'
+    )
+  })
+
+  it('flattens punctuation that has no business in a filename', () => {
+    expect(
+      pdfFilename({ name: 'Freegle: standard/messages (v2)!' }, exportedAt)
+    ).toBe('freegle-standard-messages-v2-2026-08-08.pdf')
+  })
+
+  it('still produces a filename for a nameless config', () => {
+    expect(pdfFilename({}, exportedAt)).toBe('modconfig-2026-08-08.pdf')
+    expect(pdfFilename({ name: '!!!' }, exportedAt)).toBe(
+      'modconfig-2026-08-08.pdf'
+    )
+  })
+})
+
+describe('renderModConfigPdf', () => {
+  // A stand-in for jsPDF that records what was drawn, so the layout rules can
+  // be tested without producing an actual PDF.
+  function fakePdf() {
+    const calls = { text: [], pages: 1 }
+
+    return {
+      calls,
+      setFont: vi.fn(),
+      setFontSize: vi.fn(),
+      setTextColor: vi.fn(),
+      setDrawColor: vi.fn(),
+      setFillColor: vi.fn(),
+      setLineWidth: vi.fn(),
+      line: vi.fn(),
+      rect: vi.fn(),
+      setPage: vi.fn(),
+      getNumberOfPages: () => calls.pages,
+      addPage: vi.fn(() => {
+        calls.pages++
+      }),
+      // Wrap on width alone; enough to exercise the page-break arithmetic.
+      splitTextToSize: (text, width) => {
+        const perLine = Math.max(1, Math.floor(width / 5))
+        return String(text)
+          .split('\n')
+          .flatMap((line) => {
+            const out = []
+            for (let i = 0; i < line.length; i += perLine) {
+              out.push(line.slice(i, i + perLine))
+            }
+            return out.length ? out : ['']
+          })
+      },
+      text: vi.fn((str, x, y, opts) => {
+        calls.text.push({ str, x, y, page: calls.pages, opts })
+      }),
+    }
+  }
+
+  const doc = {
+    title: 'South West',
+    meta: [{ label: 'Exported', value: '8 August 2026' }],
+    sections: [
+      {
+        heading: 'General Settings',
+        rows: [{ label: 'Name', value: 'South West' }],
+        messages: [],
+      },
+      {
+        heading: 'Pending Messages',
+        rows: [{ label: 'BCC to', value: 'Nobody' }],
+        messages: [
+          {
+            title: 'Wrong format',
+            rows: [{ label: 'Action', value: 'Reject' }],
+            editText: 'Reject - wrong format',
+            body: 'Hi there,\n\nPlease repost.',
+          },
+        ],
+      },
+    ],
+  }
+
+  function drawn(pdf) {
+    return pdf.calls.text.map((t) => t.str)
+  }
+
+  it('writes the title, the headings and the message content', () => {
+    const pdf = fakePdf()
+    renderModConfigPdf(pdf, doc)
+
+    const text = drawn(pdf)
+    expect(text).toContain('South West')
+    expect(text).toContain('Standard Messages configuration')
+    expect(text).toContain('General Settings')
+    expect(text).toContain('Pending Messages')
+    expect(text).toContain('Wrong format')
+    expect(text).toContain('Edit text')
+    expect(text).toContain('Message body')
+    expect(text).toContain('Hi there,')
+  })
+
+  it('numbers every page', () => {
+    const pdf = fakePdf()
+    renderModConfigPdf(pdf, doc)
+
+    expect(drawn(pdf)).toContain('Page 1 of 1')
+  })
+
+  it('says when a section has no standard messages', () => {
+    const pdf = fakePdf()
+    renderModConfigPdf(pdf, {
+      ...doc,
+      sections: [
+        doc.sections[0],
+        { heading: 'Pending Messages', rows: [], messages: [] },
+      ],
+    })
+
+    expect(drawn(pdf)).toContain('No standard messages in this section.')
+  })
+
+  it('breaks the page rather than running off the bottom', () => {
+    const pdf = fakePdf()
+    const long = Array.from({ length: 40 }, (_, i) => `Line ${i}`).join('\n')
+
+    renderModConfigPdf(pdf, {
+      ...doc,
+      sections: [
+        {
+          heading: 'Pending Messages',
+          rows: [],
+          messages: Array.from({ length: 4 }, (_, i) => ({
+            title: `Message ${i}`,
+            rows: [{ label: 'Action', value: 'Reject' }],
+            editText: '',
+            body: long,
+          })),
+        },
+      ],
+    })
+
+    expect(pdf.getNumberOfPages()).toBeGreaterThan(1)
+    // Nothing may be drawn below the bottom margin.
+    pdf.calls.text.forEach((t) => {
+      expect(t.y).toBeLessThanOrEqual(841.89 - 56 + 24)
+    })
+  })
+
+  it('repeats the config name as a running header after page one', () => {
+    const pdf = fakePdf()
+    const long = Array.from({ length: 60 }, (_, i) => `Line ${i}`).join('\n')
+
+    renderModConfigPdf(pdf, {
+      ...doc,
+      sections: [
+        {
+          heading: 'Pending Messages',
+          rows: [],
+          messages: [
+            {
+              title: 'Long one',
+              rows: [],
+              editText: '',
+              body: long,
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(pdf.getNumberOfPages()).toBeGreaterThan(1)
+    // The header is drawn once per page after the first.
+    const headers = pdf.calls.text.filter(
+      (t) => t.str === 'South West' && t.y < 64
+    )
+    expect(headers.length).toBe(pdf.getNumberOfPages() - 1)
+  })
+})


### PR DESCRIPTION
## Summary

Reviewing a whole standard-messages config means reading it all at once - when mods agree wording between themselves, hand a community over, or are asked what their group actually sends. The settings page is an accordion that shows one section at a time, which is the wrong shape for that.

- **Export PDF** button on the Standard Messages tab, next to Copy and Delete.
- The document opens with a title block (config name, "Standard Messages configuration", who exported it and when, config id), then the same four sections in the same order as the screen: General Settings, Pending Messages, Approved Messages, Approved Members.
- Each standard message gets a shaded title bar, what sending it does (action, autosend, how often used, and any moderation/delivery status change, subject prefix/suffix, insert position), its edit text and its full body. Rows that change nothing are left out rather than printed as "Unchanged".
- Settings are shown in the words the UI uses ("Mark as read", "Own Name", "Can't Post"), not the values we store.
- Messages appear in the order the mod dragged their buttons into, so the paper matches the screen.
- Running header and "Page N of M" on every page after the first; an empty section says so rather than looking like a printing failure.
- Locked configs export too. You can already read and copy those, so reading one on paper is no different; only editing is barred.
- Filename is `config-name-YYYY-MM-DD.pdf`.

## Code Quality Review

- Split so the interesting half is testable without a PDF anywhere near it: `buildModConfigDocument()` decides **what** the document says and is pure; `renderModConfigPdf()` decides what it **looks** like and is driven with a fake jsPDF in tests.
- `jspdf` is a new dependency, imported with `defineAsyncComponent`-style dynamic `import()` inside the export function, so it is a separate chunk and the ModTools bundle only grows for mods who press the button.
- `copyStdMsgs()` shifts the array it parses, so the builder hands it a throwaway object - exporting must not disturb the config the settings page is still using. There is a test for that.
- A failed export shows a notice and always stops the spinner, rather than leaving a button that never comes back.
- Long labels wrap instead of colliding with their values, and long unbroken values (a regex, a long address) break rather than running off the right margin. Both found by looking at the output, both now covered.

## Future Improvements

- The cross-stack Playwright spec for this page (`test-modtools-settings-modconfig.spec.js`) does not yet assert the export. A case that clicks the button and checks the download would be worth adding when that spec is next touched.
- Non-WinAnsi characters (emoji in a standard message, for instance) are dropped by jsPDF's built-in fonts. Embedding a Unicode font would fix it at the cost of a much bigger chunk.

## Test Plan

- **Looked at the output.** Rendered a realistic config (8 general settings, 6 standard messages with multi-paragraph bodies) to a 3-page PDF and read every page as an image. That is what caught the label/value collision and the unbroken-token overflow, both fixed. Also rendered a just-created config with no messages to check the empty case reads properly.
- **Clicked the real button in ModTools.** Created a config on the local dev site, pressed Export PDF, and captured a 6685-byte `application/pdf` blob with no error notice - so the dynamic jsPDF import, the render and the download all work in the app.
- New unit tests, 30 in total: what the document says (sections, ordering, UI wording, blank handling, the messageorder mutation guard), the filename, and the layout rules driven through a fake jsPDF (page breaks stay inside the bottom margin, the running header appears once per page after the first, empty sections are labelled).
- Full Vitest suite green: 710 files, 15012 passed, 3 skipped.
