### PR TITLE
ChitChat threading: clear notification landings and compact feed cards

### DIFF
--- a/iznik-nuxt3/components/NewsReplies.vue
+++ b/iznik-nuxt3/components/NewsReplies.vue
@@ -426,19 +426,19 @@ const feedMode = computed(() => {
   )
 })
 
-// The ONE unread divider (WhatsApp convention): before the first top-level
-// entry that is new, only when there is a genuine old/new split. Nested new
-// activity still gets pills and collapse exemptions, but never a divider.
+// The ONE unread divider (WhatsApp convention). It promises "everything new is
+// below here", so it sits above the first entry whose SUBTREE contains anything
+// new - not merely the first new top-level reply. Replies to an old comment
+// partway up the thread are new but live under an old parent, so anchoring on
+// the parent keeps that promise true and keeps the parent visible as context.
 const firstNewIndex = computed(() => {
   if (!seenBeforeVisit.value) return -1
-  return combinedReplies.value.findIndex((r) => isReplyNew(r))
+  return combinedReplies.value.findIndex((r) => subtreeHasNew(r))
 })
 
-const newCount = computed(() =>
-  firstNewIndex.value >= 0
-    ? combinedReplies.value.length - firstNewIndex.value
-    : 0
-)
+// Every new reply in the thread, nested ones included, so this number agrees
+// with the "View all N replies - M new" link that brought the reader here.
+const newCount = computed(() => treeCounts.value.fresh)
 
 const showDivider = computed(() => props.depth === 1 && firstNewIndex.value > 0)
 

--- a/iznik-nuxt3/components/NewsReplies.vue
+++ b/iznik-nuxt3/components/NewsReplies.vue
@@ -17,10 +17,21 @@
           {{ expanderLabel }}
         </button>
       </div>
+      <NewsUnreadDivider v-else-if="entry.divider" :count="entry.count" />
+      <nuxt-link
+        v-else-if="entry.feedCta"
+        :to="'/chitchat/' + threadhead"
+        class="view-all-replies"
+      >
+        {{ feedCtaLabel(entry) }}
+      </nuxt-link>
       <div
         v-else
         class="reply-thread"
         :data-reply-id="entry.reply.id"
+        :data-combined-ids="
+          entry.reply.combinedIds ? entry.reply.combinedIds.join(' ') : null
+        "
         :class="{ 'reply-thread--new': isReplyNew(entry.reply) }"
       >
         <NewsRefer
@@ -38,6 +49,7 @@
           :scroll-to="scrollTo"
           class="reply-content"
           :depth="depth"
+          :suppress-children="feedMode"
           @rendered="rendered"
           @subtree-rendered="childSubtreeRendered"
           @expand-combined="expandCombined"
@@ -51,6 +63,7 @@ import { ref, computed, watch, onMounted, defineAsyncComponent } from 'vue'
 import { useNewsfeedStore } from '~/stores/newsfeed'
 import { useAuthStore } from '~/stores/auth'
 import NewsRefer from '~/components/NewsRefer'
