### PR TITLE
Port V1 host health checks (reboot-required, security patches, monit) into the status pipeline

### DIFF
--- a/.env.background.example
+++ b/.env.background.example
@@ -56,6 +56,21 @@ SENTRY_LARAVEL_DSN=
 FIREBASE_HOST_PATH=/path/to/firebase.json
 
 # =============================================================================
+# Host health checks (monitor:scheduled-outcomes -> ModTools status dot)
+# =============================================================================
+# Ported from V1's scripts/cron/status.php: each target is probed over ssh
+# every 10 minutes for pending security patches, reboot-required and monit
+# health. Comma-separated ssh targets. The estate's topology must live ONLY
+# here (this file is never committed) — never in code or committed compose
+# files. Empty = host checks disabled (the default for dev/CI).
+FREEGLE_MONITORING_HOSTS=root@10.x.x.x,root@10.x.x.y
+# Private key used for those probes, as a path on the HOST. Mounted read-only
+# into the container at /etc/monitoring-ssh-key (see docker-compose.yml).
+# Same split-name pattern as FIREBASE_HOST_PATH above, and set in the compose
+# .env on the batch host (compose interpolates the mount source from it).
+MONITORING_SSH_KEY_HOST_PATH=/path/to/ssh/private/key
+
+# =============================================================================
 # Git Summary (Weekly Code Changes Report)
 # =============================================================================
 # Google Gemini API key for AI summarization

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1692,6 +1692,13 @@ services:
       # tried to open it inside the container — memory
       # project_push_dropped_devnull_firebase.
       - ${FIREBASE_HOST_PATH:-/dev/null}:/etc/firebase.json:ro
+      # SSH key for monitor:scheduled-outcomes' host health checks (reboot
+      # required / security patches / monit — see HostHealthCheck). Same
+      # split-name pattern as FIREBASE_HOST_PATH: the HOST path lives in the
+      # compose .env on the batch host; the container always sees
+      # /etc/monitoring-ssh-key. Defaults to /dev/null (dev/CI: checks are
+      # disabled anyway when FREEGLE_MONITORING_HOSTS is empty).
+      - ${MONITORING_SSH_KEY_HOST_PATH:-/dev/null}:/etc/monitoring-ssh-key:ro
     extra_hosts:
       - "db-host:${DB_HOST_IP:-127.0.0.1}"
       # Read replica for the DB read/write split. Falls back to the write host

--- a/iznik-batch/app/Console/Commands/Monitor/MonitorScheduledOutcomesCommand.php
+++ b/iznik-batch/app/Console/Commands/Monitor/MonitorScheduledOutcomesCommand.php
@@ -13,10 +13,13 @@ use Illuminate\Support\Facades\Log;
  * their work (rows written, cursor advanced), not just that the scheduler is
  * alive. Runs every 10 minutes (itself heartbeated to Sentry Crons).
  *
- * For each registered check it prints a line and, on any BREACH, escalates to
- * Sentry (\Sentry\captureMessage, guarded by function_exists exactly like
- * EmailHealthCommand/TNSyncCommand) plus Log::warning, then exits non-zero so
- * the breach shows as a red badge in the cron-jobs sysadmin tab. SKIPPED
+ * For each registered check it prints a line and, on an ERROR-severity BREACH,
+ * escalates to Sentry (\Sentry\captureMessage, guarded by function_exists
+ * exactly like EmailHealthCommand/TNSyncCommand) plus Log::warning, then exits
+ * non-zero so the breach shows as a red badge in the cron-jobs sysadmin tab.
+ * WARNING-severity breaches are published to the status dot and logged, but
+ * neither page Sentry nor fail the command — a host that needs a reboot for a
+ * fortnight should show amber, not fire an alert every 10 minutes. SKIPPED
  * results (precondition unmet / outside active window) never fail the command.
  *
  * A full pass also publishes its verdict for ModTools' platform status dot (see
@@ -80,20 +83,33 @@ class MonitorScheduledOutcomesCommand extends Command
                 Log::warning("[ScheduledOutcomes] {$breach->slug}: {$breach->message}");
             }
 
-            // Escalate to Sentry so the team (who actively watch it) are alerted
-            // promptly. Guarded because Sentry's helpers aren't loaded in every
+            // Severity splits the response. An ERROR means part of the
+            // platform is not working: escalate to Sentry and exit non-zero.
+            // A WARNING (e.g. a host needing a reboot) still turns the status
+            // dot amber via the publish above, but a long-standing warning
+            // must not page Sentry every 10 minutes or pin the cron-jobs tab
+            // red for weeks — that alarm fatigue is how real errors get missed.
+            $errors = array_values(array_filter($breaches, fn ($b) => $b->severity === 'error'));
+
+            // Guarded because Sentry's helpers aren't loaded in every
             // environment (e.g. tests) — same pattern as EmailHealthCommand.
