### PR TITLE
fix(mail): stop the users_logins Link-key get-or-create race

### DIFF
--- a/docs/developers/reference/matched-posts-email.md
+++ b/docs/developers/reference/matched-posts-email.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-05
+last_reviewed: 2026-08-09
 owner: Freegle dev team
 covers:
   - iznik-server-go/message/postmatches.go

--- a/iznik-batch/app/Models/User.php
+++ b/iznik-batch/app/Models/User.php
@@ -950,25 +950,10 @@ class User extends Model implements Auditable
      */
     public function getUserKey(): string
     {
-        // Check for existing LOGIN_LINK credential.
-        $login = UserLogin::where('userid', $this->id)
-            ->where('type', self::LOGIN_LINK)
-            ->first(['credentials']);
-
-        if ($login && $login->credentials) {
-            return $login->credentials;
-        }
-
-        // Create a new key.
-        $key = bin2hex(random_bytes(16));
-
-        UserLogin::create([
-            'userid' => $this->id,
-            'type' => self::LOGIN_LINK,
-            'credentials' => $key,
-        ]);
-
-        return $key;
+        // Delegates to LoginLinkService so there is exactly one implementation of
+        // get-or-create: this used to be a second copy, which both drifted (it never
+        // set uid) and raced the service's copy on the (userid, type) unique key.
+        return app(\App\Services\LoginLinkService::class)->getOrCreateKey((int) $this->id);
     }
 
     /**

--- a/iznik-batch/app/Services/LoginLinkService.php
+++ b/iznik-batch/app/Services/LoginLinkService.php
@@ -25,8 +25,13 @@ class LoginLinkService
             return $existing;
         }
 
+        // insertOrIgnore, not insert: two workers can both find no row (e.g. two
+        // digest shards rendering mail for the same user in the same second) and
+        // both try to create one. The loser must return the WINNER's key - its own
+        // was never stored, so handing it out would email a dead link. Re-reading
+        // after the insert returns whichever key actually landed.
         $key = bin2hex(random_bytes(16));
-        DB::table('users_logins')->insert([
+        DB::table('users_logins')->insertOrIgnore([
             'userid' => $userId,
             'type' => 'Link',
             'uid' => (string) $userId,
@@ -34,6 +39,9 @@ class LoginLinkService
             'added' => now(),
         ]);
 
-        return $key;
+        return (string) DB::table('users_logins')
+            ->where('userid', $userId)
+            ->where('type', 'Link')
+            ->value('credentials');
     }
 }

--- a/iznik-batch/tests/Unit/Services/LoginLinkServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/LoginLinkServiceTest.php
@@ -32,4 +32,36 @@ class LoginLinkServiceTest extends TestCase
         $this->assertSame($first, $second, 'must not mint a new key each call (would break links already emailed)');
         $this->assertEquals(1, DB::table('users_logins')->where('userid', $user->id)->where('type', 'Link')->count());
     }
+
+    public function test_returns_the_stored_key_not_its_own_candidate(): void
+    {
+        // The race fix works by re-reading after insertOrIgnore: whatever key is in
+        // the table is the one handed out, never a candidate that failed to land.
+        $user = $this->createTestUser();
+        DB::table('users_logins')->insert([
+            'userid' => $user->id,
+            'type' => 'Link',
+            'uid' => (string) $user->id,
+            'credentials' => 'preexisting0000000000000000000000',
+            'added' => now(),
+        ]);
+
+        $key = app(LoginLinkService::class)->getOrCreateKey((int) $user->id);
+
+        $this->assertSame('preexisting0000000000000000000000', $key);
+    }
+
+    public function test_user_get_user_key_delegates_to_the_service(): void
+    {
+        // User::getUserKey used to be a second copy of get-or-create, which both
+        // drifted (it never set uid) and raced this service on (userid, type).
+        $user = $this->createTestUser();
+
+        $fromModel = \App\Models\User::find($user->id)->getUserKey();
+        $fromService = app(LoginLinkService::class)->getOrCreateKey((int) $user->id);
+
+        $this->assertSame($fromModel, $fromService);
+        $this->assertEquals(1, DB::table('users_logins')->where('userid', $user->id)->where('type', 'Link')->count());
+        $this->assertSame((string) $user->id, DB::table('users_logins')->where('userid', $user->id)->where('type', 'Link')->value('uid'));
+    }
 }

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -536,12 +536,26 @@ func getOrCreateLoginKey(userID uint64) (string, error) {
 	// (the retired ormharness's normalise_test.go
 	// TestNormaliseColumnOrder_Insert, removed in d22ba1d6c), so the
 	// map-Create reorder is harmless.
-	db.Table("users_logins").Create(map[string]interface{}{
+	res := db.Table("users_logins").Create(map[string]interface{}{
 		"userid":      userID,
 		"type":        utils.LOGIN_TYPE_LINK,
 		"uid":         fmt.Sprintf("%d", userID),
 		"credentials": newKey,
 	})
+
+	if res.Error != nil {
+		// Most likely we lost a check-then-insert race on the (userid, type)
+		// unique key against a concurrent request. Our key was never stored, so
+		// returning it would hand out a dead link - return the winner's instead.
+		db.Table("users_logins").Select("credentials").Where("userid = ? AND type = ?", userID, utils.LOGIN_TYPE_LINK).
+			Limit(1).Scan(&existingKey)
+
+		if existingKey != "" {
+			return existingKey, nil
+		}
+
+		return "", res.Error
+	}
 
 	return newKey, nil
 }


### PR DESCRIPTION
Two workers rendering mail for the same user in the same second could both find no `Link` key and both insert on the `(userid, type)` unique index. The loser threw a 1062 duplicate-key error in PHP (killing that email render); the Go mirror was worse — it ignored the insert error and returned its never-stored candidate, i.e. a dead login link in the email.

Seen on prod 2026-08-09 at 15:10 and 18:10 (users 45056704 / 38043283, concurrent digest shards) — verified both winners' rows landed with valid 32-char keys at the exact error second, confirming the race rather than bad data (0 of 103k Link rows have empty credentials).

## Changes
- **`LoginLinkService::getOrCreateKey`**: `insertOrIgnore` then re-read, so the key handed out is always the one actually stored, whichever worker won.
- **`User::getUserKey`**: was a second copy of the same get-or-create, which both raced the service and drifted (never set `uid`). Now delegates to the service.
- **Go `getOrCreateLoginKey`** (session.go): on insert error, re-read and return the winner's stored key; only error out if nothing is stored.
- Tests: stored-key-wins invariant + delegation (single row, uid set).

Go change vet-compiled clean on a scratch checkout. PHP/Go suites run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8oov8SKo3bnVavfCz6VWR