### PR TITLE
fix(swagger): stop generate-swagger.sh destroying the spec it regenerates

### DIFF
--- a/iznik-server-go/generate-swagger.sh
+++ b/iznik-server-go/generate-swagger.sh
@@ -50,41 +50,90 @@ echo "Generating Swagger documentation..."
 # Make sure the swagger directory exists (works on both Windows and Unix)
 mkdir -p swagger 2>/dev/null || mkdir swagger 2>/dev/null
 
+# Where the finished spec lands. Overridable so callers (notably the test in
+# test/swagger_test.go) can generate somewhere disposable instead of over the
+# committed spec.
+SWAGGER_OUT="${SWAGGER_OUT:-./swagger/swagger.json}"
+
 # Generate the swagger spec
 echo "Generating spec with all files..."
 # Generate the spec with appropriate parameters based on the swagger version
 
-# First try with the base dir parameter, excluding test files which might cause issues
+# Generate to a TEMPORARY file, never straight over the destination. Writing in
+# place means a bad run has already destroyed the previous spec by the time you
+# can inspect it, and the only guard used to be "are paths empty", which does not
+# fire when the run drops models rather than routes. Measured 2026-08-09: a run
+# on an unchanged tree emitted 4 definitions where the committed spec had 115,
+# which the old flow would have written out silently.
+TMP_SPEC="$(mktemp -t swagger-spec-XXXXXX.json)"
+trap 'rm -f "$TMP_SPEC"' EXIT
+
+# Exclude test files, which might cause issues
 $SWAGGER_CMD generate spec \
-  -o ./swagger/swagger.json \
+  -o "$TMP_SPEC" \
   --scan-models \
   --include=".*" \
   --exclude=".*/vendor/.*" \
   --exclude=".*/test/.*" \
   -m
 
-if [ $? -eq 0 ]; then
-    echo "✅ Swagger spec generated successfully at ./swagger/swagger.json"
-
-    # Validate the swagger spec
-    echo "Validating the generated spec..."
-    $SWAGGER_CMD validate ./swagger/swagger.json
-
-    if [ $? -eq 0 ]; then
-        echo "✅ Swagger spec validation passed"
-    else
-        echo "⚠️ Swagger spec validation has warnings"
-        
-        # Check if paths is empty and display an error
-        if grep -q "\"paths\": {}" ./swagger/swagger.json; then
-            echo "❌ ERROR: Generated spec doesn't contain any API paths"
-            echo "Make sure your route annotations are correct (see README.md for guidance)"
-            exit 1
-        fi
-    fi
-else
+if [ $? -ne 0 ]; then
     echo "❌ Failed to generate Swagger spec - please check your swagger command"
+    echo "   The existing spec at $SWAGGER_OUT has NOT been touched."
     exit 1