-            if (function_exists('\Sentry\captureMessage')) {
-                foreach ($breaches as $breach) {
+            if (! empty($errors) && function_exists('\Sentry\captureMessage')) {
+                foreach ($errors as $breach) {
                     \Sentry\captureMessage(
                         "[ScheduledOutcomes][{$breach->severity}] {$breach->slug}: {$breach->message}"
                     );
                 }
             }
 
-            $this->error(count($breaches) . ' scheduled-outcome check(s) breached.');
+            if (! empty($errors)) {
+                $this->error(count($errors) . ' scheduled-outcome check(s) breached.');
 
-            return Command::FAILURE;
+                return Command::FAILURE;
+            }
+
+            $this->warn(count($breaches) . ' scheduled-outcome warning(s) published to the status dot.');
+
+            return Command::SUCCESS;
         }
 
         $this->info('All scheduled-outcome checks OK.');

--- a/iznik-batch/app/Monitoring/Checks/HostHealthCheck.php
+++ b/iznik-batch/app/Monitoring/Checks/HostHealthCheck.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Monitoring\Checks;
+
+use App\Monitoring\HostCommandRunner;
+use App\Monitoring\OutcomeResult;
+use Carbon\CarbonInterface;
+
+/**
+ * Per-host OS/service health, ported from V1's scripts/cron/status.php — the
+ * ssh-round-the-estate cron that died with the V1 PHP removal and left the
+ * ModTools status dot blind to host state (reboot-required sat unreported on
+ * every host). It checks what V1 checked, where the check still applies:
+ *
+ *  - pending security updates  (V1: "Security patches to apply")   → warning
+ *  - /var/run/reboot-required  (V1: "Server reboot required")      → warning
+ *  - monit summary             (V1: per-line OK-pattern match)     → warning/error
+ *
+ * V1's beanstalkd, exim-queue and V1-spool checks are not ported: beanstalkd
+ * and the V1 spool went with the V1 removal, and mail health has its own
+ * monitoring (email:health).
+ *
+ * The ssh target comes from configuration (FREEGLE_MONITORING_HOSTS) so the
+ * estate's topology never appears in the codebase.
+ */
+class HostHealthCheck extends AbstractOutcomeCheck
+{
+    /**
+     * One ssh round-trip gathers everything. Markers keep the parse
+     * independent of shell noise, and the monit block is fenced so its lines
+     * can't be confused with the scalar findings. `monit summary -B` is batch
+     * (plain-text) format — no box-drawing characters to parse around.
+     */
+    public const PROBE = <<<'SH'
+echo "REBOOT:$([ -f /var/run/reboot-required ] && echo yes || echo no)"
+echo "REBOOT_PKGS:$(sort -u /var/run/reboot-required.pkgs 2>/dev/null | head -3 | tr '\n' ' ')"
+echo "SECURITY:$(apt-get upgrade -s 2>/dev/null | grep -c '^Inst.*[Ss]ecurit')"
+if command -v monit >/dev/null 2>&1; then echo "MONIT_BEGIN"; monit summary -B 2>&1; echo "MONIT_END"; else echo "MONIT_ABSENT"; fi
+SH;
+
+    /**
+     * Monit statuses that mean the service is fine. V1's pattern list, plus
+     * "Waiting" (a Program between runs).
+     */
+    private const MONIT_OK = [
+        'Online with all services',
+        'Status ok',
+        'Accessible',
+        'Running',
+        'Waiting',
+        'OK',
+    ];
+
+    /**
+     * Monit statuses that need attention but don't mean the service is down:
+     * "Not monitored" (V1 treated it as a warning too), "Initializing" (first
+     * cycle after a monit restart) and "Resource limit matched" (service up,
+     * resource rule breached). Anything matching neither list is an error.
+     */
+    private const MONIT_WARNING = [
+        'Resource limit matched',
+        'Not monitored',
+        'Initializing',
+    ];
+
+    private readonly string $host;
+
+    public function __construct(
+        private readonly string $target,
+        private readonly HostCommandRunner $runner,
+    ) {
+        // Slug on the bare host, not the ssh target — "root@" is transport
+        // detail, and the slug is what the ModTools status modal displays.
+        $at = strrpos($target, '@');
+        $this->host = $at === false ? $target : substr($target, $at + 1);
+
+        $this->slug = "host:{$this->host}";
+        $this->category = 'host-health';
+        $this->description = "OS and service health on {$this->host}";
+    }
+
+    protected function check(CarbonInterface $now): OutcomeResult
+    {
+        $output = $this->runner->run($this->target, self::PROBE);
+
+        if ($output === null) {
+            return OutcomeResult::breach(
+                $this->slug,
+                "{$this->host} is unreachable over ssh — host down, or the monitoring key/route is not set up",
+                'warning',
+            );
+        }
+
+        [$errors, $warnings] = $this->interpret($output);
+
+        if (! empty($errors)) {
+            // Warnings ride along so the modal shows the whole host picture.
+            return OutcomeResult::breach($this->slug, implode('; ', array_merge($errors, $warnings)), 'error');
+        }
+
+        if (! empty($warnings)) {
+            return OutcomeResult::breach($this->slug, implode('; ', $warnings), 'warning');
+        }
+
+        return OutcomeResult::ok($this->slug, "{$this->host} healthy (no reboot needed, no pending security updates)");
+    }
+
+    /**
+     * @return array{0: list<string>, 1: list<string>} [errors, warnings]
+     */
+    private function interpret(string $output): array
+    {
+        $errors = [];
+        $warnings = [];
+
+        if (preg_match('/^REBOOT:yes$/m', $output)) {
+            $pkgs = '';
+            if (preg_match('/^REBOOT_PKGS:(.+)$/m', $output, $m) && trim($m[1]) !== '') {
+                $pkgs = ' (' . trim($m[1]) . ')';
+            }
+            $warnings[] = "reboot required{$pkgs}";
+        }
+
+        if (preg_match('/^SECURITY:(\d+)$/m', $output, $m) && (int) $m[1] > 0) {
+            $warnings[] = "{$m[1]} security update(s) to apply";
+        }
+
+        if (preg_match('/^MONIT_BEGIN$(.*?)^MONIT_END$/ms', $output, $m)) {
+            [$monitErrors, $monitWarnings] = $this->interpretMonit($m[1]);
+            $errors = array_merge($errors, $monitErrors);
+            $warnings = array_merge($warnings, $monitWarnings);
+        }
+        // MONIT_ABSENT: fine — not every host runs monit, same as V1's
+        // tolerance of hosts without exim.
+
+        return [$errors, $warnings];
+    }
+
+    /**
+     * Classify each service line of `monit summary -B` output. V1 pattern-
+     * matched each line against known-good statuses and alarmed on the rest;
+     * we do the same but with an explicit warning tier for states that don't
+     * mean the service is down.
+     *
+     * @return array{0: list<string>, 1: list<string>} [errors, warnings]
+     */
+    private function interpretMonit(string $monitOutput): array
+    {
+        $errors = [];
+        $warnings = [];
+        $sawDaemonHeader = false;
+
+        foreach (preg_split('/\R/', $monitOutput) as $line) {
+            $line = trim($line);
+
+            if ($line === '' || str_starts_with($line, 'Service Name')) {
+                continue;
+            }
+
+            if (str_starts_with($line, 'Monit ')) {
+                $sawDaemonHeader = true;
+                continue;
+            }
+
+            $matched = false;
+            foreach (self::MONIT_WARNING as $status) {
+                if (str_contains($line, $status)) {
+                    $warnings[] = "monit: " . preg_replace('/\s{2,}/', ' ', $line);
+                    $matched = true;
+                    break;
+                }
+            }
+
+            if (! $matched) {
+                foreach (self::MONIT_OK as $status) {
+                    if (str_contains($line, $status)) {
+                        $matched = true;
+                        break;
+                    }
+                }
+            }
+
+            if (! $matched) {
+                // Includes "Does not exist", "Execution failed", and monit's
+                // "Status not available -- the monit daemon is not running".
+                $errors[] = "monit: " . preg_replace('/\s{2,}/', ' ', $line);
+            }
+        }
+
+        // Output that never identified itself as monit at all (V1: no "Monit"
+        // in the output). The daemon-not-running message is already an error
+        // from the loop above; this catches a mangled or empty summary. A dead
+        // monit is an ERROR, not the warning V1 gave it: monit is what
+        // restarts the API services, and a silent monit death has caused a
+        // real outage before.
+        if (! $sawDaemonHeader && empty($errors) && empty($warnings)) {
+            $errors[] = 'monit: summary produced no recognisable output — daemon dead?';
+        }
+
+        return [$errors, $warnings];
+    }
+}

--- a/iznik-batch/app/Monitoring/HostCommandRunner.php
+++ b/iznik-batch/app/Monitoring/HostCommandRunner.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Monitoring;
+
+/**
+ * Runs a shell script on a remote host and returns its combined output.
+ *
+ * Abstracted so HostHealthCheck can be tested with canned output; the real
+ * implementation (SshHostCommandRunner) shells out to ssh, exactly as V1's
+ * scripts/cron/status.php did.
+ */
+interface HostCommandRunner
+{
+    /**
+     * @param  string  $target  ssh target, e.g. "root@10.0.0.1"
+     * @param  string  $script  shell script to run remotely
+     * @return string|null the script's stdout, or null if the host was unreachable
+     */
+    public function run(string $target, string $script): ?string;
+}

--- a/iznik-batch/app/Monitoring/ScheduledOutcomeRegistry.php
+++ b/iznik-batch/app/Monitoring/ScheduledOutcomeRegistry.php
@@ -6,6 +6,7 @@ use App\Models\MessageGroup;
 use App\Monitoring\Checks\BacklogCheck;
 use App\Monitoring\Checks\CallbackCheck;
 use App\Monitoring\Checks\FreshnessCheck;
+use App\Monitoring\Checks\HostHealthCheck;
 use App\Monitoring\Checks\ProducedSinceCheck;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
@@ -31,7 +32,7 @@ class ScheduledOutcomeRegistry
         $tz = config('freegle.timezone', 'Europe/London');
         $backlogMin = (int) config('freegle.monitoring.processing_backlog_max_age_minutes', 15);
 
-        return [
+        return array_merge([
             // ---- Fire-once: did it produce output this period? -------------
 
             // stats:generate-daily (daily 02:30) writes one `stats` row per
@@ -203,7 +204,35 @@ class ScheduledOutcomeRegistry
             )
                 ->describedAs('Monthly ONS CPI inflation data fetch')
                 ->inCategory('fire-once-output'),
-        ];
+        ], $this->hostHealthChecks());
+    }
+
+    /**
+     * Host-level OS/service checks (see HostHealthCheck), one per configured
+     * ssh target. The estate's topology deliberately lives ONLY in the
+     * environment (FREEGLE_MONITORING_HOSTS in the uncommitted
+     * .env.background), never in committed code; an empty list — dev, CI —
+     * yields no checks at all.
+     *
+     * @return list<HostHealthCheck>
+     */
+    private function hostHealthChecks(): array
+    {
+        $targets = array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) config('freegle.monitoring.hosts', ''))
+        )));
+
+        if (empty($targets)) {
+            return [];
+        }
+
+        $runner = app(HostCommandRunner::class);
+
+        return array_map(
+            fn (string $target) => new HostHealthCheck($target, $runner),
+            $targets,
+        );
     }
 
     /**

--- a/iznik-batch/app/Monitoring/SshHostCommandRunner.php
+++ b/iznik-batch/app/Monitoring/SshHostCommandRunner.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Monitoring;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * HostCommandRunner over ssh, mirroring how V1's status cron reached each
+ * host. BatchMode forbids interactive prompts (a missing/bad key fails fast
+ * instead of hanging the scheduler), and the known-hosts checks are disabled
+ * because the container's filesystem is ephemeral — the same trade V1 made
+ * with StrictHostKeyChecking=no.
+ */
+class SshHostCommandRunner implements HostCommandRunner
+{
+    public function __construct(
+        private readonly string $keyPath,
+        private readonly int $timeoutSeconds = 30,
+    ) {
+    }
+
+    public function run(string $target, string $script): ?string
+    {
+        $process = new Process(
+            [
+                'ssh',
+                '-o', 'ConnectTimeout=10',
+                '-o', 'BatchMode=yes',
+                '-o', 'StrictHostKeyChecking=no',
+                '-o', 'UserKnownHostsFile=/dev/null',
+                '-o', 'LogLevel=ERROR',
+                '-i', $this->keyPath,
+                $target,
+                $script,
+            ],
+            timeout: $this->timeoutSeconds,
+        );
+
+        try {
+            $process->run();
+        } catch (\Throwable) {
+            // Includes ProcessTimedOutException — a host that can't answer the
+            // probe within the timeout is unreachable for our purposes.
+            return null;
+        }
+
+        // ssh exits 255 when the CONNECTION failed (auth, route, timeout); the
+        // probe script's own exit status is irrelevant because its findings
+        // travel in stdout. Empty output is also treated as unreachable — the
+        // probe always prints its markers when it actually ran.
+        if ($process->getExitCode() === 255 || trim($process->getOutput()) === '') {
+            return null;
+        }
+
+        return $process->getOutput();
+    }
+}

