### PR TITLE
Back from an email-opened message page returns to Browse, not ChitChat

### DIFF
--- a/iznik-nuxt3/pages/message/[id].vue
+++ b/iznik-nuxt3/pages/message/[id].vue
@@ -167,6 +167,7 @@ import {
 } from '#imports'
 import { useMessageStore } from '~/stores/message'
 import { useAuthStore } from '~/stores/auth'
+import { useFavoritePage } from '~/composables/useFavoritePage'
 import { twem } from '~/composables/useTwem'
 import { dateonlyNoYear } from '~/composables/useTimeFormat'
 import MyMessage from '~/components/MyMessage'
@@ -181,6 +182,15 @@ const runtimeConfig = useRuntimeConfig()
 const route = useRoute()
 const messageStore = useMessageStore()
 const authStore = useAuthStore()
+
+// This page is the entry point from digest/notification emails, so the user's
+// context here is items, not discussion. Claim the remembered home page for
+// Browse ('mygroups' is what /browse itself sets): when their history unwinds
+// to /, goHome() then lands them on Browse. Without this, a member whose
+// remembered home page was ChitChat would press Back from an emailed OFFER and
+// be dropped in front of the public "What's on your mind?" composer — which is
+// exactly how item replies end up posted publicly on ChitChat.
+useFavoritePage('mygroups')
 
 // We don't use lazy because we want the page to be rendered for SEO.
 const id = route?.params?.id ? parseInt(route.params.id) : 0

--- a/iznik-nuxt3/tests/e2e/test-message-page-homepage.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-message-page-homepage.spec.js
@@ -1,0 +1,49 @@
+/**
+ * Message page and the remembered home page.
+ *
+ * The / route redirects logged-in users to their remembered home page
+ * (miscStore 'lasthomepage', set by the browse/chitchat/myposts pages). A
+ * member whose remembered page was ChitChat who opened a post from a digest
+ * email and pressed Back would unwind to / and be dropped in front of the
+ * public ChitChat composer — which is how item replies ("please may I be
+ * considered for this?") end up posted publicly on ChitChat instead of sent
+ * to the poster. The message page therefore claims the home page for Browse.
+ */
+
+const { test, expect } = require('./fixtures')
+const { timeouts } = require('./config')
+
+test.describe('Message page claims Browse as the home page', () => {
+  test('back to / after viewing a message lands on Browse, not ChitChat', async ({
+    page,
+    postMessage,
+    testEmail,
+  }) => {
+    const uniqueItem = `test-homepage-${Date.now()}`
+    const result = await postMessage({
+      type: 'OFFER',
+      item: uniqueItem,
+      description: 'Test item for home page redirect behaviour',
+      email: testEmail,
+    })
+    expect(result.id).toBeTruthy()
+
+    // Make ChitChat the remembered home page, and prove the remembering
+    // works: without this control step the real assertion below would pass
+    // trivially if lasthomepage persistence were broken altogether.
+    await page.gotoAndVerify('/chitchat', { maxRetries: 1 })
+    await page.gotoAndVerify('/', { maxRetries: 1 })
+    await expect(page).toHaveURL(/\/chitchat/, {
+      timeout: timeouts.navigation.default,
+    })
+
+    // Open the message page directly, as a digest email link does.
+    await page.gotoAndVerify(`/message/${result.id}`, { maxRetries: 1 })
+
+    // Unwinding to / must now land on Browse (item context), not ChitChat.
+    await page.gotoAndVerify('/', { maxRetries: 1 })
+    await expect(page).toHaveURL(/\/browse/, {
+      timeout: timeouts.navigation.default,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes a navigation funnel that causes members to post item replies publicly on ChitChat instead of replying to the poster. Traced from client logs (Loki); this pattern recurs roughly weekly across different members, usually costing a mod a manual "please reply on the post itself" nudge and delaying or losing the handover.

**The flow (reconstructed from logs, applies to any member):**

1. A member works through a digest email on their phone. Each item link opens `/message/<id>` directly — a deep link with no in-app history behind it.
2. They look at the post (photos etc.), then press **Back**, intending to return to where they came from.
3. Their history unwinds to `/`. For logged-in members, `pages/index.vue`'s `goHome()` redirects `/` to the **remembered home page** — miscStore `lasthomepage`, which is set to ChitChat if that's the page they last used as home.
4. They land on ChitChat with the "What's on your mind?" composer at the top — the first text box they've seen since reading the OFFER. They type their reply to the offer into it ("please may I be considered for this?...") and post it, publicly.
5. It compounds: the *offerer* gets a ChitChat reply notification and answers in the public thread too, so the whole allocation conversation happens on ChitChat until a mod intervenes.

**Root cause** is the interaction between email deep links and the remembered-home-page behaviour: the member's context is *items*, but the remembered home page says *discussion*.

## The fix

`pages/message/[id].vue` (the email entry point) now calls `useFavoritePage('mygroups')` — the same value `/browse` itself sets — so when the member's history unwinds to `/`, `goHome()` lands them on Browse, still in item context, where the natural next step is to open the post and reply properly. Members who deliberately live on ChitChat get it back as home the next time they visit ChitChat, exactly as before.

One line of behaviour plus an explanatory comment; uses the existing `useFavoritePage` composable (already unit-tested).

## Code Quality Review

- Reuses the established `lasthomepage` mechanism rather than adding bespoke back-button handling or history manipulation.
- Runs unconditionally in page setup, same pattern as `/browse` and `/chitchat`; harmless for logged-out visitors (`goHome()` only redirects logged-in users).
- E2E test includes a control assertion (ChitChat remembered and honoured) so it can't pass trivially if `lasthomepage` persistence breaks.

## Test Plan

- [ ] CI: new Playwright test `test-message-page-homepage.spec.js` (control: `/chitchat` → `/` lands on ChitChat; fix: after visiting `/message/<id>`, `/` lands on Browse)
- [ ] CI: full suite

## Future Improvements

Complementary (not in this PR): a reply-intent guard on the ChitChat composer — the page already pattern-matches give/wanted phrasing and shows a notice; the same mechanism could catch reply-like phrasing ("is this still available", "can I collect") and point at the recently viewed post.