+fi
+
+if grep -q "\"paths\": {}" "$TMP_SPEC"; then
+    echo "❌ ERROR: Generated spec doesn't contain any API paths"
+    echo "Make sure your route annotations are correct (see README.md for guidance)"
+    echo "   The existing spec at $SWAGGER_OUT has NOT been touched."
+    exit 1
+fi
+
+# Refuse a run that loses a large share of what the current spec documents.
+# Node rather than jq/python: it is already a dependency across this monorepo,
+# and a missing interpreter must not block generation, so an absent node only
+# warns.
+if [ -f "$SWAGGER_OUT" ] && command -v node >/dev/null 2>&1; then
+    node -e '
+      const fs = require("fs");
+      const [oldPath, newPath] = process.argv.slice(1);
+      const count = (p, k) => Object.keys(JSON.parse(fs.readFileSync(p, "utf8"))[k] || {}).length;
+      let worst = null;
+      for (const key of ["paths", "definitions", "responses"]) {
+        const before = count(oldPath, key), after = count(newPath, key);
+        // Only a big loss is suspicious; removing one retired route is normal.
+        if (before > 0 && after < before * 0.75) {
+          worst = `${key}: ${before} -> ${after}`;
+          console.error(`   ${key}: ${before} -> ${after}  (lost ${before - after})`);
+        }
+      }
+      process.exit(worst ? 1 : 0);
+    ' "$SWAGGER_OUT" "$TMP_SPEC"
+
+    if [ $? -ne 0 ]; then
+        echo "❌ ERROR: the generated spec drops more than a quarter of what the current one documents."
+        echo "   Refusing to overwrite $SWAGGER_OUT. Inspect the candidate at:"
+        echo "     $TMP_SPEC"
+        echo "   (copy it elsewhere before this script exits, or it will be cleaned up)"
+        echo "   If the loss is genuinely intended, install it by hand."
+        trap - EXIT
+        exit 1
+    fi
+fi
+
+mkdir -p "$(dirname "$SWAGGER_OUT")" 2>/dev/null
+cp "$TMP_SPEC" "$SWAGGER_OUT"
+echo "✅ Swagger spec generated successfully at $SWAGGER_OUT"
+
+# Validate the swagger spec
+echo "Validating the generated spec..."
+$SWAGGER_CMD validate "$SWAGGER_OUT"
+
+if [ $? -eq 0 ]; then
+    echo "✅ Swagger spec validation passed"
+else
+    echo "⚠️ Swagger spec validation has warnings"
 fi
 
 echo "The Swagger UI is available at http://localhost:8192/swagger/ when the server is running."

--- a/iznik-server-go/swagger/swagger.go
+++ b/iznik-server-go/swagger/swagger.go
@@ -49,6 +49,7 @@ import (
 	"github.com/freegle/iznik-server-go/config"
 	"github.com/freegle/iznik-server-go/donations"
 	"github.com/freegle/iznik-server-go/group"
+	"github.com/freegle/iznik-server-go/housekeeper"
 	"github.com/freegle/iznik-server-go/image"
 	"github.com/freegle/iznik-server-go/isochrone"
 	"github.com/freegle/iznik-server-go/job"
@@ -4093,7 +4094,16 @@ type aiImageRegenerateResponse struct {
 //	401: errorResponse
 //	403: errorResponse
 
+// The one swagger:response of the 65 here that carried no type. The annotation
+// has to sit above a declaration; on its own it declares nothing, so the $ref
+// from /housekeeper/tasks never resolved and the whole spec failed validation.
+// housekeeper.ListTasks returns a bare array of tasks, so that is what this says.
 // swagger:response housekeeperTasksResponse
+type housekeeperTasksResponse struct {
+	// The housekeeper tasks, each with its last run status and overdue flag
+	// in:body
+	Body []housekeeper.HousekeeperTask
+}
 
 // swagger:route POST /housekeeper/tasks/{key}/complete housekeeper completeHousekeeperTask
 // Mark a housekeeper task complete

--- a/iznik-server-go/swagger/swagger.json
+++ b/iznik-server-go/swagger/swagger.json
@@ -11483,6 +11483,13 @@
         }
       }
     },