--- a/iznik-batch/app/Providers/AppServiceProvider.php
+++ b/iznik-batch/app/Providers/AppServiceProvider.php
@@ -46,6 +46,15 @@ class AppServiceProvider extends ServiceProvider
             return new LokiService();
         });
 
+        // How HostHealthCheck reaches the estate's hosts (monitor:scheduled-
+        // outcomes). Bound here so tests can swap in a fake runner.
+        $this->app->bind(\App\Monitoring\HostCommandRunner::class, function () {
+            return new \App\Monitoring\SshHostCommandRunner(
+                (string) config('freegle.monitoring.host_ssh_key', '/etc/monitoring-ssh-key'),
+                (int) config('freegle.monitoring.host_ssh_timeout_seconds', 30),
+            );
+        });
+
         // Scheduler overlap mutex backend. Default (LOCK_STORE=flock) binds
         // FlockEventMutex — OS-level flock that auto-releases on process death.
         // Setting LOCK_STORE=redis (or another cache store) binds a TTL-based cache

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -963,6 +963,20 @@ return [
         // Master kill-switch. When false, monitor:scheduled-outcomes no-ops.
         'enabled' => env('FREEGLE_MONITORING_ENABLED', true),
 
+        // Host-level OS/service checks (HostHealthCheck — V1 status.php
+        // parity: security patches, reboot-required, monit). Comma-separated
+        // ssh targets, e.g. "root@10.0.0.1,root@10.0.0.2". The estate's
+        // topology must live ONLY in the environment (.env.background on the
+        // batch host), never in committed code. Empty = disabled (dev/CI).
+        'hosts' => env('FREEGLE_MONITORING_HOSTS', ''),
+        // Private key path INSIDE the container. docker-compose bind-mounts
+        // the real key from MONITORING_SSH_KEY_HOST_PATH (host-side var, same
+        // split-name pattern as FIREBASE_HOST_PATH so the host path never
+        // leaks into the container environment).
+        'host_ssh_key' => env('FREEGLE_MONITORING_SSH_KEY', '/etc/monitoring-ssh-key'),
+        // Per-host probe timeout. ConnectTimeout is 10s inside this budget.
+        'host_ssh_timeout_seconds' => (int) env('FREEGLE_MONITORING_SSH_TIMEOUT', 30),
+
         // stats:generate-daily — minimum per-group stats rows expected for
         // yesterday once the day's 02:30 run has had time to complete.
         'stats_daily_min_expected' => (int) env('FREEGLE_MONITORING_STATS_DAILY_MIN', 1),

--- a/iznik-batch/docker/Dockerfile
+++ b/iznik-batch/docker/Dockerfile
@@ -65,8 +65,11 @@ RUN cp /tmp/mjml.so "$(php-config --extension-dir)/mjml.so" \
 # osmium-tool merges the Great Britain + Ireland/Northern Ireland OSM extracts
 # into the unified uk-latest.osm.pbf that the routing server loads
 # (used by the spatial:update-data scheduled command).
+# openssh-client is for monitor:scheduled-outcomes' host health checks
+# (App\Monitoring\SshHostCommandRunner probes each host over ssh, exactly as
+# V1's status cron did).
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends osmium-tool \
+    && apt-get install -y --no-install-recommends osmium-tool openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Claude Code CLI — lets Community News research run on a Claude SUBSCRIPTION

--- a/iznik-batch/docs/scheduled-outcome-monitoring.md
+++ b/iznik-batch/docs/scheduled-outcome-monitoring.md
@@ -102,10 +102,43 @@ caused a real month-long outage of the dot:
 
 `OutcomeResult` severity decides which half of the dot a breach lands in:
 `error` means part of the platform is not working, anything else is a warning.
+Severity also decides the response: only `error` breaches escalate to Sentry
+and fail the command (red badge in the cron-jobs tab). A `warning` breach
+turns the dot amber and is logged, but a long-standing warning — a host
+awaiting a reboot for a fortnight — must not page Sentry every 10 minutes or
+pin the cron-jobs tab red; that alarm fatigue is how real errors get missed.
+
+## Host health checks (V1 status.php parity)
+
+V1's `scripts/cron/status.php` also ssh'd into every server and warned on
+pending security patches, `reboot-required` and monit failures. Those checks
+died with the V1 removal too, leaving the dot blind to host state (every host
+in the estate sat on "reboot required" with the dot green). `HostHealthCheck`
+ports them into this pipeline:
+
+| Probe | V1 equivalent | Severity |
+|---|---|---|
+| `/var/run/reboot-required` exists | "Server reboot required" | warning (names the packages) |
+| `apt-get upgrade -s` lists security packages | "Security patches to apply" | warning (with count) |
+| `monit summary -B` per-service status | per-line OK-pattern match | `Not monitored` / `Initializing` / `Resource limit matched` ⇒ warning; anything else non-OK (incl. a dead monit daemon) ⇒ **error** — monit restarts the API services, and a silent monit death has caused a real outage |
+| host unreachable over ssh | (implicit) | warning |
+
+One ssh round-trip per host gathers all three signals. V1's beanstalkd,
+exim-queue and V1-spool checks are deliberately not ported (dead tech /
+covered by `email:health`).
+
+**Topology never enters the codebase.** The ssh targets come from
+`FREEGLE_MONITORING_HOSTS` (comma-separated, in the uncommitted
+`.env.background`); the key is bind-mounted from `MONITORING_SSH_KEY_HOST_PATH`
+to `/etc/monitoring-ssh-key` (see `docker-compose.yml` and
+`.env.background.example`). Empty target list — dev, CI — registers no host
+checks at all. The batch image ships `openssh-client` for this
+(`docker/Dockerfile`).
 
 ## Implemented checks
 
-Eleven per-job checks across all four primitives:
+Eleven per-job checks across all four primitives, plus one `HostHealthCheck`
+per ssh target in `FREEGLE_MONITORING_HOSTS` (see "Host health checks" above):
 
 | Task | Primitive | Signal | Notes |
 |---|---|---|---|

--- a/iznik-batch/tests/Feature/Monitor/HostHealthCheckTest.php
+++ b/iznik-batch/tests/Feature/Monitor/HostHealthCheckTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Feature\Monitor;
+
+use App\Monitoring\Checks\HostHealthCheck;
+use App\Monitoring\HostCommandRunner;
+use App\Monitoring\OutcomeResult;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+/**
+ * HostHealthCheck ports the per-host checks from V1's scripts/cron/status.php
+ * (security patches, reboot-required, monit summary) into the outcome
+ * monitoring pipeline. These tests drive it with a fake runner returning
+ * canned probe output, so no ssh happens under test.
+ */
+class HostHealthCheckTest extends TestCase
+{
+    private function runnerReturning(?string $output): HostCommandRunner
+    {
+        return new class($output) implements HostCommandRunner
+        {
+            public ?string $lastTarget = null;
+            public ?string $lastScript = null;
+
+            public function __construct(private ?string $output)
+            {
+            }
+
+            public function run(string $target, string $script): ?string
+            {
+                $this->lastTarget = $target;
+                $this->lastScript = $script;
+
+                return $this->output;
+            }
+        };
+    }
+
+    /**
+     * Build probe output. Defaults are a completely healthy host.
+     */
+    private function probeOutput(
+        string $reboot = 'no',
+        string $rebootPkgs = '',
+        int $security = 0,
+        ?array $monitLines = ['freegle-host                     OK                          System'],
+    ): string {
+        $out = "REBOOT:{$reboot}\n";
+        $out .= "REBOOT_PKGS:{$rebootPkgs}\n";
+        $out .= "SECURITY:{$security}\n";
+
+        if ($monitLines === null) {
+            $out .= "MONIT_ABSENT\n";
+        } else {
+            $out .= "MONIT_BEGIN\n";
+            $out .= "Monit 5.31.0 uptime: 1d 2h 3m\n";
+            $out .= " Service Name                     Status                      Type          \n";
+            foreach ($monitLines as $line) {
+                $out .= " {$line}\n";
+            }
+            $out .= "MONIT_END\n";
+        }
+
+        return $out;
+    }
+
+    private function evaluate(?string $probeOutput = null, string $target = 'root@host-a'): OutcomeResult
+    {
+        $check = new HostHealthCheck($target, $this->runnerReturning($probeOutput));
+
+        return $check->evaluate(Carbon::now());
+    }
+
+    public function test_slug_is_the_host_without_the_ssh_user(): void
+    {
+        $check = new HostHealthCheck('root@host-a', $this->runnerReturning(null));
+        $this->assertSame('host:host-a', $check->slug());
+
+        $check = new HostHealthCheck('host-b', $this->runnerReturning(null));
+        $this->assertSame('host:host-b', $check->slug());
+    }
+
+    public function test_a_healthy_host_is_ok(): void
+    {
+        $result = $this->evaluate($this->probeOutput());
+
+        $this->assertTrue($result->isOk(), $result->message);
+    }
+
+    public function test_reboot_required_is_a_warning_naming_the_packages(): void
+    {
+        $result = $this->evaluate($this->probeOutput(reboot: 'yes', rebootPkgs: 'linux-base libc6'));
+
+        $this->assertTrue($result->isBreach());
+        $this->assertSame('warning', $result->severity);
+        $this->assertStringContainsString('reboot required', $result->message);
+        $this->assertStringContainsString('linux-base libc6', $result->message);
+    }
+
+    public function test_pending_security_updates_are_a_warning_with_the_count(): void
+    {
+        $result = $this->evaluate($this->probeOutput(security: 3));
+
+        $this->assertTrue($result->isBreach());
+        $this->assertSame('warning', $result->severity);
+        $this->assertStringContainsString('3 security update(s) to apply', $result->message);
+    }
+
+    public function test_a_monit_service_not_monitored_is_a_warning(): void
+    {
+        $result = $this->evaluate($this->probeOutput(monitLines: [
+            'freegle-host                     OK                          System',
+            'iznik-server-go                  Not monitored               Process',
+        ]));
+
+        $this->assertTrue($result->isBreach());
+        $this->assertSame('warning', $result->severity);
+        $this->assertStringContainsString('iznik-server-go', $result->message);
+        $this->assertStringContainsString('Not monitored', $result->message);
+    }
+
+    public function test_transient_monit_states_are_warnings_not_errors(): void
+    {
+        $result = $this->evaluate($this->probeOutput(monitLines: [
+            'php-fpm                          Initializing                Process',
+            'mysqld                           Resource limit matched      Process',
+        ]));
+
+        $this->assertTrue($result->isBreach());
+        $this->assertSame('warning', $result->severity);
+    }
+
+    public function test_a_failed_monit_service_is_an_error(): void
+    {
+        $result = $this->evaluate($this->probeOutput(monitLines: [
+            'iznik-server-go                  Does not exist              Process',
+        ]));
+
+        $this->assertTrue($result->isBreach());
+        $this->assertSame('error', $result->severity);
+        $this->assertStringContainsString('iznik-server-go', $result->message);
+    }
+
+    public function test_a_dead_monit_daemon_is_an_error(): void
+    {
+        $output = "REBOOT:no\nREBOOT_PKGS:\nSECURITY:0\nMONIT_BEGIN\n"
+            . "Status not available -- the monit daemon is not running\nMONIT_END\n";
+
+        $result = $this->evaluate($output);
+
+        $this->assertTrue($result->isBreach());
+        $this->assertSame('error', $result->severity);
+        $this->assertStringContainsString('monit', strtolower($result->message));
+    }
+
+    public function test_a_host_without_monit_is_still_ok(): void
+    {
+        $result = $this->evaluate($this->probeOutput(monitLines: null));
+
+        $this->assertTrue($result->isOk(), $result->message);
+    }
+
+    public function test_an_unreachable_host_is_a_warning(): void
+    {
+        $result = $this->evaluate(null);
+
+        $this->assertTrue($result->isBreach());
+        $this->assertSame('warning', $result->severity);
+        $this->assertStringContainsString('unreachable', $result->message);
+    }
+
+    public function test_an_error_outranks_coexisting_warnings(): void
+    {
+        $result = $this->evaluate($this->probeOutput(
+            reboot: 'yes',
+            security: 2,
+            monitLines: ['exim                             Execution failed            Process'],
+        ));
+
+        $this->assertTrue($result->isBreach());
+        $this->assertSame('error', $result->severity);
+        // The warnings still travel in the message so the modal shows the
+        // whole host picture, not just the worst finding.
+        $this->assertStringContainsString('reboot required', $result->message);
+        $this->assertStringContainsString('2 security update(s)', $result->message);
+        $this->assertStringContainsString('exim', $result->message);
+    }
+}

--- a/iznik-batch/tests/Feature/Monitor/MonitorScheduledOutcomesCommandTest.php
+++ b/iznik-batch/tests/Feature/Monitor/MonitorScheduledOutcomesCommandTest.php
@@ -80,6 +80,29 @@ class MonitorScheduledOutcomesCommandTest extends TestCase
             );
     }
 
