### PR TITLE
fix(modtools): give the platform status dot a live feed again

### DIFF
--- a/iznik-batch/app/Console/Commands/Monitor/MonitorScheduledOutcomesCommand.php
+++ b/iznik-batch/app/Console/Commands/Monitor/MonitorScheduledOutcomesCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands\Monitor;
 
+use App\Monitoring\PlatformStatusWriter;
 use App\Monitoring\ScheduledOutcomeRegistry;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
@@ -18,6 +19,10 @@ use Illuminate\Support\Facades\Log;
  * the breach shows as a red badge in the cron-jobs sysadmin tab. SKIPPED
  * results (precondition unmet / outside active window) never fail the command.
  *
+ * A full pass also publishes its verdict for ModTools' platform status dot (see
+ * PlatformStatusWriter). The dot therefore reports exactly what the monitoring
+ * decided, and cannot drift away from it, because there is only one evaluation.
+ *
  * See docs/scheduled-outcome-monitoring.md.
  */
 class MonitorScheduledOutcomesCommand extends Command
@@ -26,7 +31,7 @@ class MonitorScheduledOutcomesCommand extends Command
 
     protected $description = 'Asserts scheduled tasks did their work; alerts Sentry on outcome breaches';
 
-    public function handle(ScheduledOutcomeRegistry $registry): int
+    public function handle(ScheduledOutcomeRegistry $registry, PlatformStatusWriter $statusWriter): int
     {
         if (! config('freegle.monitoring.enabled', true)) {
             $this->info('Scheduled-outcome monitoring disabled (freegle.monitoring.enabled=false).');
@@ -48,9 +53,11 @@ class MonitorScheduledOutcomesCommand extends Command
         }
 
         $breaches = [];
+        $results = [];
 
         foreach ($checks as $check) {
             $result = $check->evaluate($now);
+            $results[] = $result;
             $line = "[{$result->status}] {$check->slug()} — {$result->message}";
 
             if ($result->isBreach()) {
@@ -59,6 +66,13 @@ class MonitorScheduledOutcomesCommand extends Command
             } else {
                 $this->info($line);
             }
+        }
+
+        // Publish for ModTools' status dot — but only on a FULL pass. With
+        // --only we have evaluated one check, and writing that would report
+        // every other subsystem as fine on no evidence.
+        if ($only === null || $only === '') {
+            $statusWriter->write($results, $now);
         }
 
         if (! empty($breaches)) {

--- a/iznik-batch/app/Monitoring/PlatformStatusWriter.php
+++ b/iznik-batch/app/Monitoring/PlatformStatusWriter.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Monitoring;
+
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Publishes the platform status that ModTools' status dot reads back through
+ * the Go API's /api/status.
+ *
+ * The old pipeline was iznik-server/scripts/cron/status.php, which SSH'd every
+ * host, ran monit, and wrote /tmp/iznik.status for the API to serve. That cron
+ * went with the V1 PHP removal (c14a7125b) and nothing replaced it, so the
+ * endpoint returned "Cannot access status file" for a month while the dot
+ * showed green to ordinary mods.
+ *
+ * A file on the API host is no longer a viable channel: the writer is Laravel
+ * (iznik-batch) and the reader is Go (apiv2), and they are separate containers
+ * on separate hosts. The blob therefore goes in the `config` table, the same
+ * channel deploy:record-commit already uses for /api/version.
+ *
+ * The verdict is not computed here. It is whatever monitor:scheduled-outcomes
+ * just decided, so the dot cannot drift away from the monitoring that actually
+ * alerts — one evaluation, two consumers. That also makes a dead writer
+ * self-reporting: the blob carries generated_at, and the Go reader turns a
+ * stale one into a warning rather than serving it as current.
+ */
+class PlatformStatusWriter
+{
+    /** The config key the Go API reads. */
+    public const CONFIG_KEY = 'status.platform';
+
+    /**
+     * Store the outcome of a full monitoring pass.
+     *
+     * @param  list<OutcomeResult>  $results  every check evaluated this pass
+     */
+    public function write(array $results, CarbonInterface $now): void
+    {
+        $info = [];
+        $anyError = false;
+        $anyWarning = false;
+
+        foreach ($results as $result) {
+            if (! $result->isBreach()) {
+                // Only breaches are published. The modal renders one row per
+                // entry, so carrying the OK checks would just be noise a mod
+                // has to read past to find the thing that is actually wrong.
+                continue;
+            }
+
+            // OutcomeResult severity is 'error' unless a check downgrades it.
+            // An error means part of the platform is not working; a warning
+            // means it still works but something needs attention. That is the
+            // same split the dot has always drawn.
+            $isError = $result->severity === 'error';
+            $anyError = $anyError || $isError;
+            $anyWarning = $anyWarning || ! $isError;
+
+            $info[$result->slug] = [
+                'error' => $isError,
+                'errortext' => $isError ? $result->message : null,
+                'warning' => ! $isError,
+                'warningtext' => $isError ? null : $result->message,
+            ];
+        }
+
+        $payload = [
+            'ret' => 0,
+            'status' => 'Success',
+            'error' => $anyError,
+            'warning' => $anyWarning,
+            // Cast so an empty set encodes as {} rather than []. The Go reader
+            // adds its own entry to this map when the status is stale, and the
+            // Vue modal iterates it; both are simpler if the shape never
+            // changes just because nothing happens to be wrong.
+            'info' => (object) $info,
+            // The reader uses this to decide whether the feed itself has died.
+            // ISO-8601 with an explicit offset so Go can parse it unambiguously.
+            'generated_at' => $now->copy()->utc()->toIso8601String(),
+        ];
+
+        DB::table('config')->upsert(
+            [['key' => self::CONFIG_KEY, 'value' => json_encode($payload)]],
+            ['key'],
+            ['value'],
+        );
+    }
+}

--- a/iznik-batch/docs/scheduled-outcome-monitoring.md
+++ b/iznik-batch/docs/scheduled-outcome-monitoring.md
@@ -75,6 +75,34 @@ correctness rules learned while populating the registry:
 4. **Cleanup/purge/in-place-update jobs are usually not monitorable** — zero
    output is the normal, healthy case (see the table below).
 
+## It also feeds the ModTools status dot
+
+Every full pass publishes its verdict through
+`App\Monitoring\PlatformStatusWriter` into the `config` row `status.platform`,
+which the Go API serves at `/api/status` (`iznik-server-go/status/status.go`)
+and `ModStatus.vue` renders as the platform status dot in the ModTools navbar.
+
+This is deliberately the *same* evaluation that alerts to Sentry, not a second
+opinion. The dot cannot drift away from the monitoring, and adding a check to
+the registry surfaces it in both places at once.
+
+Three properties are load-bearing, and each one exists because its absence
+caused a real month-long outage of the dot:
+
+- **The payload carries `generated_at`.** The Go reader turns a status older
+  than 30 minutes (three missed passes) into a warning naming the staleness,
+  instead of serving it as current. Before this, the dot's feed died with the
+  V1 PHP removal and showed green to ordinary mods for a month.
+- **Only breaches are published.** The modal renders one row per entry, so
+  carrying the healthy checks would bury the real problem.
+- **`--only` does not publish.** A single-check pass has no evidence about
+  anything else, and reporting the platform as fine on that basis would be a
+  lie. Monitoring being disabled does not publish either — the status then goes
+  stale and says so.
+
+`OutcomeResult` severity decides which half of the dot a breach lands in:
+`error` means part of the platform is not working, anything else is a warning.
+
 ## Implemented checks
 
 Eleven per-job checks across all four primitives:

--- a/iznik-batch/tests/Feature/Monitor/PlatformStatusPublishingTest.php
+++ b/iznik-batch/tests/Feature/Monitor/PlatformStatusPublishingTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\Monitor;
+
+use App\Monitoring\Checks\CallbackCheck;
+use App\Monitoring\OutcomeResult;
+use App\Monitoring\PlatformStatusWriter;
+use App\Monitoring\ScheduledOutcomeRegistry;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The platform status dot in ModTools reads what monitor:scheduled-outcomes
+ * publishes. These cover the publishing half — the Go side (serving it, and
+ * refusing to serve a stale one as current) is covered in
+ * iznik-server-go/test/status_test.go.
+ *
+ * The registry is faked the same way MonitorScheduledOutcomesCommandTest does
+ * it, so these assert on the publishing behaviour rather than on whichever
+ * checks happen to be registered today.
+ */
+class PlatformStatusPublishingTest extends TestCase
+{
+    /**
+     * @param  array<int, \App\Monitoring\OutcomeCheck>  $checks
+     */
+    private function fakeRegistry(array $checks): void
+    {
+        $registry = new class($checks) extends ScheduledOutcomeRegistry
+        {
+            public function __construct(private array $fakeChecks)
+            {
+            }
+
+            public function checks(): array
+            {
+                return $this->fakeChecks;
+            }
+        };
+
+        $this->app->instance(ScheduledOutcomeRegistry::class, $registry);
+    }
+
+    private function publishedStatus(): ?array
+    {
+        $raw = DB::table('config')->where('key', PlatformStatusWriter::CONFIG_KEY)->value('value');
+
+        return $raw === null ? null : json_decode($raw, true);
+    }
+
+    public function test_a_clean_pass_publishes_a_status_with_no_problems(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck('job:a', fn ($now) => OutcomeResult::ok('job:a', 'fine')),
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::skipped('job:b', 'not applicable')),
+        ]);
+
+        $this->artisan('monitor:scheduled-outcomes')->assertExitCode(0);
+
+        $status = $this->publishedStatus();
+
+        $this->assertNotNull($status, 'A clean pass must still publish, or the dot goes stale.');
+        $this->assertSame(0, $status['ret']);
+        $this->assertFalse($status['error']);
+        $this->assertFalse($status['warning']);
+        $this->assertSame([], $status['info']);
+        $this->assertNotEmpty($status['generated_at']);
+    }
+
+    public function test_a_breach_is_published_as_an_error_naming_the_job(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck('job:a', fn ($now) => OutcomeResult::ok('job:a', 'fine')),
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::breach('job:b', 'no rows since Tuesday')),
+        ]);
+
+        $this->artisan('monitor:scheduled-outcomes')->assertExitCode(1);
+
+        $status = $this->publishedStatus();
+
+        $this->assertTrue($status['error']);
+        $this->assertArrayHasKey('job:b', $status['info']);
+        $this->assertTrue($status['info']['job:b']['error']);
+        $this->assertSame('no rows since Tuesday', $status['info']['job:b']['errortext']);
+
+        // The healthy check is deliberately absent: the modal renders one row
+        // per entry, so carrying the OK checks would bury the real problem.
+        $this->assertArrayNotHasKey('job:a', $status['info']);
+    }
+
+    public function test_a_non_error_severity_publishes_as_a_warning_not_an_error(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck(
+                'job:b',
+                fn ($now) => OutcomeResult::breach('job:b', 'lagging a little', 'warning')
+            ),
+        ]);
+
+        $this->artisan('monitor:scheduled-outcomes')->assertExitCode(1);
+
+        $status = $this->publishedStatus();
+
+        $this->assertFalse($status['error']);
+        $this->assertTrue($status['warning']);
+        $this->assertTrue($status['info']['job:b']['warning']);
+        $this->assertSame('lagging a little', $status['info']['job:b']['warningtext']);
+    }
+
+    public function test_a_later_pass_replaces_the_previous_status(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::breach('job:b', 'broken')),
+        ]);
+        $this->artisan('monitor:scheduled-outcomes')->assertExitCode(1);
+        $this->assertTrue($this->publishedStatus()['error']);
+
+        // Recovery has to clear the dot; a status that only ever accumulates
+        // problems would stay red after the problem was fixed.
+        $this->fakeRegistry([
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::ok('job:b', 'fixed')),
+        ]);
+        $this->artisan('monitor:scheduled-outcomes')->assertExitCode(0);
+
+        $status = $this->publishedStatus();
+        $this->assertFalse($status['error']);
+        $this->assertSame([], $status['info']);
+
+        $this->assertSame(
+            1,
+            DB::table('config')->where('key', PlatformStatusWriter::CONFIG_KEY)->count(),
+            'The status must be upserted into one row, not appended.'
+        );
+    }
+
+    public function test_only_option_does_not_publish_a_partial_status(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck('job:a', fn ($now) => OutcomeResult::ok('job:a', 'fine')),
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::breach('job:b', 'broken')),
+        ]);
+
+        $this->artisan('monitor:scheduled-outcomes --only=job:a')->assertExitCode(0);
+
+        // job:b was never evaluated. Publishing this pass would report the
+        // whole platform as fine on the evidence of a single check.
+        $this->assertNull($this->publishedStatus());
+    }
+
+    public function test_disabled_monitoring_does_not_publish(): void
+    {
+        config(['freegle.monitoring.enabled' => false]);
+
+        $this->fakeRegistry([
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::breach('job:b', 'broken')),
+        ]);
+
+        $this->artisan('monitor:scheduled-outcomes')->assertExitCode(0);
+
+        // With monitoring off nothing is evaluated, so the status must go stale
+        // and be reported as such, rather than be pinned to a stale "fine".
+        $this->assertNull($this->publishedStatus());
+    }
+}