+import NewsUnreadDivider from '~/components/NewsUnreadDivider'
 
 const NewsReply = defineAsyncComponent(() =>
   import('~/components/NewsReply.vue')
@@ -83,6 +96,14 @@ const props = defineProps({
   depth: {
     type: Number,
     required: true,
+  },
+  // 'thread' renders the full conversation with head/tail collapsing.
+  // 'feed' keeps cards short: post + the two most recent replies + one
+  // honestly-counted "View all N replies" link to the thread page.
+  context: {
+    type: String,
+    required: false,
+    default: 'thread',
   },
 })
 
@@ -255,10 +276,11 @@ const filteredReplies = computed(() => {
 })
 
 // Collapse only at depth 1 (top-level replies), not for nested reply trees.
+// A deep link (scrollTo set) collapses too: the target's own row is exempted
+// below, so a notification lands on a focused view rather than the full wall.
 const shouldCollapse = computed(() => {
   return (
     !showAllReplies.value &&
-    !props.scrollTo &&
     !props.replyTo &&
     combinedReplies.value.length > COLLAPSE_THRESHOLD
   )
@@ -292,8 +314,37 @@ function subtreeHasNew(entry) {
   return childrenHaveNew(entry)
 }
 
-// Ordered render plan: hide only middle entries whose whole subtree is old.
-// A single expander sits where the first hidden entry was.
+// The reply a deep link (notification click) points at. Never hide it, or
+// anything on the path to it: the whole point of the landing is to see it.
+const scrollTargetId = computed(() => parseInt(props.scrollTo) || 0)
+
+function replyTreeContains(reply, target) {
+  if (!reply) return false
+  if (reply.id === target) return true
+  for (const kid of reply.replies || []) {
+    const child = resolveReply(kid)
+    if (child && replyTreeContains(child, target)) return true
+  }
+  return false
+}
+
+function subtreeHasScrollTarget(entry) {
+  const target = scrollTargetId.value
+  if (!target) return false
+  if (entry.id === target) return true
+  if (entry.combinedIds) {
+    if (entry.combinedIds.includes(target)) return true
+    for (const cid of entry.combinedIds) {
+      if (replyTreeContains(newsfeedStore.byId(cid), target)) return true
+    }
+    return false
+  }
+  return replyTreeContains(entry, target)
+}
+
+// Ordered render plan: hide only middle entries whose whole subtree is old
+// and does not contain the deep-link target. A single expander sits where
+// the first hidden entry was.
 const collapsePlan = computed(() => {
   const list = combinedReplies.value
   const passthrough = { entries: list.map((r) => ({ reply: r })), hidden: [] }
@@ -305,7 +356,7 @@ const collapsePlan = computed(() => {
 
   list.forEach((r, idx) => {
     const inMiddle = idx >= HEAD_COUNT && idx < list.length - TAIL_COUNT
-    if (inMiddle && !subtreeHasNew(r)) {
+    if (inMiddle && !subtreeHasNew(r) && !subtreeHasScrollTarget(r)) {
       hidden.push(r)
       if (!expanderPlaced) {
         entries.push({ expander: true })
@@ -319,7 +370,107 @@ const collapsePlan = computed(() => {
   return hidden.length ? { entries, hidden } : passthrough
 })
 
-const renderEntries = computed(() => collapsePlan.value.entries)
+// Feed cards must stay short. Above this many replies (counted across the
+// whole tree) the card switches to a view-all link plus the two most recent
+// top-level entries; at or below it, small threads render exactly as before.
+const FEED_TOTAL_THRESHOLD = 3
+const FEED_VISIBLE_TAIL = 2
+
+// Recursive {total, fresh} for one combined entry: how many reply rows its
+// subtree holds, and how many of them are newer than the visit baseline.
+function countDescendants(reply) {
+  let total = 0
+  let fresh = 0
+  for (const kid of reply?.replies || []) {
+    const child = resolveReply(kid)
+    if (!child) continue
+    total++
+    if (seenBeforeVisit.value && child.id > seenBeforeVisit.value) fresh++
+    const nested = countDescendants(child)
+    total += nested.total
+    fresh += nested.fresh
+  }
+  return { total, fresh }
+}
+
+function countEntry(entry) {
+  if (entry.combinedIds) {
+    // Combined blocks never have children (combining requires none).
+    const total = entry.combinedIds.length
+    const fresh = seenBeforeVisit.value
+      ? entry.combinedIds.filter((cid) => cid > seenBeforeVisit.value).length
+      : 0
+    return { total, fresh }
+  }
+  const own = seenBeforeVisit.value && entry.id > seenBeforeVisit.value ? 1 : 0
+  const nested = countDescendants(entry)
+  return { total: 1 + nested.total, fresh: own + nested.fresh }
+}
+
+const treeCounts = computed(() => {
+  let total = 0
+  let fresh = 0
+  for (const entry of combinedReplies.value) {
+    const c = countEntry(entry)
+    total += c.total
+    fresh += c.fresh
+  }
+  return { total, fresh }
+})
+
+const feedMode = computed(() => {
+  return (
+    props.context === 'feed' &&
+    props.depth === 1 &&
+    treeCounts.value.total > FEED_TOTAL_THRESHOLD
+  )
+})
+
+// The ONE unread divider (WhatsApp convention): before the first top-level
+// entry that is new, only when there is a genuine old/new split. Nested new
+// activity still gets pills and collapse exemptions, but never a divider.
+const firstNewIndex = computed(() => {
+  if (!seenBeforeVisit.value) return -1
+  return combinedReplies.value.findIndex((r) => isReplyNew(r))
+})
+
+const newCount = computed(() =>
+  firstNewIndex.value >= 0
+    ? combinedReplies.value.length - firstNewIndex.value
+    : 0
+)
+
+const showDivider = computed(() => props.depth === 1 && firstNewIndex.value > 0)
+
+const renderEntries = computed(() => {
+  let entries
+
+  if (feedMode.value) {
+    // Feed card: view-all link first, then only the most recent entries.
+    entries = [
+      {
+        feedCta: true,
+        total: treeCounts.value.total,
+        fresh: treeCounts.value.fresh,
+      },
+      ...combinedReplies.value
+        .slice(-FEED_VISIBLE_TAIL)
+        .map((r) => ({ reply: r })),
+    ]
+  } else {
+    entries = [...collapsePlan.value.entries]
+  }
+
+  if (showDivider.value) {
+    const first = combinedReplies.value[firstNewIndex.value]
+    const idx = entries.findIndex((e) => e.reply && e.reply.id === first.id)
+    if (idx >= 0) {
+      entries.splice(idx, 0, { divider: true, count: newCount.value })
+    }
+  }
+
+  return entries
+})
 
 // Deterministic completion for the deep-link scroll: this list's subtree is
 // rendered once every NewsReply row in the current render plan has reported
@@ -341,7 +492,7 @@ function isReferNotice(reply) {
 
 function expectedSubtreeIds() {
   return renderEntries.value
-    .filter((e) => !e.expander && !isReferNotice(e.reply))
+    .filter((e) => e.reply && !isReferNotice(e.reply))
     .map((e) => e.reply.id)
 }
 
@@ -378,7 +529,19 @@ const expanderLabel = computed(() => {
 })
 
 function entryKey(entry) {
-  return entry.expander ? 'reply-expander' : 'newsfeed-' + entry.reply.id
+  if (entry.expander) return 'reply-expander'
+  if (entry.divider) return 'unread-divider'
+  if (entry.feedCta) return 'feed-cta'
+  return 'newsfeed-' + entry.reply.id
+}
+
+function feedCtaLabel(entry) {
+  const replyWord = entry.total === 1 ? 'reply' : 'replies'
+  let label = `View all ${entry.total} ${replyWord}`
+  if (entry.fresh > 0) {
+    label += ` · ${entry.fresh} new`
+  }
+  return label
 }
 
 function expandReplies() {
@@ -422,6 +585,30 @@ function expandCombined(combinedIds) {
 
 .show-more-replies {
   margin: 0.25rem 0;
+}
+
+/* Full-width, comfortably tappable row (44px+) linking to the thread page. */
+.view-all-replies {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  width: 100%;
+  padding: 0.25rem 0;
+  color: $color-success;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    color: $color-success-hover;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-success;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .show-more-btn {

--- a/iznik-nuxt3/components/NewsReplies.vue
+++ b/iznik-nuxt3/components/NewsReplies.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="replies-container" :class="'depth-' + depth">
+  <div ref="container" class="replies-container" :class="'depth-' + depth">
     <!--
       Ordered render plan. When collapsed, middle replies WITHOUT new activity in
       their subtree hide behind one expander; a parent whose nested replies contain
@@ -20,7 +20,7 @@
       <NewsUnreadDivider v-else-if="entry.divider" :count="entry.count" />
       <nuxt-link
         v-else-if="entry.feedCta"
-        :to="'/chitchat/' + threadhead"
+        :to="feedCtaLink(entry)"
         class="view-all-replies"
       >
         {{ feedCtaLabel(entry) }}
@@ -59,7 +59,14 @@
   </div>
 </template>
 <script setup>
-import { ref, computed, watch, onMounted, defineAsyncComponent } from 'vue'
+import {
+  ref,
+  computed,
+  watch,
+  onMounted,
+  nextTick,
+  defineAsyncComponent,
+} from 'vue'
 import { useNewsfeedStore } from '~/stores/newsfeed'
 import { useAuthStore } from '~/stores/auth'
 import NewsRefer from '~/components/NewsRefer'
@@ -111,6 +118,7 @@ const emit = defineEmits(['rendered', 'subtree-rendered'])
 
 const newsfeedStore = useNewsfeedStore()
 const authStore = useAuthStore()
+const container = ref(null)
 const showAllReplies = ref(false)
 const expandedCombinedIds = ref(new Set())
 
@@ -544,8 +552,44 @@ function feedCtaLabel(entry) {
   return label
 }
 
-function expandReplies() {
+// When the link is offering new replies, say so in the URL. The thread page
+// then knows to land on the unread divider without inferring it, and the
+// link still means that after a reload or if it is shared.
+function feedCtaLink(entry) {
+  const path = '/chitchat/' + props.threadhead
+  return entry.fresh > 0 ? path + '#new' : path
+}
+
+// Expanding inserts the hidden replies ABOVE the ones already on screen, and
+// the browser holds the scroll position, so without a correction whatever the
+// reader was looking at slides down the page by the height of everything
+// revealed. Measure a row that survives the expansion, then put it back where
+// it was: the page grows upwards, out of sight, and nothing appears to move.
+async function expandReplies(e) {
+  // The first reply row below the expander is the anchor. Walk past anything
+  // that is not one - the unread divider sits there whenever the new activity
+  // begins right after the hidden replies.
+  let anchor = e?.currentTarget?.parentElement?.nextElementSibling
+  while (anchor && !anchor.getAttribute?.('data-reply-id')) {
+    anchor = anchor.nextElementSibling
+  }
+
+  const anchorId = anchor?.getAttribute?.('data-reply-id')
+  const before = anchorId ? anchor.getBoundingClientRect().top : null
+
   showAllReplies.value = true
+
+  if (before === null) return
+
+  await nextTick()
+
+  const moved = container.value?.querySelector(`[data-reply-id="${anchorId}"]`)
+  if (!moved) return
+
+  const delta = moved.getBoundingClientRect().top - before
+  if (delta) {
+    window.scrollBy(0, delta)
+  }
 }
 
 function rendered(id) {

--- a/iznik-nuxt3/components/NewsReply.vue
+++ b/iznik-nuxt3/components/NewsReply.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{ 'bg-info': scrollToThis }">
+  <div :class="{ 'deep-link-target': scrollToThis }">
     <div v-if="mod || myid === reply.userid || !reply.hidden" class="reply">
       <!-- More actions dropdown - positioned at top right of reply -->
       <button
@@ -173,7 +173,7 @@
          depth 2+ replies mounting. When the nested list reports that its
          whole subtree has mounted, this reply's subtree is complete too. -->
     <NewsReplies
-      v-if="reply?.replies?.length"
+      v-if="reply?.replies?.length && !suppressChildren"
       :id="id"
       :threadhead="threadhead"
       :scroll-to="scrollTo"
@@ -182,6 +182,13 @@
       @rendered="$emit('rendered', $event)"
       @subtree-rendered="$emit('subtree-rendered', id)"
     />
+    <nuxt-link
+      v-else-if="reply?.replies?.length && suppressChildren"
+      :to="'/chitchat/' + id"
+      class="view-child-replies"
+    >
+      View {{ childCount }} {{ childCount === 1 ? 'reply' : 'replies' }}
+    </nuxt-link>
     <div v-if="showReplyBox" class="mb-2 pb-1 ms-4">
       <div v-if="enterNewLine" class="w-100">
         <OurAtTa
@@ -386,6 +393,13 @@ const props = defineProps({
     type: Number,
     required: true,
   },
+  // Feed cards keep nested conversations behind a counted link instead of
+  // rendering them inline (set by NewsReplies in feed context).
+  suppressChildren: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 })
 
 const emit = defineEmits(['rendered', 'subtree-rendered', 'expand-combined'])
@@ -497,8 +511,26 @@ const threadUsers = computed(() => {
 })
 
 const scrollToThis = computed(() => {
-  return parseInt(props.scrollTo) === props.id
+  const target = parseInt(props.scrollTo)
+  if (!target) return false
+  if (target === props.id) return true
+  // A combined block renders as one component keyed by its first id; a deep
+  // link to any of the later messages must still light this row up.
+  return !!reply.value?.combinedIds?.includes(target)
 })
+
+// Recursive size of this reply's nested conversation, for the counted link
+// shown when children are suppressed (feed context).
+function countNested(r) {
+  let total = 0
+  for (const kid of r?.replies || []) {
+    const child = typeof kid === 'object' ? kid : newsfeedStore.byId(kid)
+    total += 1 + countNested(child)
+  }
+  return total
+}
+
+const childCount = computed(() => countNested(reply.value))
 
 const isNew = computed(() => {
   const seenBefore = newsfeedStore.seenBeforeVisit
@@ -546,10 +578,19 @@ onMounted(() => {
   // rendered.  The deep-link scroll in NewsThread is driven by these events.
   emit('rendered', props.id)
 
+  // A combined block mounts once, keyed by its first id. Announce the later
+  // ids too, or a deep link to one of them never triggers the pin.
+  for (const cid of reply.value?.combinedIds || []) {
+    if (cid !== props.id) {
+      emit('rendered', cid)
+    }
+  }
+
   // Completion signal for the deep-link pin: a reply with no children IS its
   // whole subtree. With children, the nested <NewsReplies> reports when all
   // of them (recursively) have mounted - forwarded below in the template.
-  if (!reply.value?.replies?.length) {
+  // Suppressed children (feed context) never mount, so nothing to wait for.
+  if (!reply.value?.replies?.length || props.suppressChildren) {
     emit('subtree-rendered', props.id)
   }
 })
@@ -1008,5 +1049,50 @@ function showReplyPhotoModal() {
   vertical-align: middle;
   letter-spacing: 0.02em;
   text-transform: uppercase;
+}
+
+/* Counted stand-in for a suppressed nested conversation (feed context).
+   Full-width and comfortably tappable. */
+.view-child-replies {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  width: 100%;
+  padding: 0.25rem 0 0.25rem 1rem;
+  color: $color-success;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-success;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}
+
+/* The reply a notification deep link points at. A brief flash draws the eye
+   on arrival, settling to a soft resting tint so the row stays identifiable.
+   Under reduced motion the flash is skipped but the resting cue remains. */
+.deep-link-target {
+  background-color: rgba($color-success-bg, 0.6);
+  border-radius: 4px;
+
+  @media (prefers-reduced-motion: no-preference) {
+    animation: deep-link-flash 2.4s ease-out;
+  }
+}
+
+@keyframes deep-link-flash {
+  0% {
+    background-color: $color-success-border;
+  }
+  100% {
+    background-color: rgba($color-success-bg, 0.6);
+  }
 }
 </style>

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -374,6 +374,13 @@ const props = defineProps({
     required: false,
     default: 'thread',
   },
+  // The reader asked to be taken to the new replies (the feed's "#new"
+  // link), rather than just opening the thread.
+  jumpToNew: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
   duplicateCount: {
     type: Number,
     required: false,
@@ -592,7 +599,7 @@ let deepLinkPinned = false
 const targetGone = ref(false)
 
 // scrollTo naming the thread itself means "open this thread", not "find this
-// reply": land the reader on the unread divider if there is one.
+// reply", so there is no target row to hunt for.
 const isGeneralLanding = computed(() => {
   return !!props.scrollTo && parseInt(props.scrollTo) === parseInt(props.id)
 })
@@ -604,7 +611,13 @@ onMounted(() => {
     if (deepLinkPinned) return
 
     if (isGeneralLanding.value) {
-      const divider = document.querySelector('[data-unread-divider]')
+      // Only jump to the new replies if the reader actually asked for them
+      // (the feed's "N new" link, which says so via #new). Opening a thread
+      // any other way should start at the top, like any other page.
+      const divider = props.jumpToNew
+        ? document.querySelector('[data-unread-divider]')
+        : null
+
       if (divider) {
         deepLinkPinned = true
         ownPin = scrollToAndPin(

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -151,6 +151,9 @@
         </b-card-text>
       </b-card-body>
       <template #footer>
+        <NoticeMessage v-if="targetGone" variant="info" class="mb-2">
+          That reply has been removed. Here's the rest of the conversation.
+        </NoticeMessage>
         <NewsReplies
           v-if="newsfeed?.replies?.length"
           :id="id"
@@ -158,6 +161,7 @@
           :scroll-to="scrollTo"
           :reply-to="replyingTo"
           :depth="1"
+          :context="context"
           :class="newsfeed.deleted ? 'strike me-1' : 'me-1'"
           @rendered="rendered"
           @subtree-rendered="repliesRendered = true"
@@ -362,6 +366,13 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  // 'thread' = the full conversation page; 'feed' = a short card in the
+  // ChitChat feed. Forwarded to NewsReplies, which does the shortening.
+  context: {
+    type: String,
+    required: false,
+    default: 'thread',
   },
   duplicateCount: {
     type: Number,
@@ -576,6 +587,49 @@ const repliesRendered = ref(!newsfeed.value?.replies?.length)
 let ownPin = null
 let deepLinkPinned = false
 
+// A deep link whose target row never mounted: the reply was deleted (and is
+// filtered out for non-mods) or otherwise gone. Explains the silent landing.
+const targetGone = ref(false)
+
+// scrollTo naming the thread itself means "open this thread", not "find this
+// reply": land the reader on the unread divider if there is one.
+const isGeneralLanding = computed(() => {
+  return !!props.scrollTo && parseInt(props.scrollTo) === parseInt(props.id)
+})
+
+onMounted(() => {
+  if (!props.scrollTo) return
+
+  threadContentSettled().then(() => {
+    if (deepLinkPinned) return
+
+    if (isGeneralLanding.value) {
+      const divider = document.querySelector('[data-unread-divider]')
+      if (divider) {
+        deepLinkPinned = true
+        ownPin = scrollToAndPin(
+          () => document.querySelector('[data-unread-divider]'),
+          {
+            block: 'start',
+            offset: fixedHeaderOffset(),
+            done: threadContentSettled(),
+          }
+        )
+      }
+    } else {
+      // Specific reply requested and everything has settled. If the target's
+      // row is not in the DOM by now it never will be - deleted and filtered
+      // out for non-mods, typically from a stale notification.
+      const row = document.querySelector(
+        `[data-reply-id="${props.scrollTo}"], [data-combined-ids~="${props.scrollTo}"]`
+      )
+      if (!row) {
+        targetGone.value = true
+      }
+    }
+  })
+})
+
 onBeforeUnmount(() => {
   if (ownPin) ownPin()
 })
@@ -623,8 +677,13 @@ function rendered(id) {
   // not restart a released pin.
   if (parseInt(id) === parseInt(props.scrollTo) && !deepLinkPinned) {
     deepLinkPinned = true
+    // Compound selector: a combined block renders one row keyed by its FIRST
+    // id and advertises the rest via data-combined-ids.
     ownPin = scrollToAndPin(
-      () => document.querySelector(`[data-reply-id="${props.scrollTo}"]`),
+      () =>
+        document.querySelector(
+          `[data-reply-id="${props.scrollTo}"], [data-combined-ids~="${props.scrollTo}"]`
+        ),
       {
         block: 'center',
         offset: fixedHeaderOffset(),
@@ -675,8 +734,13 @@ async function sendComment(callback) {
       // releasing when the refetch and image loads are complete.
       if (newid) {
         nextTick(() => {
+          // Compound selector: the fresh reply may have combined into the
+          // poster's previous block, whose row is keyed by the OLDER id.
           ownPin = scrollToAndPin(
-            () => document.querySelector(`[data-reply-id="${newid}"]`),
+            () =>
+              document.querySelector(
+                `[data-reply-id="${newid}"], [data-combined-ids~="${newid}"]`
+              ),
             {
               block: 'center',
               done: whenAllSettled([

--- a/iznik-nuxt3/components/NewsUnreadDivider.vue
+++ b/iznik-nuxt3/components/NewsUnreadDivider.vue
@@ -1,0 +1,69 @@
+<template>
+  <div
+    class="unread-divider"
+    data-unread-divider
+    role="separator"
+    :aria-label="label"
+  >
+    <span class="unread-divider__label">{{ label }}</span>
+  </div>
+</template>
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  count: {
+    type: Number,
+    required: true,
+  },
+})
+
+const label = computed(() => {
+  return props.count === 1
+    ? '1 new reply since your last visit'
+    : props.count + ' new replies since your last visit'
+})
+</script>
+<style scoped lang="scss">
+@import 'assets/css/_color-vars.scss';
+
+.unread-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(
+      to right,
+      transparent,
+      rgba($color-success, 0.5),
+      transparent
+    );
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    animation: unread-divider-in 0.4s ease-out;
+  }
+}
+
+@keyframes unread-divider-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.unread-divider__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: $color-success;
+  white-space: nowrap;
+}
+</style>

--- a/iznik-nuxt3/pages/chitchat/[[id]].vue
+++ b/iznik-nuxt3/pages/chitchat/[[id]].vue
@@ -651,11 +651,17 @@ onBeforeUnmount(() => {
 const settings = me.value?.settings
 distance.value = settings?.newsfeedarea || 0
 
-// Snapshot the seen baseline BEFORE any fetch is dispatched, on every view.
-// This flips delayedSeenMode on so the fetches below cannot fire an instant
-// Seen POST, and sets the fallback baseline that the first server
-// seenwatermark response then overwrites (see stores/newsfeed.js addItems).
-newsfeedStore.snapshotSeenBeforeVisit()
+// Secure the seen baseline BEFORE any fetch is dispatched. This flips
+// delayedSeenMode on so the fetches below cannot fire an instant Seen POST.
+// The feed re-snapshots per visit (existing behaviour); a thread or deep-link
+// view keeps any session baseline so New pills survive feed-to-thread
+// navigation, and only snapshots on a cold load, where the first server
+// seenwatermark response then overwrites it (see stores/newsfeed.js).
+if (id) {
+  newsfeedStore.ensureSeenBaselineForThreadView()
+} else {
+  newsfeedStore.snapshotSeenBeforeVisit()
+}
 
 // Fetch data if user is logged in
 if (me.value) {

--- a/iznik-nuxt3/pages/chitchat/[[id]].vue
+++ b/iznik-nuxt3/pages/chitchat/[[id]].vue
@@ -154,6 +154,7 @@
                 <NewsThread
                   :id="entry?.id"
                   :scroll-to="id"
+                  :context="id ? 'thread' : 'feed'"
                   :duplicate-count="getDuplicateCount(entry?.id)"
                   @rendered="rendered"
                   @expand-duplicates="expandDuplicates"
@@ -627,14 +628,10 @@ onMounted(() => {
   runCheck()
   initializeLocation()
 
-  // For feed view (not thread view), set up delayed seen marking.
-  if (!id) {
-    // Snapshot what was seen before visiting.
-    newsfeedStore.snapshotSeenBeforeVisit()
-
-    // Start 30s timer to mark as seen.
-    newsfeedStore.startDelayedSeen(30000)
-  }
+  // Start 30s timer to mark as seen. The baseline snapshot itself happens
+  // before the fetch dispatch below - on every view, not just the feed - so
+  // a notification deep link cannot instantly mark the whole thread seen.
+  newsfeedStore.startDelayedSeen(30000)
 })
 
 onBeforeUnmount(() => {
@@ -653,6 +650,12 @@ onBeforeUnmount(() => {
 // Initial data loading
 const settings = me.value?.settings
 distance.value = settings?.newsfeedarea || 0
+
+// Snapshot the seen baseline BEFORE any fetch is dispatched, on every view.
+// This flips delayedSeenMode on so the fetches below cannot fire an instant
+// Seen POST, and sets the fallback baseline that the first server
+// seenwatermark response then overwrites (see stores/newsfeed.js addItems).
+newsfeedStore.snapshotSeenBeforeVisit()
 
 // Fetch data if user is logged in
 if (me.value) {

--- a/iznik-nuxt3/pages/chitchat/[[id]].vue
+++ b/iznik-nuxt3/pages/chitchat/[[id]].vue
@@ -155,6 +155,7 @@
                   :id="entry?.id"
                   :scroll-to="id"
                   :context="id ? 'thread' : 'feed'"
+                  :jump-to-new="jumpToNew"
                   :duplicate-count="getDuplicateCount(entry?.id)"
                   @rendered="rendered"
                   @expand-duplicates="expandDuplicates"
@@ -234,6 +235,10 @@ definePageMeta({
 const runtimeConfig = useRuntimeConfig()
 const route = useRoute()
 const id = route.params.id
+
+// The feed's "N new" link ends in #new, meaning "take me to what I have not
+// read". Anything else that opens a thread just opens it at the top.
+const jumpToNew = route.hash === '#new'
 
 useHead(
   buildHead(

--- a/iznik-nuxt3/stores/newsfeed.js
+++ b/iznik-nuxt3/stores/newsfeed.js
@@ -118,6 +118,18 @@ export const useNewsfeedStore = defineStore({
       this.delayedSeenMode = true
       this.watermarkCaptured = false
     },
+    ensureSeenBaselineForThreadView() {
+      // Thread and deep-link views need delayed-seen protection like the feed,
+      // but must NOT re-snapshot when the session already has a baseline: on a
+      // feed-to-thread navigation the store holds every fetched id, so a fresh
+      // snapshot from maxSeen would wipe the New pills the reader came to see.
+      this.delayedSeenMode = true
+
+      if (this.seenBeforeVisit === null) {
+        this.seenBeforeVisit = this.maxSeen
+        this.watermarkCaptured = false
+      }
+    },
     startDelayedSeen(delayMs = 30000) {
       // Start a timer to mark items as seen after delay.
       if (this.delayedSeenTimer) {

--- a/iznik-nuxt3/stores/newsfeed.js
+++ b/iznik-nuxt3/stores/newsfeed.js
@@ -29,6 +29,9 @@ export const useNewsfeedStore = defineStore({
 
     // Timer ID for delayed seen marking.
     delayedSeenTimer: null,
+    // Whether this visit's baseline has been set from a server seenwatermark.
+    // First-write-wins per visit; reset by snapshotSeenBeforeVisit().
+    watermarkCaptured: false,
   }),
   actions: {
     init(config) {
@@ -48,7 +51,22 @@ export const useNewsfeedStore = defineStore({
       this.count = ret?.count || 0
       return this.count
     },
-    addItems(items) {
+    addItems(items, fromRecursion) {
+      // The server stamps its per-user seen watermark on the top-level item of
+      // GET /newsfeed/<id>. The FIRST one to arrive this visit becomes the
+      // "new since your last visit" baseline - before the auto-seen POST below
+      // can advance the server watermark past it. Recursed calls (nested
+      // replies) never capture: the field is only meaningful on the top level.
+      if (!fromRecursion && !this.watermarkCaptured) {
+        for (const item of items) {
+          if (typeof item.seenwatermark === 'number') {
+            this.seenBeforeVisit = item.seenwatermark
+            this.watermarkCaptured = true
+            break
+          }
+        }
+      }
+
       const prevMax = this.maxSeen
 
       items.forEach((item) => {
@@ -61,7 +79,7 @@ export const useNewsfeedStore = defineStore({
         if (item.replies?.length) {
           item.replies.forEach((reply) => {
             if (typeof reply === 'object') {
-              this.addItems([reply])
+              this.addItems([reply], true)
             }
           })
         }
@@ -91,9 +109,14 @@ export const useNewsfeedStore = defineStore({
     },
     snapshotSeenBeforeVisit() {
       // Capture what was seen before visiting the page.
-      // This is used to show the "you're up to date" divider.
+      // This is used to show the "you're up to date" divider and per-reply
+      // "New" pills. The session maxSeen is only a fallback baseline: the
+      // first server seenwatermark to arrive (see addItems) overwrites it,
+      // which is what makes "new since your last visit" survive a fresh page
+      // load, where maxSeen starts at 0.
       this.seenBeforeVisit = this.maxSeen
       this.delayedSeenMode = true
+      this.watermarkCaptured = false
     },
     startDelayedSeen(delayMs = 30000) {
       // Start a timer to mark items as seen after delay.

--- a/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
@@ -487,9 +487,9 @@ describe('NewsReplies', () => {
       const wrapper = createWrapper()
       const divider = wrapper.find('[data-unread-divider]')
       expect(divider.exists()).toBe(true)
-      expect(divider.element.nextElementSibling.getAttribute('data-reply-id')).toBe(
-        '16'
-      )
+      expect(
+        divider.element.nextElementSibling.getAttribute('data-reply-id')
+      ).toBe('16')
     })
 
     it('describes how many replies are new', () => {
@@ -586,9 +586,9 @@ describe('NewsReplies', () => {
         .map((n) => Number(n.attributes('data-reply-id')))
       expect(renderedIds).toEqual([18, 19])
       // The view-all link comes first, above the visible tail.
-      expect(wrapper.find('.replies-container').element.firstElementChild.className).toContain(
-        'view-all'
-      )
+      expect(
+        wrapper.find('.replies-container').element.firstElementChild.className
+      ).toContain('view-all')
     })
 
     it('counts nested and new replies in the view-all link', () => {

--- a/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
@@ -96,12 +96,23 @@ describe('NewsReplies', () => {
           NewsReply: {
             template:
               '<div class="news-reply" :data-id="id"><slot />{{ replyData?.message }}</div>',
-            props: ['id', 'replyData', 'threadhead', 'scrollTo', 'depth'],
+            props: [
+              'id',
+              'replyData',
+              'threadhead',
+              'scrollTo',
+              'depth',
+              'suppressChildren',
+            ],
             emits: ['rendered', 'subtree-rendered', 'expand-combined'],
           },
           NewsRefer: {
             template: '<div class="news-refer" :data-id="id" />',
             props: ['id', 'type', 'threadhead'],
+          },
+          'nuxt-link': {
+            template: '<a class="nuxt-link-stub" :href="to"><slot /></a>',
+            props: ['to'],
           },
         },
       },
@@ -377,16 +388,269 @@ describe('NewsReplies', () => {
   })
 
   describe('scrollTo behaviour', () => {
-    it('shows all replies when scrollTo is set (bypasses collapse)', () => {
+    it('still collapses on a deep link but exempts the target reply', () => {
+      // A notification deep link used to disable collapsing entirely, so a
+      // 60-reply thread rendered as a full wall. Now the collapse applies and
+      // only the target's row is exempted from hiding.
       const replies = makeReplies(10, { startId: 50 })
       mockNewsfeedStore.byId.mockImplementation((id) => {
         if (id === 1) return { id: 1, replies: replies.map((r) => r.id) }
         return replies.find((r) => r.id === id)
       })
 
-      const wrapper = createWrapper({ scrollTo: 'newsfeed-55' })
-      expect(wrapper.findAll('.news-reply').length).toBe(10)
-      expect(wrapper.find('.show-more-replies').exists()).toBe(false)
+      const wrapper = createWrapper({ scrollTo: '55' })
+      // head 2 (50, 51) + exempted target (55) + tail 3 (57, 58, 59)
+      expect(wrapper.findAll('.news-reply').length).toBe(6)
+      const renderedIds = wrapper
+        .findAll('.reply-thread')
+        .map((n) => Number(n.attributes('data-reply-id')))
+      expect(renderedIds).toContain(55)
+      expect(renderedIds).not.toContain(52)
+      expect(wrapper.find('.show-more-btn').text()).toContain(
+        'Show 4 older replies'
+      )
+    })
+
+    it('exempts a combined block when the target is a later message inside it', () => {
+      // 54 and 55 are the same user two minutes apart, so they combine into
+      // one block keyed by 54. A deep link to 55 must keep that block visible.
+      const replies = makeReplies(10, { startId: 50 })
+      replies[5] = {
+        ...replies[5],
+        userid: replies[4].userid,
+        displayname: replies[4].displayname,
+        added: '2024-01-15T14:02:00Z',
+      }
+      replies[4].added = '2024-01-15T14:00:00Z'
+      mockNewsfeedStore.byId.mockImplementation((id) => {
+        if (id === 1) return { id: 1, replies: replies.map((r) => r.id) }
+        return replies.find((r) => r.id === id)
+      })
+
+      const wrapper = createWrapper({ scrollTo: '55' })
+      const rows = wrapper.findAll('.reply-thread')
+      const renderedIds = rows.map((n) => Number(n.attributes('data-reply-id')))
+      expect(renderedIds).toContain(54)
+      // The block advertises every id it contains so the pin can find them.
+      const combinedRow = rows.find(
+        (n) => n.attributes('data-reply-id') === '54'
+      )
+      expect(combinedRow.attributes('data-combined-ids')).toContain('55')
+      expect(wrapper.find('.show-more-btn').text()).toContain(
+        'Show 3 older replies'
+      )
+    })
+
+    it('exempts a middle parent whose nested subtree contains the target', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      const child = {
+        id: 101,
+        userid: 300,
+        displayname: 'Nested User',
+        message: 'Nested target',
+        added: '2024-01-15T12:00:00Z',
+        deleted: false,
+        type: 'Reply',
+      }
+      replies[3].replies = [101] // id 13, a middle entry
+      mockNewsfeedStore.byId.mockImplementation((id) => {
+        if (id === 1) return { id: 1, replies: replies.map((r) => r.id) }
+        if (id === 101) return child
+        return replies.find((r) => r.id === id)
+      })
+
+      const wrapper = createWrapper({ scrollTo: '101' })
+      const renderedIds = wrapper
+        .findAll('.reply-thread')
+        .map((n) => Number(n.attributes('data-reply-id')))
+      expect(renderedIds).toContain(13)
+      expect(renderedIds).not.toContain(12)
+      expect(wrapper.find('.show-more-btn').text()).toContain(
+        'Show 4 older replies'
+      )
+    })
+  })
+
+  describe('unread divider', () => {
+    function withReplies(replies) {
+      mockNewsfeedStore.byId.mockImplementation((id) => {
+        if (id === 1) return { id: 1, replies: replies.map((r) => r.id) }
+        return replies.find((r) => r.id === id)
+      })
+    }
+
+    it('renders the divider immediately before the first new reply', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 15
+
+      const wrapper = createWrapper()
+      const divider = wrapper.find('[data-unread-divider]')
+      expect(divider.exists()).toBe(true)
+      expect(divider.element.nextElementSibling.getAttribute('data-reply-id')).toBe(
+        '16'
+      )
+    })
+
+    it('describes how many replies are new', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 15
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('[data-unread-divider]').text()).toContain(
+        '4 new replies since your last visit'
+      )
+    })
+
+    it('uses the singular for one new reply', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 18
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('[data-unread-divider]').text()).toContain(
+        '1 new reply since your last visit'
+      )
+    })
+
+    it('does not render when every reply is new', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 9
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('[data-unread-divider]').exists()).toBe(false)
+    })
+
+    it('does not render when nothing is new', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 20
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('[data-unread-divider]').exists()).toBe(false)
+    })
+
+    it('does not render without a baseline', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = null
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('[data-unread-divider]').exists()).toBe(false)
+    })
+
+    it('does not render inside nested reply lists', () => {
+      const replies = makeReplies(4, { startId: 10 })
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 11
+
+      const wrapper = createWrapper({ depth: 2, replyTo: 5 })
+      expect(wrapper.find('[data-unread-divider]').exists()).toBe(false)
+    })
+  })
+
+  describe('feed context', () => {
+    function withReplies(replies) {
+      mockNewsfeedStore.byId.mockImplementation((id) => {
+        if (id === 1) return { id: 1, replies: replies.map((r) => r.id) }
+        const nested = replies.flatMap((r) => r.nestedObjects || [])
+        return (
+          replies.find((r) => r.id === id) || nested.find((n) => n.id === id)
+        )
+      })
+    }
+
+    it('leaves small threads untouched', () => {
+      const replies = makeReplies(3, { startId: 10 })
+      withReplies(replies)
+
+      const wrapper = createWrapper({ context: 'feed' })
+      expect(wrapper.findAll('.news-reply').length).toBe(3)
+      expect(wrapper.find('.view-all-replies').exists()).toBe(false)
+    })
+
+    it('shows a counted view-all link and only the two most recent replies', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+
+      const wrapper = createWrapper({ context: 'feed' })
+      const cta = wrapper.find('.view-all-replies')
+      expect(cta.exists()).toBe(true)
+      expect(cta.text()).toContain('View all 10 replies')
+      expect(cta.attributes('href')).toBe('/chitchat/1')
+
+      const renderedIds = wrapper
+        .findAll('.reply-thread')
+        .map((n) => Number(n.attributes('data-reply-id')))
+      expect(renderedIds).toEqual([18, 19])
+      // The view-all link comes first, above the visible tail.
+      expect(wrapper.find('.replies-container').element.firstElementChild.className).toContain(
+        'view-all'
+      )
+    })
+
+    it('counts nested and new replies in the view-all link', () => {
+      const replies = makeReplies(5, { startId: 10 })
+      const nested = [
+        {
+          id: 101,
+          userid: 300,
+          displayname: 'Nested One',
+          message: 'Nested reply',
+          added: '2024-01-15T12:00:00Z',
+          deleted: false,
+          type: 'Reply',
+        },
+        {
+          id: 102,
+          userid: 301,
+          displayname: 'Nested Two',
+          message: 'Another nested reply',
+          added: '2024-01-15T12:05:00Z',
+          deleted: false,
+          type: 'Reply',
+        },
+      ]
+      replies[1].replies = [101, 102]
+      replies[1].nestedObjects = nested
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 13
+
+      const wrapper = createWrapper({ context: 'feed' })
+      expect(wrapper.find('.view-all-replies').text()).toContain(
+        'View all 7 replies'
+      )
+      expect(wrapper.find('.view-all-replies').text()).toContain('3 new')
+    })
+
+    it('tells the visible rows to suppress their nested lists', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+
+      const wrapper = createWrapper({ context: 'feed' })
+      const rows = wrapper.findAllComponents('.news-reply')
+      expect(rows.length).toBe(2)
+      expect(rows[0].props('suppressChildren')).toBe(true)
+    })
+
+    it('does not suppress nested lists in small threads', () => {
+      const replies = makeReplies(2, { startId: 10 })
+      withReplies(replies)
+
+      const wrapper = createWrapper({ context: 'feed' })
+      const rows = wrapper.findAllComponents('.news-reply')
+      expect(rows[0].props('suppressChildren')).toBe(false)
+    })
+
+    it('never applies feed behaviour on the thread page', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('.view-all-replies').exists()).toBe(false)
+      expect(wrapper.find('.show-more-btn').exists()).toBe(true)
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import NewsReplies from '~/components/NewsReplies.vue'
 
 const { mockReplies, mockNewsfeed } = vi.hoisted(() => {
@@ -387,6 +387,123 @@ describe('NewsReplies', () => {
     })
   })
 
+  describe('scroll anchoring when expanding', () => {
+    // Expanding inserts rows ABOVE what you are reading, so without a
+    // correction the browser keeps scrollTop and your row slides down the
+    // page by the height of everything revealed.
+    function setupTenReplies() {
+      const replies = makeReplies(10)
+      mockNewsfeedStore.byId.mockImplementation((id) => {
+        if (id === 1) return { id: 1, replies: replies.map((r) => r.id) }
+        return replies.find((r) => r.id === id)
+      })
+      return replies
+    }
+
+    it('scrolls by exactly the height the expansion added above the anchor', async () => {
+      setupTenReplies()
+      const wrapper = createWrapper()
+
+      const scrollBy = vi.fn()
+      window.scrollBy = scrollBy
+
+      // The row just below the expander is the anchor. Report it 100px down
+      // the viewport before expanding and 700px after, i.e. 600px was added.
+      let expanded = false
+      const anchorId = wrapper
+        .find('.show-more-replies')
+        .element.nextElementSibling.getAttribute('data-reply-id')
+
+      const origGetRect = Element.prototype.getBoundingClientRect
+      Element.prototype.getBoundingClientRect = function () {
+        if (this.getAttribute?.('data-reply-id') === anchorId) {
+          return { top: expanded ? 700 : 100 }
+        }
+        return origGetRect.call(this)
+      }
+
+      const btn = wrapper.find('.show-more-btn')
+      const promise = btn.trigger('click')
+      expanded = true
+      await promise
+      await flushPromises()
+
+      expect(scrollBy).toHaveBeenCalledWith(0, 600)
+
+      Element.prototype.getBoundingClientRect = origGetRect
+    })
+
+    it('does not scroll when the anchor did not move', async () => {
+      setupTenReplies()
+      const wrapper = createWrapper()
+
+      const scrollBy = vi.fn()
+      window.scrollBy = scrollBy
+
+      const origGetRect = Element.prototype.getBoundingClientRect
+      Element.prototype.getBoundingClientRect = function () {
+        if (this.getAttribute?.('data-reply-id')) return { top: 100 }
+        return origGetRect.call(this)
+      }
+
+      await wrapper.find('.show-more-btn').trigger('click')
+      await flushPromises()
+
+      expect(scrollBy).not.toHaveBeenCalled()
+
+      Element.prototype.getBoundingClientRect = origGetRect
+    })
+
+    it('anchors past the unread divider when that follows the expander', async () => {
+      // The row after the expander is not always a reply: when new activity
+      // starts right there, the divider sits between them. Anchoring on the
+      // divider (which carries no id) used to skip the correction entirely.
+      const replies = makeReplies(10, { startId: 10 })
+      mockNewsfeedStore.byId.mockImplementation((id) => {
+        if (id === 1) return { id: 1, replies: replies.map((r) => r.id) }
+        return replies.find((r) => r.id === id)
+      })
+      mockNewsfeedStore.seenBeforeVisit = 14
+
+      const wrapper = createWrapper()
+      expect(
+        wrapper.find('.show-more-replies').element.nextElementSibling
+      ).toBe(wrapper.find('[data-unread-divider]').element)
+
+      const scrollBy = vi.fn()
+      window.scrollBy = scrollBy
+
+      let expanded = false
+      const origGetRect = Element.prototype.getBoundingClientRect
+      Element.prototype.getBoundingClientRect = function () {
+        if (this.getAttribute?.('data-reply-id') === '15') {
+          return { top: expanded ? 500 : 100 }
+        }
+        return origGetRect.call(this)
+      }
+
+      const promise = wrapper.find('.show-more-btn').trigger('click')
+      expanded = true
+      await promise
+      await flushPromises()
+
+      expect(scrollBy).toHaveBeenCalledWith(0, 400)
+
+      Element.prototype.getBoundingClientRect = origGetRect
+    })
+
+    it('still expands when there is no anchor to measure', async () => {
+      setupTenReplies()
+      const wrapper = createWrapper()
+      window.scrollBy = vi.fn()
+
+      await wrapper.find('.show-more-btn').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.findAll('.news-reply').length).toBe(10)
+    })
+  })
+
   describe('scrollTo behaviour', () => {
     it('still collapses on a deep link but exempts the target reply', () => {
       // A notification deep link used to disable collapsing entirely, so a
@@ -645,6 +762,30 @@ describe('NewsReplies', () => {
       expect(
         wrapper.find('.replies-container').element.firstElementChild.className
       ).toContain('view-all')
+    })
+
+    it('points the link at the new replies when there are some', () => {
+      // The link declares the intent in the URL, so the thread page knows
+      // where to land without inferring it, and the link survives a reload.
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 15
+
+      const wrapper = createWrapper({ context: 'feed' })
+      expect(wrapper.find('.view-all-replies').attributes('href')).toBe(
+        '/chitchat/1#new'
+      )
+    })
+
+    it('links to the plain thread when nothing is new', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 100
+
+      const wrapper = createWrapper({ context: 'feed' })
+      expect(wrapper.find('.view-all-replies').attributes('href')).toBe(
+        '/chitchat/1'
+      )
     })
 
     it('counts nested and new replies in the view-all link', () => {

--- a/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
@@ -492,6 +492,62 @@ describe('NewsReplies', () => {
       ).toBe('16')
     })
 
+    it('sits above an OLD parent that carries new nested replies', () => {
+      // Scattered case: someone replied to an old comment partway up the
+      // thread. The divider has to sit above that old parent, or it would
+      // claim "everything below is new" while new replies sat above it.
+      const replies = makeReplies(10, { startId: 10 })
+      const nestedNew = {
+        id: 99,
+        userid: 300,
+        displayname: 'Nested User',
+        message: 'New nested reply',
+        added: '2024-01-15T12:00:00Z',
+        deleted: false,
+        type: 'Reply',
+      }
+      replies[2].replies = [99] // id 12, old itself, new child
+      mockNewsfeedStore.byId.mockImplementation((id) => {
+        if (id === 1) return { id: 1, replies: replies.map((r) => r.id) }
+        if (id === 99) return nestedNew
+        return replies.find((r) => r.id === id)
+      })
+      mockNewsfeedStore.seenBeforeVisit = 20
+
+      const wrapper = createWrapper()
+      const divider = wrapper.find('[data-unread-divider]')
+      expect(divider.exists()).toBe(true)
+      expect(
+        divider.element.nextElementSibling.getAttribute('data-reply-id')
+      ).toBe('12')
+    })
+
+    it('counts nested new replies so the total matches the feed link', () => {
+      const replies = makeReplies(10, { startId: 10 })
+      const nestedNew = {
+        id: 99,
+        userid: 300,
+        displayname: 'Nested User',
+        message: 'New nested reply',
+        added: '2024-01-15T12:00:00Z',
+        deleted: false,
+        type: 'Reply',
+      }
+      replies[2].replies = [99]
+      mockNewsfeedStore.byId.mockImplementation((id) => {
+        if (id === 1) return { id: 1, replies: replies.map((r) => r.id) }
+        if (id === 99) return nestedNew
+        return replies.find((r) => r.id === id)
+      })
+      // 18 and 19 are new at top level, plus the nested 99 = 3.
+      mockNewsfeedStore.seenBeforeVisit = 17
+
+      const wrapper = createWrapper()
+      expect(wrapper.find('[data-unread-divider]').text()).toContain(
+        '3 new replies since your last visit'
+      )
+    })
+
     it('describes how many replies are new', () => {
       const replies = makeReplies(10, { startId: 10 })
       withReplies(replies)

--- a/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
@@ -241,6 +241,10 @@ describe('NewsReply', () => {
             template: '<span class="user-name"></span>',
             props: ['id', 'intro'],
           },
+          'nuxt-link': {
+            template: '<a class="nuxt-link-stub" :href="to"><slot /></a>',
+            props: ['to'],
+          },
         },
       },
     })
@@ -518,20 +522,68 @@ describe('NewsReply', () => {
   })
 
   describe('scroll to', () => {
-    it('highlights when scrollTo matches id', () => {
+    it('highlights the deep-link target', () => {
       const wrapper = createWrapper({ scrollTo: '100' })
-      expect(wrapper.find('.bg-info').exists()).toBe(true)
+      expect(wrapper.find('.deep-link-target').exists()).toBe(true)
     })
 
     it('does not highlight when scrollTo does not match', () => {
       const wrapper = createWrapper({ scrollTo: '200' })
-      expect(wrapper.find('.bg-info').exists()).toBe(false)
+      expect(wrapper.find('.deep-link-target').exists()).toBe(false)
+    })
+
+    it('highlights when the target is a later message in a combined block', () => {
+      const combinedReply = {
+        ...mockReply,
+        isCombined: true,
+        combinedIds: [100, 102],
+      }
+      const wrapper = createWrapper(
+        { scrollTo: '102', replyData: combinedReply },
+        combinedReply
+      )
+      expect(wrapper.find('.deep-link-target').exists()).toBe(true)
     })
 
     it('does not start a pin itself - NewsThread owns the deep-link pin', async () => {
       const wrapper = createWrapper({ scrollTo: '' })
       await wrapper.setProps({ scrollTo: '100' })
       expect(mockScrollToAndPin).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('suppressed children (feed context)', () => {
+    it('replaces its nested list with a counted link', () => {
+      const withNested = { ...mockReply, replies: [{ id: 456 }, { id: 457 }] }
+      const wrapper = createWrapper({ suppressChildren: true }, withNested)
+
+      expect(wrapper.find('.news-replies').exists()).toBe(false)
+      const link = wrapper.find('.view-child-replies')
+      expect(link.exists()).toBe(true)
+      expect(link.text()).toContain('View 2 replies')
+      expect(link.attributes('href')).toBe('/chitchat/100')
+    })
+
+    it('uses the singular for one nested reply', () => {
+      const withNested = { ...mockReply, replies: [{ id: 456 }] }
+      const wrapper = createWrapper({ suppressChildren: true }, withNested)
+
+      expect(wrapper.find('.view-child-replies').text()).toContain(
+        'View 1 reply'
+      )
+    })
+
+    it('reports its subtree complete on mount when children are suppressed', () => {
+      const withNested = { ...mockReply, replies: [{ id: 456 }] }
+      const wrapper = createWrapper({ suppressChildren: true }, withNested)
+
+      expect(wrapper.emitted('subtree-rendered')).toBeTruthy()
+      expect(wrapper.emitted('subtree-rendered')[0]).toEqual([100])
+    })
+
+    it('shows no link when there are no children', () => {
+      const wrapper = createWrapper({ suppressChildren: true })
+      expect(wrapper.find('.view-child-replies').exists()).toBe(false)
     })
   })
 
@@ -576,6 +628,21 @@ describe('NewsReply', () => {
       const wrapper = createWrapper()
       expect(wrapper.emitted('rendered')).toBeTruthy()
       expect(wrapper.emitted('rendered')[0]).toEqual([100])
+    })
+
+    it('announces every id in a combined block on mount', () => {
+      // The deep-link pin in NewsThread listens for the target id. A combined
+      // block only mounts one component (keyed by its first id), so it must
+      // announce the later ids too or a deep link to them never pins.
+      const combinedReply = {
+        ...mockReply,
+        isCombined: true,
+        combinedIds: [100, 102],
+      }
+      const wrapper = createWrapper({ replyData: combinedReply }, combinedReply)
+      const announced = wrapper.emitted('rendered').map((args) => args[0])
+      expect(announced).toContain(100)
+      expect(announced).toContain(102)
     })
 
     it('forwards rendered events from nested replies (depth 2+)', async () => {

--- a/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
@@ -1165,16 +1165,15 @@ describe('NewsThread', () => {
     })
   })
 
-  describe('general thread landing', () => {
-    it('pins the unread divider when landing on the thread itself', async () => {
-      // scrollTo === the thread's own id: no single target reply, so land the
-      // reader on the unread divider instead.
+  describe('jump to new replies', () => {
+    it('pins the unread divider when the caller asked for the new replies', async () => {
+      // Declared intent (the feed's "#new" link), not inferred from the route.
       const divider = document.createElement('div')
       divider.setAttribute('data-unread-divider', '')
       document.body.appendChild(divider)
 
       mockNewsfeed.value.replies = [456]
-      await createWrapper({ scrollTo: '1' })
+      await createWrapper({ scrollTo: '1', jumpToNew: true })
       await flushPromises()
 
       expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
@@ -1184,9 +1183,24 @@ describe('NewsThread', () => {
       divider.remove()
     })
 
-    it('does not scroll at all when there is no divider', async () => {
+    it('does not scroll when simply opening the thread', async () => {
+      // No "#new" in the URL: opening a thread is not a request to skip to
+      // the end of it, so it opens at the top like any other page.
+      const divider = document.createElement('div')
+      divider.setAttribute('data-unread-divider', '')
+      document.body.appendChild(divider)
+
       mockNewsfeed.value.replies = [456]
       await createWrapper({ scrollTo: '1' })
+      await flushPromises()
+
+      expect(mockScrollToAndPin).not.toHaveBeenCalled()
+      divider.remove()
+    })
+
+    it('does not scroll when asked for new replies but there is no divider', async () => {
+      mockNewsfeed.value.replies = [456]
+      await createWrapper({ scrollTo: '1', jumpToNew: true })
       await flushPromises()
 
       expect(mockScrollToAndPin).not.toHaveBeenCalled()
@@ -1198,7 +1212,7 @@ describe('NewsThread', () => {
       document.body.appendChild(divider)
 
       mockNewsfeed.value.replies = [456]
-      const wrapper = await createWrapper({ scrollTo: '456' })
+      const wrapper = await createWrapper({ scrollTo: '456', jumpToNew: true })
       const replies = wrapper.findComponent('.news-replies')
       replies.vm.$emit('rendered', 456)
       await flushPromises()

--- a/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
@@ -185,7 +185,7 @@ vi.mock('~/components/NewsReplies', () => ({
   default: {
     name: 'NewsReplies',
     template: '<div class="news-replies"></div>',
-    props: ['id', 'threadhead', 'scrollTo', 'replyTo', 'depth'],
+    props: ['id', 'threadhead', 'scrollTo', 'replyTo', 'depth', 'context'],
     emits: ['rendered', 'subtree-rendered'],
   },
 }))
@@ -1133,6 +1133,117 @@ describe('NewsThread', () => {
       await flushPromises()
 
       expect(mockScrollToAndPin).not.toHaveBeenCalled()
+    })
+
+    it('forwards the rendering context to the reply list', async () => {
+      mockNewsfeed.value.replies = [456]
+      const wrapper = await createWrapper({ context: 'feed' })
+
+      const replies = wrapper.findComponent('.news-replies')
+      expect(replies.props('context')).toBe('feed')
+    })
+
+    it('finds a combined row that carries the target id', async () => {
+      // A combined block renders one row keyed by its FIRST id, advertising
+      // the rest via data-combined-ids. The pin selector must match both.
+      mockNewsfeed.value.replies = [455]
+      const wrapper = await createWrapper({ scrollTo: '456' })
+
+      const replies = wrapper.findComponent('.news-replies')
+      replies.vm.$emit('rendered', 456)
+      await flushPromises()
+
+      expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
+      const [getEl] = mockScrollToAndPin.mock.calls[0]
+
+      const row = document.createElement('div')
+      row.setAttribute('data-reply-id', '455')
+      row.setAttribute('data-combined-ids', '455 456')
+      document.body.appendChild(row)
+      expect(getEl()).toBe(row)
+      row.remove()
+    })
+  })
+
+  describe('general thread landing', () => {
+    it('pins the unread divider when landing on the thread itself', async () => {
+      // scrollTo === the thread's own id: no single target reply, so land the
+      // reader on the unread divider instead.
+      const divider = document.createElement('div')
+      divider.setAttribute('data-unread-divider', '')
+      document.body.appendChild(divider)
+
+      mockNewsfeed.value.replies = [456]
+      await createWrapper({ scrollTo: '1' })
+      await flushPromises()
+
+      expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
+      const [getEl, opts] = mockScrollToAndPin.mock.calls[0]
+      expect(opts.block).toBe('start')
+      expect(getEl()).toBe(divider)
+      divider.remove()
+    })
+
+    it('does not scroll at all when there is no divider', async () => {
+      mockNewsfeed.value.replies = [456]
+      await createWrapper({ scrollTo: '1' })
+      await flushPromises()
+
+      expect(mockScrollToAndPin).not.toHaveBeenCalled()
+    })
+
+    it('never fires the divider pin when a specific reply pin already ran', async () => {
+      const divider = document.createElement('div')
+      divider.setAttribute('data-unread-divider', '')
+      document.body.appendChild(divider)
+
+      mockNewsfeed.value.replies = [456]
+      const wrapper = await createWrapper({ scrollTo: '456' })
+      const replies = wrapper.findComponent('.news-replies')
+      replies.vm.$emit('rendered', 456)
+      await flushPromises()
+
+      expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
+      expect(mockScrollToAndPin.mock.calls[0][1].block).toBe('center')
+      divider.remove()
+    })
+  })
+
+  describe('removed deep-link target', () => {
+    it('explains when the target reply never renders', async () => {
+      // Deleted replies are filtered out for non-mods, so a stale notification
+      // can point at a row that will never mount. Say so instead of silently
+      // landing at the top.
+      mockNewsfeed.value.replies = [455]
+      const wrapper = await createWrapper({ scrollTo: '456' })
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('That reply has been removed')
+    })
+
+    it('shows no notice when the target renders normally', async () => {
+      // The component's authority is the DOM: the target's row being present
+      // (as it is on any live reply) suppresses the notice.
+      const row = document.createElement('div')
+      row.setAttribute('data-reply-id', '456')
+      document.body.appendChild(row)
+
+      mockNewsfeed.value.replies = [456]
+      const wrapper = await createWrapper({ scrollTo: '456' })
+      const replies = wrapper.findComponent('.news-replies')
+      replies.vm.$emit('rendered', 456)
+      await flushPromises()
+
+      expect(wrapper.text()).not.toContain('That reply has been removed')
+      row.remove()
+    })
+
+    it('shows no notice on a general thread landing', async () => {
+      mockNewsfeed.value.replies = [456]
+      const wrapper = await createWrapper({ scrollTo: '1' })
+      await flushPromises()
+
+      expect(wrapper.text()).not.toContain('That reply has been removed')
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/NewsUnreadDivider.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsUnreadDivider.spec.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import NewsUnreadDivider from '~/components/NewsUnreadDivider.vue'
+
+describe('NewsUnreadDivider', () => {
+  it('renders the plural label', () => {
+    const wrapper = mount(NewsUnreadDivider, { props: { count: 3 } })
+    expect(wrapper.text()).toContain('3 new replies since your last visit')
+  })
+
+  it('renders the singular label', () => {
+    const wrapper = mount(NewsUnreadDivider, { props: { count: 1 } })
+    expect(wrapper.text()).toContain('1 new reply since your last visit')
+  })
+
+  it('is exposed to assistive tech as a labelled separator', () => {
+    const wrapper = mount(NewsUnreadDivider, { props: { count: 2 } })
+    const root = wrapper.find('[data-unread-divider]')
+    expect(root.exists()).toBe(true)
+    expect(root.attributes('role')).toBe('separator')
+    expect(root.attributes('aria-label')).toContain('2 new replies')
+  })
+})

--- a/iznik-nuxt3/tests/unit/pages/chitchat/id.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/chitchat/id.spec.js
@@ -32,7 +32,11 @@ vi.mock('~/components/InfiniteLoading', () => ({
   },
 }))
 vi.mock('~/components/NewsThread.vue', () => ({
-  default: { template: '<div />', props: ['id', 'scrollTo', 'duplicateCount'] },
+  default: {
+    name: 'NewsThread',
+    template: '<div class="news-thread" />',
+    props: ['id', 'scrollTo', 'duplicateCount', 'context'],
+  },
 }))
 vi.mock('~/components/MessageListUpToDate.vue', () => ({
   default: { template: '<div />' },
@@ -84,8 +88,9 @@ vi.mock('~/composables/useMe', () => ({
   }),
 }))
 
-vi.hoisted(() => {
+const routeState = vi.hoisted(() => {
   vi.resetModules()
+  return { params: {} }
 })
 
 vi.mock('#imports', async () => {
@@ -93,7 +98,7 @@ vi.mock('#imports', async () => {
   return {
     ...actual,
     useRoute: () => ({
-      params: {},
+      params: routeState.params,
       query: {},
       path: '/',
       name: 'chitchat',
@@ -165,6 +170,7 @@ describe('chitchat/[[id]].vue loadMore', () => {
     setActivePinia(createPinia())
     mockMe.value = { id: 1, displayname: 'Test User', settings: {} }
     mockNewsfeedStore.feed = []
+    routeState.params = {}
   })
 
   afterEach(() => {
@@ -302,5 +308,62 @@ describe('chitchat/[[id]].vue loadMore', () => {
     const shown = wrapper.vm.newsfeedToShow
     expect(shown).toHaveLength(3)
     expect(shown.map((s) => s.id)).toEqual([3, 2, 1])
+  })
+
+  describe('thread rendering context', () => {
+    it('renders feed cards in feed context', async () => {
+      mockNewsfeedStore.feed = [{ id: 7, userid: 100, message: 'Hi' }]
+      mountComponent()
+      wrapper.vm.show = 1
+      await flushPromises()
+
+      const thread = wrapper.findComponent('.news-thread')
+      expect(thread.exists()).toBe(true)
+      expect(thread.props('context')).toBe('feed')
+    })
+
+    it('renders a deep-linked thread in thread context', async () => {
+      routeState.params = { id: '456' }
+      mockNewsfeedStore.fetch.mockResolvedValue({ id: 456, threadhead: 456 })
+      mockNewsfeedStore.byId.mockReturnValue({ id: 456, userid: 100 })
+      mountComponent()
+      await flushPromises()
+
+      const thread = wrapper.findComponent('.news-thread')
+      expect(thread.exists()).toBe(true)
+      expect(thread.props('context')).toBe('thread')
+    })
+  })
+
+  describe('seen baseline', () => {
+    it('snapshots the baseline before dispatching the thread fetch on a deep link', async () => {
+      routeState.params = { id: '456' }
+      mountComponent()
+      await flushPromises()
+
+      expect(mockNewsfeedStore.snapshotSeenBeforeVisit).toHaveBeenCalled()
+      expect(mockNewsfeedStore.fetch).toHaveBeenCalled()
+      // Order matters: delayedSeenMode must be on before the fetch's addItems
+      // could fire an instant Seen POST for everything in the thread.
+      expect(
+        mockNewsfeedStore.snapshotSeenBeforeVisit.mock.invocationCallOrder[0]
+      ).toBeLessThan(mockNewsfeedStore.fetch.mock.invocationCallOrder[0])
+    })
+
+    it('starts the delayed seen timer on a thread deep link', async () => {
+      routeState.params = { id: '456' }
+      mountComponent()
+      await flushPromises()
+
+      expect(mockNewsfeedStore.startDelayedSeen).toHaveBeenCalledWith(30000)
+    })
+
+    it('still snapshots and delays on the feed view', async () => {
+      mountComponent()
+      await flushPromises()
+
+      expect(mockNewsfeedStore.snapshotSeenBeforeVisit).toHaveBeenCalled()
+      expect(mockNewsfeedStore.startDelayedSeen).toHaveBeenCalledWith(30000)
+    })
   })
 })

--- a/iznik-nuxt3/tests/unit/pages/chitchat/id.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/chitchat/id.spec.js
@@ -57,6 +57,7 @@ const mockNewsfeedStore = {
   send: vi.fn(),
   byId: vi.fn(),
   snapshotSeenBeforeVisit: vi.fn(),
+  ensureSeenBaselineForThreadView: vi.fn(),
   startDelayedSeen: vi.fn(),
   markAllSeen: vi.fn(),
 }
@@ -336,18 +337,22 @@ describe('chitchat/[[id]].vue loadMore', () => {
   })
 
   describe('seen baseline', () => {
-    it('snapshots the baseline before dispatching the thread fetch on a deep link', async () => {
+    it('secures the baseline before dispatching the thread fetch on a deep link', async () => {
       routeState.params = { id: '456' }
       mountComponent()
       await flushPromises()
 
-      expect(mockNewsfeedStore.snapshotSeenBeforeVisit).toHaveBeenCalled()
+      expect(mockNewsfeedStore.ensureSeenBaselineForThreadView).toHaveBeenCalled()
       expect(mockNewsfeedStore.fetch).toHaveBeenCalled()
       // Order matters: delayedSeenMode must be on before the fetch's addItems
       // could fire an instant Seen POST for everything in the thread.
       expect(
-        mockNewsfeedStore.snapshotSeenBeforeVisit.mock.invocationCallOrder[0]
+        mockNewsfeedStore.ensureSeenBaselineForThreadView.mock
+          .invocationCallOrder[0]
       ).toBeLessThan(mockNewsfeedStore.fetch.mock.invocationCallOrder[0])
+      // The feed's own per-visit re-snapshot must NOT run here: it would wipe
+      // the baseline a feed-to-thread navigation is relying on.
+      expect(mockNewsfeedStore.snapshotSeenBeforeVisit).not.toHaveBeenCalled()
     })
 
     it('starts the delayed seen timer on a thread deep link', async () => {

--- a/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
@@ -139,6 +139,70 @@ describe('newsfeed store', () => {
       await store.fetchCount('nearby', false)
       expect(mockCount).toHaveBeenCalledWith('nearby', false)
     })
+
+  })
+
+  describe('server watermark capture', () => {
+    let store
+
+    beforeEach(() => {
+      store = useNewsfeedStore()
+      store.init({ public: {} })
+    })
+
+    it('captures the first seenwatermark into seenBeforeVisit', () => {
+      store.snapshotSeenBeforeVisit()
+      store.addItems([{ id: 100, seenwatermark: 42 }])
+
+      expect(store.seenBeforeVisit).toBe(42)
+      expect(store.watermarkCaptured).toBe(true)
+    })
+
+    it('freezes the baseline after the first capture', () => {
+      store.snapshotSeenBeforeVisit()
+      store.addItems([{ id: 100, seenwatermark: 42 }])
+      store.addItems([{ id: 200, seenwatermark: 99 }])
+
+      expect(store.seenBeforeVisit).toBe(42)
+    })
+
+    it('leaves the snapshot fallback in place when no watermark arrives', () => {
+      store.maxSeen = 55
+      store.snapshotSeenBeforeVisit()
+      store.addItems([{ id: 100 }])
+
+      expect(store.seenBeforeVisit).toBe(55)
+    })
+
+    it('does not treat a watermark on a nested reply as the baseline', () => {
+      store.snapshotSeenBeforeVisit()
+      store.addItems([
+        { id: 100, replies: [{ id: 101, seenwatermark: 42 }] },
+      ])
+
+      expect(store.seenBeforeVisit).toBe(0)
+      expect(store.watermarkCaptured).toBe(false)
+    })
+
+    it('captures before the auto-seen POST can fire', () => {
+      // Not in delayed mode: addItems would normally POST seen immediately.
+      // The capture must still win the race and set the baseline first.
+      mockSeen.mockResolvedValue({})
+      mockCount.mockResolvedValue({ count: 0 })
+      store.addItems([{ id: 100, seenwatermark: 42 }])
+
+      expect(store.seenBeforeVisit).toBe(42)
+      expect(mockSeen).toHaveBeenCalledWith(100)
+    })
+
+    it('snapshotSeenBeforeVisit resets the capture flag for a new visit', () => {
+      store.snapshotSeenBeforeVisit()
+      store.addItems([{ id: 100, seenwatermark: 42 }])
+      expect(store.watermarkCaptured).toBe(true)
+
+      store.snapshotSeenBeforeVisit()
+      expect(store.watermarkCaptured).toBe(false)
+    })
   })
 
   describe('addItems', () => {

--- a/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
@@ -139,7 +139,6 @@ describe('newsfeed store', () => {
       await store.fetchCount('nearby', false)
       expect(mockCount).toHaveBeenCalledWith('nearby', false)
     })
-
   })
 
   describe('server watermark capture', () => {
@@ -176,9 +175,7 @@ describe('newsfeed store', () => {
 
     it('does not treat a watermark on a nested reply as the baseline', () => {
       store.snapshotSeenBeforeVisit()
-      store.addItems([
-        { id: 100, replies: [{ id: 101, seenwatermark: 42 }] },
-      ])
+      store.addItems([{ id: 100, replies: [{ id: 101, seenwatermark: 42 }] }])
 
       expect(store.seenBeforeVisit).toBe(0)
       expect(store.watermarkCaptured).toBe(false)
@@ -485,8 +482,8 @@ describe('newsfeed store', () => {
 
     it('deduplicates concurrent fetches for same id', async () => {
       let resolveFirst
-      const firstPromise = new Promise((r) => {
-        resolveFirst = r
+      const firstPromise = new Promise((resolve) => {
+        resolveFirst = resolve
       })
       mockFetchNews.mockReturnValueOnce(firstPromise)
 
@@ -796,7 +793,10 @@ describe('newsfeed store', () => {
       store.init({ public: {} })
       mockSend.mockResolvedValue(999)
       // Thread refetch returns WITHOUT the new reply (replica lag).
-      mockFetchNews.mockResolvedValue({ id: 1, replies: [{ id: 2, replies: [] }] })
+      mockFetchNews.mockResolvedValue({
+        id: 1,
+        replies: [{ id: 2, replies: [] }],
+      })
 
       await store.send('hello there', 1, 1, null)
 
@@ -828,7 +828,10 @@ describe('newsfeed store', () => {
       store.init({ public: {} })
       mockSend.mockResolvedValue(1000)
       // Replying to reply 2 within thread 1; refetch misses it.
-      mockFetchNews.mockResolvedValue({ id: 1, replies: [{ id: 2, replies: [] }] })
+      mockFetchNews.mockResolvedValue({
+        id: 1,
+        replies: [{ id: 2, replies: [] }],
+      })
 
       await store.send('nested reply', 2, 1, null)
 

--- a/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
@@ -202,6 +202,38 @@ describe('newsfeed store', () => {
     })
   })
 
+  describe('ensureSeenBaselineForThreadView', () => {
+    let store
+
+    beforeEach(() => {
+      store = useNewsfeedStore()
+      store.init({ public: {} })
+    })
+
+    it('keeps an existing session baseline so New pills survive feed-to-thread navigation', () => {
+      // The user read the feed (baseline captured), items filled the store,
+      // then they clicked "View all replies". Re-snapshotting from maxSeen
+      // here would wipe every New pill they came to see.
+      store.seenBeforeVisit = 19
+      store.watermarkCaptured = true
+      store.maxSeen = 28
+
+      store.ensureSeenBaselineForThreadView()
+
+      expect(store.seenBeforeVisit).toBe(19)
+      expect(store.watermarkCaptured).toBe(true)
+      expect(store.delayedSeenMode).toBe(true)
+    })
+
+    it('snapshots on a cold load so the server watermark can be captured', () => {
+      store.ensureSeenBaselineForThreadView()
+
+      expect(store.seenBeforeVisit).toBe(0)
+      expect(store.watermarkCaptured).toBe(false)
+      expect(store.delayedSeenMode).toBe(true)
+    })
+  })
+
   describe('addItems', () => {
     let store
 

--- a/iznik-server-go/newsfeed/newsfeed.go
+++ b/iznik-server-go/newsfeed/newsfeed.go
@@ -102,6 +102,11 @@ type Newsfeed struct {
 	Replies        []Newsfeed        `json:"replies" gorm:"-"`
 	Lovelist       []NewsLove        `json:"lovelist" gorm:"-"`
 	Previews       []NewsfeedPreview `json:"previews" gorm:"-"`
+	// The user's newsfeed_users high-water mark, set only on the top-level item
+	// returned by Single() so the client can baseline "new since my last visit"
+	// on any entry path (feed card or notification deep link) without an extra
+	// request. Never populated on nested replies.
+	SeenWatermark uint64 `json:"seenwatermark,omitempty" gorm:"-"`
 }
 
 func GetNearbyDistance(uid uint64) (float64, utils.LatLng, float64, float64, float64, float64) {
@@ -641,6 +646,20 @@ func getFeed(myid uint64, gotDistance bool, distance uint64) []NewsfeedSummary {
 	return ret
 }
 
+// seenWatermarkFor returns the user's newsfeed_users high-water mark - the
+// highest newsfeed id they have marked seen - or 0 when logged out or never
+// recorded. One-row indexed SELECT, shared by Single() and Count().
+func seenWatermarkFor(myid uint64) uint64 {
+	var seen uint64
+
+	if myid > 0 {
+		db := database.DBConn
+		db.Table("newsfeed_users").Select("newsfeedid").Where("userid = ?", myid).Row().Scan(&seen)
+	}
+
+	return seen
+}
+
 func Single(c *fiber.Ctx) error {
 	myid := user.WhoAmI(c)
 
@@ -652,10 +671,12 @@ func Single(c *fiber.Ctx) error {
 		var wg sync.WaitGroup
 		var newsfeed Newsfeed
 		var replies = []Newsfeed{}
+		var seenWatermark uint64
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			seenWatermark = seenWatermarkFor(myid)
 		}()
 
 		wg.Add(1)
@@ -683,6 +704,7 @@ func Single(c *fiber.Ctx) error {
 
 		if newsfeed.ID > 0 {
 			newsfeed.Replies = replies
+			newsfeed.SeenWatermark = seenWatermark
 
 			if newsfeed.Replyto > 0 {
 				// We need to find the thread head.
@@ -1027,12 +1049,11 @@ func Count(c *fiber.Ctx) error {
 		ret = getFeed(myid, gotDistance, distance)
 	}()
 
-	db := database.DBConn
 	wg.Add(1)
 
 	go func() {
 		defer wg.Done()
-		db.Table("newsfeed_users").Select("newsfeedid").Where("userid = ?", myid).Row().Scan(&seen)
+		seen = seenWatermarkFor(myid)
 	}()
 
 	wg.Wait()

--- a/iznik-server-go/test/newsfeed_test.go
+++ b/iznik-server-go/test/newsfeed_test.go
@@ -161,6 +161,71 @@ func TestNewsfeedSeen(t *testing.T) {
 	assert.Equal(t, nfID, seenID)
 }
 
+func TestNewsfeedSingleReturnsSeenWatermark(t *testing.T) {
+	prefix := uniquePrefix("nfwr_seenwm")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+	nfID := CreateTestNewsfeed(t, userID, 52.2, -0.1, "Test seen watermark "+prefix)
+
+	// Add a reply so we can prove the field only appears on the top-level item.
+	replyBody := fmt.Sprintf(`{"message":"Watermark reply %s","replyto":%d}`, prefix, nfID)
+	replyReq := httptest.NewRequest("POST", "/api/newsfeed?jwt="+token, bytes.NewBufferString(replyBody))
+	replyReq.Header.Set("Content-Type", "application/json")
+	replyResp, _ := getApp().Test(replyReq)
+	assert.Equal(t, 200, replyResp.StatusCode)
+
+	var replyID uint64
+	database.DBConn.Raw("SELECT id FROM newsfeed WHERE replyto = ? AND userid = ? ORDER BY id DESC LIMIT 1",
+		nfID, userID).Scan(&replyID)
+	assert.Greater(t, replyID, uint64(0))
+
+	id := strconv.FormatUint(nfID, 10)
+
+	// No newsfeed_users row yet: watermark stays 0/absent, request must not error.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var single struct {
+		ID            uint64 `json:"id"`
+		SeenWatermark uint64 `json:"seenwatermark"`
+		Replies       []struct {
+			ID            uint64 `json:"id"`
+			SeenWatermark uint64 `json:"seenwatermark"`
+		} `json:"replies"`
+	}
+	json2.Unmarshal(rsp(resp), &single)
+	assert.Equal(t, nfID, single.ID)
+	assert.Equal(t, uint64(0), single.SeenWatermark)
+
+	// Mark the reply seen; the watermark must come back on the top-level object
+	// so the client can baseline "new since my last visit" on any entry path.
+	body := fmt.Sprintf(`{"id":%d,"action":"Seen"}`, replyID)
+	req := httptest.NewRequest("POST", "/api/newsfeed?jwt="+token, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ = getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	resp, _ = getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id+"?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	json2.Unmarshal(rsp(resp), &single)
+	assert.Equal(t, replyID, single.SeenWatermark)
+
+	// Nested replies never carry the watermark.
+	assert.Greater(t, len(single.Replies), 0)
+	for _, r := range single.Replies {
+		assert.Equal(t, uint64(0), r.SeenWatermark)
+	}
+
+	// Logged out: no watermark, no error.
+	resp, _ = getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var loggedOut struct {
+		SeenWatermark uint64 `json:"seenwatermark"`
+	}
+	json2.Unmarshal(rsp(resp), &loggedOut)
+	assert.Equal(t, uint64(0), loggedOut.SeenWatermark)
+}
+
 func TestNewsfeedSeenHigherIDGuard(t *testing.T) {
 	prefix := uniquePrefix("nfwr_seeng")
 	userID := CreateTestUser(t, prefix, "User")

--- a/plans/active/2026-08-08-chitchat-thread-ux.md
+++ b/plans/active/2026-08-08-chitchat-thread-ux.md
@@ -80,20 +80,21 @@ flash-fade arrival highlight, combined-block pin fix.
 
 | # | Task | Status | Notes |
 |---|------|--------|-------|
-| A1 | Go test: seenwatermark on Single (4 cases) | 🔄 | RED proven with count-variant test (suite failed exactly 1/3941); rewriting test to target Single per design |
-| A2 | Go impl: helper + field in Single | ⬜ | |
-| B1 | Store spec: watermark capture via addItems | ⬜ | rewrite my count-based draft spec |
-| B2 | Store impl | ⬜ | |
-| B3 | Page: unconditional snapshot + delayed seen | ⬜ | |
-| C1 | NewsReplies: collapse-on-deeplink + target exemption specs | ⬜ | rewrite 1 bypass test |
-| C2 | NewsReplies impl | ⬜ | |
-| C3 | Divider component + placement specs + impl | ⬜ | |
-| D1 | NewsReply flash highlight + combined pin specs + impl | ⬜ | |
-| D2 | NewsThread divider pin + targetGone notice specs + impl | ⬜ | |
-| E1 | Feed context CTA specs + impl | ⬜ | |
-| F1 | eslint changed files | ⬜ | |
-| F2 | Full vitest suite via status API | ⬜ | port 12386 |
-| F3 | Browser verify in worktree (before/after, mobile) | ⬜ | seed long thread |
-| F4 | Docs freshness | ⬜ | check covers: |
-| G1 | Go suite GREEN | ⬜ | never concurrent with vitest |
-| G2 | Push + PR | ⬜ | |
+| A1 | Go test: seenwatermark on Single (4 cases) | ✅ | RED proven (count-variant failed exactly 1/3941); test moved to Single per design |
+| A2 | Go impl: helper + field in Single | ✅ | seenWatermarkFor shared with Count |
+| B1 | Store spec: watermark capture via addItems | ✅ | RED 5 fail then GREEN 64/64 |
+| B2 | Store impl | ✅ | watermarkCaptured, first-write-wins, recursion-safe |
+| B3 | Page: baseline before fetch + delayed seen everywhere | ✅ | RED 2 fail then GREEN; later split feed/thread (see below) |
+| C1 | NewsReplies: collapse-on-deeplink + target exemption specs | ✅ | RED 6 fail |
+| C2 | NewsReplies impl | ✅ | GREEN 43/43 |
+| C3 | Divider component + placement specs + impl | ✅ | GREEN 3/3 + placement tests |
+| D1 | NewsReply flash highlight + combined pin specs + impl | ✅ | GREEN 56/56 |
+| D2 | NewsThread divider pin + targetGone notice specs + impl | ✅ | GREEN 121/121; DOM is authority for targetGone |
+| E1 | Feed context CTA specs + impl | ✅ | GREEN; suppressed children behind counted links |
+| E2 | REGRESSION found in browser: SPA feed->thread wiped pills | ✅ | ensureSeenBaselineForThreadView; keeps session baseline; GREEN 66/66 + 14/14 |
+| F1 | eslint changed files | ✅ | clean (fixed 7, incl. pre-existing) |
+| F2 | Full vitest suite via status API | 🔄 | first run 709 files / 15014 pass pre-E2; final rerun in flight (sweeper interrupted; containers resynced) |
+| F3 | Browser verify in worktree (before/after, mobile+desktop) | ✅ | seeded 27-reply thread; feed card, divider landing, deep-link flash, CTA nav all verified; screenshots in scratchpad |
+| F4 | Docs freshness | ✅ | OK, 47 pages checked, no covered path touched |
+| G1 | Go suite GREEN | ⬜ | after vitest, never concurrent |
+| G2 | Push + PR with before/after screenshots | ⬜ | orphan assets branch for images |

--- a/plans/active/2026-08-08-chitchat-thread-ux.md
+++ b/plans/active/2026-08-08-chitchat-thread-ux.md
@@ -93,8 +93,8 @@ flash-fade arrival highlight, combined-block pin fix.
 | E1 | Feed context CTA specs + impl | ✅ | GREEN; suppressed children behind counted links |
 | E2 | REGRESSION found in browser: SPA feed->thread wiped pills | ✅ | ensureSeenBaselineForThreadView; keeps session baseline; GREEN 66/66 + 14/14 |
 | F1 | eslint changed files | ✅ | clean (fixed 7, incl. pre-existing) |
-| F2 | Full vitest suite via status API | 🔄 | first run 709 files / 15014 pass pre-E2; final rerun in flight (sweeper interrupted; containers resynced) |
+| F2 | Full vitest suite via status API | ✅ | 709 files / 15,016 passed / 0 failed |
 | F3 | Browser verify in worktree (before/after, mobile+desktop) | ✅ | seeded 27-reply thread; feed card, divider landing, deep-link flash, CTA nav all verified; screenshots in scratchpad |
 | F4 | Docs freshness | ✅ | OK, 47 pages checked, no covered path touched |
-| G1 | Go suite GREEN | ⬜ | after vitest, never concurrent |
-| G2 | Push + PR with before/after screenshots | ⬜ | orphan assets branch for images |
+| G1 | Go suite GREEN | ✅ | 3,941 passed / 0 failed; TestNewsfeedSingleReturnsSeenWatermark PASS |
+| G2 | Push + PR with before/after screenshots | ✅ | PR #1292; true A/B captured by swapping master components into the container |

--- a/plans/active/2026-08-08-chitchat-thread-ux.md
+++ b/plans/active/2026-08-08-chitchat-thread-ux.md
@@ -96,5 +96,22 @@ flash-fade arrival highlight, combined-block pin fix.
 | F2 | Full vitest suite via status API | ✅ | 709 files / 15,016 passed / 0 failed |
 | F3 | Browser verify in worktree (before/after, mobile+desktop) | ✅ | seeded 27-reply thread; feed card, divider landing, deep-link flash, CTA nav all verified; screenshots in scratchpad |
 | F4 | Docs freshness | ✅ | OK, 47 pages checked, no covered path touched |
-| G1 | Go suite GREEN | ✅ | 3,941 passed / 0 failed; TestNewsfeedSingleReturnsSeenWatermark PASS |
+| G1 | Go suite GREEN | ✅ | 3,992 passed / 0 failed on the merged tree |
 | G2 | Push + PR with before/after screenshots | ✅ | PR #1292; true A/B captured by swapping master components into the container |
+| H1 | Divider must cover NESTED new replies | ✅ | Found via a scattered/nested fixture: it read "2 new" on a thread with 5 and sat BELOW three of them. Now anchors on first subtree-with-new; counts all. |
+| H2 | `#new` anchor declares the jump-to-new intent | ✅ | Feed CTA -> /chitchat/<id>#new; plain URL opens at top again. RED proven. |
+| H3 | Scroll anchoring on "Show N older replies" | ✅ | Browser caught what the unit test missed: the row after the expander can be the DIVIDER, so the anchor lookup bailed and no correction ran. Walks past non-reply rows now. |
+| H4 | Final suites on merged tree | ✅ | vitest 712 files / 15,075 pass; Go 3,992 pass; docs freshness OK; eslint clean |
+
+## Deliberately NOT built (researched, for a later decision)
+
+A pair-aware nudge for two people going many rounds with each other. Discourse is
+the only product that does this: `get_a_room_threshold` (default 3) counts replies
+to the SAME person in a topic and privately suggests a personal message instead;
+verified in discourse/discourse `site_settings.yml` + `server.en.yml`. Distinct
+from `max_consecutive_replies` (same-author hard block) and
+`dominating_topic_minimum_percent` (whole-topic 40%). Nobody else is pair-aware:
+Reddit's "Continue this thread" is purely depth; FB/IG/YouTube cap nesting at one
+level so a volley becomes a flat run; X groups only SELF-threads; Slack's answer is
+the thread pane, user-invoked. Transfers well to Freegle because it needs no
+nesting and Freegle already has private chat to point at.

--- a/plans/active/2026-08-08-chitchat-thread-ux.md
+++ b/plans/active/2026-08-08-chitchat-thread-ux.md
@@ -1,0 +1,99 @@
+# ChitChat threading UX: make notification landings and long threads usable
+
+Branch: `feature/chitchat-thread-ux` (worktree `chitchat-threads`). One-shot PR, TDD.
+
+## The complaints (Edward, 2026-08-08)
+
+1. Someone replies partway through a long thread, you get a notification, and it's not clear
+   where to look in the thread.
+2. On mobile the feed shows too much of each thread, so you scroll a lot.
+3. The threading model is confusing overall.
+
+## Grounding
+
+- Prod data (live DB, 2026-08-08): 79% of threads have 1-2 replies; in 11+ reply threads 70% of
+  replies arrive more than 24h after the thread started (notification-into-stale-thread is the
+  norm); 27% of replies are nested; long threads average 7 distinct repliers.
+- Browser-verified before-state (dev-live, real data): a 15-reply thread renders 11 blocks in the
+  FEED despite "Show 5 older replies" (kept entries drag their whole nested subtrees along);
+  a notification deep link renders the FULL thread (7.8 phone screens), lands you 4,500px deep
+  with a permanent pale-blue tint on the target, and no New pills (the seen baseline is never
+  set on that path). The deep-link fetch also instantly advances the server seen-watermark.
+- Research (Reddit/FB/YouTube/WhatsApp/Slack/Discourse/NN-g): feed cards show post + 1-2 replies
+  + honest count, never the whole thread; notification landings highlight the target with brief
+  flash-fade (static under prefers-reduced-motion); the "where's the new stuff" answer is ONE
+  unread divider the view auto-lands on; expanders are full-width, counted, >=44px.
+
+## Design (synthesis of two workflow designs, adversarially reviewed)
+
+Chassis = "unread-first" design; grafts from "focused-context" design: feed density fix,
+flash-fade arrival highlight, combined-block pin fix.
+
+### A. Server watermark => a working "new since your last visit" baseline everywhere
+- Go: `Newsfeed.SeenWatermark uint64 json:"seenwatermark,omitempty"` set ONLY on the top-level
+  object in `Single()` (skip when logged out), via a helper shared with `Count()`. It's the same
+  one-row indexed SELECT Count already does. No new endpoints, no schema changes.
+- stores/newsfeed.js: `watermarkCaptured` flag; `addItems()` captures the FIRST `seenwatermark`
+  it sees into `seenBeforeVisit` (first-write-wins per visit) before the auto-Seen logic runs.
+  `snapshotSeenBeforeVisit()` keeps its existing behaviour (fallback baseline = session maxSeen,
+  delayedSeenMode on) and additionally resets `watermarkCaptured`.
+- pages/chitchat/[[id]].vue: snapshot runs UNCONDITIONALLY at top of script setup (before any
+  fetch dispatch); `startDelayedSeen(30000)` unconditional in onMounted. Fixes both "New pills
+  dead on the notification path" and "deep link instantly marks everything seen".
+
+### B. Deep link = focused landing inside the ONE familiar thread view
+- NewsReplies.shouldCollapse: remove `!props.scrollTo`. Collapse now engages on notification
+  landings. New exemption: a middle entry stays visible if its subtree contains the scrollTo
+  target (recursive, combined-aware), alongside the existing has-new-activity exemption.
+  Result: head 2 + "Show N older replies" + target neighbourhood + tail, not a 60-reply wall.
+- Target highlight: replace permanent `bg-info` with `.deep-link-target` (persistent soft tint)
+  plus a one-shot ~2.4s flash-fade on arrival; under prefers-reduced-motion the flash is
+  disabled and the static tint applies immediately (cue never removed).
+- Combined-block pin fix (pre-existing bug): a deep link to the 2nd+ message of a combined run
+  never matches `data-reply-id`. Add `data-combined-ids` attr; compound selectors in
+  NewsThread pin + NewsReply scrollReplyIntoView; `scrollToThis` also matches combinedIds.
+- Removed-target notice: if content settles and the target row never rendered (deleted for
+  non-mods), show "That reply has been removed. Here's the rest of the conversation." instead
+  of a silent land-at-top.
+
+### C. ONE unread divider + auto-land on it for general thread landings
+- New `NewsUnreadDivider.vue` ("{n} new replies since your last visit", role=separator,
+  `data-unread-divider`, fade-in gated by prefers-reduced-motion). Rendered at depth 1 only,
+  immediately before the first NEW top-level entry, only when there's a genuine old/new split.
+  (Top-level-only is a documented scope limit; nested new items still get pills + exemptions.)
+- NewsThread: when `scrollTo === threadhead` (thread opened generally, e.g. from the feed CTA)
+  auto-pin to the divider (block 'start') after content settles, sharing the existing
+  `deepLinkPinned` guard so the specific-reply pin and the divider pin are mutually exclusive.
+  Feed cards never auto-scroll (divider is a static cue there).
+
+### D. Feed density: post + last 2 replies + honest counted CTA
+- NewsReplies gets `context` prop ('thread' default, 'feed' on the feed page via NewsThread).
+- Feed mode, small threads (total tree count <= 3): identical to today (79% case untouched).
+- Feed mode, bigger threads: ONE full-width CTA row FIRST, "View all {N} replies" or
+  "View all {N} replies · {M} new" (N, M = true recursive totals), a link to
+  /chitchat/<threadhead>; then only the LAST 2 top-level entries; their nested children are
+  suppressed and each parent instead shows a "View {n} replies" link to /chitchat/<parent id>
+  (which lands focused on that reply with children visible). All rows >=44px tall.
+- Thread page keeps head 2/tail 3/threshold 6 (unchanged numbers).
+
+## Status
+
+| # | Task | Status | Notes |
+|---|------|--------|-------|
+| A1 | Go test: seenwatermark on Single (4 cases) | 🔄 | RED proven with count-variant test (suite failed exactly 1/3941); rewriting test to target Single per design |
+| A2 | Go impl: helper + field in Single | ⬜ | |
+| B1 | Store spec: watermark capture via addItems | ⬜ | rewrite my count-based draft spec |
+| B2 | Store impl | ⬜ | |
+| B3 | Page: unconditional snapshot + delayed seen | ⬜ | |
+| C1 | NewsReplies: collapse-on-deeplink + target exemption specs | ⬜ | rewrite 1 bypass test |
+| C2 | NewsReplies impl | ⬜ | |
+| C3 | Divider component + placement specs + impl | ⬜ | |
+| D1 | NewsReply flash highlight + combined pin specs + impl | ⬜ | |
+| D2 | NewsThread divider pin + targetGone notice specs + impl | ⬜ | |
+| E1 | Feed context CTA specs + impl | ⬜ | |
+| F1 | eslint changed files | ⬜ | |
+| F2 | Full vitest suite via status API | ⬜ | port 12386 |
+| F3 | Browser verify in worktree (before/after, mobile) | ⬜ | seed long thread |
+| F4 | Docs freshness | ⬜ | check covers: |
+| G1 | Go suite GREEN | ⬜ | never concurrent with vitest |
+| G2 | Push + PR | ⬜ | |


### PR DESCRIPTION
# ChitChat threading: make "what's new" work, and stop rendering whole threads

## What was wrong

ChitChat already had the right *ingredients*: a green **NEW** badge per reply, a green tint on new rows, head/tail collapsing with a "Show N older replies" expander, and a rule that keeps a reply visible if anything in its subtree is new. None of that is added by this PR.

The problem is that on the two paths that matter most they did nothing:

1. **The baseline was almost always zero.** "New" is decided by `reply.id > seenBeforeVisit`, and `seenBeforeVisit` was only ever set on the feed page (`if (!id)`), from a client-side counter that starts at 0 on a cold page load. So opening a thread directly, or clicking a reply notification, showed **no NEW badges at all** - the feature was there and silent. The server has known the answer all along (`newsfeed_users.newsfeedid`) but never told the client.
2. **Collapsing was switched off whenever `scrollTo` was set**, and the thread page always passes it. So opening any thread - by notification or by clicking through - rendered **every reply, uncollapsed**. On a real live 15-reply thread that is 7.8 phone screens.
3. **The deep-link fetch immediately marked the whole thread seen**, before the reader had read anything, so whatever was unread became "read" on arrival.

Net effect for the reported complaint: a notification drops you into a wall of replies where nothing indicates which one you were told about, or which ones are new.

## The model now

Take the hard case Edward asked about: a 25-reply thread, nested, where new replies are scattered - three of them are replies to *old* comments partway up the thread, two are new top-level ones at the end. Same data, same viewport, both columns; the "before" column is master's components swapped into the running container.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/chitchat-thread-ux/scattered-before.png" width="330"> | <img src="https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/chitchat-thread-ux/scattered-after.png" width="330"> |
| All 25 replies. No badges anywhere. The five new replies (3h, 2h, 1h, 43m, 13m) are buried among twenty "1w" ones with nothing to distinguish them. | 11 rows. Divider, badges, expander - reading order explained below. |

Reading the "after" column top to bottom, and **why each row is there**:

| What you see | Why |
|---|---|
| The post, then two old replies | Head of the thread, always kept for context so you can see how the conversation opened. |
| **"5 new replies since your last visit"** divider | Everything new is at or below this line. It counts *all* five, including the nested ones, so it agrees with the feed card's "· 5 new". |
| Priya's week-old reply, with a NEW reply nested under it | The parent is old and would normally be collapsed away. It is kept **because its subtree contains something new** - otherwise the new reply would appear with no context and you could not tell what it was answering. |
| **"Show 14 older replies"** | The genuinely old middle of the thread, with nothing new anywhere beneath it, behind one full-width tap target. |
| Two more old parents, each with a NEW nested reply | Same rule again. This is what "new items in multiple places" looks like: each new reply travels with the comment it answers. |
| An old reply, then the two NEW top-level replies | Tail of the thread, always kept, so the end of the conversation is visible. |

So the answer to "are you just showing new items?" is no - deliberately. Nothing new is ever shown stripped of context: a new nested reply always drags its parent along with it, and the head and tail of the thread are always present.

The rule, stated once: **a reply is hidden only if it is old, and everything nested beneath it is old, and it is not the head, the tail, or the reply a notification pointed at.**

## Two other surfaces

**Notification landing.** Same rules, plus the reply you were notified about is exempt from hiding (as is its whole ancestor chain if it is nested), and it flashes briefly on arrival before settling to a soft tint - replacing the permanent pale-blue `bg-info` that carried no meaning. Under `prefers-reduced-motion` the flash is skipped and the tint applies instantly, so the cue is never lost.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/chitchat-thread-ux/ab-before-deeplink.png" width="330"> | <img src="https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/chitchat-thread-ux/ab-after-deeplink.png" width="330"> |
| 27 replies, 5.3 screens, no badges, pale blue tint on the target. | 12 rows, 3 screens, badges working, target flashed and tinted. |

**Feed card.** A thread with more than three replies now shows one full-width "View all N replies · M new" link above its two most recent replies, and their nested conversations sit behind counted "View N replies" links. Threads with three or fewer replies (79% of all threads) render exactly as before.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/chitchat-thread-ux/ab-before-feed.png" width="330"> | <img src="https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/chitchat-thread-ux/ab-after-feed.png" width="330"> |

Desktop keeps its shape and gets the same divider and badges: <img src="https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/chitchat-thread-ux/after-desktop-thread.png" width="600">

(`pr-assets/chitchat-thread-ux` holds only these images; delete after merge.)

## The changes themselves

**Already existed, now actually works:** the NEW badge and green tint (dead without a baseline), the has-new-in-subtree collapse exemption (dead because collapse was off on these paths), the feed-level "You're up to date" divider between cards.

**New:**
- `GET /newsfeed/<id>` returns the user's seen watermark on the top-level object (never on nested replies, absent when logged out), via a helper now shared with the existing count endpoint. The client takes the first one it sees per visit as the baseline. No new endpoints, no schema change.
- The baseline is secured *before* any fetch is dispatched, on every ChitChat view, and the 30-second delayed-seen the feed already used now covers thread and deep-link views - so arriving no longer marks the thread read.
- Collapsing applies on deep links, with the target's subtree exempted.
- The in-thread unread divider (`NewsUnreadDivider`), placed above the first entry whose subtree contains anything new, counting every new reply including nested ones.
- The feed's link says what it means: `/chitchat/<id>#new`. The thread page lands on the divider because the URL asked it to, not because it inferred the intent from the route - so the link still does that after a reload or if it is shared, and simply opening a thread (the "..." menu, a bookmark) starts at the top like any other page. Shares the existing pin guard, so the divider pin and the reply-target pin can never both fire.
- Expanding "Show N older replies" no longer moves the page under you. The rows appear above what you are reading, so the first reply row below the expander is measured and put back where it was afterwards: the page grows upwards, out of sight. Verified in the browser - a 1,639px expansion left the row being read at exactly the same screen position.
- Feed context: counted view-all link, two most recent replies, nested conversations behind counted links.

**Two pre-existing bugs fixed on the way:**
- A deep link to the second or later message of a *combined* reply block silently did nothing - the rendered row is keyed by the first id only, so neither the scroll nor the highlight fired. Rows now advertise every id they contain and both pin selectors match them.
- A deep link to a deleted reply landed silently at the top; it now says "That reply has been removed. Here's the rest of the conversation."

## Numbers behind the choices

From production, 2026-08-08: 79% of threads have 1-2 replies, so the feed change deliberately leaves them alone. Among threads with 11+ replies, 70% of replies arrive more than a day after the thread started - a notification into a stale long thread is the normal case, not an edge case. 27% of replies are nested, which is why the nested-context rule above matters rather than being a corner case.

## Design research

Facebook, Reddit, YouTube, WhatsApp, Slack, Discourse, Instagram and Nextdoor, on these two problems specifically. Adopted: feed cards show a post plus a reply or two and an honest count, never a whole thread; notification landings highlight the target with a brief flash that fades, static under reduced motion (GitHub/37signals convention); "where is the new stuff" is one divider the view lands on (WhatsApp/Slack) rather than a timeline scrubber, which Discourse's own reports say goes unnoticed on mobile; expanders are full-width, counted and one-way. Facebook and Reddit ship no in-thread new-since-last-visit marker at all, so that part follows chat-app convention.

## Known limitations (deliberate)

- The divider is a single line at top level. If the only new activity is nested, the divider sits above that nested reply's parent, which is right, but it cannot mark several separate places at once - the per-reply badges do that job.
- The 30s delayed-seen trade-off (leave within 30s and items stay unread) is inherited from the feed, now applied consistently.
- The baseline comes from whichever thread response lands first in a visit; tests assert the store-level first-write-wins rule rather than a network race.

## Code quality review

One render path throughout - no second page component and no forked deep-link view. The focused landing is subtractive: the existing collapse plan runs with one extra exemption. Mod visibility, combined replies, refer notices, reply composing and the PR #1000 scroll pin keep their behaviour and their tests. The Go change is one field plus a shared helper. The divider pin and target pin share one guard. The removed-target notice consults the DOM after content settles, so it cannot fire mid-stream. One existing test changed intent deliberately ("shows all replies when scrollTo is set" asserted exactly the behaviour being removed) and was rewritten rather than deleted.

## Test plan

- TDD, red first every time: Go failed exactly 1 of 3,941 before the watermark change; each frontend group verified failing before implementation.
- **Vitest: 712 files, 15,075 passed, 0 failed** (on the branch merged up to current master). Covers watermark capture and freezing, baseline preservation across feed-to-thread navigation, delayed seen on deep links, collapse with target exemption (plain, combined, nested), divider placement including the scattered/nested case and the count agreeing with the feed, badge and flash behaviour, combined-id announcements, compound pin selectors, pin mutual exclusion, removed-target notice, feed counts and child suppression.
- **Go: 3,992 passed, 0 failed** (merged tree), including the four new `TestNewsfeedSingleReturnsSeenWatermark` assertions.
- Browser-verified on seeded threads in an isolated worktree, mobile and desktop, including the scattered/nested fixture shown above.
- Docs freshness green.
- Worth flagging: hands-on verification, not the tests, caught two things - a feed-to-thread navigation that wiped the badges the "· 5 new" link had just promised (the remount re-snapshotted the baseline from what had been *fetched* rather than seen), and the divider originally counting only top-level new replies, so it read "2 new" on a thread with 5. Both fixed, both now covered by tests.

## Future improvements

- Per-thread read positions (Discourse-style) would make "new" exact rather than watermark-based; needs schema and write-path work beyond this scope.
- The feed link could jump straight to the divider once thread pages support a `#new` anchor.
- A pair-aware nudge for a long back-and-forth between the same two people, the way Discourse's `get_a_room_threshold` works (default: after three replies to the same person, privately suggest carrying on in a chat). Freegle already has private chat to point at, and unlike the depth-based collapsing other sites use, it does not need deep nesting to work. Not in this PR.