+    public function test_warning_severity_breaches_log_but_do_not_fail(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck('job:a', fn ($now) => OutcomeResult::ok('job:a', 'fine')),
+            new CallbackCheck(
+                'host:x',
+                fn ($now) => OutcomeResult::breach('host:x', 'reboot required', 'warning')
+            ),
+        ]);
+
+        Log::spy();
+
+        // A warning is visible (status dot, log) but must not exit non-zero —
+        // a host awaiting a reboot for weeks would otherwise pin the cron-jobs
+        // tab red and page Sentry every 10 minutes.
+        $this->artisan('monitor:scheduled-outcomes')
+            ->expectsOutputToContain('warning')
+            ->assertExitCode(0);
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn ($message, $context = []) => str_contains((string) $message, 'host:x'));
+    }
+
     public function test_skipped_checks_do_not_cause_failure(): void
     {
         $this->fakeRegistry([

--- a/iznik-batch/tests/Feature/Monitor/PlatformStatusPublishingTest.php
+++ b/iznik-batch/tests/Feature/Monitor/PlatformStatusPublishingTest.php
@@ -97,7 +97,10 @@ class PlatformStatusPublishingTest extends TestCase
             ),
         ]);
 
-        $this->artisan('monitor:scheduled-outcomes')->assertExitCode(1);
+        // Warnings turn the dot amber but do NOT fail the command: a
+        // long-standing warning (host awaiting reboot) must not pin the
+        // cron-jobs tab red or page Sentry every pass.
+        $this->artisan('monitor:scheduled-outcomes')->assertExitCode(0);
 
         $status = $this->publishedStatus();
 