--- a/iznik-nuxt3/modtools/components/ModStatus.vue
+++ b/iznik-nuxt3/modtools/components/ModStatus.vue
@@ -22,10 +22,9 @@
           variant="warning"
           class="mb-2"
         >
-          There is a problem. If this just mentions
-          <strong>security patches or reboots</strong>, you can ignore it, but
-          if it's something else please alert geeks@ilovefreegle.org if this
-          persists for more than an hour.
+          There is a problem. Each line below names the scheduled job whose work
+          has not happened, and what is missing. Please alert
+          geeks@ilovefreegle.org if this persists for more than an hour.
         </NoticeMessage>
         <NoticeMessage v-else-if="error" variant="warning" class="mb-2">
           There's a problem, and parts of the system may not be working. The
@@ -85,38 +84,49 @@ const warning = computed(() => {
 const headline = computed(() => {
   if (outOfDate.value) {
     return 'Not sure'
-  } else if (warning.value) {
-    return 'Warning'
   } else if (error.value) {
     return 'Error'
+  } else if (warning.value) {
+    return 'Warning'
   } else {
     return 'Fine'
   }
 })
 
+// A status we could not obtain is worth showing, and worth showing WITH a reason.
+// The old code fell back to a bare warning flag, so the modal rendered "There is
+// a problem" above an empty info block and told nobody anything.
+function feedProblem(detail) {
+  return {
+    ret: 1,
+    error: false,
+    warning: true,
+    info: {
+      'Status feed': {
+        warning: true,
+        warningtext: detail || 'Platform status is currently unavailable.',
+      },
+    },
+  }
+}
+
 async function checkStatus() {
   try {
-    status.value = await $api.status.fetch()
+    const fetched = await $api.status.fetch()
 
-    tried.value = true
+    // Stamp whenever the API answered, whatever it said. outOfDate means "we
+    // cannot reach the status API", not "the API told us something we did not
+    // like". Conflating the two pinned the headline to "Not sure" for a month
+    // while the API was answering perfectly promptly, with ret 1.
+    updated.value = Date.now()
 
-    if (status.value.ret === 0) {
-      updated.value = Date.now()
-    }
+    status.value = fetched.ret === 0 ? fetched : feedProblem(fetched.status)
   } catch (err) {
     console.warn('Status API error:', err)
-    tried.value = true
-    status.value = {
-      ret: 1,
-      warning: true,
-      info: {
-        'Status API': {
-          warning: true,
-          warningtext: 'Cannot access status file - system status unknown',
-        },
-      },
-    }
+    status.value = feedProblem('Cannot reach the status API.')
   }
+
+  tried.value = true
 
   timer = setTimeout(checkStatus, 30000)
 }

--- a/iznik-nuxt3/tests/unit/components/modtools/ModStatus.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModStatus.spec.js
@@ -1,18 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount } from '@vue/test-utils'
-import { ref, computed } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+import ModStatus from '~/modtools/components/ModStatus.vue'
 
-// Mock composables with proper Vue ref to avoid template ref warnings
-const mockHide = vi.fn()
-const mockShow = vi.fn()
-const mockModal = ref({ show: mockShow, hide: mockHide })
-
-vi.mock('~/composables/useOurModal', () => ({
-  useOurModal: () => ({
-    modal: mockModal,
-    hide: mockHide,
-  }),
-}))
+// This spec used to mount a hand-written COPY of ModStatus's template and setup()
+// rather than the component itself. That is why the platform status dot could be
+// broken for a month with the suite green: the copy was fixed, the component was
+// not. Everything below mounts the real thing.
 
 const mockSupportOrAdmin = ref(false)
 
@@ -22,443 +16,271 @@ vi.mock('~/composables/useMe', () => ({
   }),
 }))
 
