### PR TITLE
feat(modtools): a Partnerships page for council sponsorship deals

### DIFF
--- a/docs/moderators/01-getting-started.md
+++ b/docs/moderators/01-getting-started.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-09
+last_reviewed: 2026-08-08
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/modtools/pages/index.vue
@@ -65,7 +65,9 @@ Newsletter, Spam admin, Gift Aid, Clearance), granted independently of your role
 cannot see a feature this guide mentions, you may not have that permission on that
 community yet.
 
-You can see Freegle's volunteer **teams** and who is on them under `/teams`.
+You can see Freegle's volunteer **teams** and who is on them under `/teams`. A team can also
+unlock a page in its own right: being on the **Partnerships** team puts
+[Partnerships](partnerships.md) in your menu, for managing council sponsorship deals.
 
 ## Switching between communities
 

--- a/docs/moderators/README.md
+++ b/docs/moderators/README.md
@@ -41,3 +41,6 @@ A few things worth holding onto, whichever guide you are in:
 There is a moderator-facing guide to rippling out at
 [./rippling-out.md](./rippling-out.md), and the
 technical detail is in [../developers/reference/rippling-algorithm.md](../developers/reference/rippling-algorithm.md).
+
+Council sponsorship deals - who sponsors us, what they are worth, and the quarterly
+statistics councils receive - are covered in [./partnerships.md](./partnerships.md).

