### PR TITLE
fix(message store): make the 10-minute cache expiry actually fire, and repair inBounds

### DIFF
--- a/iznik-nuxt3/stores/message.js
+++ b/iznik-nuxt3/stores/message.js
@@ -11,6 +11,9 @@ import { useMiscStore } from '~/stores/misc'
 // Debounce delay for batching message fetches (ms)
 const BATCH_DELAY = 50
 
+// Refetch a cached message after this long, in case its state has changed.
+const CACHE_TTL_SECONDS = 600
+
 export const useMessageStore = defineStore({
   id: 'message',
   state: () => ({
@@ -58,14 +61,18 @@ export const useMessageStore = defineStore({
       this.count = ret?.count || 0
       return this.count
     },
+    // Whether a cached entry is old enough to be refetched. Every "do we need to
+    // go to the API" decision must use this - fetch(), processMessageBatch() and
+    // fetchMultiple() each make that call independently, and if they disagree an
+    // id can be routed into a batch by one and silently dropped by the next.
+    expired(id, now = Math.round(Date.now() / 1000)) {
+      const addedToCache = this.list[id]?.addedToCache
+      return addedToCache ? now - addedToCache > CACHE_TTL_SECONDS : false
+    },
     async fetch(id, force) {
       id = parseInt(id)
 
-      // Refetch after 10 minutes in case the state has changed.
-      const now = Math.round(Date.now() / 1000)
-      const expired = this.list[id]?.addedToCache
-        ? now - this.list[id].addedToCache > 600
-        : false
+      const expired = this.expired(id)
 
       // If already cached and not forcing/expired, return immediately
       if (!force && this.list[id] && !expired) {
@@ -130,11 +137,10 @@ export const useMessageStore = defineStore({
       const now = Math.round(Date.now() / 1000)
 
       for (const { id, force } of pending) {
-        const expired = this.list[id]?.addedToCache
-          ? now - this.list[id].addedToCache > 600
-          : false
-
-        if ((force || !this.list[id] || expired) && !this.fetching[id]) {
+        if (
+          (force || !this.list[id] || this.expired(id, now)) &&
+          !this.fetching[id]
+        ) {
           if (!idsToFetch.includes(id)) {
             idsToFetch.push(id)
           }
@@ -161,11 +167,15 @@ export const useMessageStore = defineStore({
     },
     async fetchMultiple(ids, force) {
       const left = []
+      const now = Math.round(Date.now() / 1000)
 
       ids.forEach((id) => {
         id = parseInt(id)
 
-        if ((force || !this.list[id]) && !this.fetching[id]) {
+        if (
+          (force || !this.list[id] || this.expired(id, now)) &&
+          !this.fetching[id]
+        ) {
           left.push(id)
         }
       })
@@ -896,7 +906,7 @@ export const useMessageStore = defineStore({
       const key =
         swlat + ':' + swlng + ':' + nelat + ':' + nelng + ':' + groupid
 
-      return key in this.bounds ? this.bounds[key] : []
+      return key in state.bounds ? state.bounds[key] : []
     },
     all: (state) => Object.values(state.list),
     byUser: (state) => (userid) => {

--- a/iznik-nuxt3/tests/unit/stores/message.coverage.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/message.coverage.spec.js
@@ -21,7 +21,6 @@ const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 const mockApiFetch = vi.fn()
 const mockFetchByUser = vi.fn()
 const mockSave = vi.fn()
-const mockFetch = vi.fn()
 const mockSearch = vi.fn()
 const mockSimilar = vi.fn()
 const mockMatches = vi.fn()
@@ -133,14 +132,7 @@ describe('message store - fetch() cache/batch behaviour', () => {
     expect(mockApiFetch).not.toHaveBeenCalled()
   })
 
-  // TODO: latent bug - fetch() correctly identifies an expired-but-unforced
-  // cache entry as needing a refresh and routes it into the batch, but
-  // fetchMultiple() re-derives its own "needs fetching" filter from
-  // `force || !this.list[id]` alone (it isn't told which ids were expired
-  // vs merely missing). Since the id IS cached and force is false, it never
-  // makes the API call - the stale entry is silently kept forever and the
-  // 10-minute refetch documented at stores/message.js:64-68 never fires.
-  it.skip('re-fetches when the cached entry expired more than 10 minutes ago', async () => {
+  it('re-fetches when the cached entry expired more than 10 minutes ago', async () => {
     const store = useMessageStore()
     store.init({})
     store.list[6] = {
@@ -255,7 +247,10 @@ describe('message store - handleFetchError()', () => {
     store.init({})
 
     expect(() =>
-      store.handleFetchError(30, new APIError({ response: { status: 500 } }, 'x'))
+      store.handleFetchError(
+        30,
+        new APIError({ response: { status: 500 } }, 'x')
+      )
     ).toThrow()
   })
 
@@ -1135,7 +1130,13 @@ describe('message store - reply()/spam()/move()', () => {
     store.list[400] = { id: 400 }
     mockReply.mockResolvedValue({})
 
-    await store.reply({ id: 400, groupid: 1, subject: 's', stdmsgid: 2, body: 'b' })
+    await store.reply({
+      id: 400,
+      groupid: 1,
+      subject: 's',
+      stdmsgid: 2,
+      body: 'b',
+    })
 
     expect(mockReply).toHaveBeenCalledWith(400, 1, 's', 2, 'b')
     expect(store.list[400]).toBeDefined()
@@ -1228,14 +1229,7 @@ describe('message store - remaining getters', () => {
     expect(store.helperById(900)).toEqual({ batch: {} })
   })
 
-  // TODO: latent bug - the inBounds getter is `(state) => (...) => key in
-  // this.bounds ? ... `, but the returned closure is an arrow function so
-  // `this` is never rebound to the store; it resolves to whatever `this` is
-  // in the module's lexical scope (undefined in strict ESM), so any real
-  // call throws "Cannot use 'in' operator ... in undefined" instead of
-  // reading state.bounds. Nothing in the app currently calls .inBounds(),
-  // which is presumably why this has gone unnoticed.
-  it.skip('inBounds returns the cached array for a matching key', () => {
+  it('inBounds returns the cached array for a matching key', () => {
     const store = useMessageStore()
     store.init({})
     store.bounds['1:2:3:4:5'] = [{ id: 1 }]
@@ -1243,7 +1237,7 @@ describe('message store - remaining getters', () => {
     expect(store.inBounds(1, 2, 3, 4, 5)).toEqual([{ id: 1 }])
   })
 
-  it.skip('inBounds returns an empty array when the key is not cached', () => {
+  it('inBounds returns an empty array when the key is not cached', () => {
     const store = useMessageStore()
     store.init({})
 


### PR DESCRIPTION
## Summary

Two real bugs in `stores/message.js`, both already known and both marked with `it.skip` in `tests/unit/stores/message.coverage.spec.js`. Those were the only skips left in the unit suite, and `CLAUDE.md` forbids skipping, so this fixes the bugs and enables the tests rather than leaving the markers in place.

**The 10-minute cache expiry never fired.** `processMessageBatch()` correctly identified an expired-but-cached id and routed it into the batch, and then `fetchMultiple()` re-derived its own "needs fetching" filter from `force || !this.list[id]` and dropped it again — the id *is* cached and `force` is false. A stale message was kept forever, so the refetch documented in the code never happened in practice.

The root cause is that three functions each decided independently whether a cached entry needed refreshing, and two of them disagreed. Rather than write the same test a third time, this extracts one `expired(id, now)` action and routes `fetch()`, `processMessageBatch()` and `fetchMultiple()` through it, so they cannot drift apart again. The bare `600` becomes `CACHE_TTL_SECONDS`.

**`inBounds` threw on every call.** It is an arrow-function getter taking `state`, but the body read `this.bounds`. `this` is `undefined` at that scope in strict ESM, so any call raised `Cannot use 'in' operator ... in undefined` instead of reading `state.bounds`. Nothing in the app calls it today, which is why it went unnoticed. Now reads from `state`.

## Code Quality Review

- The expiry fix is deliberately a single shared helper rather than a third copy of the same comparison. The duplication *was* the bug: two copies of the rule that disagreed.
- `expired(id, now)` takes an optional `now` so the batch paths can stamp one timestamp across a whole batch instead of drifting per id.
- Checked `expired` does not collide with anything else on the store; the other `.expired` uses in the codebase are on unrelated objects (`prompt`, `volunteering`).
- Removed an unused `mockFetch` const that was failing lint in that spec.

## Test Plan

Verified in **both** directions, since tests I un-skipped myself prove nothing if they would have passed anyway:

- With the unfixed store from master and the tests enabled: **exactly 3 failures**, and they are exactly the three being fixed — `re-fetches when the cached entry expired more than 10 minutes ago`, `inBounds returns the cached array for a matching key`, and `inBounds returns an empty array when the key is not cached` (15021 passed, 3 failed, 1 failed file).
- With the fix applied: **711 files, 15024 passed, 0 failed, and zero skips** — the unit suite now has no `.skip` anywhere.
- Lint clean on both changed files.
- Not run: Go, Laravel and Playwright, none of which this touches.