+    "housekeeperTasksResponse": {
+      "description": "",
+      "schema": {
+        "type": "array",
+        "items": {}
+      }
+    },
     "illustrationResponse": {
       "description": "",
       "schema": {

--- a/iznik-server-go/test/swagger_test.go
+++ b/iznik-server-go/test/swagger_test.go
@@ -24,16 +24,19 @@ func TestSwaggerGeneration(t *testing.T) {
 		t.Fatalf("Failed to get root directory: %v", err)
 	}
 
-	// Define paths for swagger binary and output file
+	// Define paths for swagger binary and output file. Generate into a temp dir
+	// via SWAGGER_OUT rather than over swagger/swagger.json: this test used to
+	// delete the committed spec and regenerate it, so simply running it left the
+	// checkout holding whatever that run produced. On 2026-08-09 that was 4 model
+	// definitions in place of 115.
 	swaggerScript := filepath.Join(rootDir, "generate-swagger.sh")
-	swaggerJsonPath := filepath.Join(rootDir, "swagger", "swagger.json")
+	swaggerJsonPath := filepath.Join(t.TempDir(), "swagger.json")
 
-	// Remove existing swagger.json if it exists to ensure we're testing fresh generation
-	os.Remove(swaggerJsonPath)
-
-	// Run the generate-swagger.sh script
+	// Run the generate-swagger.sh script, writing to the temp path so the
+	// committed spec is left alone.
 	cmd := exec.Command("/bin/bash", swaggerScript)
 	cmd.Dir = rootDir
+	cmd.Env = append(os.Environ(), "SWAGGER_OUT="+swaggerJsonPath)
 	output, err := cmd.CombinedOutput()
 
 	// Output command result for debugging


### PR DESCRIPTION
## Summary

`iznik-server-go/CLAUDE.md` tells you to run `generate-swagger.sh` when you add an endpoint. Doing so destroys most of the spec. Measured on an unchanged tree:

```
paths:       131 -> 127
definitions: 115 -> 4     (loses 111 model definitions)
responses:    68 -> 64
```

It writes straight over `swagger/swagger.json`, so a bad run has already destroyed the previous spec before you can inspect it. The only guard was "are paths empty", which never fires when a run drops **models** rather than routes.

`TestSwaggerGeneration` made it worse: it *deleted* the committed spec and regenerated it, so simply running the Go suite locally with `CI` unset left the checkout holding the 4-definition version.

I hit this while removing `/status` from the spec in #1293, which is how it surfaced.

### What changes

- Generate to a temp file; install it only if it retains at least three quarters of the paths, definitions and responses the current spec documents. Otherwise refuse, leave the existing file untouched, and point at the candidate.
- Add a `SWAGGER_OUT` override so the test generates into `t.TempDir()` rather than over the committed spec.
- Node for the comparison, since it is already a dependency across this monorepo; a missing interpreter only warns rather than blocking generation.

### The spec also never validated

Of 65 `swagger:response` annotations, exactly one — `housekeeperTasksResponse` — had no type beneath it. A `swagger:response` has to sit above a declaration; on its own it declares nothing, so the `$ref` from `/housekeeper/tasks` dangled and the whole spec failed validation:

```
could not resolve reference in /housekeeper/tasks to
$ref #/responses/housekeeperTasksResponse: object has no key "housekeeperTasksResponse"
```

Declaring the type makes generation report `✅ Swagger spec validation passed`, and adding the missing response to the committed spec makes `swagger validate` pass on it too. It has been invalid on master until now.

## Code Quality Review

- The threshold is a proportion rather than an exact match, so retiring a route still installs cleanly while a wholesale loss is blocked.
- The guard degrades safely: no node, or no existing spec, means generate as before. It can refuse a legitimate large removal, which is why the message says how to install by hand.
- `housekeeperTasksResponse` documents a bare array because `housekeeper.ListTasks` returns `[]HousekeeperTask` directly, not an envelope.
- The committed spec was edited surgically rather than regenerated, for the reason this PR exists.

## Test Plan

Verified in both directions, since a guard that never fires is worthless:

- **Guard fires**: pointed `SWAGGER_OUT` at a copy of the real spec; generation reported `definitions: 115 -> 4 (lost 111)`, refused to overwrite, and the target still held 115 definitions and 131 paths afterwards.
- **Happy path**: a fresh target with no existing file still generates normally at 127 paths.
- **Committed spec untouched** throughout both experiments.
- `swagger validate swagger/swagger.json` now passes; it failed before this change.
- Go suite green, including `TestSwaggerGeneration` and `TestSwaggerEndpoint` under the new temp-directory behaviour.
- Rebased onto `dc6cebd51`, which repairs the seeded-post ageing that makes five Playwright feed tests fail on master and on every branch alike; those five are unrelated to this change. The totals above predate that rebase, so the authoritative counts are CI's on this PR rather than a quoted local run.
- `bash -n` clean on the script; `gofmt` clean on both Go files.

## Not addressed here

Why the generator finds only 4 models is still open — the script already passes `--scan-models` and `-m`, so the committed spec was presumably produced by different flags or an older go-swagger. This PR makes that failure loud and harmless instead of silent and destructive; it does not restore full model scanning.