-// Mock API
 const mockStatusFetch = vi.fn()
-const mockApi = {
-  status: {
-    fetch: mockStatusFetch,
-  },
-}
 
 vi.mock('#app', () => ({
-  useNuxtApp: () => ({ $api: mockApi }),
+  useNuxtApp: () => ({ $api: { status: { fetch: mockStatusFetch } } }),
 }))
 
-// Create test component that mirrors ModStatus logic
-const ModStatusTest = {
-  template: `
-    <span title="Platform Status - click for more info" class="clickme" @click="clicked">
-      <span v-if="!tried" class="trying" />
-      <span v-else-if="error" class="error" />
-      <span v-else-if="warning && supportOrAdmin" class="warning" />
-      <span v-else class="fine" />
-      <div class="modal" v-if="showModal">
-        <div class="title">Platform Status: {{ headline }}</div>
-        <div class="content">
-          <div v-if="(warning || error) && supportOrAdmin" class="notice-support">
-            There is a problem.
-          </div>
-          <div v-else-if="error" class="notice-error">
-            There's a problem, and parts of the system may not be working.
-          </div>
-          <div v-else-if="warning" class="notice-warning">
-            There's a problem, but the system should still be working.
-          </div>
-          <div v-else class="notice-fine">
-            Everything seems fine.
-          </div>
-          <div v-if="status && status.info">
-            <div v-for="(stat, server) in status.info" :key="server" class="server-status">
-              <div v-if="stat.warning">{{ server }}: {{ stat.warningtext }}</div>
-              <div v-if="stat.error">{{ server }}: {{ stat.errortext }}</div>
-            </div>
-          </div>
-        </div>
-        <button @click="hideModal">Close</button>
-      </div>
-    </span>
-  `,
-  setup() {
-    const status = ref(null)
-    const updated = ref(null)
-    const tried = ref(false)
-    const showModal = ref(false)
-
-    const outOfDate = computed(() => {
-      return !updated.value || Date.now() - updated.value >= 1000 * 600
-    })
-
-    const error = computed(() => (status.value ? status.value.error : false))
-
-    const warning = computed(() => {
-      return outOfDate.value || (status.value && status.value.warning)
-    })
-
-    const headline = computed(() => {
-      if (outOfDate.value) {
-        return 'Not sure'
-      } else if (warning.value) {
-        return 'Warning'
-      } else if (error.value) {
-        return 'Error'
-      } else {
-        return 'Fine'
-      }
-    })
-
-    async function checkStatus() {
-      try {
-        status.value = await mockStatusFetch()
-        tried.value = true
-        if (status.value.ret === 0) {
-          updated.value = Date.now()
-        }
-      } catch (err) {
-        tried.value = true
-        status.value = {
-          ret: 1,
-          warning: true,
-          info: {
-            'Status API': {
-              warning: true,
-              warningtext: 'Cannot access status file - system status unknown',
-            },
-          },
-        }
-      }
-    }
-
-    function clicked(e) {
-      showModal.value = true
-      e.preventDefault()
-      e.stopPropagation()
-    }
-
-    function hideModal() {
-      showModal.value = false
-    }
-
-    return {
-      status,
-      updated,
-      tried,
-      showModal,
-      outOfDate,
-      error,
-      warning,
-      headline,
-      supportOrAdmin: mockSupportOrAdmin,
-      checkStatus,
-      clicked,
-      hideModal,
-    }
-  },
-}
+const OK_STATUS = { ret: 0, error: false, warning: false, info: {} }
 
 describe('ModStatus', () => {
-  function mountComponent() {
-    return mount(ModStatusTest)
+  let wrapper = null
+
+  // The component polls on a 30s timer and fetches on mount. Fake timers keep
+  // the poll from leaking between tests; mounting is always followed by
+  // flushPromises so the initial fetch has settled before we assert.
+  async function mountComponent() {
+    wrapper = mount(ModStatus, {
+      global: {
+        stubs: {
+          'b-modal': {
+            props: ['title'],
+            template:
+              '<div class="modal"><div class="title">{{ title }}</div><slot /></div>',
+          },
+          'b-button': { template: '<button><slot /></button>' },
+          NoticeMessage: {
+            props: ['variant'],
+            template: '<div class="notice" :class="variant"><slot /></div>',
+          },
+        },
+      },
+    })
+
+    await flushPromises()
+
+    return wrapper
   }
 
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
     vi.clearAllMocks()
-    vi.useFakeTimers()
     mockSupportOrAdmin.value = false
-    mockStatusFetch.mockResolvedValue({ ret: 0, error: false, warning: false })
+    mockStatusFetch.mockResolvedValue(OK_STATUS)
   })
 
   afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
     vi.useRealTimers()
   })
 
