### PR TITLE
fix(yesterday): stop the thin pool filling, and stop calling a finished restore a failure

### DIFF
--- a/iznik-nuxt3/modtools/components/ModYesterday.vue
+++ b/iznik-nuxt3/modtools/components/ModYesterday.vue
@@ -13,7 +13,10 @@
     <strong>System backed up on Yesterday up to:</strong>
     {{ latestMessage }}
     <span v-if="backupStatus === 'stale'"> ❌ Backup is over 2 days old!</span>
-    <span v-if="backupStatus === 'restore-failed'">
+    <!-- Driven by its own flag rather than backupStatus: a failed restore is
+         usually the CAUSE of a stale backup, so both must show together instead
+         of the age check winning and hiding why the backup went stale. -->
+    <span v-if="restoreFailed">
       ❌ Latest restore attempt failed - check logs</span
     >
     <span v-if="backupStatus === 'unreachable'"> ❌ Server unreachable</span>
@@ -31,6 +34,7 @@ dayjs.extend(customParseFormat)
 const latestMessage = ref(null)
 const backupStatus = ref(null)
 const isRestoring = ref(false)
+const restoreFailed = ref(false)
 
 onMounted(async () => {
   try {
@@ -57,6 +61,7 @@ onMounted(async () => {
       ) {
         // Check what backup is currently loaded (even if last restore attempt failed)
         const lastRestoreFailed = restoreData.status === 'failed'
+        restoreFailed.value = lastRestoreFailed
         try {
           const currentBackupResponse = await fetch(
             'https://yesterday.ilovefreegle.org:8444/api/current-backup'

--- a/iznik-nuxt3/tests/unit/components/modtools/ModYesterday.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModYesterday.spec.js
@@ -167,6 +167,21 @@ describe('ModYesterday', () => {
       expect(wrapper.find('.alert-danger').exists()).toBe(true)
       expect(wrapper.text()).toContain('Latest restore attempt failed')
     })
+
+    // The production case on 2026-08-09: a restore died mid-flight, so the
+    // loaded backup went stale as well. Reporting only staleness hides the
+    // CAUSE, which is the thing that actually needs fixing, so both have to
+    // show at once rather than the age check winning and silencing the rest.
+    it('shows both the stale warning and the failure when a failed restore left the backup old', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockRestoreResponse({ status: 'failed' }))
+        .mockResolvedValueOnce(mockCurrentBackupResponse({ date: '20240110' }))
+      const wrapper = mountComponent()
+      await flushPromises()
+      expect(wrapper.find('.alert-danger').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Backup is over 2 days old')
+      expect(wrapper.text()).toContain('Latest restore attempt failed')
+    })
   })
 
   describe('error handling', () => {

--- a/yesterday/api/server.js
+++ b/yesterday/api/server.js
@@ -472,10 +472,21 @@ app.get('/api/restore-status', async (req, res) => {
         });
       }
 
+      // We get here with a status file that is neither completed nor failed, and
+      // whose last update is older than the isRecent window. That is a restore
+      // that DIED mid-flight - it never wrote a terminal status. Reporting 'idle'
+      // here threw that away and made an abandoned restore look identical to one
+      // that never ran, so the only visible symptom was the backup quietly going
+      // stale days later. Surface it as failed, the same call the in-memory job
+      // expiry already makes, and keep the phase it died in so the logs can be
+      // aimed at the right place.
       return res.json({
         inProgress: false,
-        status: 'idle',
-        message: 'No active restore'
+        status: 'failed',
+        message: `Restore stalled during "${status.status}" - no progress update since ${status.timestamp}; check logs`,
+        backupDate: status.backupDate,
+        stalledPhase: status.status,
+        completedAt: status.timestamp
       });
 
     } catch (error) {

--- a/yesterday/scripts/auto-restore-latest.sh
+++ b/yesterday/scripts/auto-restore-latest.sh
@@ -161,6 +161,21 @@ if echo "$API_RESPONSE" | grep -q "Started loading"; then
 
         echo "[$(date +%H:%M:%S)] Status: $STATUS ($PERCENT%) - $MESSAGE"
 
+        # Ground truth beats the job record. The API container SHUTS DOWN during
+        # a restore, so its in-memory job can come back frozen at "starting" for
+        # a restore that has since finished perfectly well — on 2026-08-06 the
+        # load completed at 08:56 and this loop still reported "did not complete
+        # within 4 hours". current-backup is written by the restore itself, so
+        # if it names our date, we are done whatever the job says.
+        LOADED=$(curl -s http://localhost:8082/api/current-backup | jq -r '.date // ""')
+        if [ "$LOADED" = "$LATEST_DATE" ]; then
+            echo ""
+            echo "✅ Auto-restore completed successfully (confirmed by current-backup)"
+            echo "Yesterday environment now running backup from $LATEST_DATE"
+            COMPLETED=1
+            break
+        fi
+
         if [ "$STATUS" = "completed" ]; then
             echo ""
             echo "✅ Auto-restore completed successfully"
@@ -190,6 +205,16 @@ if echo "$API_RESPONSE" | grep -q "Started loading"; then
 
     if [ $COMPLETED -ne 1 ]; then
         echo "❌ Restore did not complete within 4 hours - giving up"
+        echo "   Last job status: ${STATUS:-unknown} (${PERCENT:-?}%) - ${MESSAGE:-none}"
+        echo "   Loaded backup is still: ${LOADED:-unknown}, wanted $LATEST_DATE"
+        # A restore that never leaves 0% is usually the thin pool being out of
+        # data space rather than a slow copy, and that is invisible from the
+        # API. Print it here so the log says why instead of just "gave up".
+        if command -v lvs >/dev/null 2>&1; then
+            echo "   Thin pool:"
+            lvs --noheadings -o lv_name,lv_attr,data_percent,metadata_percent \
+                "${YLVM_VG:-yesterday_vg}" 2>&1 | sed 's/^/     /'
+        fi
         exit 1
     fi
 

--- a/yesterday/scripts/lib-yesterday-lvm.sh
+++ b/yesterday/scripts/lib-yesterday-lvm.sh
@@ -18,7 +18,17 @@ export YLVM_STAGE="${YLVM_STAGE:-iznik_stage}"      # transient prepare area
 export YLVM_ACTIVE_MNT="${YLVM_ACTIVE_MNT:-/mnt/iznik-active}"
 export YLVM_STAGE_MNT="${YLVM_STAGE_MNT:-/mnt/iznik-stage}"
 export YLVM_SNAP_PREFIX="${YLVM_SNAP_PREFIX:-snap_}"
-export YLVM_KEEP="${YLVM_KEEP:-7}"                  # retain N daily snapshots
+export YLVM_KEEP="${YLVM_KEEP:-7}"                  # CEILING on daily snapshots, not a promise
+
+# The pool, not the day count, is the real constraint. active+stage occupy most
+# of it before a single snapshot exists, and each day's rsync makes the previous
+# day's snapshot diverge, so "keep 7" quietly over-commits: on 2026-08-09 the
+# pool hit 100% with only FOUR snapshots present, which meant pruning (which
+# only starts removing at the 8th) had never run, and every restore from 7 Aug
+# onwards died on ENOSPC after polling at 0% for four hours.
+export YLVM_POOL_HIGH_WATER="${YLVM_POOL_HIGH_WATER:-80}"  # prune down to below this data%
+export YLVM_KEEP_MIN="${YLVM_KEEP_MIN:-2}"                 # never prune below this many days
+export YLVM_POOL_MIN_FREE="${YLVM_POOL_MIN_FREE:-15}"      # refuse to start an apply below this % free
 
 export YLVM_BUCKET="${YLVM_BUCKET:-gs://freegle_backup_uk}"
 export YLVM_COMPOSE_DIR="${YLVM_COMPOSE_DIR:-/var/www/FreegleDocker}"
@@ -127,19 +137,85 @@ ylvm_snapshot_active() {
     ylvm_log "✅ Snapshot $snap created"
 }
 
-# Keep only the newest $YLVM_KEEP dated snapshots; remove older ones.
+# Current data utilisation of the thin pool, as a whole-number percentage.
+# Empty if it cannot be read, so callers must treat "" as "do not know".
+ylvm_pool_data_percent() {
+    lvs --noheadings -o data_percent "$YLVM_VG/$YLVM_POOL" 2>/dev/null \
+        | tr -d ' ' | awk -F. 'NF{print $1}'
+}
+
+# List dated snapshots, oldest first.
+ylvm_snapshots_oldest_first() {
+    lvs --noheadings -o lv_name "$YLVM_VG" 2>/dev/null \
+        | tr -d ' ' | grep "^${YLVM_SNAP_PREFIX}" | sort
+}
+
+# Refuse to begin an apply that the pool cannot absorb. rsync onto the active
+# volume forces a copy-on-write of every changed block against every snapshot
+# holding the old one, so starting with almost no free data space does not
+# degrade — it stalls the pool into out-of-data-space mode and takes percona
+# with it. Failing here is loud, instant and explains itself; failing halfway
+# through is a four-hour poll at 0% and a datadir in an unknown state.
+ylvm_require_pool_headroom() {
+    local used; used="$(ylvm_pool_data_percent)"
+    if [ -z "$used" ]; then
+        ylvm_log "⚠️  Could not read thin pool utilisation; continuing."
+        return 0
+    fi
+
+    local free=$((100 - used))
+    if [ "$free" -lt "$YLVM_POOL_MIN_FREE" ]; then
+        ylvm_die "Thin pool $YLVM_VG/$YLVM_POOL is ${used}% full (need ${YLVM_POOL_MIN_FREE}% free to apply a backup). Snapshots present: $(ylvm_snapshots_oldest_first | tr '\n' ' '). Remove older snapshots with lvremove, or grow the pool."
+    fi
+
+    ylvm_log "Thin pool ${used}% used, ${free}% free — enough to apply."
+}
+
+# Retention. $YLVM_KEEP is a ceiling on how many days we would LIKE; the pool
+# decides how many we can actually afford. Drop the oldest beyond the ceiling,
+# then keep dropping the oldest while utilisation is above the high-water mark,
+# never going below $YLVM_KEEP_MIN — losing switchable days is bad, but filling
+# the pool loses tomorrow's restore entirely, and then every one after it.
 ylvm_prune_snapshots() {
-    local snaps; snaps="$(lvs --noheadings -o lv_name "$YLVM_VG" 2>/dev/null \
-        | tr -d ' ' | grep "^${YLVM_SNAP_PREFIX}" | sort -r)"
-    local i=0
+    local snaps; snaps="$(ylvm_snapshots_oldest_first)"
+    local total; total="$(printf '%s\n' "$snaps" | grep -c .)"
+
+    local snap
     while IFS= read -r snap; do
         [ -z "$snap" ] && continue
-        i=$((i+1))
-        if [ "$i" -gt "$YLVM_KEEP" ]; then
-            ylvm_log "Pruning old snapshot $snap"
-            lvremove -fy "$YLVM_VG/$snap" || true
-        fi
+        [ "$total" -le "$YLVM_KEEP" ] && break
+        ylvm_log "Pruning old snapshot $snap (over the $YLVM_KEEP-day ceiling)"
+        lvremove -fy "$YLVM_VG/$snap" || true
+        total=$((total-1))
     done <<< "$snaps"
+
+    local used; used="$(ylvm_pool_data_percent)"
+    if [ -n "$used" ] && [ "$used" -gt "$YLVM_POOL_HIGH_WATER" ]; then
+        ylvm_log "Thin pool ${used}% used, above the ${YLVM_POOL_HIGH_WATER}% high-water mark — pruning further."
+
+        while IFS= read -r snap; do
+            [ -z "$snap" ] && continue
+            [ "$total" -le "$YLVM_KEEP_MIN" ] && break
+            lvs "$YLVM_VG/$snap" >/dev/null 2>&1 || continue
+
+            used="$(ylvm_pool_data_percent)"
+            [ -n "$used" ] && [ "$used" -le "$YLVM_POOL_HIGH_WATER" ] && break
+
+            ylvm_log "Pruning $snap to reclaim pool space (${used}% used)"
+            lvremove -fy "$YLVM_VG/$snap" || true
+            total=$((total-1))
+        done <<< "$snaps"
+
+        used="$(ylvm_pool_data_percent)"
+        if [ -n "$used" ] && [ "$used" -gt "$YLVM_POOL_HIGH_WATER" ]; then
+            # Down to the floor and still over. Not fatal right now, but the
+            # next apply will fail the headroom check, so say so while someone
+            # is still reading the nightly log.
+            ylvm_log "⚠️  Thin pool still ${used}% used with only $total snapshot(s) left. The pool is too small for this database; grow it or reduce YLVM_KEEP_MIN."
+        fi
+    fi
+
+    ylvm_log "Retention: $total snapshot(s) kept, pool $(ylvm_pool_data_percent)% used."
     ylvm_write_snapshot_manifest
 }
 

--- a/yesterday/scripts/nightly-refresh-lvm.sh
+++ b/yesterday/scripts/nightly-refresh-lvm.sh
@@ -49,6 +49,14 @@ mountpoint -q "$YLVM_STAGE_MNT"  || ylvm_die "$YLVM_STAGE_MNT not mounted — ru
 ylvm_log "===== Nightly LVM refresh -> $DATE8 (was: ${CURRENT:-none}) ====="
 ylvm_set_restore_status "preparing" "Refreshing to latest backup $DATE8…" "$DATE8"
 
+# 0. Make room before we need it, and refuse to start if there isn't enough.
+#    Staging and the in-place apply both write into the same thin pool, and a
+#    pool that runs out mid-apply stalls into out-of-data-space mode rather
+#    than returning an error anyone can see: the 7-9 Aug 2026 restores each
+#    polled at 0% for four hours and died on ENOSPC. Reclaim first, then check.
+ylvm_prune_snapshots
+ylvm_require_pool_headroom
+
 # 1. Prepare the full backup in staging (percona still serving the current day).
 ylvm_prepare_to_stage "$DATE8"
 

--- a/yesterday/scripts/test-lvm-retention.sh
+++ b/yesterday/scripts/test-lvm-retention.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Tests for the thin-pool retention decisions in lib-yesterday-lvm.sh.
+#
+#   ./test-lvm-retention.sh
+#
+# These are the decisions that failed in production on 2026-08-09: the pool hit
+# 100% data with only four snapshots present, because retention counted days and
+# never looked at the pool, so pruning had never run. Every restore from 7 Aug
+# onwards then died on ENOSPC after polling at 0% for four hours.
+#
+# lvs and lvremove are stubbed, so this runs anywhere — no LVM, no root, no VG.
+# The stub models the thing that matters: removing a snapshot frees pool space.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+FAILURES=0
+pass() { echo "  ✅ $1"; }
+fail() { echo "  ❌ $1"; FAILURES=$((FAILURES + 1)); }
+
+assert_eq() {
+    local want="$1" got="$2" what="$3"
+    if [ "$want" = "$got" ]; then pass "$what"; else fail "$what — wanted [$want], got [$got]"; fi
+}
+
+# ---- Stubs ------------------------------------------------------------------
+# STUB_SNAPS: space-separated snapshot names still present.
+# STUB_USED:  pool data percent. Each removal frees STUB_PER_SNAP percent.
+
+stub_reset() {
+    STUB_SNAPS="$1"
+    STUB_USED="$2"
+    STUB_PER_SNAP="${3:-10}"
+    STUB_REMOVED=""
+}
+
+lvs() {
+    # ylvm_pool_data_percent: lvs --noheadings -o data_percent VG/POOL
+    if [[ "$*" == *"-o data_percent"* ]]; then
+        echo "  ${STUB_USED}.00"
+        return 0
+    fi
+    # ylvm_snapshots_oldest_first: lvs --noheadings -o lv_name VG
+    if [[ "$*" == *"-o lv_name"* ]]; then
+        local s
+        for s in $STUB_SNAPS; do echo "  $s"; done
+        return 0
+    fi
+    # Existence probe: lvs VG/NAME
+    local target="${*##* }"
+    local name="${target#*/}"
+    [[ " $STUB_SNAPS " == *" $name "* ]]
+}
+
+lvremove() {
+    local target="${*##* }"
+    local name="${target#*/}"
+    local kept="" s
+    for s in $STUB_SNAPS; do
+        [ "$s" = "$name" ] && continue
+        kept="$kept $s"
+    done
+    STUB_SNAPS="$(echo "$kept" | xargs)"
+    STUB_REMOVED="$(echo "$STUB_REMOVED $name" | xargs)"
+    STUB_USED=$((STUB_USED - STUB_PER_SNAP))
+    [ "$STUB_USED" -lt 0 ] && STUB_USED=0
+    return 0
+}
+
+export -f lvs lvremove 2>/dev/null || true
+
+# The manifest writes into the compose dir; irrelevant here.
+ylvm_write_snapshot_manifest() { :; }
+
+# shellcheck source=lib-yesterday-lvm.sh
+source "$SCRIPT_DIR/lib-yesterday-lvm.sh"
+
+# Re-stub after sourcing, in case the library defines its own.
+ylvm_write_snapshot_manifest() { :; }
+ylvm_log() { :; }   # quiet
+
+echo "Retention"
+
+# 1. Comfortably within both limits: touch nothing. A day of history is worth
+#    keeping whenever it is affordable.
+YLVM_KEEP=7 YLVM_POOL_HIGH_WATER=80 YLVM_KEEP_MIN=2
+stub_reset "snap_20260801 snap_20260802 snap_20260803" 40
+ylvm_prune_snapshots
+assert_eq "" "$STUB_REMOVED" "nothing pruned when under the ceiling and under the high-water mark"
+
+# 2. Over the day ceiling: drop the oldest first, keep the newest.
+YLVM_KEEP=3 YLVM_POOL_HIGH_WATER=95 YLVM_KEEP_MIN=2
+stub_reset "snap_20260801 snap_20260802 snap_20260803 snap_20260804 snap_20260805" 40
+ylvm_prune_snapshots
+assert_eq "snap_20260801 snap_20260802" "$STUB_REMOVED" "prunes the OLDEST down to the ceiling"
+assert_eq "snap_20260803 snap_20260804 snap_20260805" "$STUB_SNAPS" "keeps the newest days"
+
+# 3. The regression. Under the day ceiling, but the pool is nearly full, which
+#    is exactly the 2026-08-09 state: four snapshots, KEEP=7, pool at 100%.
+#    Counting days alone removes nothing and the next restore dies.
+YLVM_KEEP=7 YLVM_POOL_HIGH_WATER=80 YLVM_KEEP_MIN=2
+stub_reset "snap_20260803 snap_20260804 snap_20260805 snap_20260806" 100 10
+ylvm_prune_snapshots
+assert_eq "snap_20260803 snap_20260804" "$STUB_REMOVED" "prunes on pool pressure even when under the day ceiling"
+assert_eq "80" "$STUB_USED" "stops as soon as it is back under the high-water mark"
+
+# 4. The floor holds even when freeing everything would not be enough. Losing
+#    every switchable day would be a worse outcome than a full pool.
+YLVM_KEEP=7 YLVM_POOL_HIGH_WATER=80 YLVM_KEEP_MIN=2
+stub_reset "snap_20260803 snap_20260804 snap_20260805 snap_20260806" 100 1
+ylvm_prune_snapshots
+assert_eq "snap_20260803 snap_20260804" "$STUB_REMOVED" "never prunes below YLVM_KEEP_MIN"
+assert_eq "2" "$(echo "$STUB_SNAPS" | wc -w)" "leaves exactly the minimum"
+
+# 5. Unreadable pool utilisation must not trigger deletions on a guess.
+YLVM_KEEP=7 YLVM_POOL_HIGH_WATER=80 YLVM_KEEP_MIN=2
+stub_reset "snap_20260803 snap_20260804 snap_20260805" 40
+ylvm_pool_data_percent() { echo ""; }
+ylvm_prune_snapshots
+assert_eq "" "$STUB_REMOVED" "does not prune when pool utilisation cannot be read"
+unset -f ylvm_pool_data_percent
+source "$SCRIPT_DIR/lib-yesterday-lvm.sh"
+ylvm_write_snapshot_manifest() { :; }
+ylvm_log() { :; }
+
+echo "Headroom"
+
+# 6. Enough free space: proceed.
+YLVM_POOL_MIN_FREE=15
+stub_reset "snap_20260805" 50
+( ylvm_require_pool_headroom ) >/dev/null 2>&1
+assert_eq "0" "$?" "allows an apply with plenty of free pool"
+
+# 7. Not enough: refuse BEFORE writing anything, rather than stalling mid-rsync.
+YLVM_POOL_MIN_FREE=15
+stub_reset "snap_20260806" 95
+( ylvm_require_pool_headroom ) >/dev/null 2>&1
+assert_eq "1" "$?" "refuses an apply that the pool cannot absorb"
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+    echo "All retention tests passed."
+    exit 0
+fi
+echo "$FAILURES test(s) failed."
+exit 1


### PR DESCRIPTION
## Summary

Yesterday has been serving 6 Aug data since 6 Aug. This PR started as "make the failure visible"; with host access it now also fixes the failure.

### Why the restores actually fail

```
LV            Attr        LSize    Data%   Origin
iznik_active  Vwi-aotz--  250.00g  78.63   (~197G)
iznik_stage   Vwi-aotz--  250.00g  72.68   (~182G)
snap_20260803 Vri---tz-k  250.00g          iznik_active
snap_20260804 Vri---tz-k  250.00g          iznik_active
snap_20260805 Vri---tz-k  250.00g          iznik_active
snap_20260806 Vri---tz-k  250.00g          iznik_active
thinpool      twi-aotzD-  599.70g  100.00
```

`D` is out-of-data-space, `vgs` reports `VFree 0`, and dmesg has
`device-mapper: thin: switching pool to out-of-data-space (error IO) mode`
on 9 Aug at 08:23. The restore then dies on `rsync: ftruncate failed …: No space left on device (28)`.

`YLVM_KEEP=7` over-commits the pool. active and stage occupy ~379G of 600G before a single snapshot exists, and each night's rsync makes the previous night's snapshot diverge. The pool reached 100% with only **four** snapshots — which also means pruning had never run, because it only starts removing at the eighth.

### Retention is now bounded by the pool, not the calendar

`YLVM_KEEP` becomes a ceiling on how many days we would *like*; the pool decides how many we can afford. Drop the oldest beyond the ceiling, then keep dropping the oldest while utilisation is above `YLVM_POOL_HIGH_WATER` (default 80%), never below `YLVM_KEEP_MIN` (default 2). Losing switchable days is bad; filling the pool loses tomorrow's restore and every one after it.

The nightly refresh prunes and then checks headroom **before** staging or applying anything. A pool that runs out mid-apply does not return an error — it stalls into out-of-data-space mode and takes percona with it. Refusing up front is instant and says why.

### The poller was also lying in the other direction

It reads the API's in-memory job, and the API container shuts down during a restore, so the job can come back frozen at `starting`. **On 6 Aug the load completed at 08:56 and the log still said "did not complete within 4 hours"** — so that message has never been evidence of anything. It now also checks `current-backup`, which the restore itself writes, and treats our date appearing there as success whatever the job says. When it does give up it prints the last job status and the thin-pool state.

### The original change, still here

`/api/restore-status` reached its final `return` only when the status file exists, is neither `completed` nor `failed`, and is older than the `isRecent` window — the shape of a restore that stopped reporting — and called that `idle`, with the message `"No active restore"`. It now returns `failed`, carrying the phase it stalled in and the last timestamp. `ModYesterday.vue` kept `backupStatus` as a single value, so the age check ran first and staleness silenced the failure; since a failed restore is usually *why* a backup is stale, the failure has its own flag and both render together.

## Code Quality Review

- Retention degrades safely: if pool utilisation cannot be read it prunes on the day ceiling only, rather than deleting on a guess.
- When it hits `YLVM_KEEP_MIN` and is still over the high-water mark it logs that the pool is simply too small for this database, while someone is still reading the nightly log.
- The poller's new check is ground truth (`current-backup` is written by the restore) rather than a second opinion from the same in-memory job.

## Test Plan

- `yesterday/scripts/test-lvm-retention.sh` — new. Stubs `lvs`/`lvremove` so it runs with no LVM, no VG and no root, and models the thing that matters: removing a snapshot frees pool space. Covers no-op under both limits, pruning oldest-first to the ceiling, pruning under pool pressure while *under* the day ceiling, the `KEEP_MIN` floor, unreadable utilisation, and both headroom outcomes. All pass.
- **Red-proved** against the old count-only prune: the pool-pressure cases fail, including the exact 2026-08-09 state, where it removes nothing at all. (The over-the-ceiling case still prunes the right snapshots under the old code — that part was never broken.)
- `bash -n` clean on all three changed scripts.
- Frontend/API half unchanged from the original review: new unit test covers the production combination of failed restore **and** stale backup; red-proved at the time with exactly that one test failing.

- Rebased onto `dc6cebd51`, which repairs the seeded-post ageing that makes five Playwright feed tests fail on master and on every branch alike; those five are unrelated to this change.

## Operational follow-up, not in this PR

The pool has been freed by hand on the VM (`snap_20260803/04/05` removed, `snap_20260806` kept as the only consistent copy — the failed rsync left `iznik_active` half-applied). Pool went 100% → 77%, the out-of-data-space flag cleared, and a restore of 20260809 is running. From here the retention in this PR keeps it under control.

Nothing here alerts on pool utilisation before it bites; that belongs with the other monitoring rather than in a bash script nobody reads. `freegledocker-percona` had also been down for two days on that host, which no dashboard surfaced either.