--- a/docs/moderators/partnerships.md
+++ b/docs/moderators/partnerships.md
@@ -1,0 +1,97 @@
+---
+last_reviewed: 2026-08-08
+owner: Freegle dev team
+covers:
+  - iznik-nuxt3/modtools/pages/partnerships.vue
+  - iznik-nuxt3/modtools/components/ModPartnership*.vue
+  - iznik-nuxt3/modtools/stores/partnerships.js
+  - iznik-nuxt3/api/PartnershipsAPI.js
+  - iznik-server-go/partnerships/**
+  - iznik-batch/app/Console/Commands/Partnerships/**
+  - iznik-batch/app/Mail/Partnerships/**
+---
+
+# Partnerships
+
+Councils sponsor Freegle. The **Partnerships** page in ModTools is where those deals live:
+who is sponsoring us, which communities each deal covers, what it is worth, whether the money
+has come in, and when it needs renewing.
+
+It also generates the quarterly statistics spreadsheets councils receive.
+
+## Who can see it
+
+Members of the **Partnerships** team, plus Support and Admin. Add someone on the
+[Teams](01-getting-started.md) page and the Partnerships entry appears in their left-hand
+menu the next time their session refreshes.
+
+The team's email address (set on the Teams page) is where the renewal reminders go.
+
+## What a partnership is
+
+A partnership is a deal with a **local authority**, not with a group. That matches how the
+deal is actually done: a council pays once, and the sponsorship shows across every Freegle
+community inside its boundary.
+
+When you create a deal, the covered communities are worked out from the council boundary
+automatically. You can see them under **Details**, add ones the boundary missed, and remove
+ones that should not be included.
+
+Each covered community gets a sponsor entry, which is what members see. Editing the tagline,
+description or link on the partnership changes all of them at once.
+
+> A deal only shows to members once it is marked **Agreed**. Until then it is a conversation,
+> not an advert, so nothing appears on the site.
+
+## The money
+
+Three separate things are tracked, because they answer different questions:
+
+| Field | Question it answers |
+|---|---|
+| **Value of the whole deal** | What did we agree, across the whole term? |
+| **Financial years** | How much of it belongs to which year? |
+| **Invoices** | What have we billed, and what has actually been paid? |
+
+Multi-year deals are the reason the middle row exists. A three-year deal is spread evenly
+across the three financial years it covers (1 April to 31 March), so the income graph shows
+it as three bars rather than all in the year it was signed.
+
+If the council pays in uneven instalments - most of it up front, say - override the split
+under **Details** and enter the real figures. The page warns you if the split does not add up
+to the deal value. Clearing the split puts it back to spreading the money evenly.
+
+Invoices are recorded separately, so **Invoiced** and **Paid** on the summary row tell you
+what is still outstanding.
+
+## Renewal reminders
+
+Three months before a sponsorship ends, the Partnerships team gets an email about it, with a
+link straight to the deal. Each deal is only chased once, so the daily check does not nag.
+
+Deals nearing their end are also flagged on the page itself, both in the banner at the top and
+as a **Renewal due** badge in the list.
+
+## Council statistics
+
+The bottom of the page generates the quarterly spreadsheet councils receive - membership,
+weight reused, CO2 and financial benefit, gifts made, a per-community breakdown, shortlink
+clicks, member stories and a postcode breakdown.
+
+Building one takes a few minutes, so it runs in the background:
+
+1. Pick the councils and the quarter, and press **Generate**.
+2. The job appears in the table below as *Pending*, then *Running*.
+3. When it says *Ready*, the spreadsheets are listed and you can download them.
+
+You do not have to keep the page open - come back later and the finished spreadsheets are
+still there. If one council fails (a boundary that no longer exists, say) the others still
+come through, and the reason is shown against the job.
+
+## Under the covers
+
+- Sponsor entries are written to `groups_sponsorship`, the same table the member site reads,
+  so nothing else had to change to show councils to members.
+- Everything the page adds lives in tables prefixed `partnerships`.
+- Reminders come from `partnerships:reminders`, run daily; the spreadsheets are built by
+  `partnerships:stats:run`, which picks up queued jobs every minute.

--- a/docs/moderators/partnerships.md
+++ b/docs/moderators/partnerships.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-08
+last_reviewed: 2026-08-09
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/modtools/pages/partnerships.vue

--- a/iznik-batch/app/Console/Commands/Partnerships/SponsorshipRemindersCommand.php
+++ b/iznik-batch/app/Console/Commands/Partnerships/SponsorshipRemindersCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Console\Commands\Partnerships;
+
+use App\Mail\Partnerships\SponsorshipExpiringMail;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Chases council sponsorships that are coming up for renewal.
+ *
+ * A council's budget round takes months, so the team needs telling well before the
+ * sponsorship lapses - three months by default. Each partnership is chased once per window
+ * (recorded in partnerships_reminders), so running this daily does not nag.
+ *
+ *   php artisan partnerships:reminders
+ *   php artisan partnerships:reminders --days=30 --type=1month
+ */
+class SponsorshipRemindersCommand extends Command
+{
+    protected $signature = 'partnerships:reminders
+                            {--days=92 : How many days ahead of expiry to warn}
+                            {--type=3months : Reminder window name, recorded so each deal is chased once}
+                            {--dry-run : Report what would be sent without sending it}';
+
+    protected $description = 'Email the Partnerships team about sponsorships nearing their end date';
+
+    public function handle(): int
+    {
+        $days = max(1, (int) $this->option('days'));
+        $type = (string) $this->option('type');
+        $dryRun = (bool) $this->option('dry-run');
+
+        $today = Carbon::today();
+        $cutoff = $today->copy()->addDays($days);
+
+        // Only agreed, visible deals are worth chasing: an unagreed one is still being
+        // negotiated, and a hidden one has already been retired by hand.
+        $due = DB::table('partnerships')
+            ->join('authorities', 'authorities.id', '=', 'partnerships.authorityid')
+            ->leftJoin('partnerships_reminders', function ($join) use ($type) {
+                $join->on('partnerships_reminders.partnershipid', '=', 'partnerships.id')
+                    ->where('partnerships_reminders.type', '=', $type);
+            })
+            ->whereNull('partnerships_reminders.id')
+            ->where('partnerships.agreed', 1)
+            ->where('partnerships.visible', 1)
+            ->whereDate('partnerships.enddate', '>=', $today->toDateString())
+            ->whereDate('partnerships.enddate', '<=', $cutoff->toDateString())
+            ->select([
+                'partnerships.id',
+                'partnerships.name',
+                'partnerships.enddate',
+                'partnerships.amount',
+                'partnerships.contactname',
+                'partnerships.contactemail',
+                'authorities.name as authorityname',
+            ])
+            ->orderBy('partnerships.enddate')
+            ->get();
+
+        if ($due->isEmpty()) {
+            $this->info('No sponsorships are due a reminder.');
+
+            return Command::SUCCESS;
+        }
+
+        $to = $this->teamEmail();
+        $from = config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org');
+        $modSite = rtrim((string) config('freegle.sites.mod', 'https://modtools.org'), '/');
+
+        foreach ($due as $partnership) {
+            $endDate = Carbon::parse($partnership->enddate);
+            $daysLeft = (int) $today->diffInDays($endDate, false);
+
+            $groupCount = (int) DB::table('partnerships_groups')
+                ->where('partnershipid', $partnership->id)
+                ->count();
+
+            $this->info(sprintf(
+                '%s (%s) ends %s - %d days left, %d %s covered.',
+                $partnership->name,
+                $partnership->authorityname,
+                $endDate->format('j M Y'),
+                $daysLeft,
+                $groupCount,
+                $groupCount === 1 ? 'community' : 'communities'
+            ));
+
+            if ($dryRun) {
+                continue;
+            }
+
+            Mail::send(new SponsorshipExpiringMail(
+                recipientEmail: $to,
+                fromEmail: $from,
+                partnershipName: $partnership->name,
+                authorityName: $partnership->authorityname,
+                endDate: $endDate->format('j M Y'),
+                daysLeft: $daysLeft,
+                amount: (float) $partnership->amount,
+                groupCount: $groupCount,
+                contactName: $partnership->contactname,
+                contactEmail: $partnership->contactemail,
+                modToolsUrl: $modSite . '/partnerships?id=' . $partnership->id,
+            ));
+
+            // Written after the send, so a send that blows up is retried on the next run
+            // rather than being silently swallowed.
+            DB::table('partnerships_reminders')->insertOrIgnore([
+                'partnershipid' => $partnership->id,
+                'type' => $type,
+                'sent' => now(),
+            ]);
+        }
+
+        $this->info(sprintf('%s %d reminder%s.',
+            $dryRun ? 'Would send' : 'Sent',
+            $due->count(),
+            $due->count() === 1 ? '' : 's'
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Where the reminders go: the Partnerships team's own address, so changing it in
+     * ModTools changes where these land.
+     */
+    private function teamEmail(): string
+    {
+        $email = DB::table('teams')->where('name', 'Partnerships')->value('email');
+
+        return $email ?: 'partnerships@ilovefreegle.org';
+    }
+}

--- a/iznik-batch/app/Console/Commands/Partnerships/StatsJobRunnerCommand.php
+++ b/iznik-batch/app/Console/Commands/Partnerships/StatsJobRunnerCommand.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Console\Commands\Partnerships;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * Renders the authority statistics spreadsheets that the ModTools Partnerships page asks for.
+ *
+ * Generating one council's report takes minutes, far longer than a web request can wait, so
+ * the page writes a row into partnerships_statsjobs and this command - run every minute by
+ * the scheduler - picks it up, runs the existing authority:stats command and stores the
+ * resulting spreadsheets in the database for the page to download.
+ *
+ * Spreadsheets live in the DB rather than on disk because the Go API serves the download and
+ * has no filesystem in common with this container.
+ *
+ *   php artisan partnerships:stats:run
+ */
+class StatsJobRunnerCommand extends Command
+{
+    protected $signature = 'partnerships:stats:run
+                            {--limit=1 : How many queued jobs to run in one pass}';
+
+    protected $description = 'Render queued authority statistics spreadsheets for the Partnerships page';
+
+    public function handle(): int
+    {
+        $limit = max(1, (int) $this->option('limit'));
+
+        $jobs = DB::table('partnerships_statsjobs')
+            ->where('status', 'Pending')
+            ->orderBy('id')
+            ->limit($limit)
+            ->get();
+
+        if ($jobs->isEmpty()) {
+            $this->info('No queued statistics jobs.');
+
+            return Command::SUCCESS;
+        }
+
+        foreach ($jobs as $job) {
+            // Claim the job before doing any work. The conditional update means a second
+            // runner that started at the same moment claims nothing and moves on.
+            $claimed = DB::table('partnerships_statsjobs')
+                ->where('id', $job->id)
+                ->where('status', 'Pending')
+                ->update(['status' => 'Running', 'started' => now()]);
+
+            if (!$claimed) {
+                continue;
+            }
+
+            $this->runJob($job);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function runJob(object $job): void
+    {
+        $outputDir = storage_path('app/partnerships-stats/' . $job->id);
+        $this->cleanDir($outputDir);
+
+        if (!is_dir($outputDir) && !mkdir($outputDir, 0775, true) && !is_dir($outputDir)) {
+            $this->failJob($job, "Could not create output directory: {$outputDir}");
+
+            return;
+        }
+
+        $ids = array_values(array_filter(array_map('intval', explode(',', (string) $job->authorityids))));
+        if (empty($ids)) {
+            $this->failJob($job, 'No authority IDs in the job.');
+
+            return;
+        }
+
+        $stored = 0;
+        $problems = [];
+
+        foreach ($ids as $authorityId) {
+            // One authority at a time so each spreadsheet can be filed against the council it
+            // belongs to, and one bad authority does not lose the whole batch.
+            try {
+                $exit = Artisan::call('authority:stats', [
+                    '--i' => (string) $authorityId,
+                    '--q' => $job->quarter,
+                    '--output' => $outputDir,
+                ]);
+
+                if ($exit !== 0) {
+                    $problems[] = sprintf('Authority %d: %s', $authorityId, trim(Artisan::output()));
+
+                    continue;
+                }
+            } catch (Throwable $e) {
+                $problems[] = sprintf('Authority %d: %s', $authorityId, $e->getMessage());
+
+                continue;
+            }
+
+            $stored += $this->storeFiles($job, $authorityId, $outputDir);
+        }
+
+        $this->cleanDir($outputDir);
+
+        if ($stored === 0) {
+            $this->failJob($job, $problems ? implode("\n", $problems) : 'No spreadsheets were produced.');
+
+            return;
+        }
+
+        DB::table('partnerships_statsjobs')->where('id', $job->id)->update([
+            'status' => 'Ready',
+            // Partial success still counts as ready - the files that did render are useful,
+            // and the errors are recorded alongside them.
+            'error' => $problems ? implode("\n", $problems) : null,
+            'completed' => now(),
+        ]);
+
+        $this->info(sprintf('Job %d: stored %d spreadsheet%s.', $job->id, $stored, $stored === 1 ? '' : 's'));
+    }
+
+    /**
+     * Move every spreadsheet now in the output directory into the database against this
+     * authority, and return how many were stored.
+     */
+    private function storeFiles(object $job, int $authorityId, string $outputDir): int
+    {
+        $stored = 0;
+
+        foreach (glob($outputDir . '/*.xlsx') ?: [] as $path) {
+            $content = @file_get_contents($path);
+            @unlink($path);
+
+            if ($content === false) {
+                continue;
+            }
+
+            DB::table('partnerships_statsfiles')->insert([
+                'jobid' => $job->id,
+                'authorityid' => $authorityId,
+                'filename' => basename($path),
+                'size' => strlen($content),
+                'content' => $content,
+            ]);
+
+            $stored++;
+        }
+
+        return $stored;
+    }
+
+    private function failJob(object $job, string $error): void
+    {
+        DB::table('partnerships_statsjobs')->where('id', $job->id)->update([
+            'status' => 'Failed',
+            'error' => $error,
+            'completed' => now(),
+        ]);
+
+        $this->error(sprintf('Job %d failed: %s', $job->id, $error));
+    }
+
+    private function cleanDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (glob($dir . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+}

--- a/iznik-batch/app/Mail/Partnerships/SponsorshipExpiringMail.php
+++ b/iznik-batch/app/Mail/Partnerships/SponsorshipExpiringMail.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Mail\Partnerships;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * Tells the Partnerships team that a council sponsorship is coming up for renewal.
+ *
+ * One mail per partnership rather than a digest: each one is a separate conversation with a
+ * separate council, and a single mail per deal is what you want to forward, reply to and
+ * chase against.
+ */
+class SponsorshipExpiringMail extends Mailable
+{
+    public function __construct(
+        public readonly string $recipientEmail,
+        public readonly string $fromEmail,
+        public readonly string $partnershipName,
+        public readonly string $authorityName,
+        public readonly string $endDate,
+        public readonly int $daysLeft,
+        public readonly float $amount,
+        public readonly int $groupCount,
+        public readonly ?string $contactName,
+        public readonly ?string $contactEmail,
+        public readonly string $modToolsUrl,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address($this->fromEmail, 'Freegle'),
+            to: [new Address($this->recipientEmail, 'Freegle Partnerships')],
+            subject: sprintf('Sponsorship renewal due: %s (ends %s)', $this->partnershipName, $this->endDate),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.text.partnerships.sponsorship-expiring',
+            with: [
+                'partnershipName' => $this->partnershipName,
+                'authorityName' => $this->authorityName,
+                'endDate' => $this->endDate,
+                'daysLeft' => $this->daysLeft,
+                'amount' => $this->amount,
+                'groupCount' => $this->groupCount,
+                'contactName' => $this->contactName,
+                'contactEmail' => $this->contactEmail,
+                'modToolsUrl' => $this->modToolsUrl,
+            ],
+        );
+    }
+}

--- a/iznik-batch/database/migrations/2026_08_08_000001_create_partnerships_tables.php
+++ b/iznik-batch/database/migrations/2026_08_08_000001_create_partnerships_tables.php
@@ -1,0 +1,204 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tables behind the ModTools Partnerships page.
+ *
+ * A partnership is a sponsorship deal with a local authority (council). The Freegle
+ * groups it covers are derived from the authority/group polygon overlap and cached in
+ * partnerships_groups; saving a partnership syncs a groups_sponsorship row per covered
+ * group so the member site shows the sponsor.
+ *
+ * Money is tracked in three places, deliberately:
+ *   - partnerships.amount     the headline value of the whole deal
+ *   - partnerships_years      how a multi-year deal splits across UK financial years
+ *   - partnerships_payments   what has actually been invoiced and paid
+ *
+ * Everything here is prefixed `partnerships` so the feature's tables are obvious.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('partnerships')) {
+            Schema::create('partnerships', function (Blueprint $table) {
+                $table->comment('Sponsorship deals with local authorities');
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('authorityid');
+                $table->string('name');
+                $table->string('tagline')->nullable();
+                $table->text('description')->nullable();
+                $table->string('linkurl')->nullable();
+                $table->string('imageurl')->nullable();
+                $table->date('startdate');
+                $table->date('enddate');
+                // The deal value across its whole term, in pounds.
+                $table->decimal('amount', 10, 2)->default(0);
+                $table->boolean('agreed')->default(false);
+                $table->date('agreeddate')->nullable();
+                $table->string('contactname')->nullable();
+                $table->string('contactemail')->nullable();
+                $table->text('notes')->nullable();
+                // Whether the sponsor should be shown on the member site.
+                $table->boolean('visible')->default(true);
+                $table->timestamp('created')->useCurrent();
+                $table->timestamp('modified')->useCurrent()->useCurrentOnUpdate();
+
+                $table->index(['authorityid'], 'authorityid');
+                $table->index(['enddate'], 'enddate');
+            });
+        }
+
+        // How a multi-year deal splits across UK financial years (1 Apr - 31 Mar).
+        // A financial year is identified by the calendar year it starts in, so 2026
+        // means 2026/27. Absent rows mean "pro-rate the amount across the term".
+        if (!Schema::hasTable('partnerships_years')) {
+            Schema::create('partnerships_years', function (Blueprint $table) {
+                $table->comment('Explicit per-financial-year split of a multi-year deal');
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('partnershipid');
+                $table->integer('financialyear');
+                $table->decimal('amount', 10, 2)->default(0);
+
+                $table->unique(['partnershipid', 'financialyear'], 'partnershipid_financialyear');
+            });
+        }
+
+        if (!Schema::hasTable('partnerships_payments')) {
+            Schema::create('partnerships_payments', function (Blueprint $table) {
+                $table->comment('Invoices raised against a partnership and what has been paid');
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('partnershipid');
+                $table->date('date');
+                $table->decimal('amount', 10, 2)->default(0);
+                $table->date('paid')->nullable();
+                $table->string('reference')->nullable();
+                $table->text('notes')->nullable();
+
+                $table->index(['partnershipid'], 'partnershipid');
+            });
+        }
+
+        // Which groups a partnership covers, and the groups_sponsorship row we created
+        // for each. Kept as a mapping table so groups_sponsorship stays untouched.
+        if (!Schema::hasTable('partnerships_groups')) {
+            Schema::create('partnerships_groups', function (Blueprint $table) {
+                $table->comment('Groups covered by a partnership and their sponsorship rows');
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('partnershipid');
+                $table->unsignedBigInteger('groupid');
+                $table->unsignedBigInteger('sponsorshipid')->nullable();
+
+                $table->unique(['partnershipid', 'groupid'], 'partnershipid_groupid');
+                $table->index(['groupid'], 'groupid');
+            });
+        }
+
+        // Reminder mails already sent, so a partnership is chased once per window.
+        if (!Schema::hasTable('partnerships_reminders')) {
+            Schema::create('partnerships_reminders', function (Blueprint $table) {
+                $table->comment('Expiry reminder mails sent to the Partnerships team');
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('partnershipid');
+                $table->string('type', 32);
+                $table->timestamp('sent')->useCurrent();
+
+                $table->unique(['partnershipid', 'type'], 'partnershipid_type');
+            });
+        }
+
+        // Authority stats spreadsheet generation is too slow for a web request, so the
+        // page queues a job here and the scheduler renders it in the background.
+        if (!Schema::hasTable('partnerships_statsjobs')) {
+            Schema::create('partnerships_statsjobs', function (Blueprint $table) {
+                $table->comment('Queued authority stats spreadsheet generation requests');
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('userid')->nullable();
+                // Comma-separated authority ids, matching authority:stats --i.
+                $table->text('authorityids');
+                $table->string('quarter')->default('3 months ago');
+                $table->enum('status', ['Pending', 'Running', 'Ready', 'Failed'])->default('Pending');
+                $table->text('error')->nullable();
+                $table->timestamp('requested')->useCurrent();
+                $table->timestamp('started')->nullable();
+                $table->timestamp('completed')->nullable();
+
+                $table->index(['status', 'requested'], 'status_requested');
+                $table->index(['userid'], 'userid');
+            });
+        }
+
+        // The rendered spreadsheets. Held as blobs rather than files because the Go API
+        // serves the download while Laravel does the rendering, and they have no shared
+        // filesystem.
+        if (!Schema::hasTable('partnerships_statsfiles')) {
+            Schema::create('partnerships_statsfiles', function (Blueprint $table) {
+                $table->comment('Spreadsheets produced by a partnerships_statsjobs run');
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('jobid');
+                $table->unsignedBigInteger('authorityid')->nullable();
+                $table->string('filename');
+                $table->unsignedInteger('size')->default(0);
+                $table->binary('content')->nullable();
+
+                $table->index(['jobid'], 'jobid');
+            });
+
+            // Blueprint's binary() gives a plain BLOB (64KB); a council spreadsheet with a
+            // postcode breakdown comfortably exceeds that, so widen it to MEDIUMBLOB (16MB).
+            DB::statement('ALTER TABLE partnerships_statsfiles MODIFY content MEDIUMBLOB NULL');
+        }
+
+        $this->addForeignKeys();
+    }
+
+    /**
+     * Cascade deletes so removing a partnership takes its years, payments, group links and
+     * reminder history with it, and a job takes its rendered files.
+     */
+    private function addForeignKeys(): void
+    {
+        $keys = [
+            ['partnerships', 'authorityid', 'authorities', 'cascade'],
+            ['partnerships_years', 'partnershipid', 'partnerships', 'cascade'],
+            ['partnerships_payments', 'partnershipid', 'partnerships', 'cascade'],
+            ['partnerships_groups', 'partnershipid', 'partnerships', 'cascade'],
+            ['partnerships_groups', 'groupid', 'groups', 'cascade'],
+            // A sponsorship row deleted by hand leaves the link in place, unpointed.
+            ['partnerships_groups', 'sponsorshipid', 'groups_sponsorship', 'set null'],
+            ['partnerships_reminders', 'partnershipid', 'partnerships', 'cascade'],
+            ['partnerships_statsfiles', 'jobid', 'partnerships_statsjobs', 'cascade'],
+        ];
+
+        foreach ($keys as [$table, $column, $references, $onDelete]) {
+            $name = $table . '_' . $column . '_foreign';
+
+            $exists = DB::table('information_schema.TABLE_CONSTRAINTS')
+                ->where('CONSTRAINT_SCHEMA', DB::getDatabaseName())
+                ->where('TABLE_NAME', $table)
+                ->where('CONSTRAINT_NAME', $name)
+                ->exists();
+
+            if (!$exists) {
+                Schema::table($table, function (Blueprint $blueprint) use ($column, $references, $onDelete) {
+                    $blueprint->foreign($column)->references('id')->on($references)->onDelete($onDelete);
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('partnerships_statsfiles');
+        Schema::dropIfExists('partnerships_statsjobs');
+        Schema::dropIfExists('partnerships_reminders');
+        Schema::dropIfExists('partnerships_groups');
+        Schema::dropIfExists('partnerships_payments');
+        Schema::dropIfExists('partnerships_years');
+        Schema::dropIfExists('partnerships');
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_08_000001_create_partnerships_tables_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_08_000001_create_partnerships_tables_migration.sql
@@ -1,0 +1,116 @@
+-- Production idempotent SQL: the tables behind the ModTools Partnerships page.
+--
+-- A partnership is a sponsorship deal with a local authority. The Freegle groups it covers
+-- are derived from the authority/group boundary overlap and cached in partnerships_groups;
+-- saving a partnership syncs a groups_sponsorship row per covered group, which is what the
+-- member site already reads.
+--
+-- Money is tracked in three places on purpose: partnerships.amount is the whole deal,
+-- partnerships_years is how a multi-year deal splits across UK financial years, and
+-- partnerships_payments is what has actually been invoiced and paid.
+--
+-- All CREATE TABLE IF NOT EXISTS, so this is safe to re-run.
+-- See 2026_08_08_000001_create_partnerships_tables.php.
+
+CREATE TABLE IF NOT EXISTS `partnerships` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `authorityid` bigint unsigned NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `tagline` varchar(255) DEFAULT NULL,
+  `description` text,
+  `linkurl` varchar(255) DEFAULT NULL,
+  `imageurl` varchar(255) DEFAULT NULL,
+  `startdate` date NOT NULL,
+  `enddate` date NOT NULL,
+  `amount` decimal(10,2) NOT NULL DEFAULT '0.00',
+  `agreed` tinyint(1) NOT NULL DEFAULT '0',
+  `agreeddate` date DEFAULT NULL,
+  `contactname` varchar(255) DEFAULT NULL,
+  `contactemail` varchar(255) DEFAULT NULL,
+  `notes` text,
+  `visible` tinyint(1) NOT NULL DEFAULT '1',
+  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `authorityid` (`authorityid`),
+  KEY `enddate` (`enddate`),
+  CONSTRAINT `partnerships_authorityid_foreign` FOREIGN KEY (`authorityid`) REFERENCES `authorities` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Sponsorship deals with local authorities';
+
+CREATE TABLE IF NOT EXISTS `partnerships_years` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `partnershipid` bigint unsigned NOT NULL,
+  -- The calendar year the financial year starts in, so 2026 means 2026/27.
+  `financialyear` int NOT NULL,
+  `amount` decimal(10,2) NOT NULL DEFAULT '0.00',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `partnershipid_financialyear` (`partnershipid`,`financialyear`),
+  CONSTRAINT `partnerships_years_partnershipid_foreign` FOREIGN KEY (`partnershipid`) REFERENCES `partnerships` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Explicit per-financial-year split of a multi-year deal';
+
+CREATE TABLE IF NOT EXISTS `partnerships_payments` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `partnershipid` bigint unsigned NOT NULL,
+  `date` date NOT NULL,
+  `amount` decimal(10,2) NOT NULL DEFAULT '0.00',
+  `paid` date DEFAULT NULL,
+  `reference` varchar(255) DEFAULT NULL,
+  `notes` text,
+  PRIMARY KEY (`id`),
+  KEY `partnershipid` (`partnershipid`),
+  CONSTRAINT `partnerships_payments_partnershipid_foreign` FOREIGN KEY (`partnershipid`) REFERENCES `partnerships` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Invoices raised against a partnership and what has been paid';
+
+CREATE TABLE IF NOT EXISTS `partnerships_groups` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `partnershipid` bigint unsigned NOT NULL,
+  `groupid` bigint unsigned NOT NULL,
+  `sponsorshipid` bigint unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `partnershipid_groupid` (`partnershipid`,`groupid`),
+  KEY `groupid` (`groupid`),
+  KEY `partnerships_groups_sponsorshipid_foreign` (`sponsorshipid`),
+  CONSTRAINT `partnerships_groups_partnershipid_foreign` FOREIGN KEY (`partnershipid`) REFERENCES `partnerships` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `partnerships_groups_groupid_foreign` FOREIGN KEY (`groupid`) REFERENCES `groups` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `partnerships_groups_sponsorshipid_foreign` FOREIGN KEY (`sponsorshipid`) REFERENCES `groups_sponsorship` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Groups covered by a partnership and their sponsorship rows';
+
+CREATE TABLE IF NOT EXISTS `partnerships_reminders` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `partnershipid` bigint unsigned NOT NULL,
+  `type` varchar(32) NOT NULL,
+  `sent` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `partnershipid_type` (`partnershipid`,`type`),
+  CONSTRAINT `partnerships_reminders_partnershipid_foreign` FOREIGN KEY (`partnershipid`) REFERENCES `partnerships` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Expiry reminder mails sent to the Partnerships team';
+
+CREATE TABLE IF NOT EXISTS `partnerships_statsjobs` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `userid` bigint unsigned DEFAULT NULL,
+  `authorityids` text NOT NULL,
+  `quarter` varchar(255) NOT NULL DEFAULT '3 months ago',
+  `status` enum('Pending','Running','Ready','Failed') NOT NULL DEFAULT 'Pending',
+  `error` text,
+  `requested` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `started` timestamp NULL DEFAULT NULL,
+  `completed` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `status_requested` (`status`,`requested`),
+  KEY `userid` (`userid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Queued authority stats spreadsheet generation requests';
+
+-- MEDIUMBLOB, not BLOB: a council spreadsheet with a postcode breakdown exceeds 64KB. The
+-- bytes live here rather than on disk because the Go API serves the download and shares no
+-- filesystem with the batch container that renders them.
+CREATE TABLE IF NOT EXISTS `partnerships_statsfiles` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `jobid` bigint unsigned NOT NULL,
+  `authorityid` bigint unsigned DEFAULT NULL,
+  `filename` varchar(255) NOT NULL,
+  `size` int unsigned NOT NULL DEFAULT '0',
+  `content` mediumblob,
+  PRIMARY KEY (`id`),
+  KEY `jobid` (`jobid`),
+  CONSTRAINT `partnerships_statsfiles_jobid_foreign` FOREIGN KEY (`jobid`) REFERENCES `partnerships_statsjobs` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Spreadsheets produced by a partnerships_statsjobs run';

--- a/iznik-batch/database/migrations/2026_08_08_000002_create_partnerships_team.php
+++ b/iznik-batch/database/migrations/2026_08_08_000002_create_partnerships_team.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The Partnerships team gates the ModTools Partnerships page: members of this team (plus
+ * Support/Admin) may see the left-hand menu entry and use the partnership API.
+ *
+ * Members are added per environment - on live they are set up by hand - so this only
+ * creates the team itself, which the permission check looks up by name.
+ */
+return new class extends Migration
+{
+    private const NAME = 'Partnerships';
+
+    public function up(): void
+    {
+        $exists = DB::table('teams')->where('name', self::NAME)->exists();
+
+        if (!$exists) {
+            DB::table('teams')->insert([
+                'name' => self::NAME,
+                'description' => 'Looks after our partnerships with local authorities: '
+                    . 'sponsorship deals, the income they bring in, and the quarterly statistics councils receive.',
+                'type' => 'Team',
+                'email' => 'partnerships@ilovefreegle.org',
+                'active' => 1,
+                'wikiurl' => null,
+                // Members work inside ModTools only; they don't need Support Tools.
+                'supporttools' => 0,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('teams')->where('name', self::NAME)->delete();
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_08_000002_create_partnerships_team_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_08_000002_create_partnerships_team_migration.sql
@@ -1,0 +1,17 @@
+-- Production idempotent SQL: the Partnerships team.
+--
+-- Membership of this team is what puts the Partnerships page in someone's ModTools menu and
+-- lets them use the partnership API (Support and Admin get in regardless). Members are added
+-- by hand per environment, so this only creates the team itself, which the permission check
+-- looks up by name.
+--
+-- The team's email is where the three-month renewal reminders go.
+-- See 2026_08_08_000002_create_partnerships_team.php.
+INSERT INTO `teams` (`name`, `description`, `type`, `email`, `active`, `supporttools`)
+SELECT 'Partnerships',
+       'Looks after our partnerships with local authorities: sponsorship deals, the income they bring in, and the quarterly statistics councils receive.',
+       'Team',
+       'partnerships@ilovefreegle.org',
+       1,
+       0
+WHERE NOT EXISTS (SELECT 1 FROM (SELECT `id` FROM `teams` WHERE `name` = 'Partnerships') x);

--- a/iznik-batch/resources/views/emails/text/partnerships/sponsorship-expiring.blade.php
+++ b/iznik-batch/resources/views/emails/text/partnerships/sponsorship-expiring.blade.php
@@ -1,0 +1,16 @@
+Sponsorship renewal due
+=======================
+
+{{ $partnershipName }} ({{ $authorityName }}) ends on {{ $endDate }}, which is {{ $daysLeft }} {{ Str::plural('day', $daysLeft) }} away.
+
+Value of the current deal: £{{ number_format($amount, 2) }}
+Freegle communities covered: {{ $groupCount }}
+@if($contactName || $contactEmail)
+
+Council contact: {{ trim(($contactName ?? '') . ' ' . ($contactEmail ? '<' . $contactEmail . '>' : '')) }}
+@endif
+
+The sponsor logo and tagline stop showing to members on the day it ends, so it is worth
+starting the renewal conversation now.
+
+Manage this partnership: {{ $modToolsUrl }}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -1454,3 +1454,19 @@ Schedule::command('community-news:discover-sources')
     ->withoutOverlapping(240)
     ->sendOutputTo(cronLog('community-news:discover-sources'))
     ->runInBackground();
+
+// Render the authority statistics spreadsheets the Partnerships page has queued. Each run
+// takes one job so a long report never blocks the next request for minutes on end.
+Schedule::command('partnerships:stats:run')
+    ->everyMinute()
+    ->withoutOverlapping(60)
+    ->sendOutputTo(cronLog('partnerships:stats:run'))
+    ->runInBackground();
+
+// Chase council sponsorships three months out from expiry. Daily, but each partnership is
+// only ever chased once per window, so this is a no-op on most days.
+Schedule::command('partnerships:reminders')
+    ->dailyAt('08:00')
+    ->withoutOverlapping(30)
+    ->sendOutputTo(cronLog('partnerships:reminders'))
+    ->runInBackground();

--- a/iznik-batch/tests/Feature/Partnerships/SponsorshipRemindersCommandTest.php
+++ b/iznik-batch/tests/Feature/Partnerships/SponsorshipRemindersCommandTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature\Partnerships;
+
+use App\Mail\Partnerships\SponsorshipExpiringMail;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Council budget rounds take months, so the Partnerships team needs warning well before a
+ * sponsorship lapses. These tests pin who gets chased, who does not, and that nobody gets
+ * chased twice for the same window.
+ */
+class SponsorshipRemindersCommandTest extends TestCase
+{
+    private int $authorityId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Mail::fake();
+
+        $this->authorityId = (int) DB::table('authorities')->insertGetId([
+            'name' => 'Reminder Test Council ' . uniqid(),
+            'polygon' => DB::raw("ST_GeomFromText('POLYGON((-1 10, 1 10, 1 12, -1 12, -1 10))', 3857)"),
+        ]);
+
+        // Other tests share this database; park anything already due so each test only sees
+        // the partnership it created.
+        DB::table('partnerships')->update(['agreed' => 0]);
+    }
+
+    /** Create a partnership ending $daysAway from today. */
+    private function partnership(int $daysAway, array $overrides = []): int
+    {
+        $end = Carbon::today()->addDays($daysAway);
+
+        return (int) DB::table('partnerships')->insertGetId(array_merge([
+            'authorityid' => $this->authorityId,
+            'name' => 'Reminder Test Partnership',
+            'startdate' => $end->copy()->subYear()->toDateString(),
+            'enddate' => $end->toDateString(),
+            'amount' => 4800,
+            'agreed' => 1,
+            'visible' => 1,
+            'contactname' => 'Waste Team',
+            'contactemail' => 'waste@example.gov.uk',
+        ], $overrides));
+    }
+
+    public function test_chases_a_sponsorship_inside_the_window(): void
+    {
+        $id = $this->partnership(60);
+
+        $this->artisan('partnerships:reminders')->assertExitCode(0);
+
+        Mail::assertSent(SponsorshipExpiringMail::class, function ($mail) {
+            return $mail->recipientEmail === 'partnerships@ilovefreegle.org'
+                && $mail->partnershipName === 'Reminder Test Partnership'
+                && $mail->daysLeft === 60;
+        });
+
+        $this->assertSame(1, DB::table('partnerships_reminders')
+            ->where('partnershipid', $id)->where('type', '3months')->count());
+    }
+
+    public function test_does_not_chase_the_same_deal_twice(): void
+    {
+        $this->partnership(60);
+
+        $this->artisan('partnerships:reminders')->assertExitCode(0);
+        Mail::assertSentCount(1);
+
+        // Running daily must not nag - the recorded reminder holds it back.
+        $this->artisan('partnerships:reminders')->assertExitCode(0);
+        Mail::assertSentCount(1);
+    }
+
+    public function test_ignores_a_deal_ending_beyond_the_window(): void
+    {
+        $this->partnership(200);
+
+        $this->artisan('partnerships:reminders')
+            ->expectsOutputToContain('No sponsorships are due a reminder')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_ignores_a_deal_that_has_already_expired(): void
+    {
+        // Chasing something that lapsed last month is not a renewal reminder.
+        $this->partnership(-10);
+
+        $this->artisan('partnerships:reminders')->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_ignores_a_deal_that_is_not_agreed(): void
+    {
+        $this->partnership(30, ['agreed' => 0]);
+
+        $this->artisan('partnerships:reminders')->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_ignores_a_deal_that_has_been_hidden(): void
+    {
+        $this->partnership(30, ['visible' => 0]);
+
+        $this->artisan('partnerships:reminders')->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_dry_run_reports_without_sending_or_recording(): void
+    {
+        $id = $this->partnership(45);
+
+        $this->artisan('partnerships:reminders', ['--dry-run' => true])
+            ->expectsOutputToContain('Would send')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+        $this->assertSame(0, DB::table('partnerships_reminders')->where('partnershipid', $id)->count());
+    }
+
+    public function test_a_shorter_window_can_be_chased_separately(): void
+    {
+        $id = $this->partnership(20);
+
+        // The three-month chase has already gone out.
+        DB::table('partnerships_reminders')->insert([
+            'partnershipid' => $id,
+            'type' => '3months',
+            'sent' => now(),
+        ]);
+
+        $this->artisan('partnerships:reminders', ['--days' => 30, '--type' => '1month'])->assertExitCode(0);
+
+        Mail::assertSent(SponsorshipExpiringMail::class);
+        $this->assertSame(1, DB::table('partnerships_reminders')
+            ->where('partnershipid', $id)->where('type', '1month')->count());
+    }
+
+    public function test_mail_reports_the_covered_community_count(): void
+    {
+        $id = $this->partnership(60);
+
+        $groupId = (int) DB::table('groups')->insertGetId([
+            'nameshort' => 'remindergrp' . uniqid(),
+            'type' => 'Freegle',
+            // groups.polyindex has no default, so a catchment has to be supplied.
+            'polyindex' => DB::raw("ST_GeomFromText('POLYGON((-0.5 10.5, 0.5 10.5, 0.5 11.5, -0.5 11.5, -0.5 10.5))', 3857)"),
+        ]);
+        DB::table('partnerships_groups')->insert([
+            'partnershipid' => $id,
+            'groupid' => $groupId,
+        ]);
+
+        $this->artisan('partnerships:reminders')->assertExitCode(0);
+
+        Mail::assertSent(SponsorshipExpiringMail::class, function ($mail) {
+            return $mail->groupCount === 1
+                && $mail->amount === 4800.0
+                && $mail->contactEmail === 'waste@example.gov.uk';
+        });
+    }
+
+    public function test_reminders_go_to_the_teams_own_address(): void
+    {
+        DB::table('teams')->where('name', 'Partnerships')->update(['email' => 'newpartnerships@ilovefreegle.org']);
+        $this->partnership(60);
+
+        $this->artisan('partnerships:reminders')->assertExitCode(0);
+
+        Mail::assertSent(SponsorshipExpiringMail::class, function ($mail) {
+            return $mail->recipientEmail === 'newpartnerships@ilovefreegle.org';
+        });
+    }
+}

--- a/iznik-batch/tests/Feature/Partnerships/StatsJobRunnerCommandTest.php
+++ b/iznik-batch/tests/Feature/Partnerships/StatsJobRunnerCommandTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature\Partnerships;
+
+use Illuminate\Support\Facades\DB;
+use Tests\Support\SeedsAuthorityStats;
+use Tests\TestCase;
+
+/**
+ * The Partnerships page cannot wait minutes for a council spreadsheet inside a web request,
+ * so it queues the work here. These tests cover the queue mechanics and that a real
+ * spreadsheet ends up in the database ready to download.
+ */
+class StatsJobRunnerCommandTest extends TestCase
+{
+    use SeedsAuthorityStats;
+
+    private function queueJob(string $authorityIds, string $quarter = '2025-05-15'): int
+    {
+        return (int) DB::table('partnerships_statsjobs')->insertGetId([
+            'authorityids' => $authorityIds,
+            'quarter' => $quarter,
+            'status' => 'Pending',
+            'requested' => now(),
+        ]);
+    }
+
+    public function test_no_queued_jobs_is_a_noop(): void
+    {
+        // Other tests share this database, so pin the "nothing to do" case by parking any
+        // jobs that happen to be queued rather than assuming the table is empty.
+        DB::table('partnerships_statsjobs')->where('status', 'Pending')->update(['status' => 'Ready']);
+
+        $this->artisan('partnerships:stats:run')
+            ->expectsOutputToContain('No queued statistics jobs')
+            ->assertExitCode(0);
+    }
+
+    public function test_renders_and_stores_a_spreadsheet(): void
+    {
+        $this->seedAuthorityScenario();
+        $jobId = $this->queueJob((string) $this->authorityId);
+
+        $this->artisan('partnerships:stats:run')->assertExitCode(0);
+
+        $job = DB::table('partnerships_statsjobs')->find($jobId);
+        $this->assertSame('Ready', $job->status, 'the job finishes ready to download');
+        $this->assertNotNull($job->completed);
+
+        $files = DB::table('partnerships_statsfiles')->where('jobid', $jobId)->get();
+        $this->assertCount(1, $files, 'one spreadsheet per authority');
+
+        $file = $files->first();
+        $this->assertSame($this->authorityId, (int) $file->authorityid);
+        $this->assertStringEndsWith('.xlsx', $file->filename);
+        $this->assertGreaterThan(0, $file->size);
+        // A real xlsx is a zip, so it starts with the zip magic bytes.
+        $this->assertSame('PK', substr($file->content, 0, 2), 'the stored bytes are a real spreadsheet');
+        $this->assertSame(strlen($file->content), (int) $file->size);
+    }
+
+    public function test_spreadsheet_is_named_after_the_authority(): void
+    {
+        $this->seedAuthorityScenario();
+        $jobId = $this->queueJob((string) $this->authorityId);
+
+        $this->artisan('partnerships:stats:run')->assertExitCode(0);
+
+        $filename = DB::table('partnerships_statsfiles')->where('jobid', $jobId)->value('filename');
+        $this->assertStringContainsString('Test Authority (B)', $filename);
+    }
+
+    public function test_unknown_authority_fails_the_job_with_a_reason(): void
+    {
+        $jobId = $this->queueJob('999999999');
+
+        $this->artisan('partnerships:stats:run')->assertExitCode(0);
+
+        $job = DB::table('partnerships_statsjobs')->find($jobId);
+        $this->assertSame('Failed', $job->status);
+        $this->assertNotEmpty($job->error, 'the page shows why it failed');
+        $this->assertSame(0, DB::table('partnerships_statsfiles')->where('jobid', $jobId)->count());
+    }
+
+    public function test_job_with_no_authority_ids_fails(): void
+    {
+        $jobId = $this->queueJob('');
+
+        $this->artisan('partnerships:stats:run')->assertExitCode(0);
+
+        $job = DB::table('partnerships_statsjobs')->find($jobId);
+        $this->assertSame('Failed', $job->status);
+        $this->assertStringContainsString('No authority IDs', $job->error);
+    }
+
+    public function test_a_claimed_job_is_not_run_again(): void
+    {
+        $this->seedAuthorityScenario();
+        $jobId = $this->queueJob((string) $this->authorityId);
+
+        $this->artisan('partnerships:stats:run')->assertExitCode(0);
+        $this->assertSame(1, DB::table('partnerships_statsfiles')->where('jobid', $jobId)->count());
+
+        // A second pass must not pick the finished job up again and double the files.
+        $this->artisan('partnerships:stats:run')->assertExitCode(0);
+        $this->assertSame(1, DB::table('partnerships_statsfiles')->where('jobid', $jobId)->count());
+    }
+
+    public function test_only_the_requested_number_of_jobs_runs_per_pass(): void
+    {
+        DB::table('partnerships_statsjobs')->where('status', 'Pending')->update(['status' => 'Ready']);
+
+        $first = $this->queueJob('999999999');
+        $second = $this->queueJob('999999998');
+
+        $this->artisan('partnerships:stats:run', ['--limit' => 1])->assertExitCode(0);
+
+        $this->assertSame('Failed', DB::table('partnerships_statsjobs')->find($first)->status);
+        $this->assertSame('Pending', DB::table('partnerships_statsjobs')->find($second)->status,
+            'the second job waits for the next pass');
+    }
+
+    public function test_partial_failure_still_delivers_what_worked(): void
+    {
+        $this->seedAuthorityScenario();
+        // One good council and one that does not exist.
+        $jobId = $this->queueJob($this->authorityId . ',999999999');
+
+        $this->artisan('partnerships:stats:run')->assertExitCode(0);
+
+        $job = DB::table('partnerships_statsjobs')->find($jobId);
+        $this->assertSame('Ready', $job->status, 'the spreadsheet that did render is still worth having');
+        $this->assertStringContainsString('999999999', (string) $job->error, 'the failure is recorded alongside it');
+        $this->assertSame(1, DB::table('partnerships_statsfiles')->where('jobid', $jobId)->count());
+    }
+}

--- a/iznik-nuxt3/api/AuthorityAPI.js
+++ b/iznik-nuxt3/api/AuthorityAPI.js
@@ -8,4 +8,8 @@ export default class AuthorityAPI extends BaseAPI {
   async fetchMessages(id) {
     return await this.$getv2('/authority/' + id + '/message')
   }
+
+  async search(search, limit = 20) {
+    return await this.$getv2('/authority', { search, limit })
+  }
 }

--- a/iznik-nuxt3/api/PartnershipsAPI.js
+++ b/iznik-nuxt3/api/PartnershipsAPI.js
@@ -1,0 +1,77 @@
+import BaseAPI from '@/api/BaseAPI'
+
+/**
+ * The council sponsorship deals behind the ModTools Partnerships page: the deals themselves,
+ * the groups each one covers, the money, and the queued generation of authority statistics
+ * spreadsheets.
+ */
+export default class PartnershipsAPI extends BaseAPI {
+  async list() {
+    const { partnerships } = await this.$getv2('/partnership')
+    return partnerships
+  }
+
+  async fetch(id) {
+    return await this.$getv2('/partnership/' + id)
+  }
+
+  async summary() {
+    const { summary } = await this.$getv2('/partnership/summary')
+    return summary
+  }
+
+  async add(params) {
+    const { id } = await this.$postv2('/partnership', params)
+    return id
+  }
+
+  async edit(id, params) {
+    await this.$patchv2('/partnership/' + id, params)
+  }
+
+  async remove(id) {
+    await this.$delv2('/partnership/' + id)
+  }
+
+  async fetchGroups(id) {
+    return await this.$getv2('/partnership/' + id + '/group')
+  }
+
+  async patchGroups(id, params) {
+    return await this.$patchv2('/partnership/' + id + '/group', params)
+  }
+
+  async setYears(id, years) {
+    await this.$putv2('/partnership/' + id + '/year', { years })
+  }
+
+  async addPayment(id, params) {
+    const { id: paymentid } = await this.$postv2(
+      '/partnership/' + id + '/payment',
+      params
+    )
+    return paymentid
+  }
+
+  async editPayment(id, paymentid, params) {
+    await this.$patchv2('/partnership/' + id + '/payment/' + paymentid, params)
+  }
+
+  async removePayment(id, paymentid) {
+    await this.$delv2('/partnership/' + id + '/payment/' + paymentid)
+  }
+
+  async listStatsJobs() {
+    const { jobs } = await this.$getv2('/partnership/statsjob')
+    return jobs
+  }
+
+  async addStatsJob(params) {
+    const { id } = await this.$postv2('/partnership/statsjob', params)
+    return id
+  }
+
+  async removeStatsJob(id) {
+    await this.$delv2('/partnership/statsjob/' + id)
+  }
+}

--- a/iznik-nuxt3/api/index.js
+++ b/iznik-nuxt3/api/index.js
@@ -8,9 +8,9 @@
  *    --- DO NOT EDIT ---
  */
 
+import AIImagesAPI from './AIImagesAPI.js'
 import AddressAPI from './AddressAPI.js'
 import AdminsAPI from './AdminsAPI.js'
-import AIImagesAPI from './AIImagesAPI.js'
 import AlertAPI from './AlertAPI.js'
 import AuthorityAPI from './AuthorityAPI.js'
 import BanditAPI from './BanditAPI.js'
@@ -25,6 +25,7 @@ import DomainAPI from './DomainAPI.js'
 import DonationsAPI from './DonationsAPI.js'
 import EmailTrackingAPI from './EmailTrackingAPI.js'
 import ExportAPI from './ExportAPI.js'
+import FirstReplyAPI from './FirstReplyAPI.js'
 import GiftAidAPI from './GiftAidAPI.js'
 import GroupAPI from './GroupAPI.js'
 import HousekeeperAPI from './HousekeeperAPI.js'
@@ -41,10 +42,9 @@ import ModConfigsAPI from './ModConfigsAPI.js'
 import NewsAPI from './NewsAPI.js'
 import NoticeboardAPI from './NoticeboardAPI.js'
 import NotificationAPI from './NotificationAPI.js'
+import PartnershipsAPI from './PartnershipsAPI.js'
 import RecommendationsAPI from './RecommendationsAPI.js'
 import RipplingAPI from './RipplingAPI.js'
-import FirstReplyAPI from '@/api/FirstReplyAPI'
-import TownAPI from './TownAPI.js'
 import SessionAPI from './SessionAPI.js'
 import ShortlinksAPI from './ShortlinksAPI.js'
 import SpammersAPI from './SpammersAPI.js'
@@ -52,6 +52,7 @@ import StatusAPI from './StatusAPI.js'
 import StoriesAPI from './StoriesAPI.js'
 import SystemLogsAPI from './SystemLogsAPI.js'
 import TeamAPI from './TeamAPI.js'
+import TownAPI from './TownAPI.js'
 import TrystAPI from './TrystAPI.js'
 import UserAPI from './UserAPI.js'
 import UserSearchAPI from './UserSearchAPI.js'
@@ -61,9 +62,9 @@ import VolunteeringAPI from './VolunteeringAPI.js'
 export default (config) => {
   const options = config
   return {
+    aiimages: new AIImagesAPI(options),
     address: new AddressAPI(options),
     admins: new AdminsAPI(options),
-    aiimages: new AIImagesAPI(options),
     alert: new AlertAPI(options),
     authority: new AuthorityAPI(options),
     bandit: new BanditAPI(options),
@@ -78,6 +79,7 @@ export default (config) => {
     donations: new DonationsAPI(options),
     emailtracking: new EmailTrackingAPI(options),
     export: new ExportAPI(options),
+    firstreply: new FirstReplyAPI(options),
     giftaid: new GiftAidAPI(options),
     group: new GroupAPI(options),
     housekeeper: new HousekeeperAPI(options),
@@ -94,10 +96,9 @@ export default (config) => {
     news: new NewsAPI(options),
     noticeboard: new NoticeboardAPI(options),
     notification: new NotificationAPI(options),
+    partnerships: new PartnershipsAPI(options),
     recommendations: new RecommendationsAPI(options),
     rippling: new RipplingAPI(options),
-    firstreply: new FirstReplyAPI(options),
-    town: new TownAPI(options),
     session: new SessionAPI(options),
     shortlinks: new ShortlinksAPI(options),
     spammers: new SpammersAPI(options),
@@ -105,6 +106,7 @@ export default (config) => {
     stories: new StoriesAPI(options),
     systemlogs: new SystemLogsAPI(options),
     team: new TeamAPI(options),
+    town: new TownAPI(options),
     tryst: new TrystAPI(options),
     user: new UserAPI(options),
     usersearch: new UserSearchAPI(options),

--- a/iznik-nuxt3/modtools/app.vue
+++ b/iznik-nuxt3/modtools/app.vue
@@ -77,6 +77,7 @@ import { computed } from '#imports'
 import { useModGroupStore } from '~/stores/modgroup'
 import { useSystemConfigStore } from '~/stores/systemconfig'
 import { useEmailTrackingStore } from '~/modtools/stores/emailtracking'
+import { usePartnershipsStore } from '~/modtools/stores/partnerships'
 
 // We're having trouble accessing the Nuxt config from within a Pinia store.  So instead we access it here, then
 // pass it in to each store via an init() action.
@@ -133,6 +134,7 @@ const spammerStore = useSpammerStore()
 const stdmsgStore = useStdmsgStore()
 const systemConfigStore = useSystemConfigStore()
 const emailTrackingStore = useEmailTrackingStore()
+const partnershipsStore = usePartnershipsStore()
 
 miscStore.init(runtimeConfig)
 groupStore.init(runtimeConfig)
@@ -175,6 +177,7 @@ spammerStore.init(runtimeConfig)
 stdmsgStore.init(runtimeConfig)
 systemConfigStore.init(runtimeConfig)
 emailTrackingStore.init(runtimeConfig)
+partnershipsStore.init(runtimeConfig)
 
 miscStore.modtools = true
 mobileStore.init(runtimeConfig)

--- a/iznik-nuxt3/modtools/components/ModPartnershipDetail.vue
+++ b/iznik-nuxt3/modtools/components/ModPartnershipDetail.vue
@@ -1,0 +1,305 @@
+<template>
+  <div v-if="detail" class="border-start ps-3 mt-2">
+    <b-row>
+      <b-col cols="12" lg="6">
+        <h5>Communities covered</h5>
+        <p class="text-muted small">
+          Worked out from the council boundary. Each one gets a sponsor entry
+          showing the tagline and link above.
+        </p>
+        <NoticeMessage v-if="!detail.groups.length" variant="warning">
+          No communities are covered, so nothing is showing to members.
+        </NoticeMessage>
+        <ul v-else class="list-unstyled mb-2">
+          <li
+            v-for="g in detail.groups"
+            :key="'pg-' + g.groupid"
+            class="d-flex align-items-center justify-content-between"
+          >
+            <span>{{ g.namedisplay }}</span>
+            <b-button
+              variant="link"
+              size="sm"
+              class="text-danger"
+              @click="removeGroup(g.groupid)"
+            >
+              Remove
+            </b-button>
+          </li>
+        </ul>
+
+        <SpinButton
+          variant="secondary"
+          icon-name="sync"
+          label="Re-check the boundary"
+          size="sm"
+          @handle="redetect"
+        />
+
+        <div v-if="missing.length" class="mt-2">
+          <p class="small mb-1">
+            Inside the boundary but not covered by this deal:
+          </p>
+          <b-button
+            v-for="g in missing"
+            :key="'avail-' + g.groupid"
+            variant="white"
+            size="sm"
+            class="me-1 mb-1"
+            @click="addGroup(g.groupid)"
+          >
+            + {{ g.namedisplay }}
+          </b-button>
+        </div>
+      </b-col>
+
+      <b-col cols="12" lg="6">
+        <h5>Financial years</h5>
+        <p class="text-muted small">
+          {{
+            hasExplicitYears
+              ? 'Split as agreed with the council.'
+              : 'Spread evenly across the term. Override it below if the council pays in uneven instalments.'
+          }}
+        </p>
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Year</th>
+              <th class="text-end">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="y in years" :key="'fy-' + y.financialyear">
+              <td>{{ y.label }}</td>
+              <td class="text-end">
+                <b-form-input
+                  v-model="y.amount"
+                  type="number"
+                  size="sm"
+                  class="text-end"
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="d-flex align-items-center gap-2">
+          <SpinButton
+            variant="primary"
+            icon-name="save"
+            label="Save split"
+            size="sm"
+            spinclass="text-white"
+            @handle="saveYears"
+          />
+          <SpinButton
+            v-if="hasExplicitYears"
+            variant="white"
+            icon-name="undo"
+            label="Spread evenly"
+            size="sm"
+            @handle="clearYears"
+          />
+        </div>
+        <p v-if="yearsTotal !== null" class="small mt-1 mb-0">
+          Split totals £{{ formatMoney(yearsTotal) }} against a deal value of
+          £{{ formatMoney(detail.partnership.amount) }}.
+          <span v-if="Math.abs(yearsTotal - detail.partnership.amount) > 0.01">
+            <strong class="text-danger">These don't match.</strong>
+          </span>
+        </p>
+      </b-col>
+    </b-row>
+
+    <h5 class="mt-3">Invoices</h5>
+    <table class="table table-sm">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th class="text-end">Amount</th>
+          <th>Reference</th>
+          <th>Paid</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="p in detail.payments" :key="'pay-' + p.id">
+          <td>{{ p.date }}</td>
+          <td class="text-end">£{{ formatMoney(p.amount) }}</td>
+          <td>{{ p.reference }}</td>
+          <td>
+            <span v-if="p.paid" class="text-success">{{ p.paid }}</span>
+            <b-button
+              v-else
+              variant="link"
+              size="sm"
+              class="p-0"
+              @click="markPaid(p)"
+            >
+              Mark paid today
+            </b-button>
+          </td>
+          <td class="text-end">
+            <b-button
+              variant="link"
+              size="sm"
+              class="text-danger p-0"
+              @click="removePayment(p)"
+            >
+              Delete
+            </b-button>
+          </td>
+        </tr>
+        <tr v-if="!detail.payments.length">
+          <td colspan="5" class="text-muted">Nothing invoiced yet.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <b-row class="align-items-end g-2">
+      <b-col cols="6" md="3">
+        <label class="small mb-0">Invoice date</label>
+        <b-form-input v-model="newPayment.date" type="date" size="sm" />
+      </b-col>
+      <b-col cols="6" md="2">
+        <label class="small mb-0">Amount (£)</label>
+        <b-form-input v-model="newPayment.amount" type="number" size="sm" />
+      </b-col>
+      <b-col cols="6" md="3">
+        <label class="small mb-0">Reference</label>
+        <b-form-input v-model="newPayment.reference" size="sm" />
+      </b-col>
+      <b-col cols="6" md="2">
+        <label class="small mb-0">Paid on</label>
+        <b-form-input v-model="newPayment.paid" type="date" size="sm" />
+      </b-col>
+      <b-col cols="12" md="2">
+        <SpinButton
+          variant="primary"
+          icon-name="plus"
+          label="Add"
+          size="sm"
+          spinclass="text-white"
+          :disabled="!newPayment.date"
+          @handle="addPayment"
+        />
+      </b-col>
+    </b-row>
+  </div>
+</template>
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { usePartnershipsStore } from '~/stores/partnerships'
+
+const props = defineProps({
+  id: {
+    type: Number,
+    required: true,
+  },
+})
+
+const partnershipsStore = usePartnershipsStore()
+
+const available = ref([])
+const years = ref([])
+const hasExplicitYears = ref(false)
+const newPayment = ref({ date: '', amount: null, reference: '', paid: '' })
+
+const detail = computed(() => partnershipsStore.byId(props.id))
+
+// Groups inside the council boundary that this deal doesn't currently cover - usually
+// because someone removed them by hand, occasionally because the boundary has moved.
+const missing = computed(() => {
+  if (!detail.value) {
+    return []
+  }
+
+  const covered = new Set(detail.value.groups.map((g) => g.groupid))
+  return available.value.filter((g) => !covered.has(g.groupid))
+})
+
+const yearsTotal = computed(() => {
+  if (!years.value.length) {
+    return null
+  }
+
+  return years.value.reduce((t, y) => t + (parseFloat(y.amount) || 0), 0)
+})
+
+function formatMoney(v) {
+  return (parseFloat(v) || 0).toLocaleString('en-GB', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+async function load() {
+  const ret = await partnershipsStore.fetchOne(props.id)
+  syncYears(ret)
+
+  const groups = await partnershipsStore.fetchGroups(props.id)
+  available.value = groups.available
+}
+
+// The API returns the pro-rata split when no year-by-year split has been agreed, and says
+// which of the two it gave us.
+function syncYears(ret) {
+  years.value = (ret?.years || []).map((y) => ({ ...y }))
+  hasExplicitYears.value = Boolean(ret?.explicityears)
+}
+
+watch(() => props.id, load, { immediate: true })
+
+async function addGroup(groupid) {
+  await partnershipsStore.addGroup(props.id, groupid)
+}
+
+async function removeGroup(groupid) {
+  await partnershipsStore.removeGroup(props.id, groupid)
+}
+
+async function redetect(callback) {
+  await partnershipsStore.redetectGroups(props.id)
+  callback?.()
+}
+
+async function saveYears(callback) {
+  await partnershipsStore.setYears(
+    props.id,
+    years.value.map((y) => ({
+      financialyear: y.financialyear,
+      amount: parseFloat(y.amount) || 0,
+    }))
+  )
+  hasExplicitYears.value = true
+  callback?.()
+}
+
+async function clearYears(callback) {
+  await partnershipsStore.setYears(props.id, [])
+  hasExplicitYears.value = false
+  syncYears(partnershipsStore.byId(props.id))
+  callback?.()
+}
+
+async function addPayment(callback) {
+  await partnershipsStore.addPayment(props.id, {
+    date: newPayment.value.date,
+    amount: parseFloat(newPayment.value.amount) || 0,
+    reference: newPayment.value.reference,
+    paid: newPayment.value.paid,
+  })
+  newPayment.value = { date: '', amount: null, reference: '', paid: '' }
+  callback?.()
+}
+
+async function markPaid(payment) {
+  await partnershipsStore.editPayment(props.id, payment.id, {
+    paid: new Date().toISOString().substring(0, 10),
+  })
+}
+
+async function removePayment(payment) {
+  await partnershipsStore.removePayment(props.id, payment.id)
+}
+</script>

--- a/iznik-nuxt3/modtools/components/ModPartnershipEditModal.vue
+++ b/iznik-nuxt3/modtools/components/ModPartnershipEditModal.vue
@@ -1,0 +1,279 @@
+<template>
+  <div>
+    <b-modal ref="modal" size="lg" no-stacking @hidden="onHide">
+      <template #title>
+        {{ partnership ? 'Edit partnership' : 'New partnership' }}
+      </template>
+      <template #default>
+        <NoticeMessage v-if="error" variant="danger" class="mb-2">
+          {{ error }}
+        </NoticeMessage>
+
+        <b-form-group v-if="!partnership" label="Council">
+          <b-input-group>
+            <b-form-input
+              v-model="authoritySearch"
+              placeholder="Search for a council, e.g. Northshire"
+              @keyup.enter="searchAuthorities"
+            />
+            <SpinButton
+              variant="secondary"
+              icon-name="search"
+              label="Search"
+              @handle="searchAuthorities"
+            />
+          </b-input-group>
+          <div v-if="authorityResults.length" class="mt-1">
+            <b-button
+              v-for="a in authorityResults"
+              :key="'authority-' + a.id"
+              :variant="form.authorityid === a.id ? 'primary' : 'white'"
+              class="me-1 mb-1"
+              @click="pickAuthority(a)"
+            >
+              {{ a.name }}
+              <span v-if="a.area_code" class="small text-muted">
+                ({{ a.area_code }})
+              </span>
+            </b-button>
+          </div>
+          <p v-else-if="searched" class="text-muted small mt-1">
+            No councils matched that.
+          </p>
+        </b-form-group>
+
+        <b-form-group
+          label="Name shown to members"
+          description="Defaults to the council's own name."
+        >
+          <b-form-input
+            v-model="form.name"
+            placeholder="e.g. Northshire Council"
+          />
+        </b-form-group>
+
+        <b-row>
+          <b-col cols="12" md="6">
+            <b-form-group label="Starts">
+              <b-form-input v-model="form.startdate" type="date" />
+            </b-form-group>
+          </b-col>
+          <b-col cols="12" md="6">
+            <b-form-group label="Ends">
+              <b-form-input v-model="form.enddate" type="date" />
+            </b-form-group>
+          </b-col>
+        </b-row>
+
+        <b-row>
+          <b-col cols="12" md="6">
+            <b-form-group
+              label="Value of the whole deal (£)"
+              description="For a multi-year deal, the total across all the years."
+            >
+              <b-form-input v-model="form.amount" type="number" min="0" />
+            </b-form-group>
+          </b-col>
+          <b-col cols="12" md="6">
+            <b-form-group label="Agreed on">
+              <b-form-input v-model="form.agreeddate" type="date" />
+            </b-form-group>
+          </b-col>
+        </b-row>
+
+        <OurToggle
+          :value="form.agreed"
+          class="mb-2"
+          :height="30"
+          :width="250"
+          :font-size="14"
+          :sync="true"
+          :labels="{ checked: 'Agreed', unchecked: 'Not agreed yet' }"
+          variant="modgreen"
+          @change="form.agreed = !form.agreed"
+        />
+
+        <OurToggle
+          :value="form.visible"
+          class="mb-3"
+          :height="30"
+          :width="250"
+          :font-size="14"
+          :sync="true"
+          :labels="{
+            checked: 'Show to members',
+            unchecked: 'Hide from members',
+          }"
+          variant="modgreen"
+          @change="form.visible = !form.visible"
+        />
+
+        <NoticeMessage v-if="!form.agreed" variant="info" class="mb-3">
+          Until the deal is marked as agreed, members won't see the council on
+          any of the communities it covers.
+        </NoticeMessage>
+
+        <b-form-group
+          label="Tagline"
+          description="The short line members see beside the council's name."
+        >
+          <b-form-input
+            v-model="form.tagline"
+            placeholder="e.g. Reuse and recycling in your area"
+          />
+        </b-form-group>
+
+        <b-form-group label="Description">
+          <b-form-textarea v-model="form.description" rows="3" />
+        </b-form-group>
+
+        <b-form-group label="Link">
+          <b-form-input
+            v-model="form.linkurl"
+            placeholder="https://www.example.gov.uk/recycling"
+          />
+        </b-form-group>
+
+        <b-form-group label="Logo image URL">
+          <b-form-input v-model="form.imageurl" />
+        </b-form-group>
+
+        <b-row>
+          <b-col cols="12" md="6">
+            <b-form-group label="Council contact name">
+              <b-form-input v-model="form.contactname" />
+            </b-form-group>
+          </b-col>
+          <b-col cols="12" md="6">
+            <b-form-group label="Council contact email">
+              <b-form-input v-model="form.contactemail" type="email" />
+            </b-form-group>
+          </b-col>
+        </b-row>
+
+        <b-form-group label="Notes">
+          <b-form-textarea v-model="form.notes" rows="3" />
+        </b-form-group>
+      </template>
+      <template #footer>
+        <b-button variant="white" @click="hide">Cancel</b-button>
+        <SpinButton
+          variant="primary"
+          icon-name="save"
+          label="Save"
+          spinclass="text-white"
+          @handle="save"
+        />
+      </template>
+    </b-modal>
+  </div>
+</template>
+<script setup>
+import { ref } from 'vue'
+import { useOurModal } from '~/composables/useOurModal'
+import { usePartnershipsStore } from '~/stores/partnerships'
+import api from '~/api'
+
+const props = defineProps({
+  partnership: {
+    type: Object,
+    required: false,
+    default: null,
+  },
+})
+
+const emit = defineEmits(['hidden', 'saved'])
+
+const { modal, hide } = useOurModal()
+const partnershipsStore = usePartnershipsStore()
+const runtimeConfig = useRuntimeConfig()
+
+const error = ref(null)
+const authoritySearch = ref('')
+const authorityResults = ref([])
+const searched = ref(false)
+
+const form = ref({
+  authorityid: props.partnership?.authorityid ?? null,
+  name: props.partnership?.name ?? '',
+  startdate: props.partnership?.startdate ?? '',
+  enddate: props.partnership?.enddate ?? '',
+  amount: props.partnership?.amount ?? 0,
+  agreed: props.partnership?.agreed ?? false,
+  agreeddate: props.partnership?.agreeddate ?? '',
+  visible: props.partnership?.visible ?? true,
+  tagline: props.partnership?.tagline ?? '',
+  description: props.partnership?.description ?? '',
+  linkurl: props.partnership?.linkurl ?? '',
+  imageurl: props.partnership?.imageurl ?? '',
+  contactname: props.partnership?.contactname ?? '',
+  contactemail: props.partnership?.contactemail ?? '',
+  notes: props.partnership?.notes ?? '',
+})
+
+async function searchAuthorities(callback) {
+  searched.value = true
+
+  if (authoritySearch.value) {
+    authorityResults.value = await api(runtimeConfig).authority.search(
+      authoritySearch.value
+    )
+  }
+
+  if (callback) {
+    callback()
+  }
+}
+
+function pickAuthority(a) {
+  form.value.authorityid = a.id
+
+  // A new deal is normally branded with the council's own name.
+  if (!form.value.name) {
+    form.value.name = a.name
+  }
+}
+
+function onHide() {
+  emit('hidden')
+}
+
+async function save(callback) {
+  error.value = null
+
+  if (!props.partnership && !form.value.authorityid) {
+    error.value = 'Please choose a council.'
+    callback?.()
+    return
+  }
+
+  if (!form.value.startdate || !form.value.enddate) {
+    error.value = 'Please give both a start and an end date.'
+    callback?.()
+    return
+  }
+
+  if (form.value.enddate < form.value.startdate) {
+    error.value = "The end date can't be before the start date."
+    callback?.()
+    return
+  }
+
+  const params = { ...form.value, amount: parseFloat(form.value.amount) || 0 }
+
+  try {
+    if (props.partnership) {
+      await partnershipsStore.edit(props.partnership.id, params)
+    } else {
+      await partnershipsStore.add(params)
+    }
+
+    emit('saved')
+    hide()
+  } catch (e) {
+    error.value = e.message || 'Could not save that.'
+  }
+
+  callback?.()
+}
+</script>

--- a/iznik-nuxt3/modtools/components/ModPartnershipStats.vue
+++ b/iznik-nuxt3/modtools/components/ModPartnershipStats.vue
@@ -31,6 +31,10 @@
       </b-col>
     </b-row>
 
+    <NoticeMessage v-if="downloadError" variant="danger" class="mb-2">
+      {{ downloadError }}
+    </NoticeMessage>
+
     <NoticeMessage v-if="!councilOptions.length" variant="info">
       Add a partnership first - the councils you have deals with are the ones
       you can generate statistics for here.
@@ -111,6 +115,7 @@ const runtimeConfig = useRuntimeConfig()
 const selected = ref([])
 const quarter = ref('3 months ago')
 const timer = ref(null)
+const downloadError = ref(null)
 
 const jobs = computed(() => partnershipsStore.statsJobs)
 
@@ -188,6 +193,14 @@ async function download(file) {
     { headers }
   )
 
+  if (!response.ok) {
+    // Without this an error response saves as a .xlsx that Excel then refuses to open,
+    // which looks like a broken spreadsheet rather than a failed download.
+    downloadError.value = `Could not download ${file.filename} (${response.status}).`
+    return
+  }
+
+  downloadError.value = null
   const url = URL.createObjectURL(await response.blob())
 
   try {

--- a/iznik-nuxt3/modtools/components/ModPartnershipStats.vue
+++ b/iznik-nuxt3/modtools/components/ModPartnershipStats.vue
@@ -1,0 +1,239 @@
+<template>
+  <div>
+    <h3>Council statistics</h3>
+    <p class="text-muted">
+      The quarterly spreadsheet councils receive. It takes a few minutes to
+      build, so ask for it here and come back for the download - you don't have
+      to keep this page open.
+    </p>
+
+    <b-row class="align-items-end g-2 mb-2">
+      <b-col cols="12" md="5">
+        <label class="small mb-0">Councils</label>
+        <b-form-select v-model="selected" :options="councilOptions" multiple />
+        <p class="small text-muted mb-0">
+          Hold Ctrl (or Cmd) to pick more than one.
+        </p>
+      </b-col>
+      <b-col cols="12" md="4">
+        <label class="small mb-0">Quarter</label>
+        <b-form-select v-model="quarter" :options="quarterOptions" />
+      </b-col>
+      <b-col cols="12" md="3">
+        <SpinButton
+          variant="primary"
+          icon-name="file-excel"
+          label="Generate"
+          spinclass="text-white"
+          :disabled="!selected.length"
+          @handle="generate"
+        />
+      </b-col>
+    </b-row>
+
+    <NoticeMessage v-if="!councilOptions.length" variant="info">
+      Add a partnership first - the councils you have deals with are the ones
+      you can generate statistics for here.
+    </NoticeMessage>
+
+    <table v-if="jobs.length" class="table table-sm">
+      <thead>
+        <tr>
+          <th>Requested</th>
+          <th>Councils</th>
+          <th>Quarter</th>
+          <th>Status</th>
+          <th>Spreadsheets</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="job in jobs" :key="'job-' + job.id">
+          <td>{{ job.requested }}</td>
+          <td>{{ councilNames(job.authorityids) }}</td>
+          <td>{{ job.quarter }}</td>
+          <td>
+            <b-badge :variant="statusVariant(job.status)">
+              {{ job.status }}
+            </b-badge>
+            <div v-if="job.error" class="small text-danger">
+              {{ job.error }}
+            </div>
+          </td>
+          <td>
+            <div v-for="file in job.files" :key="'file-' + file.id">
+              <b-button variant="link" size="sm" @click="download(file)">
+                {{ file.filename }}
+              </b-button>
+              <span class="text-muted small">
+                ({{ Math.round(file.size / 1024) }}KB)
+              </span>
+            </div>
+            <span
+              v-if="!job.files.length && job.status !== 'Failed'"
+              class="text-muted small"
+            >
+              Building...
+            </span>
+          </td>
+          <td class="text-end">
+            <b-button
+              variant="link"
+              size="sm"
+              class="text-danger p-0"
+              @click="remove(job)"
+            >
+              Delete
+            </b-button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRuntimeConfig } from '#imports'
+import { usePartnershipsStore } from '~/stores/partnerships'
+import { useAuthStore } from '~/stores/auth'
+
+const props = defineProps({
+  // The councils we have deals with: [{ authorityid, authorityname }, ...].
+  partnerships: {
+    type: Array,
+    required: true,
+  },
+})
+
+const partnershipsStore = usePartnershipsStore()
+const runtimeConfig = useRuntimeConfig()
+
+const selected = ref([])
+const quarter = ref('3 months ago')
+const timer = ref(null)
+
+const jobs = computed(() => partnershipsStore.statsJobs)
+
+// One entry per council, however many deals we have had with it.
+const councilOptions = computed(() => {
+  const seen = new Map()
+
+  props.partnerships.forEach((p) => {
+    if (!seen.has(p.authorityid)) {
+      seen.set(p.authorityid, { value: p.authorityid, text: p.authorityname })
+    }
+  })
+
+  return [...seen.values()].sort((a, b) => a.text.localeCompare(b.text))
+})
+
+// The last four completed quarters, plus the command's own default.
+const quarterOptions = computed(() => {
+  const options = [{ value: '3 months ago', text: 'Last full quarter' }]
+  const now = new Date()
+
+  for (let i = 1; i <= 4; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i * 3, 1)
+    const q = Math.floor(d.getMonth() / 3) + 1
+    const start = new Date(d.getFullYear(), (q - 1) * 3, 1)
+    options.push({
+      value: start.toISOString().substring(0, 10),
+      text: `${d.getFullYear()} Q${q}`,
+    })
+  }
+
+  return options
+})
+
+function statusVariant(status) {
+  if (status === 'Ready') {
+    return 'success'
+  }
+
+  if (status === 'Failed') {
+    return 'danger'
+  }
+
+  return 'info'
+}
+
+function councilNames(ids) {
+  return String(ids)
+    .split(',')
+    .map((id) => {
+      const match = councilOptions.value.find(
+        (o) => String(o.value) === id.trim()
+      )
+      return match ? match.text : id
+    })
+    .join(', ')
+}
+
+// Fetched rather than linked, so the spreadsheet is authenticated by the usual headers
+// instead of putting a token in the URL (and therefore in browser history).
+async function download(file) {
+  const authStore = useAuthStore()
+  const headers = {}
+
+  if (authStore?.auth?.jwt) {
+    headers.Authorization = JSON.stringify(authStore.auth.jwt)
+  }
+
+  if (authStore?.auth?.persistent) {
+    headers.Authorization2 = JSON.stringify(authStore.auth.persistent)
+  }
+
+  const response = await fetch(
+    runtimeConfig.public.APIv2 + '/partnership/statsfile/' + file.id,
+    { headers }
+  )
+
+  const url = URL.createObjectURL(await response.blob())
+
+  try {
+    const link = document.createElement('a')
+    link.href = url
+    link.download = file.filename
+    link.click()
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+async function generate(callback) {
+  await partnershipsStore.addStatsJob({
+    authorityids: selected.value,
+    quarter: quarter.value,
+  })
+
+  // The job we just queued is Pending, so start the poll back up if it had stopped.
+  if (!timer.value) {
+    poll()
+  }
+
+  callback?.()
+}
+
+async function remove(job) {
+  await partnershipsStore.removeStatsJob(job.id)
+}
+
+// Poll while anything is building. Generation takes minutes, so a slow tick is plenty and
+// keeps this off the API's back when the page is left open.
+async function poll() {
+  timer.value = null
+  await partnershipsStore.fetchStatsJobs()
+
+  if (partnershipsStore.statsRunning) {
+    timer.value = setTimeout(poll, 10000)
+  }
+}
+
+onMounted(poll)
+
+onBeforeUnmount(() => {
+  if (timer.value) {
+    clearTimeout(timer.value)
+  }
+})
+</script>

--- a/iznik-nuxt3/modtools/components/ModPartnershipTotal.vue
+++ b/iznik-nuxt3/modtools/components/ModPartnershipTotal.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="totalbox rounded p-2" :class="variantClass">
+    <div class="small text-muted">{{ label }}</div>
+    <div class="fs-4 fw-bold"><span v-if="money">£</span>{{ formatted }}</div>
+  </div>
+</template>
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  label: {
+    type: String,
+    required: true,
+  },
+  value: {
+    type: Number,
+    required: true,
+  },
+  // Money is rounded to whole pounds - pence are noise at this scale.
+  money: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  variant: {
+    type: String,
+    required: false,
+    default: null,
+  },
+})
+
+const formatted = computed(() =>
+  (props.value || 0).toLocaleString('en-GB', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+)
+
+const variantClass = computed(() =>
+  props.variant ? 'border-' + props.variant : 'border-secondary'
+)
+</script>
+<style scoped lang="scss">
+.totalbox {
+  border: 1px solid;
+  min-width: 8rem;
+}
+</style>

--- a/iznik-nuxt3/modtools/composables/useModMe.js
+++ b/iznik-nuxt3/modtools/composables/useModMe.js
@@ -42,6 +42,19 @@ export function useModMe() {
   const hasPermissionClearance = computed(() => {
     return hasPermission('Clearance')
   })
+  // Some pages are gated on team membership rather than a permission flag. Support and
+  // Admin get in regardless, matching what the API allows.
+  function onTeam(name) {
+    const { me, supportOrAdmin } = useMe()
+    if (supportOrAdmin.value) {
+      return true
+    }
+    const teams = me.value ? me.value.teams : null
+    return Boolean(teams && teams.includes(name))
+  }
+  const onPartnershipsTeam = computed(() => {
+    return onTeam('Partnerships')
+  })
   // Needed for some modtoolstasks but /mixins/me.js/myGroups() OK for most mod tasks as it is a copy of modgroup.list
   const myModGroups = computed(() => {
     // But do we need to do other stuff in myGroups() eg sorting?
@@ -150,6 +163,8 @@ export function useModMe() {
     hasPermissionSpamAdmin,
     hasPermissionGiftAid,
     hasPermissionClearance,
+    onTeam,
+    onPartnershipsTeam,
     myModGroups,
     myModGroup,
     amAModOn,

--- a/iznik-nuxt3/modtools/layouts/default.vue
+++ b/iznik-nuxt3/modtools/layouts/default.vue
@@ -266,6 +266,12 @@
           name="Teams"
           @mobilehidemenu="mobilehidemenu"
         />
+        <ModMenuItemLeft
+          v-if="onPartnershipsTeam"
+          link="/partnerships"
+          name="Partnerships"
+          @mobilehidemenu="mobilehidemenu"
+        />
         <div>
           <ExternalLink
             href="https://wiki.ilovefreegle.org/ModTools"
@@ -338,6 +344,7 @@ const {
   hasPermissionSpamAdmin,
   hasPermissionGiftAid,
   hasPermissionClearance,
+  onPartnershipsTeam,
   checkWork,
   resetCheckWork,
 } = useModMe()

--- a/iznik-nuxt3/modtools/pages/partnerships.vue
+++ b/iznik-nuxt3/modtools/pages/partnerships.vue
@@ -175,6 +175,7 @@
 </template>
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { GChart } from 'vue-google-charts'
 import { useRoute, useRuntimeConfig, useHead } from '#imports'
 import { usePartnershipsStore } from '~/stores/partnerships'
 import { useMe } from '~/composables/useMe'

--- a/iznik-nuxt3/modtools/pages/partnerships.vue
+++ b/iznik-nuxt3/modtools/pages/partnerships.vue
@@ -1,0 +1,281 @@
+<template>
+  <div class="bg-white ps-2 pe-2 pb-4">
+    <client-only>
+      <h1>Partnerships</h1>
+      <p>
+        Sponsorship deals with local authorities. Each one covers the Freegle
+        communities inside the council's boundary, and shows the council's
+        tagline and link to members there.
+      </p>
+
+      <NoticeMessage v-if="!canUse" variant="warning">
+        You need to be on the Partnerships team to use this page.
+      </NoticeMessage>
+
+      <template v-else>
+        <div v-if="summary" class="d-flex flex-wrap gap-3 mb-3">
+          <ModPartnershipTotal
+            label="Agreed income"
+            :value="summary.agreed"
+            money
+          />
+          <ModPartnershipTotal
+            label="In discussion"
+            :value="summary.total - summary.agreed"
+            money
+          />
+          <ModPartnershipTotal
+            label="Invoiced"
+            :value="summary.invoiced"
+            money
+          />
+          <ModPartnershipTotal label="Paid" :value="summary.paid" money />
+          <ModPartnershipTotal
+            label="Outstanding"
+            :value="summary.outstanding"
+            money
+            :variant="summary.outstanding > 0 ? 'warning' : null"
+          />
+          <ModPartnershipTotal label="Live deals" :value="summary.active" />
+        </div>
+
+        <NoticeMessage v-if="expiring.length" variant="warning" class="mb-3">
+          <strong>
+            {{ expiring.length }}
+            {{
+              expiring.length === 1 ? 'sponsorship runs' : 'sponsorships run'
+            }}
+            out within three months:
+          </strong>
+          {{ expiring.map((p) => p.name + ' (' + p.enddate + ')').join(', ') }}.
+          The Partnerships team gets an email about each one too.
+        </NoticeMessage>
+
+        <div v-if="chartData.length > 1" class="mb-4">
+          <h3>Income by financial year</h3>
+          <p class="text-muted small">
+            Multi-year deals are spread across the years they cover, so a
+            three-year deal shows in three bars rather than all in the year it
+            was signed.
+          </p>
+          <GChart
+            type="ColumnChart"
+            :data="chartData"
+            :options="chartOptions"
+            class="chart"
+          />
+        </div>
+
+        <div class="d-flex justify-content-between align-items-center">
+          <h3 class="mb-0">Deals</h3>
+          <b-button variant="primary" @click="addPartnership">
+            <v-icon icon="plus" /> Add partnership
+          </b-button>
+        </div>
+
+        <table class="table table-sm mt-2">
+          <thead>
+            <tr>
+              <th>Council</th>
+              <th>Runs</th>
+              <th class="text-end">Value</th>
+              <th class="text-end">Paid</th>
+              <th>Communities</th>
+              <th>Status</th>
+              <th />
+            </tr>
+          </thead>
+          <template v-for="p in partnerships" :key="'partnership-' + p.id">
+            <tbody>
+              <tr>
+                <td>
+                  <strong>{{ p.name }}</strong>
+                  <div
+                    v-if="p.name !== p.authorityname"
+                    class="small text-muted"
+                  >
+                    {{ p.authorityname }}
+                  </div>
+                </td>
+                <td>{{ p.startdate }} to {{ p.enddate }}</td>
+                <td class="text-end">£{{ formatMoney(p.amount) }}</td>
+                <td class="text-end">£{{ formatMoney(p.paid) }}</td>
+                <td>{{ p.groupcount }}</td>
+                <td>
+                  <b-badge v-if="!p.agreed" variant="secondary">
+                    In discussion
+                  </b-badge>
+                  <b-badge v-else-if="p.expired" variant="danger">
+                    Ended
+                  </b-badge>
+                  <b-badge v-else-if="p.expiring" variant="warning">
+                    Renewal due
+                  </b-badge>
+                  <b-badge v-else variant="success">Live</b-badge>
+                  <b-badge v-if="!p.visible" variant="light" class="ms-1">
+                    Hidden
+                  </b-badge>
+                </td>
+                <td class="text-end text-nowrap">
+                  <b-button variant="link" size="sm" @click="toggle(p.id)">
+                    {{ expanded === p.id ? 'Hide' : 'Details' }}
+                  </b-button>
+                  <b-button
+                    variant="link"
+                    size="sm"
+                    @click="editPartnership(p)"
+                  >
+                    Edit
+                  </b-button>
+                  <b-button
+                    variant="link"
+                    size="sm"
+                    class="text-danger"
+                    @click="confirmDelete(p)"
+                  >
+                    Delete
+                  </b-button>
+                </td>
+              </tr>
+              <tr v-if="expanded === p.id">
+                <td colspan="7">
+                  <ModPartnershipDetail :id="p.id" />
+                </td>
+              </tr>
+            </tbody>
+          </template>
+          <tbody v-if="!partnerships.length">
+            <tr>
+              <td colspan="7" class="text-muted">
+                No partnerships yet. Add the first one above.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <hr />
+
+        <ModPartnershipStats :partnerships="partnerships" />
+      </template>
+
+      <ModPartnershipEditModal
+        v-if="showEdit"
+        :partnership="editing"
+        @hidden="showEdit = false"
+      />
+      <ConfirmModal
+        v-if="deleting"
+        :title="'Delete the ' + deleting.name + ' partnership?'"
+        message="The council will stop showing as a sponsor on every community it covers."
+        @confirm="doDelete"
+        @hidden="deleting = null"
+      />
+    </client-only>
+  </div>
+</template>
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRuntimeConfig, useHead } from '#imports'
+import { usePartnershipsStore } from '~/stores/partnerships'
+import { useMe } from '~/composables/useMe'
+import { buildHead } from '~/composables/useMTBuildHead'
+
+const partnershipsStore = usePartnershipsStore()
+const route = useRoute()
+const runtimeConfig = useRuntimeConfig()
+const { me, supportOrAdmin } = useMe()
+
+const showEdit = ref(false)
+const editing = ref(null)
+const deleting = ref(null)
+const expanded = ref(null)
+
+useHead(
+  buildHead(
+    route,
+    runtimeConfig,
+    'Partnerships',
+    'Sponsorship deals with local authorities'
+  )
+)
+
+// Members of the Partnerships team run this; Support and Admin can see it too.
+const canUse = computed(() => {
+  return (
+    supportOrAdmin.value || Boolean(me.value?.teams?.includes('Partnerships'))
+  )
+})
+
+const partnerships = computed(() => partnershipsStore.list)
+const summary = computed(() => partnershipsStore.summary)
+const expiring = computed(() => partnershipsStore.expiring)
+
+function formatMoney(v) {
+  return (parseFloat(v) || 0).toLocaleString('en-GB', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+// Agreed and hoped-for money are stacked separately, so a fat pipeline never reads as
+// income we already have.
+const chartData = computed(() => {
+  const rows = [['Financial year', 'Agreed', 'In discussion']]
+
+  summary.value?.years?.forEach((y) => {
+    rows.push([y.label, y.agreed, y.pipeline])
+  })
+
+  return rows
+})
+
+const chartOptions = {
+  height: 320,
+  isStacked: true,
+  legend: { position: 'top' },
+  colors: ['#5B8930', '#c0c0c0'],
+  vAxis: { format: '£#,##0', minValue: 0 },
+  chartArea: { width: '85%', height: '70%' },
+}
+
+function toggle(id) {
+  expanded.value = expanded.value === id ? null : id
+}
+
+function addPartnership() {
+  editing.value = null
+  showEdit.value = true
+}
+
+function editPartnership(p) {
+  editing.value = p
+  showEdit.value = true
+}
+
+function confirmDelete(p) {
+  deleting.value = p
+}
+
+async function doDelete() {
+  await partnershipsStore.remove(deleting.value.id)
+  deleting.value = null
+}
+
+onMounted(async () => {
+  if (canUse.value) {
+    await partnershipsStore.refresh()
+
+    // A reminder email links straight to the deal it is chasing.
+    const id = parseInt(route.query.id)
+    if (id) {
+      expanded.value = id
+    }
+  }
+})
+</script>
+<style scoped lang="scss">
+.chart {
+  width: 100%;
+  max-width: 900px;
+}
+</style>

--- a/iznik-nuxt3/modtools/stores/partnerships.js
+++ b/iznik-nuxt3/modtools/stores/partnerships.js
@@ -1,0 +1,128 @@
+import { defineStore } from 'pinia'
+import api from '~/api'
+
+/**
+ * State for the ModTools Partnerships page: the council sponsorship deals, the totals and
+ * financial-year split behind the income graph, and the queued authority statistics runs.
+ */
+export const usePartnershipsStore = defineStore({
+  id: 'partnerships',
+  state: () => ({
+    list: [],
+    // Keyed by partnership id: { partnership, groups, years, payments }.
+    detail: {},
+    summary: null,
+    statsJobs: [],
+  }),
+  actions: {
+    init(config) {
+      this.config = config
+    },
+    async fetch() {
+      this.list = await api(this.config).partnerships.list()
+      return this.list
+    },
+    async fetchSummary() {
+      this.summary = await api(this.config).partnerships.summary()
+      return this.summary
+    },
+    async fetchOne(id) {
+      const ret = await api(this.config).partnerships.fetch(id)
+      this.detail[id] = ret
+      return ret
+    },
+    async add(params) {
+      const id = await api(this.config).partnerships.add(params)
+      await this.refresh()
+      return id
+    },
+    async edit(id, params) {
+      await api(this.config).partnerships.edit(id, params)
+      await this.fetchOne(id)
+      await this.refresh()
+    },
+    async remove(id) {
+      await api(this.config).partnerships.remove(id)
+      delete this.detail[id]
+      await this.refresh()
+    },
+    async fetchGroups(id) {
+      return await api(this.config).partnerships.fetchGroups(id)
+    },
+    async addGroup(id, groupid) {
+      await api(this.config).partnerships.patchGroups(id, {
+        action: 'Add',
+        groupid,
+      })
+      await this.fetchOne(id)
+    },
+    async removeGroup(id, groupid) {
+      await api(this.config).partnerships.patchGroups(id, {
+        action: 'Remove',
+        groupid,
+      })
+      await this.fetchOne(id)
+    },
+    async redetectGroups(id) {
+      await api(this.config).partnerships.patchGroups(id, {
+        action: 'Redetect',
+      })
+      await this.fetchOne(id)
+    },
+    async setYears(id, years) {
+      await api(this.config).partnerships.setYears(id, years)
+      await this.fetchOne(id)
+      await this.fetchSummary()
+    },
+    async addPayment(id, params) {
+      const paymentid = await api(this.config).partnerships.addPayment(
+        id,
+        params
+      )
+      await this.fetchOne(id)
+      await this.refresh()
+      return paymentid
+    },
+    async editPayment(id, paymentid, params) {
+      await api(this.config).partnerships.editPayment(id, paymentid, params)
+      await this.fetchOne(id)
+      await this.refresh()
+    },
+    async removePayment(id, paymentid) {
+      await api(this.config).partnerships.removePayment(id, paymentid)
+      await this.fetchOne(id)
+      await this.refresh()
+    },
+    // The list and the headline figures always move together, so refresh them as a pair.
+    async refresh() {
+      await this.fetch()
+      await this.fetchSummary()
+    },
+    async fetchStatsJobs() {
+      this.statsJobs = await api(this.config).partnerships.listStatsJobs()
+      return this.statsJobs
+    },
+    async addStatsJob(params) {
+      const id = await api(this.config).partnerships.addStatsJob(params)
+      await this.fetchStatsJobs()
+      return id
+    },
+    async removeStatsJob(id) {
+      await api(this.config).partnerships.removeStatsJob(id)
+      await this.fetchStatsJobs()
+    },
+  },
+  getters: {
+    byId: (state) => (id) => state.detail[id] || null,
+    // Deals within three months of their end date, soonest first - the renewal worklist.
+    expiring: (state) =>
+      state.list
+        .filter((p) => p.expiring)
+        .sort((a, b) => a.enddate.localeCompare(b.enddate)),
+    // Anything still generating, so the page knows to keep polling.
+    statsRunning: (state) =>
+      state.statsJobs.some(
+        (j) => j.status === 'Pending' || j.status === 'Running'
+      ),
+  },
+})

--- a/iznik-nuxt3/tests/unit/components/ModPartnershipDetail.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ModPartnershipDetail.spec.js
@@ -1,0 +1,330 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { reactive } from 'vue'
+
+import ModPartnershipDetail from '~/modtools/components/ModPartnershipDetail.vue'
+
+const detail = {}
+
+const store = reactive({
+  byId: (id) => detail[id] || null,
+  fetchOne: vi.fn(),
+  fetchGroups: vi.fn(),
+  addGroup: vi.fn(),
+  removeGroup: vi.fn(),
+  redetectGroups: vi.fn(),
+  setYears: vi.fn(),
+  addPayment: vi.fn(),
+  editPayment: vi.fn(),
+  removePayment: vi.fn(),
+})
+
+vi.mock('~/stores/partnerships', () => ({
+  usePartnershipsStore: () => store,
+}))
+
+function setDetail(overrides = {}) {
+  detail[1] = {
+    partnership: { id: 1, name: 'Northshire Council', amount: 9000 },
+    groups: [
+      {
+        groupid: 100,
+        nameshort: 'northshire',
+        namedisplay: 'Northshire Freegle',
+      },
+    ],
+    years: [
+      { financialyear: 2026, label: '2026/27', amount: 4500 },
+      { financialyear: 2027, label: '2027/28', amount: 4500 },
+    ],
+    payments: [],
+    explicityears: false,
+    ...overrides,
+  }
+  return detail[1]
+}
+
+function mountDetail() {
+  return mount(ModPartnershipDetail, {
+    props: { id: 1 },
+    global: {
+      stubs: {
+        'b-row': { template: '<div><slot /></div>' },
+        'b-col': { template: '<div><slot /></div>' },
+        'b-button': {
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+          props: ['variant', 'size'],
+          emits: ['click'],
+        },
+        'b-form-input': {
+          template:
+            '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+          props: ['modelValue', 'type', 'size', 'min'],
+        },
+        SpinButton: {
+          template:
+            '<button class="spin" :data-label="label" :disabled="disabled" @click="$emit(\'handle\')" />',
+          props: [
+            'variant',
+            'iconName',
+            'label',
+            'size',
+            'spinclass',
+            'disabled',
+          ],
+        },
+        NoticeMessage: {
+          template: '<div class="notice"><slot /></div>',
+          props: ['variant'],
+        },
+      },
+    },
+  })
+}
+
+function spin(wrapper, label) {
+  return wrapper
+    .findAll('button.spin')
+    .find((b) => b.attributes('data-label') === label)
+}
+
+describe('ModPartnershipDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const d = setDetail()
+    store.fetchOne.mockResolvedValue(d)
+    store.fetchGroups.mockResolvedValue({
+      groups: d.groups,
+      available: d.groups,
+    })
+  })
+
+  it('loads the deal and the council boundary when it opens', async () => {
+    mountDetail()
+    await flushPromises()
+
+    expect(store.fetchOne).toHaveBeenCalledWith(1)
+    expect(store.fetchGroups).toHaveBeenCalledWith(1)
+  })
+
+  it('lists the communities covered', async () => {
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Northshire Freegle')
+  })
+
+  it('warns when the deal covers nothing, so nothing shows to members', async () => {
+    const d = setDetail({ groups: [] })
+    store.fetchOne.mockResolvedValue(d)
+    store.fetchGroups.mockResolvedValue({ groups: [], available: [] })
+
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No communities are covered')
+  })
+
+  it('offers groups inside the boundary that the deal has dropped', async () => {
+    const d = setDetail()
+    store.fetchOne.mockResolvedValue(d)
+    store.fetchGroups.mockResolvedValue({
+      groups: d.groups,
+      available: [
+        ...d.groups,
+        {
+          groupid: 200,
+          nameshort: 'eastborough',
+          namedisplay: 'Eastborough Freegle',
+        },
+      ],
+    })
+
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Eastborough Freegle')
+
+    const add = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Eastborough'))
+    await add.trigger('click')
+
+    expect(store.addGroup).toHaveBeenCalledWith(1, 200)
+  })
+
+  it('removes a community from the deal', async () => {
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    const remove = wrapper.findAll('button').find((b) => b.text() === 'Remove')
+    await remove.trigger('click')
+
+    expect(store.removeGroup).toHaveBeenCalledWith(1, 100)
+  })
+
+  it('re-checks the boundary on demand', async () => {
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    await spin(wrapper, 'Re-check the boundary').trigger('click')
+
+    expect(store.redetectGroups).toHaveBeenCalledWith(1)
+  })
+
+  it('says the split was worked out when none has been agreed', async () => {
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Spread evenly across the term')
+  })
+
+  it('says the split was agreed when it was', async () => {
+    const d = setDetail({ explicityears: true })
+    store.fetchOne.mockResolvedValue(d)
+
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Split as agreed with the council')
+  })
+
+  it('flags a split that does not add up to the deal value', async () => {
+    const d = setDetail({
+      years: [
+        { financialyear: 2026, label: '2026/27', amount: 1000 },
+        { financialyear: 2027, label: '2027/28', amount: 1000 },
+      ],
+    })
+    store.fetchOne.mockResolvedValue(d)
+
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain("These don't match")
+  })
+
+  it('does not flag a split that adds up', async () => {
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain("These don't match")
+  })
+
+  it('saves the year-by-year split', async () => {
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    await spin(wrapper, 'Save split').trigger('click')
+    await flushPromises()
+
+    expect(store.setYears).toHaveBeenCalledWith(1, [
+      { financialyear: 2026, amount: 4500 },
+      { financialyear: 2027, amount: 4500 },
+    ])
+  })
+
+  it('can drop back to spreading the money evenly', async () => {
+    const d = setDetail({ explicityears: true })
+    store.fetchOne.mockResolvedValue(d)
+
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    await spin(wrapper, 'Spread evenly').trigger('click')
+    await flushPromises()
+
+    expect(store.setYears).toHaveBeenCalledWith(1, [])
+  })
+
+  it('hides the reset when no split has been agreed', async () => {
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(spin(wrapper, 'Spread evenly')).toBeUndefined()
+  })
+
+  it('says when nothing has been invoiced', async () => {
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Nothing invoiced yet')
+  })
+
+  it('lists invoices and lets an unpaid one be marked paid', async () => {
+    const d = setDetail({
+      payments: [
+        {
+          id: 5,
+          date: '2026-04-15',
+          amount: 4500,
+          paid: null,
+          reference: 'INV-1',
+        },
+      ],
+    })
+    store.fetchOne.mockResolvedValue(d)
+
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('INV-1')
+    expect(wrapper.text()).toContain('£4,500.00')
+
+    const mark = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Mark paid today')
+    await mark.trigger('click')
+
+    expect(store.editPayment).toHaveBeenCalledWith(
+      1,
+      5,
+      expect.objectContaining({ paid: expect.any(String) })
+    )
+  })
+
+  it('shows the date a paid invoice was settled', async () => {
+    const d = setDetail({
+      payments: [
+        {
+          id: 5,
+          date: '2026-04-15',
+          amount: 4500,
+          paid: '2026-05-01',
+          reference: '',
+        },
+      ],
+    })
+    store.fetchOne.mockResolvedValue(d)
+
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('2026-05-01')
+    expect(wrapper.text()).not.toContain('Mark paid today')
+  })
+
+  it('deletes an invoice', async () => {
+    const d = setDetail({
+      payments: [
+        { id: 5, date: '2026-04-15', amount: 4500, paid: null, reference: '' },
+      ],
+    })
+    store.fetchOne.mockResolvedValue(d)
+
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    const del = wrapper.findAll('button').find((b) => b.text() === 'Delete')
+    await del.trigger('click')
+
+    expect(store.removePayment).toHaveBeenCalledWith(1, 5)
+  })
+
+  it('will not add an invoice without a date', async () => {
+    const wrapper = mountDetail()
+    await flushPromises()
+
+    expect(spin(wrapper, 'Add').attributes('disabled')).toBeDefined()
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ModPartnershipEditModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ModPartnershipEditModal.spec.js
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref, reactive } from 'vue'
+
+import ModPartnershipEditModal from '~/modtools/components/ModPartnershipEditModal.vue'
+
+const mockHide = vi.fn()
+const mockModal = ref(null)
+
+vi.mock('~/composables/useOurModal', () => ({
+  useOurModal: () => ({ modal: mockModal, hide: mockHide, show: vi.fn() }),
+}))
+
+const store = reactive({
+  add: vi.fn(),
+  edit: vi.fn(),
+})
+
+vi.mock('~/stores/partnerships', () => ({
+  usePartnershipsStore: () => store,
+}))
+
+const mockAuthoritySearch = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    authority: { search: mockAuthoritySearch },
+  }),
+}))
+
+function mountModal(props = {}) {
+  return mount(ModPartnershipEditModal, {
+    props,
+    global: {
+      stubs: {
+        'b-modal': {
+          template:
+            '<div><slot name="title" /><slot /><slot name="footer" /></div>',
+        },
+        'b-row': { template: '<div><slot /></div>' },
+        'b-col': { template: '<div><slot /></div>' },
+        'b-input-group': { template: '<div><slot /></div>' },
+        'b-form-group': {
+          template: '<div><label>{{ label }}</label><slot /></div>',
+          props: ['label', 'description'],
+        },
+        'b-form-input': {
+          template:
+            '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+          props: ['modelValue', 'type', 'placeholder', 'min'],
+        },
+        'b-form-textarea': {
+          template:
+            '<textarea :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+          props: ['modelValue', 'rows'],
+        },
+        'b-button': {
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+          props: ['variant', 'size'],
+          emits: ['click'],
+        },
+        SpinButton: {
+          template: '<button class="spin" @click="$emit(\'handle\')" />',
+          props: ['variant', 'iconName', 'label', 'spinclass'],
+        },
+        OurToggle: {
+          template: '<div class="toggle" @click="$emit(\'change\')" />',
+          props: [
+            'value',
+            'labels',
+            'variant',
+            'height',
+            'width',
+            'fontSize',
+            'sync',
+          ],
+        },
+        NoticeMessage: {
+          template: '<div class="notice"><slot /></div>',
+          props: ['variant'],
+        },
+      },
+    },
+  })
+}
+
+const existing = {
+  id: 1,
+  authorityid: 10,
+  name: 'Northshire Council',
+  startdate: '2026-04-01',
+  enddate: '2027-03-31',
+  amount: 6000,
+  agreed: true,
+  visible: true,
+  tagline: 'Reuse in Northshire',
+  description: 'desc',
+  linkurl: 'https://northshire.example.gov.uk',
+  imageurl: '',
+  contactname: 'Waste team',
+  contactemail: 'waste@northshire.example.gov.uk',
+  notes: '',
+}
+
+/** Save is the last SpinButton on the form; a new deal also has a council-search one. */
+async function save(wrapper) {
+  const buttons = wrapper.findAll('button.spin')
+  await buttons[buttons.length - 1].trigger('click')
+  await flushPromises()
+}
+
+/** Search is the first SpinButton, and only exists while adding a new deal. */
+async function searchCouncils(wrapper, term) {
+  await wrapper.find('input').setValue(term)
+  await wrapper.findAll('button.spin')[0].trigger('click')
+  await flushPromises()
+}
+
+describe('ModPartnershipEditModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthoritySearch.mockResolvedValue([])
+  })
+
+  it('titles itself for a new deal', () => {
+    const wrapper = mountModal()
+
+    expect(wrapper.text()).toContain('New partnership')
+  })
+
+  it('titles itself for an edit and prefills the fields', () => {
+    const wrapper = mountModal({ partnership: existing })
+
+    expect(wrapper.text()).toContain('Edit partnership')
+    const values = wrapper.findAll('input').map((i) => i.element.value)
+    expect(values).toContain('Northshire Council')
+    expect(values).toContain('2026-04-01')
+    expect(values).toContain('Reuse in Northshire')
+  })
+
+  it('only offers the council picker for a new deal', () => {
+    // A new deal has the council-search button as well as Save; an edit has only Save,
+    // because moving a deal to a different council is not something to do by accident.
+    expect(mountModal().findAll('button.spin')).toHaveLength(2)
+    expect(
+      mountModal({ partnership: existing }).findAll('button.spin')
+    ).toHaveLength(1)
+  })
+
+  it('refuses to save a new deal with no council', async () => {
+    const wrapper = mountModal()
+
+    await save(wrapper)
+
+    expect(wrapper.text()).toContain('Please choose a council')
+    expect(store.add).not.toHaveBeenCalled()
+  })
+
+  it('refuses to save without both dates', async () => {
+    const wrapper = mountModal({ partnership: { ...existing, enddate: '' } })
+
+    await save(wrapper)
+
+    expect(wrapper.text()).toContain('give both a start and an end date')
+    expect(store.edit).not.toHaveBeenCalled()
+  })
+
+  it('refuses an end date before the start date', async () => {
+    const wrapper = mountModal({
+      partnership: {
+        ...existing,
+        startdate: '2027-04-01',
+        enddate: '2026-03-31',
+      },
+    })
+
+    await save(wrapper)
+
+    expect(wrapper.text()).toContain("end date can't be before the start date")
+    expect(store.edit).not.toHaveBeenCalled()
+  })
+
+  it('saves an edit and closes', async () => {
+    const wrapper = mountModal({ partnership: existing })
+
+    await save(wrapper)
+
+    expect(store.edit).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        name: 'Northshire Council',
+        amount: 6000,
+        tagline: 'Reuse in Northshire',
+        linkurl: 'https://northshire.example.gov.uk',
+      })
+    )
+    expect(wrapper.emitted('saved')).toBeTruthy()
+    expect(mockHide).toHaveBeenCalled()
+  })
+
+  it('searches for a council and names the deal after the one picked', async () => {
+    mockAuthoritySearch.mockResolvedValue([
+      { id: 42, name: 'Southbury', area_code: 'UTA' },
+    ])
+
+    const wrapper = mountModal()
+    await searchCouncils(wrapper, 'Southbury')
+
+    expect(mockAuthoritySearch).toHaveBeenCalledWith('Southbury')
+
+    const pick = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Southbury'))
+    await pick.trigger('click')
+    await flushPromises()
+
+    const values = wrapper.findAll('input').map((i) => i.element.value)
+    expect(values).toContain('Southbury')
+  })
+
+  it('saves a new deal once a council has been picked', async () => {
+    mockAuthoritySearch.mockResolvedValue([{ id: 42, name: 'Southbury' }])
+
+    const wrapper = mountModal()
+    await searchCouncils(wrapper, 'Southbury')
+
+    await wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Southbury'))
+      .trigger('click')
+
+    // Dates are required, so fill them in the way the form does.
+    const inputs = wrapper.findAll('input')
+    await inputs[2].setValue('2026-04-01')
+    await inputs[3].setValue('2027-03-31')
+
+    await save(wrapper)
+
+    expect(store.add).toHaveBeenCalledWith(
+      expect.objectContaining({ authorityid: 42, name: 'Southbury' })
+    )
+  })
+
+  it('says so when no council matches', async () => {
+    const wrapper = mountModal()
+    await searchCouncils(wrapper, 'Nowhere')
+
+    expect(wrapper.text()).toContain('No councils matched')
+  })
+
+  it('warns that an unagreed deal stays hidden from members', () => {
+    const wrapper = mountModal({ partnership: { ...existing, agreed: false } })
+
+    expect(wrapper.text()).toContain("members won't see the council")
+  })
+
+  it('surfaces a save failure rather than closing silently', async () => {
+    store.edit.mockRejectedValueOnce(new Error('Server said no'))
+    const wrapper = mountModal({ partnership: existing })
+
+    await save(wrapper)
+
+    expect(wrapper.text()).toContain('Server said no')
+    expect(mockHide).not.toHaveBeenCalled()
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ModPartnershipStats.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ModPartnershipStats.spec.js
@@ -198,6 +198,35 @@ describe('ModPartnershipStats', () => {
     expect(store.fetchStatsJobs).toHaveBeenCalledTimes(1)
   })
 
+  it('says so when a download fails, rather than saving a broken spreadsheet', async () => {
+    store.statsJobs = [
+      {
+        id: 5,
+        authorityids: '10',
+        quarter: '3 months ago',
+        status: 'Ready',
+        requested: '2026-08-08 10:00:00',
+        files: [
+          { id: 1, filename: 'Freegle-Statistics-Northshire.xlsx', size: 2048 },
+        ],
+      },
+    ]
+
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 })
+
+    const wrapper = mountStats()
+    await flushPromises()
+
+    const link = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Freegle-Statistics'))
+    await link.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Could not download')
+    expect(wrapper.text()).toContain('403')
+  })
+
   it('deletes a job', async () => {
     store.statsJobs = [
       {

--- a/iznik-nuxt3/tests/unit/components/ModPartnershipStats.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ModPartnershipStats.spec.js
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { reactive } from 'vue'
+
+import ModPartnershipStats from '~/modtools/components/ModPartnershipStats.vue'
+
+const store = reactive({
+  statsJobs: [],
+  statsRunning: false,
+  fetchStatsJobs: vi.fn(),
+  addStatsJob: vi.fn(),
+  removeStatsJob: vi.fn(),
+})
+
+vi.mock('~/stores/partnerships', () => ({
+  usePartnershipsStore: () => store,
+}))
+
+vi.mock('~/stores/auth', () => ({
+  useAuthStore: () => ({ auth: { jwt: 'jwt-token', persistent: null } }),
+}))
+
+const partnerships = [
+  { id: 1, authorityid: 10, authorityname: 'Northshire' },
+  { id: 2, authorityid: 11, authorityname: 'Southbury' },
+  // A second deal with the same council must not give a duplicate option.
+  { id: 3, authorityid: 10, authorityname: 'Northshire' },
+]
+
+function mountStats(props = {}) {
+  return mount(ModPartnershipStats, {
+    props: { partnerships, ...props },
+    global: {
+      stubs: {
+        'b-row': { template: '<div><slot /></div>' },
+        'b-col': { template: '<div><slot /></div>' },
+        'b-badge': { template: '<span><slot /></span>', props: ['variant'] },
+        'b-button': {
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+          props: ['variant', 'size'],
+          emits: ['click'],
+        },
+        'b-form-select': {
+          template:
+            '<select><option v-for="o in options" :key="o.value" :value="o.value">{{ o.text }}</option></select>',
+          props: ['modelValue', 'options', 'multiple'],
+        },
+        SpinButton: {
+          template:
+            '<button :disabled="disabled" @click="$emit(\'handle\')" />',
+          props: ['variant', 'iconName', 'label', 'spinclass', 'disabled'],
+        },
+        NoticeMessage: { template: '<div><slot /></div>', props: ['variant'] },
+        'v-icon': { template: '<i />' },
+      },
+    },
+  })
+}
+
+describe('ModPartnershipStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    store.statsJobs = []
+    store.statsRunning = false
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('loads the jobs when it appears', async () => {
+    mountStats()
+    await flushPromises()
+
+    expect(store.fetchStatsJobs).toHaveBeenCalled()
+  })
+
+  it('offers each council once, however many deals we have had with it', async () => {
+    const wrapper = mountStats()
+    await flushPromises()
+
+    // The first select is the council picker; the second is the quarter.
+    const options = wrapper.findAll('select')[0].findAll('option')
+
+    expect(options).toHaveLength(2)
+    // Sorted by name, so a long list is easy to pick from.
+    expect(options.map((o) => o.text())).toEqual(['Northshire', 'Southbury'])
+  })
+
+  it('offers the last full quarter plus recent ones', async () => {
+    const wrapper = mountStats()
+    await flushPromises()
+
+    const quarters = wrapper.findAll('select')[1].findAll('option')
+
+    expect(quarters[0].text()).toBe('Last full quarter')
+    expect(quarters).toHaveLength(5)
+  })
+
+  it('nudges you to add a partnership when there are no councils', async () => {
+    const wrapper = mountStats({ partnerships: [] })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Add a partnership first')
+  })
+
+  it('names the councils on a job rather than showing bare ids', async () => {
+    store.statsJobs = [
+      {
+        id: 5,
+        authorityids: '10,11',
+        quarter: '3 months ago',
+        status: 'Ready',
+        requested: '2026-08-08 10:00:00',
+        files: [
+          { id: 1, filename: 'Freegle-Statistics-Northshire.xlsx', size: 2048 },
+        ],
+      },
+    ]
+
+    const wrapper = mountStats()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Northshire, Southbury')
+    expect(wrapper.text()).toContain('Freegle-Statistics-Northshire.xlsx')
+  })
+
+  it('says a job is still building while it has no files', async () => {
+    store.statsJobs = [
+      {
+        id: 5,
+        authorityids: '10',
+        quarter: '3 months ago',
+        status: 'Running',
+        requested: '2026-08-08 10:00:00',
+        files: [],
+      },
+    ]
+
+    const wrapper = mountStats()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Building...')
+  })
+
+  it('shows why a job failed', async () => {
+    store.statsJobs = [
+      {
+        id: 5,
+        authorityids: '10',
+        quarter: '3 months ago',
+        status: 'Failed',
+        error: 'Authority 10 not found',
+        requested: '2026-08-08 10:00:00',
+        files: [],
+      },
+    ]
+
+    const wrapper = mountStats()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Authority 10 not found')
+    expect(wrapper.text()).not.toContain('Building...')
+  })
+
+  it('keeps polling while something is still building', async () => {
+    store.statsRunning = true
+    mountStats()
+    await flushPromises()
+
+    expect(store.fetchStatsJobs).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(10000)
+
+    expect(store.fetchStatsJobs).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops polling once everything has finished', async () => {
+    mountStats()
+    await flushPromises()
+
+    expect(store.fetchStatsJobs).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(60000)
+
+    expect(store.fetchStatsJobs).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops polling when the page is left', async () => {
+    store.statsRunning = true
+    const wrapper = mountStats()
+    await flushPromises()
+
+    wrapper.unmount()
+    await vi.advanceTimersByTimeAsync(60000)
+
+    expect(store.fetchStatsJobs).toHaveBeenCalledTimes(1)
+  })
+
+  it('deletes a job', async () => {
+    store.statsJobs = [
+      {
+        id: 5,
+        authorityids: '10',
+        quarter: '3 months ago',
+        status: 'Ready',
+        requested: '2026-08-08 10:00:00',
+        files: [],
+      },
+    ]
+
+    const wrapper = mountStats()
+    await flushPromises()
+
+    const deleteButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Delete')
+    await deleteButton.trigger('click')
+
+    expect(store.removeStatsJob).toHaveBeenCalledWith(5)
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ModPartnershipTotal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ModPartnershipTotal.spec.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import ModPartnershipTotal from '~/modtools/components/ModPartnershipTotal.vue'
+
+function mountTotal(props) {
+  return mount(ModPartnershipTotal, { props })
+}
+
+describe('ModPartnershipTotal', () => {
+  it('shows the label and the value', () => {
+    const wrapper = mountTotal({ label: 'Live deals', value: 4 })
+
+    expect(wrapper.text()).toContain('Live deals')
+    expect(wrapper.text()).toContain('4')
+  })
+
+  it('adds a pound sign and thousands separators for money', () => {
+    const wrapper = mountTotal({ label: 'Paid', value: 12345, money: true })
+
+    expect(wrapper.text()).toContain('£12,345')
+  })
+
+  it('rounds pence away - they are noise at this scale', () => {
+    const wrapper = mountTotal({ label: 'Paid', value: 1200.49, money: true })
+
+    expect(wrapper.text()).toContain('£1,200')
+    expect(wrapper.text()).not.toContain('.49')
+  })
+
+  it('omits the pound sign for plain counts', () => {
+    const wrapper = mountTotal({ label: 'Live deals', value: 3 })
+
+    expect(wrapper.text()).not.toContain('£')
+  })
+
+  it('uses the requested border variant to flag a figure needing attention', () => {
+    const wrapper = mountTotal({
+      label: 'Outstanding',
+      value: 500,
+      money: true,
+      variant: 'warning',
+    })
+
+    expect(wrapper.find('.totalbox').classes()).toContain('border-warning')
+  })
+
+  it('falls back to a neutral border', () => {
+    const wrapper = mountTotal({ label: 'Paid', value: 0, money: true })
+
+    expect(wrapper.find('.totalbox').classes()).toContain('border-secondary')
+  })
+})

--- a/iznik-nuxt3/tests/unit/modtools/app-store-init.spec.js
+++ b/iznik-nuxt3/tests/unit/modtools/app-store-init.spec.js
@@ -1,0 +1,33 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Pinia stores here can't read the Nuxt config themselves, so modtools/app.vue reads it once
+ * and hands it to every store via init(). A store that is used by a page but never gets that
+ * call fails at runtime with "Cannot read properties of undefined (reading 'public')" on its
+ * first API call - and unit tests don't catch it, because they mock the store away.
+ */
+const app = readFileSync(
+  resolve(__dirname, '../../../modtools/app.vue'),
+  'utf8'
+)
+
+describe('modtools/app.vue store wiring', () => {
+  it('hands the runtime config to every store it creates', () => {
+    const created = [
+      ...app.matchAll(/const (\w+Store) = use\w+Store\(\)/g),
+    ].map((m) => m[1])
+    const initialised = new Set(
+      [...app.matchAll(/(\w+Store)\.init\(runtimeConfig\)/g)].map((m) => m[1])
+    )
+
+    expect(created.length).toBeGreaterThan(0)
+    expect(created.filter((s) => !initialised.has(s))).toEqual([])
+  })
+
+  it('sets up the partnerships store', () => {
+    expect(app).toContain('const partnershipsStore = usePartnershipsStore()')
+    expect(app).toContain('partnershipsStore.init(runtimeConfig)')
+  })
+})

--- a/iznik-nuxt3/tests/unit/pages/modtools/partnerships.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/partnerships.spec.js
@@ -49,61 +49,63 @@ const partnership = (overrides = {}) => ({
   ...overrides,
 })
 
-function mountPage() {
-  return mount(PartnershipsPage, {
-    global: {
-      stubs: {
-        'client-only': { template: '<div><slot /></div>' },
-        'b-badge': {
-          template: '<span class="badge"><slot /></span>',
-          props: ['variant'],
-        },
-        // emits must be declared, or the parent's @click also falls through to the root
-        // <button> as a native listener and every click fires the handler twice.
-        'b-button': {
-          template: '<button @click="$emit(\'click\')"><slot /></button>',
-          props: ['variant', 'size'],
-          emits: ['click'],
-        },
-        NoticeMessage: {
-          name: 'NoticeMessage',
-          template: '<div class="notice"><slot /></div>',
-          props: ['variant'],
-        },
-        GChart: {
-          name: 'GChart',
-          template: '<div class="gchart" />',
-          props: ['data', 'options', 'type'],
-        },
-        ModPartnershipTotal: {
-          name: 'ModPartnershipTotal',
-          template: '<div class="total">{{ label }}:{{ value }}</div>',
-          props: ['label', 'value', 'money', 'variant'],
-        },
-        ModPartnershipDetail: {
-          name: 'ModPartnershipDetail',
-          template: '<div class="detail" />',
-          props: ['id'],
-        },
-        ModPartnershipStats: {
-          name: 'ModPartnershipStats',
-          template: '<div class="stats" />',
-          props: ['partnerships'],
-        },
-        ModPartnershipEditModal: {
-          name: 'ModPartnershipEditModal',
-          template: '<div class="editmodal" />',
-          props: ['partnership'],
-        },
-        ConfirmModal: {
-          name: 'ConfirmModal',
-          template: '<div class="confirm" />',
-          props: ['title', 'message'],
-        },
-        'v-icon': { template: '<i />' },
-      },
+// A fresh object each time, so a test can drop one stub and check the real component
+// resolves.
+function stubs() {
+  return {
+    'client-only': { template: '<div><slot /></div>' },
+    'b-badge': {
+      template: '<span class="badge"><slot /></span>',
+      props: ['variant'],
     },
-  })
+    // emits must be declared, or the parent's @click also falls through to the root
+    // <button> as a native listener and every click fires the handler twice.
+    'b-button': {
+      template: '<button @click="$emit(\'click\')"><slot /></button>',
+      props: ['variant', 'size'],
+      emits: ['click'],
+    },
+    NoticeMessage: {
+      name: 'NoticeMessage',
+      template: '<div class="notice"><slot /></div>',
+      props: ['variant'],
+    },
+    GChart: {
+      name: 'GChart',
+      template: '<div class="gchart" />',
+      props: ['data', 'options', 'type'],
+    },
+    ModPartnershipTotal: {
+      name: 'ModPartnershipTotal',
+      template: '<div class="total">{{ label }}:{{ value }}</div>',
+      props: ['label', 'value', 'money', 'variant'],
+    },
+    ModPartnershipDetail: {
+      name: 'ModPartnershipDetail',
+      template: '<div class="detail" />',
+      props: ['id'],
+    },
+    ModPartnershipStats: {
+      name: 'ModPartnershipStats',
+      template: '<div class="stats" />',
+      props: ['partnerships'],
+    },
+    ModPartnershipEditModal: {
+      name: 'ModPartnershipEditModal',
+      template: '<div class="editmodal" />',
+      props: ['partnership'],
+    },
+    ConfirmModal: {
+      name: 'ConfirmModal',
+      template: '<div class="confirm" />',
+      props: ['title', 'message'],
+    },
+    'v-icon': { template: '<i />' },
+  }
+}
+
+function mountPage() {
+  return mount(PartnershipsPage, { global: { stubs: stubs() } })
 }
 
 describe('modtools partnerships page', () => {
@@ -342,5 +344,38 @@ describe('modtools partnerships page', () => {
     await flushPromises()
 
     expect(store.remove).toHaveBeenCalledWith(1)
+  })
+
+  // Stubbing GChart hid the fact that the page never imported it, so the real page logged
+  // "Failed to resolve component" and rendered no graph at all. Mount without that stub.
+  it('resolves the chart component it renders', async () => {
+    const warnings = []
+    const warn = console.warn
+    console.warn = (...args) => warnings.push(args.join(' '))
+
+    try {
+      store.list = [partnership()]
+      store.summary = {
+        agreed: 6000,
+        total: 6000,
+        invoiced: 3000,
+        paid: 3000,
+        outstanding: 0,
+        active: 1,
+        years: [{ label: '2026/27', agreed: 6000, pipeline: 0 }],
+      }
+
+      const withoutChart = stubs()
+      delete withoutChart.GChart
+
+      mount(PartnershipsPage, { global: { stubs: withoutChart } })
+      await flushPromises()
+    } finally {
+      console.warn = warn
+    }
+
+    expect(
+      warnings.filter((w) => w.includes('Failed to resolve component'))
+    ).toEqual([])
   })
 })

--- a/iznik-nuxt3/tests/unit/pages/modtools/partnerships.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/partnerships.spec.js
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref, reactive } from 'vue'
+
+import PartnershipsPage from '~/modtools/pages/partnerships.vue'
+
+const me = ref({ id: 1, teams: ['Partnerships'] })
+const supportOrAdmin = ref(false)
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({ me, supportOrAdmin }),
+}))
+
+vi.mock('~/composables/useMTBuildHead', () => ({
+  buildHead: () => ({}),
+}))
+
+const store = reactive({
+  list: [],
+  summary: null,
+  expiring: [],
+  statsJobs: [],
+  statsRunning: false,
+  refresh: vi.fn(),
+  remove: vi.fn(),
+  fetchStatsJobs: vi.fn(),
+  addStatsJob: vi.fn(),
+  removeStatsJob: vi.fn(),
+})
+
+vi.mock('~/stores/partnerships', () => ({
+  usePartnershipsStore: () => store,
+}))
+
+const partnership = (overrides = {}) => ({
+  id: 1,
+  name: 'Northshire Council',
+  authorityid: 10,
+  authorityname: 'Northshire',
+  startdate: '2026-04-01',
+  enddate: '2027-03-31',
+  amount: 6000,
+  paid: 3000,
+  groupcount: 4,
+  agreed: true,
+  visible: true,
+  expiring: false,
+  expired: false,
+  ...overrides,
+})
+
+function mountPage() {
+  return mount(PartnershipsPage, {
+    global: {
+      stubs: {
+        'client-only': { template: '<div><slot /></div>' },
+        'b-badge': {
+          template: '<span class="badge"><slot /></span>',
+          props: ['variant'],
+        },
+        // emits must be declared, or the parent's @click also falls through to the root
+        // <button> as a native listener and every click fires the handler twice.
+        'b-button': {
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+          props: ['variant', 'size'],
+          emits: ['click'],
+        },
+        NoticeMessage: {
+          name: 'NoticeMessage',
+          template: '<div class="notice"><slot /></div>',
+          props: ['variant'],
+        },
+        GChart: {
+          name: 'GChart',
+          template: '<div class="gchart" />',
+          props: ['data', 'options', 'type'],
+        },
+        ModPartnershipTotal: {
+          name: 'ModPartnershipTotal',
+          template: '<div class="total">{{ label }}:{{ value }}</div>',
+          props: ['label', 'value', 'money', 'variant'],
+        },
+        ModPartnershipDetail: {
+          name: 'ModPartnershipDetail',
+          template: '<div class="detail" />',
+          props: ['id'],
+        },
+        ModPartnershipStats: {
+          name: 'ModPartnershipStats',
+          template: '<div class="stats" />',
+          props: ['partnerships'],
+        },
+        ModPartnershipEditModal: {
+          name: 'ModPartnershipEditModal',
+          template: '<div class="editmodal" />',
+          props: ['partnership'],
+        },
+        ConfirmModal: {
+          name: 'ConfirmModal',
+          template: '<div class="confirm" />',
+          props: ['title', 'message'],
+        },
+        'v-icon': { template: '<i />' },
+      },
+    },
+  })
+}
+
+describe('modtools partnerships page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    me.value = { id: 1, teams: ['Partnerships'] }
+    supportOrAdmin.value = false
+    store.list = []
+    store.summary = null
+    store.expiring = []
+  })
+
+  it('turns away someone not on the team', async () => {
+    me.value = { id: 1, teams: ['ChitChat Moderation'] }
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('need to be on the Partnerships team')
+    expect(store.refresh).not.toHaveBeenCalled()
+  })
+
+  it('lets Support in without team membership', async () => {
+    me.value = { id: 1 }
+    supportOrAdmin.value = true
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('need to be on the Partnerships team')
+    expect(store.refresh).toHaveBeenCalled()
+  })
+
+  it('loads the deals and totals for a team member', async () => {
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(store.refresh).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('No partnerships yet')
+  })
+
+  it('shows the headline totals', async () => {
+    store.summary = {
+      total: 10000,
+      agreed: 6000,
+      invoiced: 5000,
+      paid: 3000,
+      outstanding: 2000,
+      active: 2,
+      years: [],
+    }
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    const totals = wrapper.findAll('.total').map((t) => t.text())
+    expect(totals).toContain('Agreed income:6000')
+    // Anything not yet agreed is money we hope for, not money we have.
+    expect(totals).toContain('In discussion:4000')
+    expect(totals).toContain('Outstanding:2000')
+  })
+
+  it('lists a deal with its council, term and money', async () => {
+    store.list = [partnership()]
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    const text = wrapper.text()
+    expect(text).toContain('Northshire Council')
+    expect(text).toContain('2026-04-01 to 2027-03-31')
+    expect(text).toContain('£6,000')
+    expect(text).toContain('£3,000')
+  })
+
+  it('marks a deal that has not been agreed', async () => {
+    store.list = [partnership({ agreed: false })]
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('In discussion')
+  })
+
+  it('marks a deal that has ended', async () => {
+    store.list = [partnership({ expired: true })]
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Ended')
+  })
+
+  it('marks a deal that needs renewing', async () => {
+    store.list = [partnership({ expiring: true })]
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Renewal due')
+  })
+
+  it('marks a deal hidden from members', async () => {
+    store.list = [partnership({ visible: false })]
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Hidden')
+  })
+
+  it('calls out the renewals coming up', async () => {
+    store.expiring = [partnership({ expiring: true })]
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('sponsorship runs')
+    expect(wrapper.text()).toContain('Northshire Council (2027-03-31)')
+  })
+
+  it('draws the income graph split by financial year', async () => {
+    store.summary = {
+      total: 9000,
+      agreed: 9000,
+      invoiced: 0,
+      paid: 0,
+      outstanding: 0,
+      active: 1,
+      years: [
+        { financialyear: 2026, label: '2026/27', agreed: 3000, pipeline: 0 },
+        { financialyear: 2027, label: '2027/28', agreed: 3000, pipeline: 500 },
+      ],
+    }
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    const chart = wrapper.findComponent({ name: 'GChart' })
+    expect(chart.exists()).toBe(true)
+    expect(chart.props('data')).toEqual([
+      ['Financial year', 'Agreed', 'In discussion'],
+      ['2026/27', 3000, 0],
+      ['2027/28', 3000, 500],
+    ])
+  })
+
+  it('leaves the graph out when there is nothing to draw', async () => {
+    store.summary = {
+      total: 0,
+      agreed: 0,
+      invoiced: 0,
+      paid: 0,
+      outstanding: 0,
+      active: 0,
+      years: [],
+    }
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'GChart' }).exists()).toBe(false)
+  })
+
+  it('opens the details for one deal at a time', async () => {
+    store.list = [partnership()]
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.find('.detail').exists()).toBe(false)
+
+    const details = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Details')
+    await details.trigger('click')
+
+    expect(wrapper.find('.detail').exists()).toBe(true)
+
+    const hide = wrapper.findAll('button').find((b) => b.text() === 'Hide')
+    await hide.trigger('click')
+
+    expect(wrapper.find('.detail').exists()).toBe(false)
+  })
+
+  it('opens the editor for a new deal', async () => {
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.find('.editmodal').exists()).toBe(false)
+
+    const add = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Add partnership'))
+    await add.trigger('click')
+
+    expect(wrapper.find('.editmodal').exists()).toBe(true)
+    expect(
+      wrapper
+        .findComponent({ name: 'ModPartnershipEditModal' })
+        .props('partnership')
+    ).toBeNull()
+  })
+
+  it('opens the editor on an existing deal', async () => {
+    store.list = [partnership()]
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    const edit = wrapper.findAll('button').find((b) => b.text() === 'Edit')
+    await edit.trigger('click')
+
+    expect(
+      wrapper
+        .findComponent({ name: 'ModPartnershipEditModal' })
+        .props('partnership').id
+    ).toBe(1)
+  })
+
+  it('asks before deleting, because it pulls the sponsor off the site', async () => {
+    store.list = [partnership()]
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.find('.confirm').exists()).toBe(false)
+
+    const del = wrapper.findAll('button').find((b) => b.text() === 'Delete')
+    await del.trigger('click')
+
+    expect(wrapper.find('.confirm').exists()).toBe(true)
+    expect(store.remove).not.toHaveBeenCalled()
+
+    await wrapper.findComponent({ name: 'ConfirmModal' }).vm.$emit('confirm')
+    await flushPromises()
+
+    expect(store.remove).toHaveBeenCalledWith(1)
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/partnerships.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/partnerships.spec.js
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockList = vi.fn()
+const mockFetch = vi.fn()
+const mockSummary = vi.fn()
+const mockAdd = vi.fn()
+const mockEdit = vi.fn()
+const mockRemove = vi.fn()
+const mockFetchGroups = vi.fn()
+const mockPatchGroups = vi.fn()
+const mockSetYears = vi.fn()
+const mockAddPayment = vi.fn()
+const mockEditPayment = vi.fn()
+const mockRemovePayment = vi.fn()
+const mockListStatsJobs = vi.fn()
+const mockAddStatsJob = vi.fn()
+const mockRemoveStatsJob = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    partnerships: {
+      list: mockList,
+      fetch: mockFetch,
+      summary: mockSummary,
+      add: mockAdd,
+      edit: mockEdit,
+      remove: mockRemove,
+      fetchGroups: mockFetchGroups,
+      patchGroups: mockPatchGroups,
+      setYears: mockSetYears,
+      addPayment: mockAddPayment,
+      editPayment: mockEditPayment,
+      removePayment: mockRemovePayment,
+      listStatsJobs: mockListStatsJobs,
+      addStatsJob: mockAddStatsJob,
+      removeStatsJob: mockRemoveStatsJob,
+    },
+  }),
+}))
+
+describe('partnerships store', () => {
+  let usePartnershipsStore
+
+  const partnership = (overrides = {}) => ({
+    id: 1,
+    name: 'Northshire Council',
+    authorityid: 10,
+    authorityname: 'Northshire',
+    startdate: '2026-04-01',
+    enddate: '2027-03-31',
+    amount: 6000,
+    agreed: true,
+    expiring: false,
+    expired: false,
+    ...overrides,
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+
+    mockList.mockResolvedValue([])
+    mockSummary.mockResolvedValue({ total: 0, years: [] })
+    mockFetch.mockResolvedValue({
+      partnership: partnership(),
+      groups: [],
+      years: [],
+      payments: [],
+    })
+
+    const mod = await import('~/stores/partnerships')
+    usePartnershipsStore = mod.usePartnershipsStore
+  })
+
+  const makeStore = () => {
+    const store = usePartnershipsStore()
+    store.init({ public: {} })
+    return store
+  }
+
+  describe('initial state', () => {
+    it('starts empty', () => {
+      const store = makeStore()
+      expect(store.list).toEqual([])
+      expect(store.detail).toEqual({})
+      expect(store.summary).toBeNull()
+      expect(store.statsJobs).toEqual([])
+    })
+  })
+
+  describe('fetching', () => {
+    it('stores the list', async () => {
+      mockList.mockResolvedValue([partnership()])
+      const store = makeStore()
+
+      await store.fetch()
+
+      expect(store.list).toHaveLength(1)
+      expect(store.list[0].name).toBe('Northshire Council')
+    })
+
+    it('stores the summary', async () => {
+      mockSummary.mockResolvedValue({ total: 6000, years: [] })
+      const store = makeStore()
+
+      await store.fetchSummary()
+
+      expect(store.summary.total).toBe(6000)
+    })
+
+    it('keeps detail keyed by id so several can be open at once', async () => {
+      const store = makeStore()
+
+      await store.fetchOne(1)
+
+      expect(store.byId(1).partnership.name).toBe('Northshire Council')
+      expect(store.byId(2)).toBeNull()
+    })
+
+    it('refresh reloads the list and the totals together', async () => {
+      const store = makeStore()
+
+      await store.refresh()
+
+      expect(mockList).toHaveBeenCalled()
+      expect(mockSummary).toHaveBeenCalled()
+    })
+  })
+
+  describe('editing', () => {
+    it('add refreshes so new deals appear in the totals', async () => {
+      mockAdd.mockResolvedValue(7)
+      const store = makeStore()
+
+      const id = await store.add({ authorityid: 10 })
+
+      expect(id).toBe(7)
+      expect(mockAdd).toHaveBeenCalledWith({ authorityid: 10 })
+      expect(mockList).toHaveBeenCalled()
+      expect(mockSummary).toHaveBeenCalled()
+    })
+
+    it('edit reloads the deal it changed', async () => {
+      const store = makeStore()
+
+      await store.edit(1, { tagline: 'New' })
+
+      expect(mockEdit).toHaveBeenCalledWith(1, { tagline: 'New' })
+      expect(mockFetch).toHaveBeenCalledWith(1)
+    })
+
+    it('remove drops the cached detail', async () => {
+      const store = makeStore()
+      await store.fetchOne(1)
+      expect(store.byId(1)).not.toBeNull()
+
+      await store.remove(1)
+
+      expect(store.byId(1)).toBeNull()
+      expect(mockRemove).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('groups', () => {
+    it('adds a group and reloads the deal', async () => {
+      const store = makeStore()
+
+      await store.addGroup(1, 55)
+
+      expect(mockPatchGroups).toHaveBeenCalledWith(1, {
+        action: 'Add',
+        groupid: 55,
+      })
+      expect(mockFetch).toHaveBeenCalledWith(1)
+    })
+
+    it('removes a group', async () => {
+      const store = makeStore()
+
+      await store.removeGroup(1, 55)
+
+      expect(mockPatchGroups).toHaveBeenCalledWith(1, {
+        action: 'Remove',
+        groupid: 55,
+      })
+    })
+
+    it('re-derives from the council boundary', async () => {
+      const store = makeStore()
+
+      await store.redetectGroups(1)
+
+      expect(mockPatchGroups).toHaveBeenCalledWith(1, { action: 'Redetect' })
+    })
+  })
+
+  describe('money', () => {
+    it('saving a year split refreshes the totals behind the graph', async () => {
+      const store = makeStore()
+
+      await store.setYears(1, [{ financialyear: 2026, amount: 6000 }])
+
+      expect(mockSetYears).toHaveBeenCalledWith(1, [
+        { financialyear: 2026, amount: 6000 },
+      ])
+      expect(mockSummary).toHaveBeenCalled()
+    })
+
+    it('adding a payment refreshes the deal and the totals', async () => {
+      mockAddPayment.mockResolvedValue(3)
+      const store = makeStore()
+
+      const id = await store.addPayment(1, { date: '2026-04-15', amount: 100 })
+
+      expect(id).toBe(3)
+      expect(mockFetch).toHaveBeenCalledWith(1)
+      expect(mockSummary).toHaveBeenCalled()
+    })
+
+    it('marking a payment paid refreshes the totals', async () => {
+      const store = makeStore()
+
+      await store.editPayment(1, 3, { paid: '2026-05-01' })
+
+      expect(mockEditPayment).toHaveBeenCalledWith(1, 3, { paid: '2026-05-01' })
+      expect(mockSummary).toHaveBeenCalled()
+    })
+
+    it('deleting a payment refreshes the totals', async () => {
+      const store = makeStore()
+
+      await store.removePayment(1, 3)
+
+      expect(mockRemovePayment).toHaveBeenCalledWith(1, 3)
+      expect(mockSummary).toHaveBeenCalled()
+    })
+  })
+
+  describe('expiring getter', () => {
+    it('lists only deals running out, soonest first', async () => {
+      mockList.mockResolvedValue([
+        partnership({ id: 1, enddate: '2026-12-01', expiring: true }),
+        partnership({ id: 2, enddate: '2030-01-01', expiring: false }),
+        partnership({ id: 3, enddate: '2026-09-01', expiring: true }),
+      ])
+      const store = makeStore()
+
+      await store.fetch()
+
+      expect(store.expiring.map((p) => p.id)).toEqual([3, 1])
+    })
+  })
+
+  describe('stats jobs', () => {
+    it('queues a job and reloads the list', async () => {
+      mockAddStatsJob.mockResolvedValue(9)
+      mockListStatsJobs.mockResolvedValue([
+        { id: 9, status: 'Pending', files: [] },
+      ])
+      const store = makeStore()
+
+      const id = await store.addStatsJob({ authorityids: [10] })
+
+      expect(id).toBe(9)
+      expect(store.statsJobs).toHaveLength(1)
+    })
+
+    it('knows when something is still building', async () => {
+      mockListStatsJobs.mockResolvedValue([
+        { id: 9, status: 'Running', files: [] },
+      ])
+      const store = makeStore()
+
+      await store.fetchStatsJobs()
+
+      expect(store.statsRunning).toBe(true)
+    })
+
+    it('knows when everything has finished', async () => {
+      mockListStatsJobs.mockResolvedValue([
+        { id: 9, status: 'Ready', files: [] },
+        { id: 8, status: 'Failed', files: [] },
+      ])
+      const store = makeStore()
+
+      await store.fetchStatsJobs()
+
+      expect(store.statsRunning).toBe(false)
+    })
+
+    it('deleting a job reloads the list', async () => {
+      mockListStatsJobs.mockResolvedValue([])
+      const store = makeStore()
+
+      await store.removeStatsJob(9)
+
+      expect(mockRemoveStatsJob).toHaveBeenCalledWith(9)
+      expect(store.statsJobs).toEqual([])
+    })
+  })
+})

--- a/iznik-server-go/authority/authority.go
+++ b/iznik-server-go/authority/authority.go
@@ -36,13 +36,13 @@ var AreaCodes = map[string]string{
 
 // Authority represents a local authority.
 type Authority struct {
-	ID       uint64                    `json:"id"`
-	Name     string                    `json:"name"`
-	AreaCode *string                   `json:"area_code"`
-	Polygon  string                    `json:"polygon"`
-	Centre   Centre                    `json:"centre"`
-	Groups   []Group                   `json:"groups"`
-	Stats    map[string]PostcodeStats  `json:"stats,omitempty"`
+	ID       uint64                   `json:"id"`
+	Name     string                   `json:"name"`
+	AreaCode *string                  `json:"area_code"`
+	Polygon  string                   `json:"polygon"`
+	Centre   Centre                   `json:"centre"`
+	Groups   []Group                  `json:"groups"`
+	Stats    map[string]PostcodeStats `json:"stats,omitempty"`
 }
 
 // Centre represents the centre point of an authority.
@@ -53,15 +53,15 @@ type Centre struct {
 
 // Group represents a Freegle group overlapping with an authority.
 type Group struct {
-	ID          uint64   `json:"id"`
-	Nameshort   string   `json:"nameshort"`
-	Namefull    *string  `json:"namefull"`
-	Namedisplay string   `json:"namedisplay"`
-	Lat         float64  `json:"lat"`
-	Lng         float64  `json:"lng"`
-	Poly        *string  `json:"poly"`
-	Overlap     float64  `json:"overlap"`
-	Overlap2    float64  `json:"overlap2"`
+	ID          uint64  `json:"id"`
+	Nameshort   string  `json:"nameshort"`
+	Namefull    *string `json:"namefull"`
+	Namedisplay string  `json:"namedisplay"`
+	Lat         float64 `json:"lat"`
+	Lng         float64 `json:"lng"`
+	Poly        *string `json:"poly"`
+	Overlap     float64 `json:"overlap"`
+	Overlap2    float64 `json:"overlap2"`
 }
 
 // SearchResult represents an authority search result.
@@ -124,28 +124,71 @@ func Single(c *fiber.Ctx) error {
 		}
 	}
 
-	// Query overlapping groups.
-	var groups []struct {
-		ID        uint64   `gorm:"column:id"`
-		Nameshort string   `gorm:"column:nameshort"`
-		Namefull  *string  `gorm:"column:namefull"`
-		Lat       float64  `gorm:"column:lat"`
-		Lng       float64  `gorm:"column:lng"`
-		Poly      *string  `gorm:"column:poly"`
-		Overlap   float64  `gorm:"column:overlap"`
-		Overlap2  float64  `gorm:"column:overlap2"`
+	responseGroups := GroupsForAuthority(id)
+
+	authority := Authority{
+		ID:       authRow.ID,
+		Name:     authRow.Name,
+		AreaCode: areaCodeFriendly,
+		Polygon:  authRow.Polygon,
+		Centre: Centre{
+			Lat: authRow.Lat,
+			Lng: authRow.Lng,
+		},
+		Groups: responseGroups,
 	}
+
+	// Include stats if requested.
+	if includeStats {
+		stats, err := GetStatsByAuthority(id, start, end)
+		if err == nil {
+			authority.Stats = stats
+		}
+	}
+
+	return c.JSON(authority)
+}
+
+// GroupsForAuthority returns the live Freegle groups whose catchment meaningfully
+// overlaps an authority's boundary. "Meaningfully" means at least 5% of the group sits
+// inside the authority, or the authority is at least 5% of the group - so a small
+// authority inside a big group still counts.
+//
+// Shared with the Partnerships page, which uses it to work out which groups a council
+// sponsorship covers.
+func GroupsForAuthority(id uint64) []Group {
+	db := database.DBConn
+
+	var groups []struct {
+		ID        uint64  `gorm:"column:id"`
+		Nameshort string  `gorm:"column:nameshort"`
+		Namefull  *string `gorm:"column:namefull"`
+		Lat       float64 `gorm:"column:lat"`
+		Lng       float64 `gorm:"column:lng"`
+		Poly      *string `gorm:"column:poly"`
+		Overlap   float64 `gorm:"column:overlap"`
+		Overlap2  float64 `gorm:"column:overlap2"`
+	}
+
+	// ST_Area errors on anything that isn't a polygon, and a single such group aborts the
+	// whole query rather than being skipped - so the geometry-type check has to guard the
+	// area calls themselves, not just filter rows. A group whose catchment is not an area
+	// cannot meaningfully overlap an authority anyway, so it scores zero.
+	const polygonal = "ST_GeometryType(polyindex) IN ('POLYGON', 'MULTIPOLYGON') " +
+		"AND ST_GeometryType(Coalesce(simplified, polygon)) IN ('POLYGON', 'MULTIPOLYGON')"
 
 	db.Table("groups").
 		Select("groups.id, nameshort, namefull, lat, lng, "+
 			"CASE WHEN poly IS NOT NULL THEN poly ELSE polyofficial END AS poly, "+
-			"CASE WHEN ST_GeometryType(St_intersection(polyindex, Coalesce(simplified, polygon))) != 'GEOMCOLLECTION' THEN "+
+			"CASE WHEN NOT ("+polygonal+") THEN 0 "+
+			"WHEN ST_GeometryType(St_intersection(polyindex, Coalesce(simplified, polygon))) != 'GEOMCOLLECTION' THEN "+
 			"CASE WHEN polyindex = Coalesce(simplified, polygon) THEN 1 "+
 			"ELSE St_area(St_intersection(polyindex, Coalesce(simplified, polygon))) / St_area(polyindex) "+
 			"END "+
 			"ELSE 0 "+
 			"END AS overlap, "+
-			"CASE WHEN ST_GeometryType(St_intersection(polyindex, Coalesce(simplified, polygon))) != 'GEOMCOLLECTION' THEN "+
+			"CASE WHEN NOT ("+polygonal+") THEN 0 "+
+			"WHEN ST_GeometryType(St_intersection(polyindex, Coalesce(simplified, polygon))) != 'GEOMCOLLECTION' THEN "+
 			"CASE WHEN polyindex = Coalesce(simplified, polygon) THEN 1 "+
 			"ELSE St_area(polyindex) / St_area(St_intersection(polyindex, Coalesce(simplified, polygon))) "+
 			"END "+
@@ -188,27 +231,7 @@ func Single(c *fiber.Ctx) error {
 		responseGroups = []Group{}
 	}
 
-	authority := Authority{
-		ID:       authRow.ID,
-		Name:     authRow.Name,
-		AreaCode: areaCodeFriendly,
-		Polygon:  authRow.Polygon,
-		Centre: Centre{
-			Lat: authRow.Lat,
-			Lng: authRow.Lng,
-		},
-		Groups: responseGroups,
-	}
-
-	// Include stats if requested.
-	if includeStats {
-		stats, err := GetStatsByAuthority(id, start, end)
-		if err == nil {
-			authority.Stats = stats
-		}
-	}
-
-	return c.JSON(authority)
+	return responseGroups
 }
 
 // Search searches authorities by name.

--- a/iznik-server-go/partnerships/finance.go
+++ b/iznik-server-go/partnerships/finance.go
@@ -1,0 +1,108 @@
+package partnerships
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// The UK financial year runs 1 April to 31 March and is named after the calendar year
+// it starts in, so financial year 2026 is 2026/27.
+const financialYearStartMonth = time.April
+
+// FinancialYear returns the financial year a date falls in.
+func FinancialYear(t time.Time) int {
+	if t.Month() < financialYearStartMonth {
+		return t.Year() - 1
+	}
+
+	return t.Year()
+}
+
+// FinancialYearLabel renders a financial year the way finance people write it: "2026/27".
+func FinancialYearLabel(fy int) string {
+	return fmt.Sprintf("%d/%02d", fy, (fy+1)%100)
+}
+
+// FinancialYearBounds returns the first and last day of a financial year, inclusive.
+func FinancialYearBounds(fy int) (time.Time, time.Time) {
+	start := time.Date(fy, financialYearStartMonth, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(1, 0, -1)
+
+	return start, end
+}
+
+// YearAmount is one financial year's share of a deal.
+//
+// The column tag is load-bearing: GORM would otherwise look for `financial_year`, and scan
+// a zero into every year read back from partnerships_years.
+type YearAmount struct {
+	FinancialYear int     `json:"financialyear" gorm:"column:financialyear"`
+	Label         string  `json:"label" gorm:"-"`
+	Amount        float64 `json:"amount"`
+}
+
+// SplitAcrossFinancialYears apportions a deal's value across the financial years its term
+// covers, by the number of days of the term falling in each year. A deal running 1 January
+// to 31 December therefore shows roughly a quarter of its value in the first financial year
+// and three quarters in the second, which is what "how does our income split over years"
+// needs to mean for the multi-year council deals.
+//
+// Amounts are rounded to pence, with any rounding difference absorbed by the final year so
+// the parts always add back up to the whole.
+func SplitAcrossFinancialYears(start, end time.Time, amount float64) []YearAmount {
+	start = truncateDay(start)
+	end = truncateDay(end)
+
+	if end.Before(start) {
+		return []YearAmount{}
+	}
+
+	// Inclusive of both ends: a one-day deal is one day, not zero.
+	totalDays := int(end.Sub(start).Hours()/24) + 1
+
+	years := []YearAmount{}
+	allocated := 0.0
+
+	for fy := FinancialYear(start); fy <= FinancialYear(end); fy++ {
+		fyStart, fyEnd := FinancialYearBounds(fy)
+
+		from := fyStart
+		if start.After(from) {
+			from = start
+		}
+
+		to := fyEnd
+		if end.Before(to) {
+			to = end
+		}
+
+		days := int(to.Sub(from).Hours()/24) + 1
+		if days <= 0 {
+			continue
+		}
+
+		share := round2(amount * float64(days) / float64(totalDays))
+		years = append(years, YearAmount{
+			FinancialYear: fy,
+			Label:         FinancialYearLabel(fy),
+			Amount:        share,
+		})
+		allocated += share
+	}
+
+	// Push the rounding difference into the last year so the split is exact.
+	if len(years) > 0 {
+		years[len(years)-1].Amount = round2(years[len(years)-1].Amount + (amount - allocated))
+	}
+
+	return years
+}
+
+func truncateDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func round2(v float64) float64 {
+	return math.Round(v*100) / 100
+}

--- a/iznik-server-go/partnerships/finance_test.go
+++ b/iznik-server-go/partnerships/finance_test.go
@@ -1,0 +1,108 @@
+package partnerships
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func date(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+
+	return t
+}
+
+func TestFinancialYearBoundary(t *testing.T) {
+	// 31 March is still the old financial year; 1 April starts the new one.
+	assert.Equal(t, 2025, FinancialYear(date("2026-03-31")))
+	assert.Equal(t, 2026, FinancialYear(date("2026-04-01")))
+	assert.Equal(t, 2026, FinancialYear(date("2026-12-31")))
+	assert.Equal(t, 2026, FinancialYear(date("2027-01-01")))
+}
+
+func TestFinancialYearLabel(t *testing.T) {
+	assert.Equal(t, "2026/27", FinancialYearLabel(2026))
+	// The century rollover must not print "2099/100".
+	assert.Equal(t, "2099/00", FinancialYearLabel(2099))
+	assert.Equal(t, "2009/10", FinancialYearLabel(2009))
+}
+
+func TestFinancialYearBounds(t *testing.T) {
+	start, end := FinancialYearBounds(2026)
+	assert.Equal(t, "2026-04-01", start.Format("2006-01-02"))
+	assert.Equal(t, "2027-03-31", end.Format("2006-01-02"))
+}
+
+func TestSplitWithinOneFinancialYear(t *testing.T) {
+	years := SplitAcrossFinancialYears(date("2026-04-01"), date("2027-03-31"), 1200)
+
+	assert.Len(t, years, 1)
+	assert.Equal(t, 2026, years[0].FinancialYear)
+	assert.Equal(t, "2026/27", years[0].Label)
+	assert.Equal(t, 1200.0, years[0].Amount)
+}
+
+func TestSplitAcrossTwoFinancialYears(t *testing.T) {
+	// A calendar year deal: 90 days in 2025/26 (Jan-Mar) and 275 in 2026/27.
+	years := SplitAcrossFinancialYears(date("2026-01-01"), date("2026-12-31"), 3650)
+
+	assert.Len(t, years, 2)
+	assert.Equal(t, 2025, years[0].FinancialYear)
+	assert.Equal(t, 2026, years[1].FinancialYear)
+	assert.InDelta(t, 900.0, years[0].Amount, 0.01)
+	assert.InDelta(t, 2750.0, years[1].Amount, 0.01)
+}
+
+func TestSplitOfMultiYearDeal(t *testing.T) {
+	// Three whole financial years, so close to an even three-way split. Not exactly even:
+	// 2027/28 contains a leap day, so it earns a fractionally larger share.
+	years := SplitAcrossFinancialYears(date("2026-04-01"), date("2029-03-31"), 9000)
+
+	assert.Len(t, years, 3)
+	for _, y := range years {
+		assert.InDelta(t, 3000.0, y.Amount, 10.0, "each year gets roughly a third")
+	}
+
+	assert.Greater(t, years[1].Amount, years[0].Amount, "the leap-year financial year is a day longer")
+}
+
+func TestSplitAlwaysSumsToTheWhole(t *testing.T) {
+	// A term whose day counts do not divide cleanly still adds back up exactly - the
+	// rounding difference lands in the last year rather than vanishing.
+	years := SplitAcrossFinancialYears(date("2026-02-15"), date("2029-07-14"), 10000)
+
+	total := 0.0
+	for _, y := range years {
+		total += y.Amount
+	}
+
+	assert.InDelta(t, 10000.0, total, 0.001)
+	assert.Equal(t, 2025, years[0].FinancialYear)
+	assert.Equal(t, 2029, years[len(years)-1].FinancialYear)
+}
+
+func TestSplitOfSingleDay(t *testing.T) {
+	years := SplitAcrossFinancialYears(date("2026-06-01"), date("2026-06-01"), 500)
+
+	assert.Len(t, years, 1)
+	assert.Equal(t, 500.0, years[0].Amount)
+}
+
+func TestSplitOfInvertedDatesIsEmpty(t *testing.T) {
+	years := SplitAcrossFinancialYears(date("2026-06-01"), date("2026-05-01"), 500)
+
+	assert.Empty(t, years)
+}
+
+func TestSplitOfZeroAmount(t *testing.T) {
+	years := SplitAcrossFinancialYears(date("2026-01-01"), date("2026-12-31"), 0)
+
+	assert.Len(t, years, 2)
+	for _, y := range years {
+		assert.Equal(t, 0.0, y.Amount)
+	}
+}

--- a/iznik-server-go/partnerships/partnerships.go
+++ b/iznik-server-go/partnerships/partnerships.go
@@ -103,15 +103,19 @@ func CanUse(myid uint64) bool {
 }
 
 // requireUser rejects the request unless the caller may manage partnerships. It returns the
-// caller's id, or an error already shaped as a JSON response.
+// caller's id, or an error for the handler to return straight back.
+//
+// These must be real errors rather than c.Status(...).JSON(...): that writes a response but
+// returns nil, so the caller's `err != nil` check passes and the handler carries on and
+// overwrites the refusal with the data it was meant to be withholding.
 func requireUser(c *fiber.Ctx) (uint64, error) {
 	myid := user.WhoAmI(c)
 	if myid == 0 {
-		return 0, c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"ret": 1, "status": "Not logged in"})
+		return 0, fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
 	}
 
 	if !CanUse(myid) {
-		return 0, c.Status(fiber.StatusForbidden).JSON(fiber.Map{"ret": 2, "status": "Permission denied"})
+		return 0, fiber.NewError(fiber.StatusForbidden, "Permission denied")
 	}
 
 	return myid, nil

--- a/iznik-server-go/partnerships/partnerships.go
+++ b/iznik-server-go/partnerships/partnerships.go
@@ -1,0 +1,1060 @@
+// Package partnerships backs the ModTools Partnerships page: the sponsorship deals we have
+// with local authorities, the groups each one covers, the money involved, and the on-demand
+// generation of the quarterly statistics spreadsheets councils receive.
+//
+// A partnership is held against an authority rather than a group, because that is how the
+// deal is actually done. The groups it covers are derived from the authority/group boundary
+// overlap and cached in partnerships_groups; each covered group gets a groups_sponsorship
+// row so the member site shows the council as a sponsor.
+package partnerships
+
+import (
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/freegle/iznik-server-go/auth"
+	"github.com/freegle/iznik-server-go/authority"
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/user"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// TeamName is the ModTools team whose members may use this page.
+const TeamName = "Partnerships"
+
+// ExpiryWarningDays is how far ahead a sponsorship counts as "expiring soon" - three months,
+// matching the reminder mail the Partnerships team gets.
+const ExpiryWarningDays = 92
+
+// dateFmt selects DATE columns as plain YYYY-MM-DD strings. The driver runs with
+// parseTime=True, so without this they come back as time.Time and serialise with a
+// spurious time and zone.
+const dateFmt = "'%Y-%m-%d'"
+
+// Partnership is one sponsorship deal with a local authority.
+type Partnership struct {
+	ID            uint64  `json:"id"`
+	Authorityid   uint64  `json:"authorityid"`
+	Authorityname string  `json:"authorityname"`
+	Name          string  `json:"name"`
+	Tagline       *string `json:"tagline"`
+	Description   *string `json:"description"`
+	Linkurl       *string `json:"linkurl"`
+	Imageurl      *string `json:"imageurl"`
+	Startdate     string  `json:"startdate"`
+	Enddate       string  `json:"enddate"`
+	Amount        float64 `json:"amount"`
+	Agreed        bool    `json:"agreed"`
+	Agreeddate    *string `json:"agreeddate"`
+	Contactname   *string `json:"contactname"`
+	Contactemail  *string `json:"contactemail"`
+	Notes         *string `json:"notes"`
+	Visible       bool    `json:"visible"`
+
+	// Derived, for the list view.
+	Groupcount int     `json:"groupcount"`
+	Invoiced   float64 `json:"invoiced"`
+	Paid       float64 `json:"paid"`
+	Expired    bool    `json:"expired"`
+	Expiring   bool    `json:"expiring"`
+}
+
+// Group is one Freegle group covered by a partnership.
+type Group struct {
+	Groupid       uint64  `json:"groupid"`
+	Nameshort     string  `json:"nameshort"`
+	Namedisplay   string  `json:"namedisplay"`
+	Sponsorshipid *uint64 `json:"sponsorshipid"`
+}
+
+// Payment is money invoiced against a partnership, and whether it has come in.
+type Payment struct {
+	ID        uint64  `json:"id"`
+	Date      string  `json:"date"`
+	Amount    float64 `json:"amount"`
+	Paid      *string `json:"paid"`
+	Reference *string `json:"reference"`
+	Notes     *string `json:"notes"`
+}
+
+// CanUse reports whether a user may see and manage partnerships: a member of the
+// Partnerships team, or Support/Admin.
+func CanUse(myid uint64) bool {
+	if myid == 0 {
+		return false
+	}
+
+	if auth.IsAdminOrSupport(myid) {
+		return true
+	}
+
+	db := database.DBConn
+	var count int64
+	db.Table("teams_members tm").
+		Joins("INNER JOIN teams t ON tm.teamid = t.id").
+		Where("t.name = ? AND tm.userid = ?", TeamName, myid).
+		Count(&count)
+
+	return count > 0
+}
+
+// requireUser rejects the request unless the caller may manage partnerships. It returns the
+// caller's id, or an error already shaped as a JSON response.
+func requireUser(c *fiber.Ctx) (uint64, error) {
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return 0, c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"ret": 1, "status": "Not logged in"})
+	}
+
+	if !CanUse(myid) {
+		return 0, c.Status(fiber.StatusForbidden).JSON(fiber.Map{"ret": 2, "status": "Permission denied"})
+	}
+
+	return myid, nil
+}
+
+// selectList is the column list for a partnership row, with the derived money and group
+// counts folded in so the list view is a single query.
+func selectList() string {
+	return "partnerships.id, partnerships.authorityid, authorities.name AS authorityname, " +
+		"partnerships.name, partnerships.tagline, partnerships.description, partnerships.linkurl, " +
+		"partnerships.imageurl, DATE_FORMAT(partnerships.startdate, " + dateFmt + ") AS startdate, " +
+		"DATE_FORMAT(partnerships.enddate, " + dateFmt + ") AS enddate, partnerships.amount, " +
+		"partnerships.agreed, DATE_FORMAT(partnerships.agreeddate, " + dateFmt + ") AS agreeddate, " +
+		"partnerships.contactname, partnerships.contactemail, partnerships.notes, partnerships.visible, " +
+		"(SELECT COUNT(*) FROM partnerships_groups pg WHERE pg.partnershipid = partnerships.id) AS groupcount, " +
+		"COALESCE((SELECT SUM(amount) FROM partnerships_payments pp WHERE pp.partnershipid = partnerships.id), 0) AS invoiced, " +
+		"COALESCE((SELECT SUM(amount) FROM partnerships_payments pp WHERE pp.partnershipid = partnerships.id AND pp.paid IS NOT NULL), 0) AS paid, " +
+		"partnerships.enddate < CURDATE() AS expired, " +
+		"(partnerships.enddate >= CURDATE() AND partnerships.enddate <= DATE_ADD(CURDATE(), INTERVAL ? DAY)) AS expiring"
+}
+
+// List returns every partnership, the deal running out soonest last.
+//
+// @Summary List partnerships
+// @Tags partnerships
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership [get]
+func List(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	db := database.DBConn
+
+	var partnerships []Partnership
+	db.Table("partnerships").
+		Select(selectList(), ExpiryWarningDays).
+		Joins("INNER JOIN authorities ON authorities.id = partnerships.authorityid").
+		Order("partnerships.enddate DESC, partnerships.id DESC").
+		Scan(&partnerships)
+
+	if partnerships == nil {
+		partnerships = []Partnership{}
+	}
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "partnerships": partnerships})
+}
+
+// Single returns one partnership with the groups it covers, its financial-year split and
+// its payments.
+//
+// @Summary Get a partnership
+// @Tags partnerships
+// @Produce json
+// @Param id path integer true "Partnership ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/{id} [get]
+func Single(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	if id == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	p := load(id)
+	if p.ID == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Not found"})
+	}
+
+	years, explicit := yearsFor(p)
+
+	return c.JSON(fiber.Map{
+		"ret":         0,
+		"status":      "Success",
+		"partnership": p,
+		"groups":      groupsFor(id),
+		"years":       years,
+		// Whether the split above was agreed year by year or worked out pro-rata, so the
+		// page can say which it is showing.
+		"explicityears": explicit,
+		"payments":      paymentsFor(id),
+	})
+}
+
+// load reads one partnership with its derived figures. A zero ID means it does not exist.
+func load(id uint64) Partnership {
+	db := database.DBConn
+
+	var p Partnership
+	db.Table("partnerships").
+		Select(selectList(), ExpiryWarningDays).
+		Joins("INNER JOIN authorities ON authorities.id = partnerships.authorityid").
+		Where("partnerships.id = ?", id).
+		Scan(&p)
+
+	return p
+}
+
+// groupsFor lists the groups a partnership covers.
+func groupsFor(id uint64) []Group {
+	db := database.DBConn
+
+	var groups []Group
+	db.Table("partnerships_groups pg").
+		Select("pg.groupid, g.nameshort, COALESCE(NULLIF(g.namefull, ''), g.nameshort) AS namedisplay, pg.sponsorshipid").
+		Joins("INNER JOIN `groups` g ON g.id = pg.groupid").
+		Where("pg.partnershipid = ?", id).
+		Order("namedisplay ASC").
+		Scan(&groups)
+
+	if groups == nil {
+		groups = []Group{}
+	}
+
+	return groups
+}
+
+// yearsFor returns how the deal's value falls into financial years, and whether that split
+// was agreed year by year rather than worked out. Explicit rows win, so a deal with an
+// uneven agreed schedule (say most of the money up front) reports what was actually agreed
+// rather than a pro-rata guess.
+func yearsFor(p Partnership) ([]YearAmount, bool) {
+	db := database.DBConn
+
+	var explicit []YearAmount
+	db.Table("partnerships_years").
+		Select("financialyear, amount").
+		Where("partnershipid = ?", p.ID).
+		Order("financialyear ASC").
+		Scan(&explicit)
+
+	if len(explicit) > 0 {
+		for i := range explicit {
+			explicit[i].Label = FinancialYearLabel(explicit[i].FinancialYear)
+		}
+
+		return explicit, true
+	}
+
+	start, errStart := time.Parse("2006-01-02", p.Startdate)
+	end, errEnd := time.Parse("2006-01-02", p.Enddate)
+	if errStart != nil || errEnd != nil {
+		return []YearAmount{}, false
+	}
+
+	return SplitAcrossFinancialYears(start, end, p.Amount), false
+}
+
+// paymentsFor lists the invoices raised against a partnership.
+func paymentsFor(id uint64) []Payment {
+	db := database.DBConn
+
+	var payments []Payment
+	db.Table("partnerships_payments").
+		Select("id, DATE_FORMAT(date, "+dateFmt+") AS date, amount, "+
+			"DATE_FORMAT(paid, "+dateFmt+") AS paid, reference, notes").
+		Where("partnershipid = ?", id).
+		Order("date ASC, id ASC").
+		Scan(&payments)
+
+	if payments == nil {
+		payments = []Payment{}
+	}
+
+	return payments
+}
+
+// createRequest is the body accepted by Create and (with everything optional) Update.
+// Pointers distinguish "not supplied" from "set to empty", so a tagline can be cleared.
+type createRequest struct {
+	Authorityid  utils.FlexUint64   `json:"authorityid"`
+	Name         *string            `json:"name"`
+	Tagline      *string            `json:"tagline"`
+	Description  *string            `json:"description"`
+	Linkurl      *string            `json:"linkurl"`
+	Imageurl     *string            `json:"imageurl"`
+	Startdate    *string            `json:"startdate"`
+	Enddate      *string            `json:"enddate"`
+	Amount       *utils.FlexFloat64 `json:"amount"`
+	Agreed       *bool              `json:"agreed"`
+	Agreeddate   *string            `json:"agreeddate"`
+	Contactname  *string            `json:"contactname"`
+	Contactemail *string            `json:"contactemail"`
+	Notes        *string            `json:"notes"`
+	Visible      *bool              `json:"visible"`
+}
+
+// Create adds a partnership, works out which groups the authority covers, and writes the
+// sponsorship rows the member site reads.
+//
+// @Summary Create a partnership
+// @Tags partnerships
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership [post]
+func Create(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	var req createRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Invalid body"})
+	}
+
+	if req.Authorityid == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing authorityid"})
+	}
+
+	if req.Startdate == nil || req.Enddate == nil || *req.Startdate == "" || *req.Enddate == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing startdate or enddate"})
+	}
+
+	db := database.DBConn
+
+	var authorityName string
+	db.Table("authorities").Select("name").Where("id = ?", uint64(req.Authorityid)).Scan(&authorityName)
+	if authorityName == "" {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Authority not found"})
+	}
+
+	// Default the display name to the council's own name - that is what a member should see.
+	name := authorityName
+	if req.Name != nil && *req.Name != "" {
+		name = *req.Name
+	}
+
+	row := map[string]interface{}{
+		"authorityid":  uint64(req.Authorityid),
+		"name":         name,
+		"tagline":      req.Tagline,
+		"description":  req.Description,
+		"linkurl":      req.Linkurl,
+		"imageurl":     req.Imageurl,
+		"startdate":    *req.Startdate,
+		"enddate":      *req.Enddate,
+		"amount":       floatOr(req.Amount, 0),
+		"agreed":       boolOr(req.Agreed, false),
+		"agreeddate":   nullableDate(req.Agreeddate),
+		"contactname":  req.Contactname,
+		"contactemail": req.Contactemail,
+		"notes":        req.Notes,
+		"visible":      boolOr(req.Visible, true),
+	}
+
+	if err := db.Table("partnerships").Create(row).Error; err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"ret": 1, "status": "Create failed"})
+	}
+
+	newIDInt, _ := row["@id"].(int64)
+	id := uint64(newIDInt)
+
+	detectGroups(db, id, uint64(req.Authorityid))
+	syncSponsorships(db, id)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "id": id})
+}
+
+// Update changes a partnership and re-syncs its sponsorship rows, so editing the tagline,
+// the link or the dates immediately changes what members see.
+//
+// @Summary Update a partnership
+// @Tags partnerships
+// @Accept json
+// @Produce json
+// @Param id path integer true "Partnership ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/{id} [patch]
+func Update(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	if id == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	var req createRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Invalid body"})
+	}
+
+	db := database.DBConn
+
+	var existingAuthority uint64
+	db.Table("partnerships").Select("authorityid").Where("id = ?", id).Scan(&existingAuthority)
+	if existingAuthority == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Not found"})
+	}
+
+	updates := map[string]interface{}{}
+	setString(updates, "name", req.Name)
+	setNullableString(updates, "tagline", req.Tagline)
+	setNullableString(updates, "description", req.Description)
+	setNullableString(updates, "linkurl", req.Linkurl)
+	setNullableString(updates, "imageurl", req.Imageurl)
+	setString(updates, "startdate", req.Startdate)
+	setString(updates, "enddate", req.Enddate)
+	setNullableString(updates, "agreeddate", req.Agreeddate)
+	setNullableString(updates, "contactname", req.Contactname)
+	setNullableString(updates, "contactemail", req.Contactemail)
+	setNullableString(updates, "notes", req.Notes)
+
+	if req.Amount != nil {
+		updates["amount"] = float64(*req.Amount)
+	}
+	if req.Agreed != nil {
+		updates["agreed"] = *req.Agreed
+	}
+	if req.Visible != nil {
+		updates["visible"] = *req.Visible
+	}
+
+	// Moving the deal to a different council changes which groups it covers.
+	authorityChanged := req.Authorityid != 0 && uint64(req.Authorityid) != existingAuthority
+	if authorityChanged {
+		var exists int64
+		db.Table("authorities").Where("id = ?", uint64(req.Authorityid)).Count(&exists)
+		if exists == 0 {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Authority not found"})
+		}
+		updates["authorityid"] = uint64(req.Authorityid)
+	}
+
+	if len(updates) > 0 {
+		db.Table("partnerships").Where("id = ?", id).Updates(updates)
+	}
+
+	if authorityChanged {
+		removeSponsorships(db, id)
+		db.Table("partnerships_groups").Where("partnershipid = ?", id).Delete(nil)
+		detectGroups(db, id, uint64(req.Authorityid))
+	}
+
+	syncSponsorships(db, id)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// Delete removes a partnership. Its sponsorship rows go too, so the council stops appearing
+// on the member site straight away; years, payments and group links cascade in the schema.
+//
+// @Summary Delete a partnership
+// @Tags partnerships
+// @Produce json
+// @Param id path integer true "Partnership ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/{id} [delete]
+func Delete(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	if id == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	db := database.DBConn
+	removeSponsorships(db, id)
+	db.Table("partnerships").Where("id = ?", id).Delete(nil)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// Groups lists the groups a partnership covers, alongside the groups the authority's
+// boundary suggests, so a mistake in the overlap can be corrected by hand.
+//
+// @Summary List the groups a partnership covers
+// @Tags partnerships
+// @Produce json
+// @Param id path integer true "Partnership ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/{id}/group [get]
+func Groups(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	if id == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	db := database.DBConn
+
+	var authorityid uint64
+	db.Table("partnerships").Select("authorityid").Where("id = ?", id).Scan(&authorityid)
+	if authorityid == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Not found"})
+	}
+
+	available := []Group{}
+	for _, g := range authority.GroupsForAuthority(authorityid) {
+		available = append(available, Group{
+			Groupid:     g.ID,
+			Nameshort:   g.Nameshort,
+			Namedisplay: g.Namedisplay,
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"ret":       0,
+		"status":    "Success",
+		"groups":    groupsFor(id),
+		"available": available,
+	})
+}
+
+// PatchGroups adds or removes a group from a partnership, or re-derives the whole list from
+// the authority boundary.
+//
+// @Summary Change the groups a partnership covers
+// @Tags partnerships
+// @Accept json
+// @Produce json
+// @Param id path integer true "Partnership ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/{id}/group [patch]
+func PatchGroups(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	if id == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	var req struct {
+		Action  string           `json:"action"`
+		Groupid utils.FlexUint64 `json:"groupid"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Invalid body"})
+	}
+
+	db := database.DBConn
+
+	var authorityid uint64
+	db.Table("partnerships").Select("authorityid").Where("id = ?", id).Scan(&authorityid)
+	if authorityid == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Not found"})
+	}
+
+	switch req.Action {
+	case "Add":
+		if req.Groupid == 0 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing groupid"})
+		}
+		addGroup(db, id, uint64(req.Groupid))
+	case "Remove":
+		if req.Groupid == 0 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing groupid"})
+		}
+		removeSponsorshipForGroup(db, id, uint64(req.Groupid))
+		db.Table("partnerships_groups").
+			Where("partnershipid = ? AND groupid = ?", id, uint64(req.Groupid)).
+			Delete(nil)
+	case "Redetect":
+		detectGroups(db, id, authorityid)
+	default:
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Unknown action"})
+	}
+
+	syncSponsorships(db, id)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "groups": groupsFor(id)})
+}
+
+// PutYears replaces the explicit financial-year split for a multi-year deal. Sending an
+// empty list drops back to pro-rating the deal across its term.
+//
+// @Summary Set the financial-year split of a partnership
+// @Tags partnerships
+// @Accept json
+// @Produce json
+// @Param id path integer true "Partnership ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/{id}/year [put]
+func PutYears(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	if id == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	var req struct {
+		Years []struct {
+			Financialyear utils.FlexInt     `json:"financialyear"`
+			Amount        utils.FlexFloat64 `json:"amount"`
+		} `json:"years"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Invalid body"})
+	}
+
+	db := database.DBConn
+
+	var count int64
+	db.Table("partnerships").Where("id = ?", id).Count(&count)
+	if count == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Not found"})
+	}
+
+	db.Table("partnerships_years").Where("partnershipid = ?", id).Delete(nil)
+
+	for _, y := range req.Years {
+		if y.Financialyear == 0 {
+			continue
+		}
+		db.Table("partnerships_years").Clauses(clause.Insert{Modifier: "REPLACE"}).
+			Create(map[string]interface{}{
+				"partnershipid": id,
+				"financialyear": int(y.Financialyear),
+				"amount":        float64(y.Amount),
+			})
+	}
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// paymentRequest is the body for creating or editing an invoice.
+type paymentRequest struct {
+	Date      *string            `json:"date"`
+	Amount    *utils.FlexFloat64 `json:"amount"`
+	Paid      *string            `json:"paid"`
+	Reference *string            `json:"reference"`
+	Notes     *string            `json:"notes"`
+}
+
+// CreatePayment records an invoice against a partnership.
+//
+// @Summary Add a payment to a partnership
+// @Tags partnerships
+// @Accept json
+// @Produce json
+// @Param id path integer true "Partnership ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/{id}/payment [post]
+func CreatePayment(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	if id == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	var req paymentRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Invalid body"})
+	}
+
+	if req.Date == nil || *req.Date == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing date"})
+	}
+
+	db := database.DBConn
+
+	var count int64
+	db.Table("partnerships").Where("id = ?", id).Count(&count)
+	if count == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Not found"})
+	}
+
+	row := map[string]interface{}{
+		"partnershipid": id,
+		"date":          *req.Date,
+		"amount":        floatOr(req.Amount, 0),
+		"paid":          nullableDate(req.Paid),
+		"reference":     req.Reference,
+		"notes":         req.Notes,
+	}
+
+	if err := db.Table("partnerships_payments").Create(row).Error; err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"ret": 1, "status": "Create failed"})
+	}
+
+	newIDInt, _ := row["@id"].(int64)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "id": uint64(newIDInt)})
+}
+
+// UpdatePayment edits an invoice - most often to mark it paid.
+//
+// @Summary Update a payment
+// @Tags partnerships
+// @Accept json
+// @Produce json
+// @Param id path integer true "Partnership ID"
+// @Param paymentid path integer true "Payment ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/{id}/payment/{paymentid} [patch]
+func UpdatePayment(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	paymentid, _ := strconv.ParseUint(c.Params("paymentid"), 10, 64)
+	if id == 0 || paymentid == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	var req paymentRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Invalid body"})
+	}
+
+	db := database.DBConn
+
+	var count int64
+	db.Table("partnerships_payments").Where("id = ? AND partnershipid = ?", paymentid, id).Count(&count)
+	if count == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Not found"})
+	}
+
+	updates := map[string]interface{}{}
+	setString(updates, "date", req.Date)
+	setNullableString(updates, "reference", req.Reference)
+	setNullableString(updates, "notes", req.Notes)
+
+	if req.Amount != nil {
+		updates["amount"] = float64(*req.Amount)
+	}
+	// An empty paid date means "not paid after all", so it must clear the column.
+	if req.Paid != nil {
+		updates["paid"] = nullableDate(req.Paid)
+	}
+
+	if len(updates) > 0 {
+		db.Table("partnerships_payments").Where("id = ?", paymentid).Updates(updates)
+	}
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// DeletePayment removes an invoice.
+//
+// @Summary Delete a payment
+// @Tags partnerships
+// @Produce json
+// @Param id path integer true "Partnership ID"
+// @Param paymentid path integer true "Payment ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/{id}/payment/{paymentid} [delete]
+func DeletePayment(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	paymentid, _ := strconv.ParseUint(c.Params("paymentid"), 10, 64)
+	if id == 0 || paymentid == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	db := database.DBConn
+	db.Table("partnerships_payments").Where("id = ? AND partnershipid = ?", paymentid, id).Delete(nil)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// Summary totals the partnership income and splits it by financial year, which is what the
+// page's headline figures and its income graph are drawn from.
+//
+// @Summary Partnership income totals and financial-year split
+// @Tags partnerships
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/summary [get]
+func Summary(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	db := database.DBConn
+
+	var partnerships []Partnership
+	db.Table("partnerships").
+		Select(selectList(), ExpiryWarningDays).
+		Joins("INNER JOIN authorities ON authorities.id = partnerships.authorityid").
+		Scan(&partnerships)
+
+	// Aggregate the per-partnership splits into one row per financial year. Agreed and
+	// unagreed money is kept apart so a pipeline of hoped-for deals never flatters the
+	// income figures.
+	type bucket struct {
+		agreed   float64
+		pipeline float64
+	}
+	buckets := map[int]*bucket{}
+
+	var total, agreedTotal, invoiced, paid float64
+	active, expiring := 0, 0
+
+	for _, p := range partnerships {
+		total += p.Amount
+		invoiced += p.Invoiced
+		paid += p.Paid
+
+		if p.Agreed {
+			agreedTotal += p.Amount
+		}
+		if !p.Expired {
+			active++
+		}
+		if p.Expiring {
+			expiring++
+		}
+
+		years, _ := yearsFor(p)
+		for _, y := range years {
+			b, ok := buckets[y.FinancialYear]
+			if !ok {
+				b = &bucket{}
+				buckets[y.FinancialYear] = b
+			}
+			if p.Agreed {
+				b.agreed += y.Amount
+			} else {
+				b.pipeline += y.Amount
+			}
+		}
+	}
+
+	// One row per financial year, oldest first, so the graph reads left to right.
+	fys := make([]int, 0, len(buckets))
+	for fy := range buckets {
+		fys = append(fys, fy)
+	}
+	sort.Ints(fys)
+
+	years := make([]fiber.Map, 0, len(fys))
+	for _, fy := range fys {
+		years = append(years, fiber.Map{
+			"financialyear": fy,
+			"label":         FinancialYearLabel(fy),
+			"agreed":        round2(buckets[fy].agreed),
+			"pipeline":      round2(buckets[fy].pipeline),
+			"total":         round2(buckets[fy].agreed + buckets[fy].pipeline),
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"ret":    0,
+		"status": "Success",
+		"summary": fiber.Map{
+			"count":       len(partnerships),
+			"active":      active,
+			"expiring":    expiring,
+			"total":       round2(total),
+			"agreed":      round2(agreedTotal),
+			"invoiced":    round2(invoiced),
+			"paid":        round2(paid),
+			"outstanding": round2(invoiced - paid),
+			"years":       years,
+		},
+	})
+}
+
+// detectGroups fills partnerships_groups from the authority's boundary overlap. Existing
+// rows are left alone, so groups added or removed by hand survive a later re-detect.
+func detectGroups(db *gorm.DB, partnershipid uint64, authorityid uint64) {
+	for _, g := range authority.GroupsForAuthority(authorityid) {
+		addGroup(db, partnershipid, g.ID)
+	}
+}
+
+// addGroup links a group to a partnership, ignoring a group that is already linked.
+func addGroup(db *gorm.DB, partnershipid uint64, groupid uint64) {
+	db.Table("partnerships_groups").Clauses(clause.Insert{Modifier: "IGNORE"}).
+		Create(map[string]interface{}{
+			"partnershipid": partnershipid,
+			"groupid":       groupid,
+		})
+}
+
+// syncSponsorships writes one groups_sponsorship row per covered group, so the member site
+// shows the council as a sponsor of every group the deal covers.
+//
+// The row is only visible while the deal is agreed: an unagreed deal is a conversation, not
+// something to advertise.
+func syncSponsorships(db *gorm.DB, partnershipid uint64) {
+	var p struct {
+		Name         string
+		Tagline      *string
+		Description  *string
+		Linkurl      *string
+		Imageurl     *string
+		Startdate    string
+		Enddate      string
+		Amount       float64
+		Agreed       bool
+		Contactname  *string
+		Contactemail *string
+		Notes        *string
+		Visible      bool
+	}
+
+	db.Table("partnerships").
+		Select("name, tagline, description, linkurl, imageurl, "+
+			"DATE_FORMAT(startdate, "+dateFmt+") AS startdate, DATE_FORMAT(enddate, "+dateFmt+") AS enddate, "+
+			"amount, agreed, contactname, contactemail, notes, visible").
+		Where("id = ?", partnershipid).
+		Scan(&p)
+
+	if p.Name == "" {
+		return
+	}
+
+	// groups_sponsorship requires a contact, and orders sponsors by amount.
+	fields := map[string]interface{}{
+		"name":         p.Name,
+		"linkurl":      p.Linkurl,
+		"startdate":    p.Startdate,
+		"enddate":      p.Enddate,
+		"contactname":  stringOr(p.Contactname, ""),
+		"contactemail": stringOr(p.Contactemail, ""),
+		"amount":       int(p.Amount),
+		"notes":        p.Notes,
+		"imageurl":     p.Imageurl,
+		"visible":      p.Visible && p.Agreed,
+		"tagline":      p.Tagline,
+		"description":  p.Description,
+	}
+
+	var links []struct {
+		Groupid       uint64
+		Sponsorshipid *uint64
+	}
+	db.Table("partnerships_groups").
+		Select("groupid, sponsorshipid").
+		Where("partnershipid = ?", partnershipid).
+		Scan(&links)
+
+	for _, link := range links {
+		if link.Sponsorshipid != nil {
+			db.Table("groups_sponsorship").Where("id = ?", *link.Sponsorshipid).Updates(fields)
+
+			continue
+		}
+
+		row := map[string]interface{}{"groupid": link.Groupid}
+		for k, v := range fields {
+			row[k] = v
+		}
+
+		if err := db.Table("groups_sponsorship").Create(row).Error; err != nil {
+			continue
+		}
+
+		newIDInt, _ := row["@id"].(int64)
+		db.Table("partnerships_groups").
+			Where("partnershipid = ? AND groupid = ?", partnershipid, link.Groupid).
+			Update("sponsorshipid", uint64(newIDInt))
+	}
+}
+
+// sponsorshipIDs is the subquery of the sponsorship rows a partnership created.
+func sponsorshipIDs(db *gorm.DB, partnershipid uint64) *gorm.DB {
+	return db.Table("partnerships_groups").
+		Select("sponsorshipid").
+		Where("partnershipid = ? AND sponsorshipid IS NOT NULL", partnershipid)
+}
+
+// removeSponsorships deletes every groups_sponsorship row this partnership created.
+func removeSponsorships(db *gorm.DB, partnershipid uint64) {
+	db.Table("groups_sponsorship").
+		Where("id IN (?)", sponsorshipIDs(db, partnershipid)).
+		Delete(nil)
+}
+
+// removeSponsorshipForGroup drops the sponsorship for one group leaving a partnership.
+func removeSponsorshipForGroup(db *gorm.DB, partnershipid uint64, groupid uint64) {
+	db.Table("groups_sponsorship").
+		Where("id IN (?)", sponsorshipIDs(db, partnershipid).Where("groupid = ?", groupid)).
+		Delete(nil)
+}
+
+// --- small helpers -------------------------------------------------------------------
+
+func setString(updates map[string]interface{}, column string, v *string) {
+	if v != nil && *v != "" {
+		updates[column] = *v
+	}
+}
+
+// setNullableString lets an empty string clear the column, which is how the UI removes a
+// tagline or a link.
+func setNullableString(updates map[string]interface{}, column string, v *string) {
+	if v == nil {
+		return
+	}
+
+	if *v == "" {
+		updates[column] = nil
+
+		return
+	}
+
+	updates[column] = *v
+}
+
+func nullableDate(v *string) interface{} {
+	if v == nil || *v == "" {
+		return nil
+	}
+
+	return *v
+}
+
+func stringOr(v *string, fallback string) string {
+	if v == nil {
+		return fallback
+	}
+
+	return *v
+}
+
+func floatOr(v *utils.FlexFloat64, fallback float64) float64 {
+	if v == nil {
+		return fallback
+	}
+
+	return float64(*v)
+}
+
+func boolOr(v *bool, fallback bool) bool {
+	if v == nil {
+		return fallback
+	}
+
+	return *v
+}

--- a/iznik-server-go/partnerships/partnerships.go
+++ b/iznik-server-go/partnerships/partnerships.go
@@ -884,8 +884,9 @@ func Summary(c *fiber.Ctx) error {
 	})
 }
 
-// detectGroups fills partnerships_groups from the authority's boundary overlap. Existing
-// rows are left alone, so groups added or removed by hand survive a later re-detect.
+// detectGroups fills partnerships_groups from the authority's boundary overlap. Groups added
+// by hand from outside the boundary are left alone; a group removed by hand that is still
+// inside the boundary does come back, which is the point of asking for a re-detect.
 func detectGroups(db *gorm.DB, partnershipid uint64, authorityid uint64) {
 	for _, g := range authority.GroupsForAuthority(authorityid) {
 		addGroup(db, partnershipid, g.ID)

--- a/iznik-server-go/partnerships/stats.go
+++ b/iznik-server-go/partnerships/stats.go
@@ -1,0 +1,238 @@
+package partnerships
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/gofiber/fiber/v2"
+)
+
+// Generating a council's quarterly statistics spreadsheet takes minutes, not the seconds a
+// web request can wait for, so the page queues a job and polls for it. The Laravel scheduler
+// picks the job up (partnerships:stats:run), renders the spreadsheets and stores the bytes
+// in partnerships_statsfiles; the download below streams them back out.
+
+// StatsFile is one rendered spreadsheet belonging to a job.
+type StatsFile struct {
+	ID       uint64 `json:"id"`
+	Jobid    uint64 `json:"jobid"`
+	Filename string `json:"filename"`
+	Size     uint32 `json:"size"`
+}
+
+// StatsJob is a queued request to render authority statistics spreadsheets.
+type StatsJob struct {
+	ID           uint64      `json:"id"`
+	Authorityids string      `json:"authorityids"`
+	Quarter      string      `json:"quarter"`
+	Status       string      `json:"status"`
+	Error        *string     `json:"error"`
+	Requested    string      `json:"requested"`
+	Completed    *string     `json:"completed"`
+	Files        []StatsFile `json:"files"`
+}
+
+// maxStatsJobs is how many recent jobs the page shows. Older ones are still in the table but
+// are of no interest once their spreadsheets have been downloaded.
+const maxStatsJobs = 20
+
+// CreateStatsJob queues a spreadsheet generation run.
+//
+// @Summary Queue authority statistics generation
+// @Tags partnerships
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/statsjob [post]
+func CreateStatsJob(c *fiber.Ctx) error {
+	myid, err := requireUser(c)
+	if err != nil {
+		return err
+	}
+
+	var req struct {
+		Authorityids []utils.FlexUint64 `json:"authorityids"`
+		Quarter      string             `json:"quarter"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Invalid body"})
+	}
+
+	ids := []string{}
+	for _, id := range req.Authorityids {
+		if id > 0 {
+			ids = append(ids, strconv.FormatUint(uint64(id), 10))
+		}
+	}
+
+	if len(ids) == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing authorityids"})
+	}
+
+	quarter := req.Quarter
+	if quarter == "" {
+		// The same default the command has: the last full quarter.
+		quarter = "3 months ago"
+	}
+
+	db := database.DBConn
+
+	row := map[string]interface{}{
+		"userid": myid,
+		// The command's --i option takes a comma-separated list.
+		"authorityids": strings.Join(ids, ","),
+		"quarter":      quarter,
+		"status":       "Pending",
+	}
+
+	if err := db.Table("partnerships_statsjobs").Create(row).Error; err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"ret": 1, "status": "Create failed"})
+	}
+
+	newIDInt, _ := row["@id"].(int64)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "id": uint64(newIDInt)})
+}
+
+// ListStatsJobs returns the recent generation runs with the files each produced, which is
+// what the page polls while a run is in progress.
+//
+// @Summary List authority statistics generation jobs
+// @Tags partnerships
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/statsjob [get]
+func ListStatsJobs(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	db := database.DBConn
+
+	var jobs []StatsJob
+	db.Table("partnerships_statsjobs").
+		Select("id, authorityids, quarter, status, error, " +
+			"DATE_FORMAT(requested, '%Y-%m-%d %H:%i:%s') AS requested, " +
+			"DATE_FORMAT(completed, '%Y-%m-%d %H:%i:%s') AS completed").
+		Order("id DESC").
+		Limit(maxStatsJobs).
+		Scan(&jobs)
+
+	if len(jobs) == 0 {
+		return c.JSON(fiber.Map{"ret": 0, "status": "Success", "jobs": []StatsJob{}})
+	}
+
+	jobids := make([]uint64, 0, len(jobs))
+	for _, j := range jobs {
+		jobids = append(jobids, j.ID)
+	}
+
+	// One query for all the files, then attach - a per-job query would be N+1 on a page
+	// that polls every few seconds.
+	var files []StatsFile
+	db.Table("partnerships_statsfiles").
+		Select("id, jobid, filename, size").
+		Where("jobid IN ?", jobids).
+		Order("id ASC").
+		Scan(&files)
+
+	byJob := map[uint64][]StatsFile{}
+	for _, f := range files {
+		byJob[f.Jobid] = append(byJob[f.Jobid], f)
+	}
+
+	for i := range jobs {
+		jobs[i].Files = byJob[jobs[i].ID]
+		if jobs[i].Files == nil {
+			jobs[i].Files = []StatsFile{}
+		}
+	}
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "jobs": jobs})
+}
+
+// DownloadStatsFile streams one rendered spreadsheet.
+//
+// @Summary Download a generated statistics spreadsheet
+// @Tags partnerships
+// @Produce application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+// @Param id path integer true "File ID"
+// @Success 200 {file} binary
+// @Router /api/partnership/statsfile/{id} [get]
+func DownloadStatsFile(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	if id == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	db := database.DBConn
+
+	var file struct {
+		Filename string
+		Content  []byte
+	}
+	db.Table("partnerships_statsfiles").
+		Select("filename, content").
+		Where("id = ?", id).
+		Scan(&file)
+
+	if file.Filename == "" {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Not found"})
+	}
+
+	c.Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+	// The browser saves it under the council's own name rather than a bare "statsfile".
+	c.Set("Content-Disposition", "attachment; filename=\""+sanitiseFilename(file.Filename)+"\"")
+
+	return c.Send(file.Content)
+}
+
+// DeleteStatsJob discards a generation run and the spreadsheets it produced.
+//
+// @Summary Delete a statistics generation job
+// @Tags partnerships
+// @Produce json
+// @Param id path integer true "Job ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/partnership/statsjob/{id} [delete]
+func DeleteStatsJob(c *fiber.Ctx) error {
+	if _, err := requireUser(c); err != nil {
+		return err
+	}
+
+	id, _ := strconv.ParseUint(c.Params("id"), 10, 64)
+	if id == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 2, "status": "Missing id"})
+	}
+
+	db := database.DBConn
+	db.Table("partnerships_statsjobs").Where("id = ?", id).Delete(nil)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// sanitiseFilename keeps a generated filename safe to put in a Content-Disposition header:
+// quotes and control characters would let a crafted authority name break out of it.
+func sanitiseFilename(name string) string {
+	out := make([]rune, 0, len(name))
+	for _, r := range name {
+		if r < 32 || r == '"' || r == '\\' || r == '/' {
+			out = append(out, '_')
+
+			continue
+		}
+		out = append(out, r)
+	}
+
+	if len(out) == 0 {
+		return "statistics.xlsx"
+	}
+
+	return string(out)
+}

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -63,6 +63,7 @@ import (
 	"github.com/freegle/iznik-server-go/newsfeed"
 	"github.com/freegle/iznik-server-go/noticeboard"
 	"github.com/freegle/iznik-server-go/notification"
+	"github.com/freegle/iznik-server-go/partnerships"
 	"github.com/freegle/iznik-server-go/recommendations"
 	"github.com/freegle/iznik-server-go/rippling"
 	"github.com/freegle/iznik-server-go/session"
@@ -1377,6 +1378,25 @@ func SetupRoutes(app *fiber.App) {
 		rg.Post("/team", deprecation.Marker("POST /team", "2026-08-01"), team.PostTeam)
 		rg.Patch("/team", team.PatchTeam)
 		rg.Delete("/team", deprecation.Marker("DELETE /team", "2026-08-01"), team.DeleteTeam)
+
+		// Partnerships (ModTools). The literal paths must be registered before
+		// /partnership/:id, or "summary" and "statsjob" would be matched as ids.
+		rg.Get("/partnership/summary", partnerships.Summary)
+		rg.Get("/partnership/statsjob", partnerships.ListStatsJobs)
+		rg.Post("/partnership/statsjob", partnerships.CreateStatsJob)
+		rg.Delete("/partnership/statsjob/:id", partnerships.DeleteStatsJob)
+		rg.Get("/partnership/statsfile/:id", partnerships.DownloadStatsFile)
+		rg.Get("/partnership", partnerships.List)
+		rg.Post("/partnership", partnerships.Create)
+		rg.Get("/partnership/:id", partnerships.Single)
+		rg.Patch("/partnership/:id", partnerships.Update)
+		rg.Delete("/partnership/:id", partnerships.Delete)
+		rg.Get("/partnership/:id/group", partnerships.Groups)
+		rg.Patch("/partnership/:id/group", partnerships.PatchGroups)
+		rg.Put("/partnership/:id/year", partnerships.PutYears)
+		rg.Post("/partnership/:id/payment", partnerships.CreatePayment)
+		rg.Patch("/partnership/:id/payment/:paymentid", partnerships.UpdatePayment)
+		rg.Delete("/partnership/:id/payment/:paymentid", partnerships.DeletePayment)
 
 		// Mod Configs
 		rg.Get("/modtools/modconfig", modconfig.GetModConfig)

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1756,6 +1756,24 @@ func GetSession(c *fiber.Ctx) error {
 		me["permissions"] = perms
 	}
 
+	// Team membership gates a few ModTools pages (currently Partnerships). This is not
+	// gated on systemrole: some team members are ordinary members by role - the account a
+	// team shares for its own inbox, for instance - and they still need their page. The
+	// table is tiny and indexed on userid, so the lookup is cheap enough to always do.
+	var teams []string
+	db.Table("teams_members tm").
+		Select("t.name").
+		Joins("INNER JOIN teams t ON t.id = tm.teamid").
+		Where("tm.userid = ?", myid).
+		Order("t.name ASC").
+		Scan(&teams)
+
+	if teams == nil {
+		teams = []string{}
+	}
+
+	me["teams"] = teams
+
 	if emails == nil {
 		emails = make([]EmailRow, 0)
 	}

--- a/iznik-server-go/test/partnerships_test.go
+++ b/iznik-server-go/test/partnerships_test.go
@@ -102,10 +102,17 @@ func defaultBody(authorityID uint64) string {
 		`"linkurl":"https://example.gov.uk/reuse","agreed":true}`, authorityID)
 }
 
+// A refusal has to withhold the data as well as set the status. Checking only the status
+// code missed a bypass where the handler ran anyway and overwrote the refusal with the
+// deals, so every one of these asserts on the body too.
 func TestPartnershipRequiresLogin(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/partnership", nil)
 	resp, _ := getApp().Test(req)
 	assert.Equal(t, 401, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.NotContains(t, result, "partnerships")
 }
 
 func TestPartnershipRequiresTeamMembership(t *testing.T) {
@@ -116,6 +123,46 @@ func TestPartnershipRequiresTeamMembership(t *testing.T) {
 	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership?jwt=%s", token), nil)
 	resp, _ := getApp().Test(req)
 	assert.Equal(t, 403, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.NotContains(t, result, "partnerships")
+}
+
+func TestPartnershipSummaryRequiresLogin(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/partnership/summary", nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 401, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.NotContains(t, result, "summary")
+}
+
+func TestPartnershipStatsJobsRequireLogin(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/partnership/statsjob", nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 401, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.NotContains(t, result, "jobs")
+}
+
+// A refused write must not write. The bypass let the handler run on, so a logged-out
+// caller could have created a deal.
+func TestPartnershipCreateRefusedWithoutLoginCreatesNothing(t *testing.T) {
+	prefix := uniquePrefix("PartnershipNoCreate")
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	req := httptest.NewRequest("POST", "/api/partnership", strings.NewReader(defaultBody(authorityID)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 401, resp.StatusCode)
+
+	var count int64
+	database.DBConn.Table("partnerships").Where("authorityid = ?", authorityID).Count(&count)
+	assert.Equal(t, int64(0), count)
 }
 
 func TestPartnershipTeamMemberIsAllowed(t *testing.T) {

--- a/iznik-server-go/test/partnerships_test.go
+++ b/iznik-server-go/test/partnerships_test.go
@@ -1,0 +1,1023 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The partnerships tests work against a made-up council whose boundary contains a
+// made-up group, so the group-overlap detection has something real to find.
+
+// createPartnershipAuthority makes an authority covering a square of Scotland.
+func createPartnershipAuthority(t *testing.T, prefix string) uint64 {
+	db := database.DBConn
+	name := "TestAuthority_" + prefix
+
+	result := db.Exec("INSERT INTO authorities (name, polygon) VALUES (?, "+
+		"ST_GeomFromText('POLYGON((-4 55, -3 55, -3 57, -4 57, -4 55))', 3857))", name)
+	require.NoError(t, result.Error)
+
+	var id uint64
+	db.Raw("SELECT id FROM authorities WHERE name = ? ORDER BY id DESC LIMIT 1", name).Scan(&id)
+	require.NotZero(t, id)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM authorities WHERE id = ?", id)
+	})
+
+	return id
+}
+
+// createPartnershipGroup makes a published, on-map Freegle group with a real catchment
+// polygon sitting inside the test authority, so the overlap calculation returns it.
+func createPartnershipGroup(t *testing.T, prefix string) uint64 {
+	db := database.DBConn
+	name := "TestPGroup_" + prefix
+
+	result := db.Exec(fmt.Sprintf("INSERT INTO `groups` (nameshort, namefull, type, onhere, publish, onmap, "+
+		"polyindex, lat, lng) VALUES (?, ?, 'Freegle', 1, 1, 1, "+
+		"ST_GeomFromText('POLYGON((-3.9 55.1, -3.1 55.1, -3.1 56.9, -3.9 56.9, -3.9 55.1))', %d), 55.9533, -3.1883)",
+		utils.SRID), name, "Test Partnership Group "+prefix)
+	require.NoError(t, result.Error)
+
+	var id uint64
+	db.Raw("SELECT id FROM `groups` WHERE nameshort = ? ORDER BY id DESC LIMIT 1", name).Scan(&id)
+	require.NotZero(t, id)
+
+	return id
+}
+
+// partnershipsUser makes a user on the Partnerships team, which is the audience for the page.
+func partnershipsUser(t *testing.T, prefix string) (uint64, string) {
+	db := database.DBConn
+
+	// The team is created by migration; make sure it exists for a bare test schema.
+	db.Exec("INSERT IGNORE INTO teams (name, description, type) VALUES ('Partnerships', 'Partnerships', 'Team')")
+
+	var teamID uint64
+	db.Raw("SELECT id FROM teams WHERE name = 'Partnerships'").Scan(&teamID)
+	require.NotZero(t, teamID)
+
+	userID := CreateTestUser(t, prefix+"_partner", "Moderator")
+	db.Exec("INSERT IGNORE INTO teams_members (userid, teamid) VALUES (?, ?)", userID, teamID)
+
+	_, token := CreateTestSession(t, userID)
+
+	return userID, token
+}
+
+// createPartnership posts a partnership and returns its id.
+func createPartnership(t *testing.T, token string, authorityID uint64, body string) uint64 {
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	require.Equal(t, float64(0), result["ret"], "create should succeed")
+
+	id := uint64(result["id"].(float64))
+	require.NotZero(t, id)
+
+	t.Cleanup(func() {
+		database.DBConn.Exec("DELETE FROM partnerships WHERE id = ?", id)
+	})
+
+	return id
+}
+
+func defaultBody(authorityID uint64) string {
+	return fmt.Sprintf(`{"authorityid":%d,"startdate":"2026-04-01","enddate":"2027-03-31",`+
+		`"amount":6000,"tagline":"Reuse in your area","description":"Your council supports Freegle",`+
+		`"linkurl":"https://example.gov.uk/reuse","agreed":true}`, authorityID)
+}
+
+func TestPartnershipRequiresLogin(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/partnership", nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestPartnershipRequiresTeamMembership(t *testing.T) {
+	prefix := uniquePrefix("PartnershipNoPerm")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 403, resp.StatusCode)
+}
+
+func TestPartnershipTeamMemberIsAllowed(t *testing.T) {
+	prefix := uniquePrefix("PartnershipPerm")
+	_, token := partnershipsUser(t, prefix)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Contains(t, result, "partnerships")
+}
+
+func TestPartnershipAdminIsAllowedWithoutTeam(t *testing.T) {
+	prefix := uniquePrefix("PartnershipAdmin")
+	adminID := CreateTestUser(t, prefix+"_admin", "Admin")
+	_, token := CreateTestSession(t, adminID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestPartnershipCreateDefaultsNameToAuthority(t *testing.T) {
+	prefix := uniquePrefix("PartnershipCreate")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	p := result["partnership"].(map[string]interface{})
+
+	assert.Equal(t, "TestAuthority_"+prefix, p["name"], "name defaults to the council's own name")
+	assert.Equal(t, "2026-04-01", p["startdate"], "dates come back as plain YYYY-MM-DD")
+	assert.Equal(t, "2027-03-31", p["enddate"])
+	assert.Equal(t, float64(6000), p["amount"])
+	assert.Equal(t, true, p["agreed"])
+	assert.Equal(t, "Reuse in your area", p["tagline"])
+}
+
+func TestPartnershipCreateRejectsMissingAuthority(t *testing.T) {
+	prefix := uniquePrefix("PartnershipNoAuth")
+	_, token := partnershipsUser(t, prefix)
+
+	body := `{"startdate":"2026-04-01","enddate":"2027-03-31"}`
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestPartnershipCreateRejectsUnknownAuthority(t *testing.T) {
+	prefix := uniquePrefix("PartnershipBadAuth")
+	_, token := partnershipsUser(t, prefix)
+
+	body := `{"authorityid":999999999,"startdate":"2026-04-01","enddate":"2027-03-31"}`
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestPartnershipCreateRejectsMissingDates(t *testing.T) {
+	prefix := uniquePrefix("PartnershipNoDates")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	body := fmt.Sprintf(`{"authorityid":%d}`, authorityID)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestPartnershipDetectsCoveredGroups(t *testing.T) {
+	prefix := uniquePrefix("PartnershipGroups")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+	groupID := createPartnershipGroup(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/%d/group?jwt=%s", id, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	groups := result["groups"].([]interface{})
+	found := false
+	for _, g := range groups {
+		if uint64(g.(map[string]interface{})["groupid"].(float64)) == groupID {
+			found = true
+		}
+	}
+	assert.True(t, found, "the group inside the council boundary is covered by the deal")
+}
+
+func TestPartnershipWritesSponsorshipRows(t *testing.T) {
+	prefix := uniquePrefix("PartnershipSponsor")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+	groupID := createPartnershipGroup(t, prefix)
+
+	createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	db := database.DBConn
+	var sponsor struct {
+		Name    string
+		Tagline *string
+		Linkurl *string
+		Visible bool
+		Amount  int
+	}
+	db.Raw("SELECT name, tagline, linkurl, visible, amount FROM groups_sponsorship WHERE groupid = ? "+
+		"ORDER BY id DESC LIMIT 1", groupID).Scan(&sponsor)
+
+	assert.Equal(t, "TestAuthority_"+prefix, sponsor.Name)
+	require.NotNil(t, sponsor.Tagline)
+	assert.Equal(t, "Reuse in your area", *sponsor.Tagline)
+	require.NotNil(t, sponsor.Linkurl)
+	assert.Equal(t, "https://example.gov.uk/reuse", *sponsor.Linkurl)
+	assert.True(t, sponsor.Visible, "an agreed, visible deal shows on the member site")
+	assert.Equal(t, 6000, sponsor.Amount)
+}
+
+func TestPartnershipNotAgreedIsHiddenFromMembers(t *testing.T) {
+	prefix := uniquePrefix("PartnershipUnagreed")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+	groupID := createPartnershipGroup(t, prefix)
+
+	body := fmt.Sprintf(`{"authorityid":%d,"startdate":"2026-04-01","enddate":"2027-03-31","amount":100,"agreed":false}`,
+		authorityID)
+	createPartnership(t, token, authorityID, body)
+
+	db := database.DBConn
+	var visible bool
+	db.Raw("SELECT visible FROM groups_sponsorship WHERE groupid = ? ORDER BY id DESC LIMIT 1", groupID).Scan(&visible)
+
+	assert.False(t, visible, "a deal that is not agreed yet must not be advertised")
+}
+
+func TestPartnershipUpdateChangesSponsorship(t *testing.T) {
+	prefix := uniquePrefix("PartnershipEdit")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+	groupID := createPartnershipGroup(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	body := `{"tagline":"New tagline","description":"New description","linkurl":"https://example.gov.uk/new"}`
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	db := database.DBConn
+	var sponsor struct {
+		Tagline     *string
+		Description *string
+		Linkurl     *string
+	}
+	db.Raw("SELECT tagline, description, linkurl FROM groups_sponsorship WHERE groupid = ? "+
+		"ORDER BY id DESC LIMIT 1", groupID).Scan(&sponsor)
+
+	require.NotNil(t, sponsor.Tagline)
+	assert.Equal(t, "New tagline", *sponsor.Tagline)
+	require.NotNil(t, sponsor.Description)
+	assert.Equal(t, "New description", *sponsor.Description)
+	require.NotNil(t, sponsor.Linkurl)
+	assert.Equal(t, "https://example.gov.uk/new", *sponsor.Linkurl)
+}
+
+func TestPartnershipUpdateCanClearTagline(t *testing.T) {
+	prefix := uniquePrefix("PartnershipClear")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	body := `{"tagline":""}`
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	db := database.DBConn
+	var tagline *string
+	db.Raw("SELECT tagline FROM partnerships WHERE id = ?", id).Scan(&tagline)
+
+	assert.Nil(t, tagline, "an empty tagline clears the field rather than being ignored")
+}
+
+func TestPartnershipUpdateOfUnknownIdIs404(t *testing.T) {
+	prefix := uniquePrefix("PartnershipEdit404")
+	_, token := partnershipsUser(t, prefix)
+
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/partnership/999999999?jwt=%s", token),
+		strings.NewReader(`{"tagline":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestPartnershipDeleteRemovesSponsorship(t *testing.T) {
+	prefix := uniquePrefix("PartnershipDelete")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+	groupID := createPartnershipGroup(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	db := database.DBConn
+	var before int64
+	db.Raw("SELECT COUNT(*) FROM groups_sponsorship WHERE groupid = ?", groupID).Scan(&before)
+	require.Equal(t, int64(1), before)
+
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var after int64
+	db.Raw("SELECT COUNT(*) FROM groups_sponsorship WHERE groupid = ?", groupID).Scan(&after)
+	assert.Equal(t, int64(0), after, "deleting the deal takes the sponsor off the member site")
+
+	var partnerships int64
+	db.Raw("SELECT COUNT(*) FROM partnerships WHERE id = ?", id).Scan(&partnerships)
+	assert.Equal(t, int64(0), partnerships)
+}
+
+func TestPartnershipRemoveGroupDropsItsSponsorship(t *testing.T) {
+	prefix := uniquePrefix("PartnershipDropGroup")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+	groupID := createPartnershipGroup(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	body := fmt.Sprintf(`{"action":"Remove","groupid":%d}`, groupID)
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/partnership/%d/group?jwt=%s", id, token),
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	db := database.DBConn
+	var sponsorships int64
+	db.Raw("SELECT COUNT(*) FROM groups_sponsorship WHERE groupid = ?", groupID).Scan(&sponsorships)
+	assert.Equal(t, int64(0), sponsorships)
+
+	var links int64
+	db.Raw("SELECT COUNT(*) FROM partnerships_groups WHERE partnershipid = ? AND groupid = ?", id, groupID).Scan(&links)
+	assert.Equal(t, int64(0), links)
+}
+
+func TestPartnershipAddGroupCreatesSponsorship(t *testing.T) {
+	prefix := uniquePrefix("PartnershipAddGroup")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	// A group nowhere near the council - added by hand because the deal covers it anyway.
+	outsideGroup := CreateTestGroup(t, prefix+"_outside")
+
+	body := fmt.Sprintf(`{"action":"Add","groupid":%d}`, outsideGroup)
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/partnership/%d/group?jwt=%s", id, token),
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	db := database.DBConn
+	var sponsorships int64
+	db.Raw("SELECT COUNT(*) FROM groups_sponsorship WHERE groupid = ?", outsideGroup).Scan(&sponsorships)
+	assert.Equal(t, int64(1), sponsorships)
+}
+
+func TestPartnershipGroupActionNeedsGroupid(t *testing.T) {
+	prefix := uniquePrefix("PartnershipGroupBad")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/partnership/%d/group?jwt=%s", id, token),
+		strings.NewReader(`{"action":"Add"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestPartnershipGroupUnknownAction(t *testing.T) {
+	prefix := uniquePrefix("PartnershipGroupAct")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/partnership/%d/group?jwt=%s", id, token),
+		strings.NewReader(`{"action":"Wibble"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestPartnershipPaymentsAndTotals(t *testing.T) {
+	prefix := uniquePrefix("PartnershipPay")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	// Two invoices, only one of them settled.
+	for _, body := range []string{
+		`{"date":"2026-04-15","amount":3000,"paid":"2026-05-01","reference":"INV-1"}`,
+		`{"date":"2026-10-15","amount":3000,"reference":"INV-2"}`,
+	} {
+		req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/%d/payment?jwt=%s", id, token),
+			strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := getApp().Test(req)
+		require.Equal(t, 200, resp.StatusCode)
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	p := result["partnership"].(map[string]interface{})
+	assert.Equal(t, float64(6000), p["invoiced"], "both invoices count towards invoiced")
+	assert.Equal(t, float64(3000), p["paid"], "only the settled one counts as paid")
+
+	payments := result["payments"].([]interface{})
+	require.Len(t, payments, 2)
+	first := payments[0].(map[string]interface{})
+	assert.Equal(t, "2026-04-15", first["date"])
+	assert.Equal(t, "2026-05-01", first["paid"])
+}
+
+func TestPartnershipPaymentMarkedPaidThenUnpaid(t *testing.T) {
+	prefix := uniquePrefix("PartnershipPayEdit")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/%d/payment?jwt=%s", id, token),
+		strings.NewReader(`{"date":"2026-04-15","amount":1000}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var created map[string]interface{}
+	json2.Unmarshal(rsp(resp), &created)
+	paymentID := uint64(created["id"].(float64))
+	require.NotZero(t, paymentID)
+
+	// Mark it paid.
+	req = httptest.NewRequest("PATCH", fmt.Sprintf("/api/partnership/%d/payment/%d?jwt=%s", id, paymentID, token),
+		strings.NewReader(`{"paid":"2026-05-02"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ = getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	db := database.DBConn
+	var paid *string
+	db.Raw("SELECT DATE_FORMAT(paid, '%Y-%m-%d') FROM partnerships_payments WHERE id = ?", paymentID).Scan(&paid)
+	require.NotNil(t, paid)
+	assert.Equal(t, "2026-05-02", *paid)
+
+	// And back to unpaid - an empty date must clear it, not be ignored.
+	req = httptest.NewRequest("PATCH", fmt.Sprintf("/api/partnership/%d/payment/%d?jwt=%s", id, paymentID, token),
+		strings.NewReader(`{"paid":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ = getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	db.Raw("SELECT DATE_FORMAT(paid, '%Y-%m-%d') FROM partnerships_payments WHERE id = ?", paymentID).Scan(&paid)
+	assert.Nil(t, paid)
+}
+
+func TestPartnershipDeletePayment(t *testing.T) {
+	prefix := uniquePrefix("PartnershipPayDel")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/%d/payment?jwt=%s", id, token),
+		strings.NewReader(`{"date":"2026-04-15","amount":1000}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var created map[string]interface{}
+	json2.Unmarshal(rsp(resp), &created)
+	paymentID := uint64(created["id"].(float64))
+
+	req = httptest.NewRequest("DELETE", fmt.Sprintf("/api/partnership/%d/payment/%d?jwt=%s", id, paymentID, token), nil)
+	resp, _ = getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	db := database.DBConn
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM partnerships_payments WHERE id = ?", paymentID).Scan(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestPartnershipPaymentNeedsDate(t *testing.T) {
+	prefix := uniquePrefix("PartnershipPayNoDate")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/%d/payment?jwt=%s", id, token),
+		strings.NewReader(`{"amount":1000}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestPartnershipProRatesAcrossFinancialYears(t *testing.T) {
+	prefix := uniquePrefix("PartnershipFY")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	// A three-year deal, so the money should show across three financial years.
+	body := fmt.Sprintf(`{"authorityid":%d,"startdate":"2026-04-01","enddate":"2029-03-31","amount":9000,"agreed":true}`,
+		authorityID)
+	id := createPartnership(t, token, authorityID, body)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	years := result["years"].([]interface{})
+	require.Len(t, years, 3)
+	assert.Equal(t, float64(2026), years[0].(map[string]interface{})["financialyear"])
+	assert.Equal(t, "2026/27", years[0].(map[string]interface{})["label"])
+	assert.Equal(t, float64(2028), years[2].(map[string]interface{})["financialyear"])
+}
+
+func TestPartnershipExplicitYearsBeatProRata(t *testing.T) {
+	prefix := uniquePrefix("PartnershipFYExplicit")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	body := fmt.Sprintf(`{"authorityid":%d,"startdate":"2026-04-01","enddate":"2028-03-31","amount":9000,"agreed":true}`,
+		authorityID)
+	id := createPartnership(t, token, authorityID, body)
+
+	// The council pays most of it up front, so the pro-rata split is wrong.
+	years := `{"years":[{"financialyear":2026,"amount":7000},{"financialyear":2027,"amount":2000}]}`
+	req := httptest.NewRequest("PUT", fmt.Sprintf("/api/partnership/%d/year?jwt=%s", id, token),
+		strings.NewReader(years))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	req = httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), nil)
+	resp, _ = getApp().Test(req)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	got := result["years"].([]interface{})
+	require.Len(t, got, 2)
+	assert.Equal(t, float64(7000), got[0].(map[string]interface{})["amount"])
+	assert.Equal(t, float64(2000), got[1].(map[string]interface{})["amount"])
+	assert.Equal(t, "2026/27", got[0].(map[string]interface{})["label"])
+}
+
+func TestPartnershipEmptyYearsRestoresProRata(t *testing.T) {
+	prefix := uniquePrefix("PartnershipFYReset")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	body := fmt.Sprintf(`{"authorityid":%d,"startdate":"2026-04-01","enddate":"2028-03-31","amount":9000,"agreed":true}`,
+		authorityID)
+	id := createPartnership(t, token, authorityID, body)
+
+	for _, years := range []string{
+		`{"years":[{"financialyear":2026,"amount":7000},{"financialyear":2027,"amount":2000}]}`,
+		`{"years":[]}`,
+	} {
+		req := httptest.NewRequest("PUT", fmt.Sprintf("/api/partnership/%d/year?jwt=%s", id, token),
+			strings.NewReader(years))
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := getApp().Test(req)
+		require.Equal(t, 200, resp.StatusCode)
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), nil)
+	resp, _ := getApp().Test(req)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	got := result["years"].([]interface{})
+	require.Len(t, got, 2)
+	// Roughly half each - not exactly, because 2027/28 contains a leap day.
+	assert.InDelta(t, 4500.0, got[0].(map[string]interface{})["amount"].(float64), 20.0,
+		"with no explicit split we go back to pro-rating")
+}
+
+func TestPartnershipSummaryTotals(t *testing.T) {
+	prefix := uniquePrefix("PartnershipSummary")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	id := createPartnership(t, token, authorityID, defaultBody(authorityID))
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/%d/payment?jwt=%s", id, token),
+		strings.NewReader(`{"date":"2026-04-15","amount":2000,"paid":"2026-05-01"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	req = httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/summary?jwt=%s", token), nil)
+	resp, _ = getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	summary := result["summary"].(map[string]interface{})
+	assert.GreaterOrEqual(t, summary["total"].(float64), float64(6000))
+	assert.GreaterOrEqual(t, summary["invoiced"].(float64), float64(2000))
+	assert.GreaterOrEqual(t, summary["paid"].(float64), float64(2000))
+	assert.Contains(t, summary, "years")
+
+	// The financial year the deal sits in must appear in the graph data.
+	years := summary["years"].([]interface{})
+	found := false
+	for _, y := range years {
+		if y.(map[string]interface{})["financialyear"].(float64) == 2026 {
+			found = true
+			assert.Contains(t, y.(map[string]interface{}), "agreed")
+			assert.Contains(t, y.(map[string]interface{}), "pipeline")
+		}
+	}
+	assert.True(t, found, "2026/27 income shows in the per-year breakdown")
+}
+
+func TestPartnershipSummarySeparatesAgreedFromPipeline(t *testing.T) {
+	prefix := uniquePrefix("PartnershipPipeline")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	// Deliberately not agreed: hoped-for money must not be counted as income.
+	body := fmt.Sprintf(`{"authorityid":%d,"startdate":"2026-04-01","enddate":"2027-03-31","amount":5000,"agreed":false}`,
+		authorityID)
+	createPartnership(t, token, authorityID, body)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/summary?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	summary := result["summary"].(map[string]interface{})
+	for _, y := range summary["years"].([]interface{}) {
+		year := y.(map[string]interface{})
+		if year["financialyear"].(float64) == 2026 {
+			assert.GreaterOrEqual(t, year["pipeline"].(float64), float64(5000))
+		}
+	}
+}
+
+func TestPartnershipExpiringFlag(t *testing.T) {
+	prefix := uniquePrefix("PartnershipExpiring")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	// Ends in a month, so it should be flagged as running out.
+	soon := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	body := fmt.Sprintf(`{"authorityid":%d,"startdate":"2020-04-01","enddate":"%s","amount":1000,"agreed":true}`,
+		authorityID, soon)
+	id := createPartnership(t, token, authorityID, body)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), nil)
+	resp, _ := getApp().Test(req)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	p := result["partnership"].(map[string]interface{})
+	assert.Equal(t, true, p["expiring"])
+	assert.Equal(t, false, p["expired"])
+}
+
+func TestPartnershipExpiredFlag(t *testing.T) {
+	prefix := uniquePrefix("PartnershipExpired")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	body := fmt.Sprintf(`{"authorityid":%d,"startdate":"2019-04-01","enddate":"2020-03-31","amount":1000,"agreed":true}`,
+		authorityID)
+	id := createPartnership(t, token, authorityID, body)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/%d?jwt=%s", id, token), nil)
+	resp, _ := getApp().Test(req)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	p := result["partnership"].(map[string]interface{})
+	assert.Equal(t, true, p["expired"])
+	assert.Equal(t, false, p["expiring"])
+}
+
+func TestPartnershipSingleUnknownIdIs404(t *testing.T) {
+	prefix := uniquePrefix("PartnershipGet404")
+	_, token := partnershipsUser(t, prefix)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/999999999?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestPartnershipStatsJobQueued(t *testing.T) {
+	prefix := uniquePrefix("PartnershipStatsJob")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	body := fmt.Sprintf(`{"authorityids":[%d],"quarter":"2026-04-01"}`, authorityID)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/statsjob?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	jobID := uint64(result["id"].(float64))
+	require.NotZero(t, jobID)
+
+	t.Cleanup(func() {
+		database.DBConn.Exec("DELETE FROM partnerships_statsjobs WHERE id = ?", jobID)
+	})
+
+	db := database.DBConn
+	var job struct {
+		Authorityids string
+		Quarter      string
+		Status       string
+	}
+	db.Raw("SELECT authorityids, quarter, status FROM partnerships_statsjobs WHERE id = ?", jobID).Scan(&job)
+
+	assert.Equal(t, fmt.Sprintf("%d", authorityID), job.Authorityids)
+	assert.Equal(t, "2026-04-01", job.Quarter)
+	assert.Equal(t, "Pending", job.Status, "the scheduler picks it up from Pending")
+}
+
+func TestPartnershipStatsJobNeedsAuthorities(t *testing.T) {
+	prefix := uniquePrefix("PartnershipStatsNone")
+	_, token := partnershipsUser(t, prefix)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/statsjob?jwt=%s", token),
+		strings.NewReader(`{"authorityids":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestPartnershipStatsJobDefaultsQuarter(t *testing.T) {
+	prefix := uniquePrefix("PartnershipStatsQ")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	body := fmt.Sprintf(`{"authorityids":[%d]}`, authorityID)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/statsjob?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	jobID := uint64(result["id"].(float64))
+
+	t.Cleanup(func() {
+		database.DBConn.Exec("DELETE FROM partnerships_statsjobs WHERE id = ?", jobID)
+	})
+
+	var quarter string
+	database.DBConn.Raw("SELECT quarter FROM partnerships_statsjobs WHERE id = ?", jobID).Scan(&quarter)
+	assert.Equal(t, "3 months ago", quarter, "same default as the authority:stats command")
+}
+
+func TestPartnershipStatsJobListIncludesFiles(t *testing.T) {
+	prefix := uniquePrefix("PartnershipStatsList")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	body := fmt.Sprintf(`{"authorityids":[%d]}`, authorityID)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/statsjob?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var created map[string]interface{}
+	json2.Unmarshal(rsp(resp), &created)
+	jobID := uint64(created["id"].(float64))
+
+	t.Cleanup(func() {
+		database.DBConn.Exec("DELETE FROM partnerships_statsjobs WHERE id = ?", jobID)
+	})
+
+	db := database.DBConn
+	db.Exec("UPDATE partnerships_statsjobs SET status = 'Ready', completed = NOW() WHERE id = ?", jobID)
+	db.Exec("INSERT INTO partnerships_statsfiles (jobid, authorityid, filename, size, content) VALUES (?, ?, ?, ?, ?)",
+		jobID, authorityID, "Freegle-Statistics-Test.xlsx", 5, []byte("hello"))
+
+	req = httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/statsjob?jwt=%s", token), nil)
+	resp, _ = getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	jobs := result["jobs"].([]interface{})
+	var found map[string]interface{}
+	for _, j := range jobs {
+		if uint64(j.(map[string]interface{})["id"].(float64)) == jobID {
+			found = j.(map[string]interface{})
+		}
+	}
+	require.NotNil(t, found, "the job we queued is listed")
+	assert.Equal(t, "Ready", found["status"])
+
+	files := found["files"].([]interface{})
+	require.Len(t, files, 1)
+	assert.Equal(t, "Freegle-Statistics-Test.xlsx", files[0].(map[string]interface{})["filename"])
+}
+
+func TestPartnershipStatsFileDownload(t *testing.T) {
+	prefix := uniquePrefix("PartnershipStatsDl")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	db := database.DBConn
+	db.Exec("INSERT INTO partnerships_statsjobs (authorityids, quarter, status) VALUES (?, '3 months ago', 'Ready')",
+		fmt.Sprintf("%d", authorityID))
+
+	var jobID uint64
+	db.Raw("SELECT id FROM partnerships_statsjobs ORDER BY id DESC LIMIT 1").Scan(&jobID)
+	require.NotZero(t, jobID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM partnerships_statsjobs WHERE id = ?", jobID)
+	})
+
+	db.Exec("INSERT INTO partnerships_statsfiles (jobid, authorityid, filename, size, content) VALUES (?, ?, ?, ?, ?)",
+		jobID, authorityID, "Freegle-Statistics-Somewhere.xlsx", 9, []byte("spreadsheet"))
+
+	var fileID uint64
+	db.Raw("SELECT id FROM partnerships_statsfiles WHERE jobid = ? ORDER BY id DESC LIMIT 1", jobID).Scan(&fileID)
+	require.NotZero(t, fileID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/statsfile/%d?jwt=%s", fileID, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Disposition"), "Freegle-Statistics-Somewhere.xlsx")
+	assert.Equal(t, "spreadsheet", string(rsp(resp)))
+}
+
+func TestPartnershipStatsFileUnknownIdIs404(t *testing.T) {
+	prefix := uniquePrefix("PartnershipStatsDl404")
+	_, token := partnershipsUser(t, prefix)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership/statsfile/999999999?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestPartnershipStatsJobDelete(t *testing.T) {
+	prefix := uniquePrefix("PartnershipStatsDel")
+	_, token := partnershipsUser(t, prefix)
+	authorityID := createPartnershipAuthority(t, prefix)
+
+	body := fmt.Sprintf(`{"authorityids":[%d]}`, authorityID)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/partnership/statsjob?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var created map[string]interface{}
+	json2.Unmarshal(rsp(resp), &created)
+	jobID := uint64(created["id"].(float64))
+
+	req = httptest.NewRequest("DELETE", fmt.Sprintf("/api/partnership/statsjob/%d?jwt=%s", jobID, token), nil)
+	resp, _ = getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var count int64
+	database.DBConn.Raw("SELECT COUNT(*) FROM partnerships_statsjobs WHERE id = ?", jobID).Scan(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestSessionReportsTeamMembership(t *testing.T) {
+	prefix := uniquePrefix("PartnershipSession")
+	_, token := partnershipsUser(t, prefix)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/session?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	me := result["me"].(map[string]interface{})
+	require.Contains(t, me, "teams", "ModTools needs to know which teams a volunteer is on")
+
+	teams := me["teams"].([]interface{})
+	found := false
+	for _, team := range teams {
+		if team.(string) == "Partnerships" {
+			found = true
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestSessionReportsNoTeamsForSomeoneOnNone(t *testing.T) {
+	prefix := uniquePrefix("PartnershipSessionUser")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/session?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	me := result["me"].(map[string]interface{})
+	require.Contains(t, me, "teams")
+	assert.Empty(t, me["teams"])
+}
+
+func TestSessionReportsTeamsForAPlainMemberOnATeam(t *testing.T) {
+	// Some team members are ordinary members by role - a team's own shared account, for
+	// instance - and they still have to be able to reach their team's page.
+	prefix := uniquePrefix("PartnershipSessionShared")
+	db := database.DBConn
+
+	db.Exec("INSERT IGNORE INTO teams (name, description, type) VALUES ('Partnerships', 'Partnerships', 'Team')")
+
+	var teamID uint64
+	db.Raw("SELECT id FROM teams WHERE name = 'Partnerships'").Scan(&teamID)
+	require.NotZero(t, teamID)
+
+	userID := CreateTestUser(t, prefix, "User")
+	db.Exec("INSERT IGNORE INTO teams_members (userid, teamid) VALUES (?, ?)", userID, teamID)
+
+	_, token := CreateTestSession(t, userID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/session?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	me := result["me"].(map[string]interface{})
+	require.Contains(t, me, "teams")
+	assert.Contains(t, me["teams"], "Partnerships")
+}
+
+func TestPartnershipPlainMemberOnTheTeamMayUseThePage(t *testing.T) {
+	prefix := uniquePrefix("PartnershipSharedAcct")
+	db := database.DBConn
+
+	db.Exec("INSERT IGNORE INTO teams (name, description, type) VALUES ('Partnerships', 'Partnerships', 'Team')")
+
+	var teamID uint64
+	db.Raw("SELECT id FROM teams WHERE name = 'Partnerships'").Scan(&teamID)
+
+	userID := CreateTestUser(t, prefix, "User")
+	db.Exec("INSERT IGNORE INTO teams_members (userid, teamid) VALUES (?, ?)", userID, teamID)
+
+	_, token := CreateTestSession(t, userID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/partnership?jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+}

--- a/plans/active/2026-08-08-modtools-partnerships.md
+++ b/plans/active/2026-08-08-modtools-partnerships.md
@@ -40,10 +40,28 @@ spreadsheets.
 | 5 | Laravel: stats job runner command + tests | ✅ | `partnerships:stats:run` |
 | 6 | Laravel: expiry reminder command + mail + tests | ✅ | `partnerships:reminders`, 18 Laravel tests green |
 | 7 | Frontend: API + store + page + components + menu | ✅ | |
-| 8 | Vitest tests | ✅ | 83 green |
-| 9 | Run Go / Laravel / vitest suites | ✅ | Go 3992✓, Laravel 18✓, vitest 84✓ |
+| 8 | Vitest tests | ✅ | 87 |
+| 9 | Run Go / Laravel / vitest suites | ✅ | vitest 15058✓ full suite |
 | 10 | Live DB | ✅ | Tables created; team + members + logins already existed - see below |
 | 11 | Docs + PR | ✅ | PR #1291 |
+| 12 | Drive the page in a browser + screenshots | ✅ | Found three bugs unit tests missed - see below |
+
+## Bugs found by driving the real page
+
+Unit tests mock the API and stub the components, so they passed while the page was broken
+end to end. Loading it in a browser against the worktree's own containers found three
+things at once, each now fixed with a test that fails without the fix:
+
+- **`requireUser` refused the request but the handler carried on.** `c.Status(...).JSON(...)`
+  writes a response and returns `nil`, so the caller's `err != nil` check passed and the
+  handler ran anyway - overwriting the refusal with the very data it was withholding. Every
+  partnerships endpoint served its payload to anyone, under a 401. Now a real
+  `fiber.NewError`, and the permission tests assert on the body, not just the status.
+- **The partnerships store never got the runtime config.** `modtools/app.vue` hands each
+  store the Nuxt config via `init()`, and the new one was missing from that list, so the
+  first API call died on `Cannot read properties of undefined (reading 'public')`.
+- **The page never imported `GChart`**, so the income graph silently did not render. The
+  page test stubbed the component, which hid it.
 
 ## Bugs this turned up along the way
 

--- a/plans/active/2026-08-08-modtools-partnerships.md
+++ b/plans/active/2026-08-08-modtools-partnerships.md
@@ -41,9 +41,9 @@ spreadsheets.
 | 6 | Laravel: expiry reminder command + mail + tests | ✅ | `partnerships:reminders`, 18 Laravel tests green |
 | 7 | Frontend: API + store + page + components + menu | ✅ | |
 | 8 | Vitest tests | ✅ | 83 green |
-| 9 | Run Go / Laravel / vitest suites | 🔄 | Laravel + vitest green; final Go run in flight |
-| 10 | Live DB | ✅ | Team + members + logins already existed - see below |
-| 11 | Docs + PR | 🔄 | |
+| 9 | Run Go / Laravel / vitest suites | ✅ | Go 3992✓, Laravel 18✓, vitest 84✓ |
+| 10 | Live DB | ✅ | Tables created; team + members + logins already existed - see below |
+| 11 | Docs + PR | ✅ | PR #1291 |
 
 ## Bugs this turned up along the way
 
@@ -69,5 +69,6 @@ Checked over the tunnel before changing anything, and the intended state was alr
   member's account uses a personal address, and the shared account uses a different
   `@ilovefreegle.org` one. Left as-is rather than guessing at mail routing.
 
-The only outstanding live change is creating the `partnerships*` tables, which the production
-SQL twins alongside the migrations do.
+The `partnerships*` tables have been created on live from the production SQL twins alongside
+the migrations: seven tables, eight foreign keys, `content` as MEDIUMBLOB. Nothing reads or
+writes them until the code deploys.

--- a/plans/active/2026-08-08-modtools-partnerships.md
+++ b/plans/active/2026-08-08-modtools-partnerships.md
@@ -1,0 +1,73 @@
+# ModTools Partnerships page
+
+Worktree: `/home/edward/FreegleDocker-partnerships` (branch `feature/modtools-partnerships`, status port 12339, traefik 12342)
+
+## Goal
+
+A Partnerships page in ModTools, gated on a new **Partnerships** team, which manages council
+sponsorship deals end to end: which councils have a live sponsorship, the groups each deal
+covers, the money (agreed / invoiced / paid, split by UK financial year), reminder mails three
+months before expiry, and on-demand generation + download of the quarterly authority stats
+spreadsheets.
+
+## Design decisions
+
+- **Tables** are prefixed `partnerships_` (`partnerships` itself carries the prefix).
+- **A partnership is with an authority (council)**, not a group. The groups it affects are
+  derived from the authority ∩ group polygon overlap (the same query `/authority/{id}` already
+  uses) and can be trimmed by hand. Saving a partnership syncs `groups_sponsorship` rows for
+  those groups so the member site shows the sponsor.
+- **Money**: `partnerships.amount` is the headline deal value. Multi-year deals get explicit
+  `partnerships_years` rows (financial year + amount); when there are none, the amount is
+  pro-rated across the UK financial years (1 Apr - 31 Mar) the deal spans. Payments are tracked
+  in `partnerships_payments` so "invoiced vs paid" is visible.
+- **Stats generation is async**: the page POSTs a job row, the Laravel scheduler picks it up,
+  renders the spreadsheets with the existing `AuthorityStatsCommand` renderer and stores the
+  bytes in `partnerships_statsfiles`; the page polls and downloads from apiv2. Blob-in-DB
+  avoids needing a shared volume between the Go and Laravel containers.
+- **Reminders** go to the Partnerships team email (partnerships@ilovefreegle.org) when a
+  sponsorship is within 3 months of expiry, recorded in `partnerships_reminders` so each
+  partnership is only chased once per window.
+
+## Status
+
+| # | Task | Status | Notes |
+|---|------|--------|-------|
+| 1 | Worktree + codebase exploration | ✅ | |
+| 2 | Laravel migrations for `partnerships*` tables | ✅ | 7 tables + team seed, with production SQL twins |
+| 3 | Go: `partnerships` package - CRUD, group sync, FY summary + tests | ✅ | 40 tests |
+| 4 | Go: session exposes team memberships | ✅ | `teams` on `me`, not gated on systemrole (see below) |
+| 5 | Laravel: stats job runner command + tests | ✅ | `partnerships:stats:run` |
+| 6 | Laravel: expiry reminder command + mail + tests | ✅ | `partnerships:reminders`, 18 Laravel tests green |
+| 7 | Frontend: API + store + page + components + menu | ✅ | |
+| 8 | Vitest tests | ✅ | 83 green |
+| 9 | Run Go / Laravel / vitest suites | 🔄 | Laravel + vitest green; final Go run in flight |
+| 10 | Live DB | ✅ | Team + members + logins already existed - see below |
+| 11 | Docs + PR | 🔄 | |
+
+## Bugs this turned up along the way
+
+- **`authority.GroupsForAuthority` aborted on a non-polygon `polyindex`.** `ST_Area` errors
+  on a point, and one such group killed the whole query rather than being skipped - so
+  `/authority/{id}` returned no groups at all. The geometry-type check now guards the area
+  calls themselves.
+- **`YearAmount.FinancialYear` needed an explicit GORM column tag.** The default namer looks
+  for `financial_year`, so every explicitly-agreed year split read back as year zero.
+- **The session `teams` list must not be gated on systemrole.** A team's own shared account
+  is an ordinary member by role, and on live one of the Partnerships team members is exactly
+  that - gating on systemrole would have hidden the page from them.
+
+## Live database
+
+Checked over the tunnel before changing anything, and the intended state was already there:
+
+- The **Partnerships** team exists (id 139) with `partnerships@ilovefreegle.org` as its
+  address, and already has the three intended people on it.
+- All three already have a Native (username/password) login, so there was nothing to create.
+  Their existing passwords were left alone.
+- The two `@ilovefreegle.org` addresses named in the request are not on those accounts: one
+  member's account uses a personal address, and the shared account uses a different
+  `@ilovefreegle.org` one. Left as-is rather than guessing at mail routing.
+
+The only outstanding live change is creating the `partnerships*` tables, which the production
+SQL twins alongside the migrations do.


### PR DESCRIPTION
## Summary

A **Partnerships** page in ModTools for the council sponsorship deals, gated on a new
Partnerships team.

Those deals had nowhere to live. The only trace of one was a `groups_sponsorship` row per
group, with no record of who agreed what, for how long, or whether the money arrived.

- **A partnership is held against an authority, not a group** — that is how the deal is
  done. A council pays once and the sponsorship shows across every community inside its
  boundary. The covered groups are derived from the authority/group overlap (the query
  `/authority/{id}` already used, now shared), and can be corrected by hand.
- **Each covered group gets a `groups_sponsorship` row**, so the member site needs no
  changes. Editing the tagline, description or link changes them all at once. A deal is only
  visible to members once it is marked agreed — an unagreed deal is a conversation, not an
  advert.
- **Money is tracked in three places on purpose**: the whole deal value, how a multi-year
  deal splits across UK financial years, and what has been invoiced and paid. The split is
  pro-rated by day count unless a year-by-year split has been agreed, which is what lets the
  income graph show a three-year deal as three bars rather than a spike in the year it was
  signed. Agreed money and hoped-for money are stacked separately, so a fat pipeline never
  reads as income we already have.
- **Renewal reminders** reach the team three months before a sponsorship ends, once per deal
  per window, with a link straight to it.
- **Council statistics** are generated on demand. They take minutes rather than seconds, so
  the page queues a job and polls; the spreadsheets live in the database because the Go API
  serving the download shares no filesystem with the batch container rendering them. One
  council failing does not lose the rest of the batch.

Access is by membership of the Partnerships team, which is also what puts the entry in the
left-hand menu. Deliberately not gated on systemrole: a team's own shared account is an
ordinary member by role and still needs its page.

All new tables are prefixed `partnerships`.

## Screenshots

Councils, communities, amounts and contacts below are made up for the screenshots. No real
partnership appears.

The page: totals, the renewals due, income by financial year, and the deals themselves.

![Partnerships page](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/modtools-partnerships/partnerships-overview.png)

A deal opened up: the communities it covers, the year-by-year split, and the invoices.

![A deal in detail](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/modtools-partnerships/partnerships-detail.png)

Editing a deal — the tagline, description and link members see, and whether it has been
agreed.

![Editing a deal](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/modtools-partnerships/partnerships-edit.png)

Those images live on `pr-assets/modtools-partnerships`, a throwaway branch that can be
deleted after merge.

## Code quality review

Six bugs are fixed here, each with a test that fails without the fix.

Three of them are in this branch's own code, and all three survived a green unit suite
because unit tests mock the API and stub the components. Driving the page in a browser
against a real API is what shows them:

- **`requireUser` refused the request and then served it anyway.**
  `c.Status(...).JSON(...)` writes a response but returns `nil`, so the caller's
  `err != nil` check passed and the handler carried on, overwriting the refusal with the
  data it was withholding. Every partnerships endpoint answered anyone with a full payload
  under a 401 — including, for the write endpoints, doing the write. It is now a real
  `fiber.NewError`, and the permission tests assert on the body and on the absence of a
  written row, not just on the status code.
- **The partnerships store was never handed the runtime config.** `modtools/app.vue` reads
  the Nuxt config once and passes it to each store via `init()`; the new store was missing
  from that list, so its first API call died on `Cannot read properties of undefined
  (reading 'public')` and the page rendered the error screen. A test now asserts that every
  store `modtools/app.vue` creates is also initialised, so the next one cannot be forgotten.
- **The page never imported `GChart`**, so the income graph did not render at all. The page
  test stubbed the component, which hid it; it now also mounts without that stub and fails
  on any unresolved component.

Three are pre-existing or incidental:

- **`authority.GroupsForAuthority` aborted on a non-polygon `polyindex`.** `ST_Area` errors
  on a point, and one such group kills the whole query rather than being skipped — so
  `/authority/{id}` returned *no* groups at all. The geometry check guards the area calls
  themselves, not just the rows, because MySQL evaluates the select list per row.
- **`YearAmount.FinancialYear` needs an explicit GORM column tag.** The default namer looks
  for `financial_year`, so every agreed year split read back silently as year zero.
- **The `b-button` test stub double-fired clicks.** An undeclared emit also falls through as
  a native listener, so every handler ran twice and toggles cancelled themselves out.

Known limits of the implementation: `Summary` runs one small indexed query per partnership
for its year split, which is fine at this scale but is the first thing to batch if the list
grows; and the statistics download is fetched with the usual auth headers rather than linked
with a token in the URL, to keep it out of browser history.

## Future improvements

- The moderator guide has no screenshots. The ones above use invented data, and the guide
  should show the real page once there are real deals on it.
- `partnerships:reminders` accepts `--days` and `--type`, so a shorter second chase
  (`--days=30 --type=1month`) works today, but only the three-month one is scheduled.
- `imageurl` for the sponsor logo is typed in by hand and never validated.

## Test plan

Run locally against this branch, all green:

- **Go** — full suite, 3995 passed, 0 failed. 55 of those are new: financial-year splitting
  including leap years and rounding, permissions (including that a refusal withholds the
  data and writes nothing), group detection, sponsorship sync on create/edit/delete/
  group-change, the agreed-vs-visible rule, payments and totals, explicit vs pro-rata year
  splits, expiry flags, stats job queueing and download.
- **Laravel** — 18 passed, 0 failed. Reminder windows (inside, beyond, expired, unagreed,
  hidden), not chasing twice, dry run, per-window types, the team's own address; job
  claiming, partial failure, unknown authority, and a real `.xlsx` landing in the database.
- **Vitest** — full suite, 15058 passed, 0 failed. 87 of those are new: store, page (access,
  totals, badges, graph, expand, edit, delete confirmation, component resolution), the four
  components, and the app store-wiring check.
- The page was also driven end to end in a browser against the worktree's own API and
  database, which is where the screenshots come from.
- `scripts/check-docs-freshness.mjs` passes.

## Database

Migrations plus idempotent production SQL twins. The tables have been created on live, where
the Partnerships team already existed with the right members.