-  describe('rendering', () => {
-    it('renders a clickable span', () => {
-      const wrapper = mountComponent()
-      expect(wrapper.find('.clickme').exists()).toBe(true)
-    })
+  describe('the dot', () => {
+    it('shows the trying indicator until the first answer arrives', () => {
+      // Deliberately never resolves, so we observe the pre-answer state.
+      mockStatusFetch.mockReturnValue(new Promise(() => {}))
+      wrapper = mount(ModStatus, {
+        global: { stubs: { 'b-modal': true, NoticeMessage: true } },
+      })
 
-    it('shows trying indicator before status is fetched', () => {
-      const wrapper = mountComponent()
       expect(wrapper.find('.trying').exists()).toBe(true)
     })
 
-    it('shows fine indicator when status is OK', async () => {
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      await wrapper.vm.$nextTick()
+    it('shows fine when the platform is healthy', async () => {
+      await mountComponent()
 
       expect(wrapper.find('.fine').exists()).toBe(true)
-      expect(wrapper.find('.error').exists()).toBe(false)
-      expect(wrapper.find('.warning').exists()).toBe(false)
     })
 
-    it('shows error indicator when status has error', async () => {
-      mockStatusFetch.mockResolvedValue({ ret: 0, error: true, warning: false })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      await wrapper.vm.$nextTick()
+    it('shows error when the published status has an error', async () => {
+      mockStatusFetch.mockResolvedValue({ ...OK_STATUS, error: true })
+      await mountComponent()
 
       expect(wrapper.find('.error').exists()).toBe(true)
     })
 
-    it('shows warning indicator for supportOrAdmin when status has warning', async () => {
+    it('shows warning to support and admin when there is a warning', async () => {
       mockSupportOrAdmin.value = true
-      mockStatusFetch.mockResolvedValue({ ret: 0, error: false, warning: true })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      await wrapper.vm.$nextTick()
+      mockStatusFetch.mockResolvedValue({ ...OK_STATUS, warning: true })
+      await mountComponent()
 
       expect(wrapper.find('.warning').exists()).toBe(true)
     })
 
-    it('does not show warning for non-admin when warning exists', async () => {
+    it('does not show warning to an ordinary mod', async () => {
+      // Deliberate: warnings are geek-facing detail. Errors are not gated.
       mockSupportOrAdmin.value = false
-      mockStatusFetch.mockResolvedValue({ ret: 0, error: false, warning: true })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      await wrapper.vm.$nextTick()
+      mockStatusFetch.mockResolvedValue({ ...OK_STATUS, warning: true })
+      await mountComponent()
 
-      // Non-admins see fine, not warning
       expect(wrapper.find('.warning').exists()).toBe(false)
       expect(wrapper.find('.fine').exists()).toBe(true)
     })
   })
 
-  describe('computed properties', () => {
-    describe('outOfDate', () => {
-      it('returns true when updated is null', () => {
-        const wrapper = mountComponent()
-        expect(wrapper.vm.outOfDate).toBe(true)
-      })
+  describe('freshness', () => {
+    it('stamps the timestamp when the API answers ret 0', async () => {
+      await mountComponent()
 
-      it('returns true when updated is more than 10 minutes ago', async () => {
-        const wrapper = mountComponent()
-        // Set updated to 11 minutes ago
-        wrapper.vm.updated = Date.now() - 1000 * 660
-        await wrapper.vm.$nextTick()
-        expect(wrapper.vm.outOfDate).toBe(true)
-      })
-
-      it('returns false when updated recently', async () => {
-        const wrapper = mountComponent()
-        await wrapper.vm.checkStatus()
-        expect(wrapper.vm.outOfDate).toBe(false)
-      })
+      expect(wrapper.vm.updated).not.toBeNull()
+      expect(wrapper.vm.outOfDate).toBe(false)
+      expect(wrapper.vm.headline).toBe('Fine')
     })
 
-    describe('error', () => {
-      it('returns false when status is null', () => {
-        const wrapper = mountComponent()
-        expect(wrapper.vm.error).toBe(false)
-      })
+    it('stamps the timestamp when the API answers ret 1, because it answered', async () => {
+      // The month-long bug. The API was replying promptly with ret 1 (its
+      // writer was dead), but only ret 0 stamped `updated`, so outOfDate stayed
+      // true forever: headline pinned to "Not sure", and a warning banner with
+      // no detail under it. outOfDate must mean "cannot reach the API".
+      mockStatusFetch.mockResolvedValue({ ret: 1, status: 'Nope' })
+      await mountComponent()
 
-      it('returns true when status has error flag', async () => {
-        mockStatusFetch.mockResolvedValue({ ret: 0, error: true })
-        const wrapper = mountComponent()
-        await wrapper.vm.checkStatus()
-        expect(wrapper.vm.error).toBe(true)
-      })
-
-      it('returns false when status has no error flag', async () => {
-        mockStatusFetch.mockResolvedValue({ ret: 0, error: false })
-        const wrapper = mountComponent()
-        await wrapper.vm.checkStatus()
-        expect(wrapper.vm.error).toBe(false)
-      })
+      expect(wrapper.vm.updated).not.toBeNull()
+      expect(wrapper.vm.outOfDate).toBe(false)
     })
 
-    describe('warning', () => {
-      it('returns true when outOfDate', () => {
-        const wrapper = mountComponent()
-        expect(wrapper.vm.warning).toBe(true)
-      })
+    it('leaves the timestamp alone when the API cannot be reached', async () => {
+      mockStatusFetch.mockRejectedValue(new Error('Network error'))
+      await mountComponent()
 
-      it('returns true when status has warning flag', async () => {
-        mockStatusFetch.mockResolvedValue({ ret: 0, warning: true })
-        const wrapper = mountComponent()
-        await wrapper.vm.checkStatus()
-        expect(wrapper.vm.warning).toBe(true)
-      })
-
-      it('returns false when status is fresh with no warning', async () => {
-        mockStatusFetch.mockResolvedValue({ ret: 0, warning: false })
-        const wrapper = mountComponent()
-        await wrapper.vm.checkStatus()
-        expect(wrapper.vm.warning).toBe(false)
-      })
+      expect(wrapper.vm.updated).toBeNull()
+      expect(wrapper.vm.outOfDate).toBe(true)
+      expect(wrapper.vm.headline).toBe('Not sure')
     })
 
-    describe('headline', () => {
-      it('returns "Not sure" when outOfDate', () => {
-        const wrapper = mountComponent()
-        expect(wrapper.vm.headline).toBe('Not sure')
-      })
+    it('goes out of date once an answer is more than ten minutes old', async () => {
+      await mountComponent()
+      expect(wrapper.vm.outOfDate).toBe(false)
 
-      it('returns "Fine" when status is OK and fresh', async () => {
-        mockStatusFetch.mockResolvedValue({
-          ret: 0,
-          error: false,
-          warning: false,
-        })
-        const wrapper = mountComponent()
-        await wrapper.vm.checkStatus()
-        expect(wrapper.vm.headline).toBe('Fine')
-      })
+      wrapper.vm.updated = Date.now() - 1000 * 601
 
-      it('returns "Warning" when warning exists', async () => {
-        mockStatusFetch.mockResolvedValue({
-          ret: 0,
-          error: false,
-          warning: true,
-        })
-        const wrapper = mountComponent()
-        await wrapper.vm.checkStatus()
-        expect(wrapper.vm.headline).toBe('Warning')
-      })
-
-      it('returns "Warning" not "Error" when both error and warning exist', async () => {
-        // Note: headline logic checks warning before error when not outOfDate
-        mockStatusFetch.mockResolvedValue({
-          ret: 0,
-          error: true,
-          warning: true,
-        })
-        const wrapper = mountComponent()
-        await wrapper.vm.checkStatus()
-        // warning is true, so headline is "Warning"
-        expect(wrapper.vm.headline).toBe('Warning')
-      })
+      expect(wrapper.vm.outOfDate).toBe(true)
+      expect(wrapper.vm.headline).toBe('Not sure')
     })
   })
 
-  describe('checkStatus method', () => {
-    it('calls API status fetch', async () => {
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      expect(mockStatusFetch).toHaveBeenCalled()
+  describe('headline', () => {
+    it('says Error, not Warning, when both are set', async () => {
+      // Error is the more severe of the two. The headline used to test warning
+      // first, so a platform with a real error announced itself as a warning
+      // while the dot next to it was red.
+      mockStatusFetch.mockResolvedValue({
+        ...OK_STATUS,
+        error: true,
+        warning: true,
+      })
+      await mountComponent()
+
+      expect(wrapper.vm.headline).toBe('Error')
     })
 
-    it('sets tried to true after fetch', async () => {
-      const wrapper = mountComponent()
-      expect(wrapper.vm.tried).toBe(false)
-      await wrapper.vm.checkStatus()
-      expect(wrapper.vm.tried).toBe(true)
+    it('says Warning when only a warning is set', async () => {
+      mockStatusFetch.mockResolvedValue({ ...OK_STATUS, warning: true })
+      await mountComponent()
+
+      expect(wrapper.vm.headline).toBe('Warning')
     })
+  })
 
-    it('sets status from API response', async () => {
-      const statusData = { ret: 0, error: false, warning: false, info: {} }
-      mockStatusFetch.mockResolvedValue(statusData)
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      expect(wrapper.vm.status).toEqual(statusData)
-    })
+  describe('when the status cannot be obtained', () => {
+    it('explains a ret 1 using the reason the API gave', async () => {
+      mockStatusFetch.mockResolvedValue({
+        ret: 1,
+        status: 'Platform status has not been published yet',
+      })
+      await mountComponent()
 
-    it('updates timestamp when ret is 0', async () => {
-      mockStatusFetch.mockResolvedValue({ ret: 0 })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      expect(wrapper.vm.updated).not.toBeNull()
-    })
-
-    it('does not update timestamp when ret is not 0', async () => {
-      mockStatusFetch.mockResolvedValue({ ret: 1 })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      expect(wrapper.vm.updated).toBeNull()
-    })
-
-    it('handles API error gracefully', async () => {
-      mockStatusFetch.mockRejectedValue(new Error('Network error'))
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-
-      expect(wrapper.vm.tried).toBe(true)
-      expect(wrapper.vm.status.warning).toBe(true)
-      expect(wrapper.vm.status.info['Status API'].warningtext).toContain(
-        'Cannot access status file'
+      expect(wrapper.vm.headline).toBe('Warning')
+      expect(wrapper.vm.status.info['Status feed'].warningtext).toBe(
+        'Platform status has not been published yet'
       )
     })
-  })
 
-  describe('clicked method', () => {
-    it('opens modal on click', async () => {
-      const wrapper = mountComponent()
-      await wrapper.find('.clickme').trigger('click')
+    it('explains an unreachable API', async () => {
+      mockStatusFetch.mockRejectedValue(new Error('Network error'))
+      await mountComponent()
 
-      expect(wrapper.vm.showModal).toBe(true)
-      expect(wrapper.find('.modal').exists()).toBe(true)
+      expect(wrapper.vm.status.warning).toBe(true)
+      expect(wrapper.vm.status.info['Status feed'].warningtext).toContain(
+        'Cannot reach the status API'
+      )
     })
 
-    it('displays headline in modal title', async () => {
-      const wrapper = mountComponent()
-      await wrapper.find('.clickme').trigger('click')
-
-      expect(wrapper.find('.title').text()).toContain('Not sure')
-    })
-  })
-
-  describe('modal content', () => {
-    it('shows fine notice when status is OK', async () => {
-      mockStatusFetch.mockResolvedValue({
-        ret: 0,
-        error: false,
-        warning: false,
-      })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      await wrapper.find('.clickme').trigger('click')
-
-      expect(wrapper.find('.notice-fine').exists()).toBe(true)
-    })
-
-    it('shows error notice when error flag is set', async () => {
-      mockStatusFetch.mockResolvedValue({ ret: 0, error: true })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      await wrapper.find('.clickme').trigger('click')
-
-      expect(wrapper.find('.notice-error').exists()).toBe(true)
-    })
-
-    it('shows warning notice for non-admin when warning flag is set', async () => {
-      mockSupportOrAdmin.value = false
-      mockStatusFetch.mockResolvedValue({ ret: 0, error: false, warning: true })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
-      await wrapper.find('.clickme').trigger('click')
-
-      expect(wrapper.find('.notice-warning').exists()).toBe(true)
-    })
-
-    it('shows support notice for admin when warning exists', async () => {
+    it('never leaves the modal with a problem and no explanation', async () => {
+      // The original symptom: "There is a problem" over an empty info block.
       mockSupportOrAdmin.value = true
-      mockStatusFetch.mockResolvedValue({ ret: 0, error: false, warning: true })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
+      mockStatusFetch.mockResolvedValue({ ret: 1, status: 'Nope' })
+      await mountComponent()
+
       await wrapper.find('.clickme').trigger('click')
 
-      expect(wrapper.find('.notice-support').exists()).toBe(true)
+      expect(wrapper.text()).toContain('There is a problem')
+      expect(wrapper.text()).toContain('Nope')
+    })
+  })
+
+  describe('the modal', () => {
+    it('opens on click and shows the headline', async () => {
+      await mountComponent()
+
+      await wrapper.find('.clickme').trigger('click')
+
+      expect(wrapper.find('.modal').exists()).toBe(true)
+      expect(wrapper.find('.title').text()).toContain('Platform Status: Fine')
     })
 
-    it('displays server-specific status info', async () => {
+    it('lists each breached job with what is wrong', async () => {
+      mockSupportOrAdmin.value = true
       mockStatusFetch.mockResolvedValue({
         ret: 0,
-        error: false,
+        error: true,
         warning: true,
         info: {
-          'Web Server': {
+          'chats:process-incoming': {
+            error: true,
+            errortext: 'queue backing up',
+            warning: false,
+            warningtext: null,
+          },
+          'stats:generate-daily': {
+            error: false,
+            errortext: null,
             warning: true,
-            warningtext: 'High load',
+            warningtext: 'no rows for yesterday',
           },
         },
       })
-      const wrapper = mountComponent()
-      await wrapper.vm.checkStatus()
+      await mountComponent()
+
       await wrapper.find('.clickme').trigger('click')
 
-      expect(wrapper.text()).toContain('Web Server')
-      expect(wrapper.text()).toContain('High load')
+      const text = wrapper.text()
+      expect(text).toContain('chats:process-incoming')
+      expect(text).toContain('queue backing up')
+      expect(text).toContain('stats:generate-daily')
+      expect(text).toContain('no rows for yesterday')
     })
 
-    it('calls hideModal function', async () => {
-      const wrapper = mountComponent()
-      await wrapper.find('.clickme').trigger('click')
-      expect(wrapper.vm.showModal).toBe(true)
+    it('says everything is fine when nothing is wrong', async () => {
+      await mountComponent()
 
-      // Directly call the hideModal method
-      wrapper.vm.hideModal()
-      await wrapper.vm.$nextTick()
-      expect(wrapper.vm.showModal).toBe(false)
+      await wrapper.find('.clickme').trigger('click')
+
+      expect(wrapper.text()).toContain('Everything seems fine')
+    })
+  })
+
+  describe('polling', () => {
+    it('re-checks on a timer', async () => {
+      await mountComponent()
+      expect(mockStatusFetch).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(30000)
+
+      expect(mockStatusFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('stops polling once unmounted', async () => {
+      await mountComponent()
+      expect(mockStatusFetch).toHaveBeenCalledTimes(1)
+
+      wrapper.unmount()
+      wrapper = null
+
+      await vi.advanceTimersByTimeAsync(60000)
+
+      expect(mockStatusFetch).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -1356,7 +1356,7 @@ func SetupRoutes(app *fiber.App) {
 		// System Status
 		// @Router /status [get]
 		// @Summary Get system status
-		// @Description Returns the system status from /tmp/iznik.status
+		// @Description Returns the platform status published by the batch system's outcome monitoring
 		// @Tags status
 		// @Produce json
 		// @Success 200 {object} map[string]interface{}

--- a/iznik-server-go/status/status.go
+++ b/iznik-server-go/status/status.go
@@ -1,9 +1,12 @@
 package status
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/gofiber/fiber/v2"
@@ -110,24 +113,112 @@ func readGitHead(dir string) string {
 	return ""
 }
 
-// GetStatus reads the system status file and returns its contents.
+// StatusConfigKey is the config row that carries the published platform status.
+// Written by Laravel's monitor:scheduled-outcomes (App\Monitoring\PlatformStatusWriter).
+const StatusConfigKey = "status.platform"
+
+// StatusMaxAge is how old a published status may be before we stop presenting it
+// as current. The writer runs every ten minutes, so this tolerates three missed
+// passes; beyond that the feed itself is the thing that is broken.
+const StatusMaxAge = 30 * time.Minute
+
+// GetStatus returns the platform status published by the batch system.
+//
+// This used to read /tmp/iznik.status, written by iznik-server/scripts/cron/status.php.
+// That cron went with the V1 PHP removal and nothing replaced it, so the endpoint
+// returned "Cannot access status file" for a month and nothing noticed. A file on
+// this host cannot work now anyway: the writer is Laravel, in a different container
+// on a different host. The status therefore travels through the `config` table, the
+// same channel /api/version already uses for the Laravel deploy commit.
+//
+// A status older than StatusMaxAge is reported as a warning naming the staleness,
+// rather than served as though it were current. That is the specific failure that
+// went unnoticed last time: a dead writer must not look like a healthy platform.
 //
 // @Summary Get system status
-// @Description Returns the contents of /tmp/iznik.status, which is written by the batch system
+// @Description Returns the platform status published by the batch system's outcome monitoring. A status older than 30 minutes is downgraded to a warning about the status feed itself.
 // @Tags status
 // @Produce json
 // @Success 200 {object} map[string]interface{}
 // @Router /api/status [get]
 func GetStatus(c *fiber.Ctx) error {
-	data, err := os.ReadFile("/tmp/iznik.status")
-	if err != nil {
+	if database.DBConn == nil {
 		return c.JSON(fiber.Map{
 			"ret":    1,
-			"status": "Cannot access status file",
+			"status": "Cannot read platform status",
 		})
 	}
-	c.Set("Content-Type", "application/json")
-	return c.Send(data)
+
+	var value string
+	database.DBConn.Table("config").
+		Select("value").
+		Where("`key` = ?", StatusConfigKey).
+		Scan(&value)
+
+	if value == "" {
+		// Never published. Distinct from "published but stale": on a fresh
+		// deploy the monitor may simply not have run yet.
+		return c.JSON(fiber.Map{
+			"ret":    1,
+			"status": "Platform status has not been published yet",
+		})
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(value), &payload); err != nil {
+		return c.JSON(fiber.Map{
+			"ret":    1,
+			"status": "Platform status is not readable",
+		})
+	}
+
+	if age, ok := statusAge(payload); ok && age > StatusMaxAge {
+		markStatusStale(payload, age)
+	}
+
+	return c.JSON(payload)
+}
+
+// statusAge returns how long ago the payload was generated. The bool is false if
+// the payload carries no parseable generated_at, in which case we leave it alone
+// rather than guess — an unreadable timestamp is the writer's bug, not a staleness
+// signal, and inventing one would hide a status that is otherwise fine.
+func statusAge(payload map[string]interface{}) (time.Duration, bool) {
+	raw, ok := payload["generated_at"].(string)
+	if !ok || raw == "" {
+		return 0, false
+	}
+
+	generated, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return 0, false
+	}
+
+	return time.Since(generated), true
+}
+
+// markStatusStale rewrites a payload in place so a stale feed presents as a
+// warning in its own right. The existing contents are kept: the last known state
+// is still the best information available, it just cannot be trusted as current.
+func markStatusStale(payload map[string]interface{}, age time.Duration) {
+	payload["warning"] = true
+
+	info, ok := payload["info"].(map[string]interface{})
+	if !ok || info == nil {
+		info = map[string]interface{}{}
+		payload["info"] = info
+	}
+
+	info["Status feed"] = map[string]interface{}{
+		"warning": true,
+		"warningtext": fmt.Sprintf(
+			"Platform status was last published %d minutes ago (expected every 10). "+
+				"The monitoring that produces it may have stopped, so what follows may be out of date.",
+			int(age.Minutes()),
+		),
+		"error":     false,
+		"errortext": nil,
+	}
 }
 
 // GetVersion returns the deployed commit of the Go API binary and the Laravel batch server.

--- a/iznik-server-go/swagger/swagger.go
+++ b/iznik-server-go/swagger/swagger.go
@@ -3123,7 +3123,8 @@ type shortlinksResponse struct {
 // swagger:route GET /status status getStatus
 // Get system status
 //
-// Returns the system status from /tmp/iznik.status
+// Returns the platform status published by the batch system's outcome monitoring.
+// A status older than 30 minutes is downgraded to a warning about the feed itself.
 //
 // Responses:
 //

--- a/iznik-server-go/test/status_test.go
+++ b/iznik-server-go/test/status_test.go
@@ -2,60 +2,179 @@ package test
 
 import (
 	json2 "encoding/json"
+	"fmt"
 	"net/http/httptest"
-	"os"
 	"testing"
+	"time"
 
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/status"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetStatus(t *testing.T) {
-	// Write a test status file.
-	statusJSON := `{"ret":0,"status":"OK","version":"1.0"}`
-	err := os.WriteFile("/tmp/iznik.status", []byte(statusJSON), 0644)
-	assert.NoError(t, err)
-	defer os.Remove("/tmp/iznik.status")
+// publishStatus puts a status blob in the config table exactly as Laravel's
+// PlatformStatusWriter does, generated the given duration ago.
+func publishStatus(t *testing.T, body string, age time.Duration) {
+	t.Helper()
 
-	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/status", nil))
-	assert.Equal(t, 200, resp.StatusCode)
+	generated := time.Now().UTC().Add(-age).Format(time.RFC3339)
+	value := fmt.Sprintf(`{%s,"generated_at":"%s"}`, body, generated)
 
-	var result map[string]interface{}
-	json2.Unmarshal(rsp(resp), &result)
-	assert.Equal(t, float64(0), result["ret"])
-	assert.Equal(t, "OK", result["status"])
-	assert.Equal(t, "1.0", result["version"])
+	res := database.DBConn.Exec(
+		"INSERT INTO config (`key`, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value)",
+		status.StatusConfigKey, value,
+	)
+	assert.NoError(t, res.Error)
+
+	t.Cleanup(func() {
+		database.DBConn.Exec("DELETE FROM config WHERE `key` = ?", status.StatusConfigKey)
+	})
 }
 
-func TestGetStatusMissing(t *testing.T) {
-	// Ensure no status file exists.
-	os.Remove("/tmp/iznik.status")
+func clearStatus(t *testing.T) {
+	t.Helper()
+	database.DBConn.Exec("DELETE FROM config WHERE `key` = ?", status.StatusConfigKey)
+}
 
-	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/status", nil))
+func getStatus(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", path, nil))
 	assert.Equal(t, 200, resp.StatusCode)
 
 	var result map[string]interface{}
-	json2.Unmarshal(rsp(resp), &result)
+	err := json2.Unmarshal(rsp(resp), &result)
+	assert.NoError(t, err)
+
+	return result
+}
+
+func TestGetStatus(t *testing.T) {
+	publishStatus(t, `"ret":0,"status":"Success","error":false,"warning":false,"info":{}`, time.Minute)
+
+	result := getStatus(t, "/api/status")
+
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Equal(t, "Success", result["status"])
+	assert.Equal(t, false, result["error"])
+	assert.Equal(t, false, result["warning"])
+}
+
+func TestGetStatusReportsPublishedBreaches(t *testing.T) {
+	publishStatus(t, `"ret":0,"status":"Success","error":true,"warning":false,`+
+		`"info":{"chats:process-incoming":{"error":true,"errortext":"queue backing up","warning":false,"warningtext":null}}`,
+		time.Minute)
+
+	result := getStatus(t, "/api/status")
+
+	assert.Equal(t, true, result["error"])
+
+	info := result["info"].(map[string]interface{})
+	entry := info["chats:process-incoming"].(map[string]interface{})
+	assert.Equal(t, true, entry["error"])
+	assert.Equal(t, "queue backing up", entry["errortext"])
+}
+
+// The failure that went unnoticed for a month was a dead writer looking exactly
+// like a healthy platform. A status nobody has refreshed must not be served as
+// though it were current.
+func TestGetStatusStalePublishBecomesAWarning(t *testing.T) {
+	publishStatus(t, `"ret":0,"status":"Success","error":false,"warning":false,"info":{}`, 2*time.Hour)
+
+	result := getStatus(t, "/api/status")
+
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Equal(t, true, result["warning"], "a stale status must warn")
+
+	info := result["info"].(map[string]interface{})
+	entry, ok := info["Status feed"].(map[string]interface{})
+	assert.True(t, ok, "a stale status must say so in info, not just flip a flag")
+	assert.Equal(t, true, entry["warning"])
+	assert.Contains(t, entry["warningtext"], "120 minutes ago")
+}
+
+// A status inside the window is left exactly as published — no invented warning.
+func TestGetStatusFreshPublishIsNotMarkedStale(t *testing.T) {
+	publishStatus(t, `"ret":0,"status":"Success","error":false,"warning":false,"info":{}`, 5*time.Minute)
+
+	result := getStatus(t, "/api/status")
+
+	assert.Equal(t, false, result["warning"])
+	assert.NotContains(t, result["info"].(map[string]interface{}), "Status feed")
+}
+
+// A stale status keeps whatever it last knew — that is still the best available
+// information, it just cannot be presented as current.
+func TestGetStatusStalePublishKeepsItsExistingEntries(t *testing.T) {
+	publishStatus(t, `"ret":0,"status":"Success","error":true,"warning":false,`+
+		`"info":{"stats:generate-daily":{"error":true,"errortext":"no rows","warning":false,"warningtext":null}}`,
+		2*time.Hour)
+
+	result := getStatus(t, "/api/status")
+
+	info := result["info"].(map[string]interface{})
+	assert.Contains(t, info, "stats:generate-daily")
+	assert.Contains(t, info, "Status feed")
+	assert.Equal(t, true, result["error"], "staleness must not erase a known error")
+}
+
+func TestGetStatusNeverPublished(t *testing.T) {
+	clearStatus(t)
+
+	result := getStatus(t, "/api/status")
+
 	assert.Equal(t, float64(1), result["ret"])
-	assert.Equal(t, "Cannot access status file", result["status"])
+	assert.Equal(t, "Platform status has not been published yet", result["status"])
+}
+
+func TestGetStatusUnreadablePublish(t *testing.T) {
+	res := database.DBConn.Exec(
+		"INSERT INTO config (`key`, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value)",
+		status.StatusConfigKey, "this is not json",
+	)
+	assert.NoError(t, res.Error)
+	defer database.DBConn.Exec("DELETE FROM config WHERE `key` = ?", status.StatusConfigKey)
+
+	result := getStatus(t, "/api/status")
+
+	assert.Equal(t, float64(1), result["ret"])
+	assert.Equal(t, "Platform status is not readable", result["status"])
+}
+
+// A payload with no usable timestamp is the writer's bug. Guessing a staleness
+// we cannot measure would hide a status that is otherwise perfectly good.
+func TestGetStatusWithoutTimestampIsServedUnchanged(t *testing.T) {
+	res := database.DBConn.Exec(
+		"INSERT INTO config (`key`, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value)",
+		status.StatusConfigKey, `{"ret":0,"status":"Success","error":false,"warning":false,"info":{}}`,
+	)
+	assert.NoError(t, res.Error)
+	defer database.DBConn.Exec("DELETE FROM config WHERE `key` = ?", status.StatusConfigKey)
+
+	result := getStatus(t, "/api/status")
+
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Equal(t, false, result["warning"])
+}
+
+func TestGetStatusV2Path(t *testing.T) {
+	publishStatus(t, `"ret":0,"status":"Success","error":false,"warning":false,"info":{}`, time.Minute)
+
+	result := getStatus(t, "/apiv2/status")
+
+	assert.Equal(t, float64(0), result["ret"])
 }
 
 func TestGetVersion(t *testing.T) {
-	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/version", nil))
-	assert.Equal(t, 200, resp.StatusCode)
+	result := getStatus(t, "/api/version")
 
-	var result map[string]interface{}
-	json2.Unmarshal(rsp(resp), &result)
 	assert.Contains(t, result, "build")
 	assert.Contains(t, result, "commit")
 	assert.Contains(t, result, "laravel_commit")
 }
 
-func TestGetStatusV2Path(t *testing.T) {
-	statusJSON := `{"ret":0,"status":"OK"}`
-	err := os.WriteFile("/tmp/iznik.status", []byte(statusJSON), 0644)
-	assert.NoError(t, err)
-	defer os.Remove("/tmp/iznik.status")
+func TestGetVersionV2Path(t *testing.T) {
+	result := getStatus(t, "/apiv2/version")
 
-	resp, _ := getApp().Test(httptest.NewRequest("GET", "/apiv2/status", nil))
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Contains(t, result, "commit")
 }


### PR DESCRIPTION
## Summary

The ModTools platform status dot has been dead since the V1 PHP removal. `/apiv2/status` served `/tmp/iznik.status`, whose only writer was `iznik-server/scripts/cron/status.php`, deleted in `c14a7125b` on 2026-07-09. Live has returned `{"ret":1,"status":"Cannot access status file"}` ever since. Support and admin saw a permanent **"Platform Status: Not sure"** over a detail-free *"There is a problem"*; ordinary mods saw green, because the orange dot is gated on `supportOrAdmin`.

This rebuilds the pipeline. **It replaces #1293, which retired the dot instead** — that was the wrong call.

### Where the status comes from now

A file on the API host cannot be the channel any more: the writer is Laravel and the reader is Go, in different containers on different hosts. The status now travels through the `config` table, the same channel `/api/version` already uses for the Laravel deploy commit.

The verdict is not computed afresh. `monitor:scheduled-outcomes` already asks, every ten minutes, whether each scheduled job actually did its work, and already escalates to Sentry when it did not. It now publishes that same verdict for the dot. One evaluation, two consumers — the dot cannot drift away from the monitoring that pages people, and adding a check to the registry surfaces it in both places at once.

### Why it cannot rot the same way again

- **The payload carries `generated_at`.** The Go reader turns a status older than 30 minutes (three missed passes) into a warning naming the staleness, rather than serving it as current. A dead writer must not look like a healthy platform — that is the exact failure that went unnoticed for a month.
- **`--only` never publishes.** A single-check pass has no evidence about anything else, and reporting the platform fine on that basis would be a lie. Monitoring disabled does not publish either, so the status goes stale and says so.
- **Only breaches are published**, so the modal names the jobs that are wrong instead of burying them among the healthy ones.

### Two frontend bugs went with it

`ModStatus` only stamped `updated` when `ret` was 0. While the API answered promptly with `ret` 1, the component decided it was out of date — that is what pinned the headline to "Not sure" and rendered the warning banner with nothing under it. `outOfDate` now means "cannot reach the status API", and a `ret` 1 becomes a warning carrying the reason the API gave.

The headline also tested `warning` before `error`, so a platform with a real error announced itself as merely a warning next to a red dot.

The `supportOrAdmin` gate on the orange dot is left alone. It looks deliberate — warnings are geek-facing detail — and errors were never gated.

## Code Quality Review

- **`ModStatus.spec.js` mounted a hand-written COPY of the component, not the component.** That is why all of this survived a green suite for a month. It now mounts the real thing, and covers the dot states, freshness semantics, the modal contents and the poll lifecycle.
- No duplicated verdict logic: `PlatformStatusWriter` consumes the `OutcomeResult`s the monitor already produced, and `OutcomeResult::severity` decides error vs warning.
- `info` is cast to an object so an empty set encodes as `{}` rather than `[]`; the Go reader adds to that map and the Vue modal iterates it, and neither should have to care that nothing happens to be wrong.
- A payload with no parseable `generated_at` is served unchanged rather than guessed at — an unreadable timestamp is the writer's bug, and inventing a staleness would hide a status that is otherwise fine.
- Docs updated in the same PR: `iznik-batch/docs/scheduled-outcome-monitoring.md` gains a section describing the publishing contract and why each property is load-bearing.

## Test Plan

Verified locally against this branch:

- **Go: full suite green, no failures.** Every status test confirmed present and passing by name, including that a stale publish warns, that it keeps its existing entries, and that a missing timestamp is served unchanged.
- **Laravel `PlatformStatusPublishingTest`: green** — clean pass, error breach, warning-severity breach, recovery replacing the previous status, and both non-publishing paths.
- **Vitest `ModStatus.spec.js`: green** against the real component. **Red-proved:** with the two fixes reverted, exactly the three tests that encode them fail and the rest pass.
- `tests/unit/pages/chitchat/id.spec.js` fails locally only against a stale baked `/app` in the `modtools-dev-local` container; it passes once that container is rebuilt, and nothing here touches chitchat.
- Branch is rebased onto `dc6cebd51`, which repairs the seeded-post ageing that makes five Playwright feed tests fail on master and on every branch alike. Those five are unrelated to this change.
- `check-docs-freshness.mjs` passes; eslint clean on both changed frontend files.

Exact totals are deliberately left to the CI run on this PR rather than quoted from local runs.

## Not covered by this PR

Mail-flow health (`monitor:email-health`) still alerts only to Sentry and does not appear on the dot. Folding it in means extracting its checks into a shared probe so the two do not duplicate thresholds, which is worth doing separately rather than bundling here.