--- a/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeRegistryTest.php
+++ b/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeRegistryTest.php
@@ -211,4 +211,42 @@ class ScheduledOutcomeRegistryTest extends TestCase
             'An unheld stale Pending post must breach the contentcheck backlog'
         );
     }
+
+    /**
+     * Host health checks exist ONLY when ssh targets are configured — the
+     * estate's topology comes from the environment, never from code, and an
+     * empty list (dev, CI) must contribute nothing to the registry.
+     */
+    public function test_host_checks_come_from_config_and_default_to_none(): void
+    {
+        config(['freegle.monitoring.hosts' => '']);
+        $slugs = array_map(
+            fn (OutcomeCheck $c) => $c->slug(),
+            (new ScheduledOutcomeRegistry())->checks()
+        );
+        $this->assertEmpty(
+            array_filter($slugs, fn (string $s) => str_starts_with($s, 'host:')),
+            'No host checks may exist without configured targets'
+        );
+
+        // A fake runner so no ssh could ever happen under test.
+        $this->app->instance(
+            \App\Monitoring\HostCommandRunner::class,
+            new class implements \App\Monitoring\HostCommandRunner
+            {
+                public function run(string $target, string $script): ?string
+                {
+                    return null;
+                }
+            }
+        );
+
+        config(['freegle.monitoring.hosts' => 'root@host-a, root@host-b']);
+        $slugs = array_map(
+            fn (OutcomeCheck $c) => $c->slug(),
+            (new ScheduledOutcomeRegistry())->checks()
+        );
+        $this->assertContains('host:host-a', $slugs);
+        $this->assertContains('host:host-b', $slugs);
+    }
 }


### PR DESCRIPTION
## Summary

- The ModTools status dot has been blind to host state since the V1 PHP removal: V1's `scripts/cron/status.php` ssh'd into every server and warned on pending security patches, `reboot-required` and monit failures, and nothing replaced those checks. Right now every host in the estate needs a reboot (kernel + libc6 security updates applied by unattended-upgrades but never booted into) while the dot shows green.
- New `HostHealthCheck` (one per configured ssh target) probes each host in a single ssh round-trip and classifies:
  - `/var/run/reboot-required` → **warning**, naming the packages (V1: "Server reboot required")
  - pending apt security updates → **warning** with count (V1: "Security patches to apply")
  - `monit summary -B` per-service state → `Not monitored` / `Initializing` / `Resource limit matched` are **warnings**; anything else non-OK — including a dead monit daemon — is an **error** (monit restarts the API services; a silent monit death caused the July db1 routing outage)
  - unreachable host → **warning**
- **Topology never enters the codebase**: ssh targets come from `FREEGLE_MONITORING_HOSTS` in the uncommitted `.env.background`; the key is bind-mounted from `MONITORING_SSH_KEY_HOST_PATH` (same split-name pattern as `FIREBASE_HOST_PATH`); an empty list (dev/CI) registers no host checks. `.env.background.example` documents both with placeholders only.
- Severity now splits the response in `monitor:scheduled-outcomes`: only **error** breaches page Sentry and exit non-zero; **warning** breaches turn the dot amber and are logged. A host awaiting a reboot for weeks must not page Sentry every 10 minutes — that alarm fatigue is how real errors get missed. (One existing test assertion updated to match this deliberate behaviour change.)
- Batch image gains `openssh-client`; V1's beanstalkd/exim-queue/V1-spool checks deliberately not ported (dead tech / covered by `email:health`).

## Code Quality Review

- TDD: `HostHealthCheckTest` written first against a fake `HostCommandRunner` (no ssh under test); covers healthy, reboot, security count, monit warning/error tiers, dead daemon, monit-absent hosts, unreachable hosts, severity precedence, slug derivation.
- `HostCommandRunner` is container-bound so tests swap a fake; probe parsing is marker-fenced so monit output can't be confused with the scalar findings.
- Registry check remains construction-cheap: the ssh runner is only resolved when targets are configured.
- Monit parsing is case-sensitive by design ("the monit daemon is not running" must not match `Running`).

## Deploy notes (after merge)

1. On the batch host: add `FREEGLE_MONITORING_HOSTS=<targets>` to `.env.background` and `MONITORING_SSH_KEY_HOST_PATH=<key path>` to the compose `.env`.
2. Rebuild + force-recreate `batch-prod` (image change for openssh-client; env_file changes need force-recreate).
3. Expect the dot to go **amber immediately**: every host currently needs a reboot, db2/db3/ha each have 2 "Not monitored" monit services, db3 has a "Resource limit matched". That's the fix working.

## Test Plan

- [ ] CI: Laravel suite (new `HostHealthCheckTest`, updated command/registry/publishing tests)
- [ ] CI: full cross-stack suite