### PR TITLE
fix(rippling): hold reach inner bounds to a usefulness bar (db3 saturation)

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -276,10 +276,19 @@ retracted, so re-approval restores the copy without re-rippling.
   that margin, so superset/subset hold by construction), shipped as
   `catchment_outer`/`catchment_inner` on point-form `/v1/catchment`, and verified against
   the stored polygon on write (`Ripple\ReachBoundsService`); otherwise derived in SQL
-  (`ST_Buffer(ST_Simplify(polygon, tol), ±tol)`, tol 0.002°). A rejection clip that
-  shrinks the polygon NULLs `inner_bound` in the same statement
-  (`ClipReachForRejectedGroup`, `reapplyClips`), since a stale inner bound would keep
-  showing the post in the just-rejected area.
+  (`ST_Buffer(ST_Simplify(polygon, tol), ±tol)`, tol 0.002°). A provided inner is held to
+  a **usefulness** bar as well as a correctness one
+  (`ReachBoundsService::ensureUsefulInner`, `INNER_MIN_AREA_RATIO`): the routing grid's
+  erosion disintegrates ribbon-shaped rural reaches and ships a town-core fragment
+  covering 1–2% of the polygon, which verifies as a subset yet sends nearly every
+  in-outer viewer to the full polygon test (the Aug 2026 db3 saturation — the band ran
+  at ~58% against the designed 7–19%). An inner covering less than half the polygon's
+  area — or missing altogether — is replaced by the SQL derivation from the stored
+  polygon (~90% coverage); `ripple:backfill-inner-bounds` repairs rows written before
+  this guard existed. A rejection clip that shrinks the polygon NULLs `inner_bound` in
+  the same statement (`ClipReachForRejectedGroup`, `reapplyClips`), since a stale inner
+  bound would keep showing the post in the just-rejected area; the sync that follows the
+  clip then re-derives a safe inner from the clipped polygon.
 
   The single-point gates consult the same sandwich: `ReachQueryService::isWithinReach`
   (browse Nearby / reply-eligibility / held-reply release in batch), the message-list

--- a/iznik-batch/app/Console/Commands/Ripple/BackfillInnerBoundsCommand.php
+++ b/iznik-batch/app/Console/Commands/Ripple/BackfillInnerBoundsCommand.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Console\Commands\Ripple;
+
+use App\Console\Concerns\PreventsOverlapping;
+use App\Services\Ripple\ReachBoundsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * One-shot repair for rippling_reach rows whose inner bound is missing or uselessly
+ * small — the town-core-fragment inners the routing grid's erosion produced for rural
+ * reaches, which sent ~58% of browse candidates to the full polygon test and saturated
+ * db3 (Aug 2026). Re-derives the inner from the stored polygon via
+ * ReachBoundsService::ensureUsefulInner, one row at a time, paced for Galera.
+ *
+ * Safe to re-run (idempotent — a useful inner is never rewritten). Degraded
+ * completed-post rows (POINT outer) are skipped. Run with --dry-run first on
+ * production to see the candidate count.
+ */
+class BackfillInnerBoundsCommand extends Command
+{
+    use PreventsOverlapping;
+
+    protected $signature = 'ripple:backfill-inner-bounds
+                            {--dry-run : Report how many rows would be fixed without changing anything}
+                            {--limit=0 : Max rows to fix (0 = no limit)}
+                            {--sleep-ms=200 : Pause between row updates, to pace Galera replication}
+                            {--min-ratio= : Override the inner/polygon area share below which an inner is re-derived}';
+
+    protected $description = 'Re-derive missing or uselessly small rippling_reach inner bounds from the stored polygon';
+
+    public function handle(ReachBoundsService $bounds): int
+    {
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            $dryRun = (bool) $this->option('dry-run');
+            $limit = max(0, (int) $this->option('limit'));
+            $sleepUs = max(0, (int) $this->option('sleep-ms')) * 1000;
+            $minRatio = $this->option('min-ratio') !== null && is_numeric($this->option('min-ratio'))
+                ? (float) $this->option('min-ratio')
+                : ReachBoundsService::INNER_MIN_AREA_RATIO;
+
+            $stats = ['scanned' => 0, 'candidates' => 0, 'derived' => 0, 'nulled' => 0, 'skipped' => 0, 'errors' => 0];
+            $lastId = 0;
+
+            // PK-chunked scan carrying no GIS work, so one row's invalid geometry can
+            // only fail its own per-row check, never a whole chunk. rippling_reach is
+            // ~17GB of polygon BLOBs — nothing here may read them in bulk.
+            while (true) {
+                $msgids = DB::table('rippling_reach')
+                    ->where('msgid', '>', $lastId)
+                    ->orderBy('msgid')
+                    ->limit(500)
+                    ->pluck('msgid');
+
+                if ($msgids->isEmpty()) {
+                    break;
+                }
+
+                foreach ($msgids as $msgid) {
+                    $lastId = (int) $msgid;
+                    $stats['scanned']++;
+
+                    try {
+                        // keep-raw: ST_GeometryType/ST_Area GIS expressions per single row
+                        $row = DB::selectOne(
+                            'SELECT ST_GeometryType(outer_bound) AS outer_type,
+                                    inner_bound IS NULL AS missing,
+                                    COALESCE(ST_Area(inner_bound) / NULLIF(ST_Area(polygon), 0), 0) AS ratio
+                               FROM rippling_reach
+                              WHERE msgid = ? AND polygon IS NOT NULL AND outer_bound IS NOT NULL',
+                            [$lastId]
+                        );
+                    } catch (\Throwable) {
+                        // Unmeasurable geometry: let ensureUsefulInner's own ladder decide.
+                        $row = null;
+                        $stats['errors']++;
+                    }
+
+                    if ($row !== null
+                        && ($row->outer_type === 'POINT'
+                            || (!(int) $row->missing && (float) $row->ratio >= $minRatio))) {
+                        // Healthy row — but its check still read the polygon's off-page
+                        // BLOB for ST_Area, so even a fix-nothing scan is a bulk polygon
+                        // read: the very load this command exists to reduce. Pace it.
+                        usleep(10000);
+
+                        continue;
+                    }
+
+                    $stats['candidates']++;
+
+                    if ($dryRun) {
+                        // Same pacing rationale as the healthy-row path: the check above
+                        // already cost a polygon BLOB read even though nothing changes.
+                        usleep(10000);
+
+                        continue;
+                    }
+
+                    $outcome = $bounds->ensureUsefulInner($lastId, $minRatio);
+                    $stats[$outcome === 'kept' ? 'skipped' : $outcome]++;
+
+                    if ($limit > 0 && ($stats['derived'] + $stats['nulled']) >= $limit) {
+                        break 2;
+                    }
+                    if ($sleepUs > 0) {
+                        usleep($sleepUs);
+                    }
+                }
+
+                $this->output->write("\rScanned {$stats['scanned']}, candidates {$stats['candidates']}...");
+            }
+            $this->output->writeln('');
+
+            if ($dryRun) {
+                $this->info("[DRY RUN] {$stats['candidates']} of {$stats['scanned']} row(s) would have their inner bound re-derived. Run without --dry-run to apply.");
+
+                return Command::SUCCESS;
+            }
+
+            $this->info(sprintf(
+                'Scanned %d row(s): %d candidate(s) — %d re-derived, %d nulled (derivation unusable), %d skipped, %d unmeasurable.',
+                $stats['scanned'],
+                $stats['candidates'],
+                $stats['derived'],
+                $stats['nulled'],
+                $stats['skipped'],
+                $stats['errors']
+            ));
+            Log::info('ripple:backfill-inner-bounds complete', $stats);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
+    }
+}

--- a/iznik-batch/app/Services/Ripple/ReachBoundsService.php
+++ b/iznik-batch/app/Services/Ripple/ReachBoundsService.php
@@ -35,6 +35,19 @@ class ReachBoundsService
 {
     public const TOLERANCE = 0.002;
 
+    /**
+     * The least share of the polygon's area an inner bound may cover and still be worth
+     * keeping. Correctness (inner ⊆ polygon) is necessary but not sufficient: the routing
+     * grid's 3-cell erosion disintegrates ribbon-shaped rural reaches and ships the
+     * largest surviving fragment — a town-core blob covering 1–2% of the polygon. Such an
+     * inner verifies, but every viewer between it and the outer bound pays the full
+     * ~178KB polygon test, which is what saturated db3 in Aug 2026 (band 58% vs the
+     * designed 7–19%). Below this share the SQL derivation from the stored polygon
+     * (~90% coverage) is always the better inner. 0.5 rather than something tighter so
+     * legitimately-eroded urban inners (solid grids lose only their rim) never churn.
+     */
+    public const INNER_MIN_AREA_RATIO = 0.5;
+
     /** Cached column-existence check so a pre-migration deploy degrades to a no-op. */
     private static ?bool $columnsExist = null;
 
@@ -73,6 +86,11 @@ class ReachBoundsService
      * bounds are verified against the stored polygon — they bound the raw tick
      * isochrone, while the stored polygon may have been unioned with the origin
      * group's area and clipped by rejections, so verbatim trust would be wrong.
+     *
+     * The provided INNER is additionally held to a usefulness bar, not just a
+     * correctness one: a verified inner covering a sliver of the polygon (see
+     * INNER_MIN_AREA_RATIO) or no inner at all ends as a polygon-derived inner, never
+     * as NULL, because NULL sends every in-outer viewer to the full polygon test.
      */
     public function sync(int $msgid, ?string $outerWkt = null, ?string $innerWkt = null): void
     {
@@ -123,6 +141,74 @@ class ReachBoundsService
             // cheap accept, keep the verified outer.
             $this->nullInner($msgid);
         }
+
+        // The provided inner may be correct yet useless (see INNER_MIN_AREA_RATIO), or
+        // missing altogether, or just NULLed above. In all three cases a polygon-derived
+        // inner restores the cheap accept the sandwich exists for.
+        $this->ensureUsefulInner($msgid);
+    }
+
+    /**
+     * Replace a missing or uselessly small inner bound with one derived from the stored
+     * polygon; keep a useful one untouched. Degraded completed-post rows (POINT outer)
+     * are never resurrected. Returns 'kept', 'derived', 'nulled' or 'skipped' so the
+     * backfill command can report what happened.
+     */
+    public function ensureUsefulInner(int $msgid, float $minRatio = self::INNER_MIN_AREA_RATIO): string
+    {
+        if (!$this->ready()) {
+            return 'skipped';
+        }
+
+        try {
+            // keep-raw: ST_GeometryType/ST_Area GIS expressions; useReadPdo=false (own-write read)
+            $row = DB::select(
+                'SELECT ST_GeometryType(outer_bound) AS outer_type,
+                        inner_bound IS NULL AS missing,
+                        COALESCE(ST_Area(inner_bound) / NULLIF(ST_Area(polygon), 0), 0) AS ratio
+                   FROM rippling_reach
+                  WHERE msgid = ? AND polygon IS NOT NULL AND outer_bound IS NOT NULL',
+                [$msgid],
+                false
+            )[0] ?? null;
+
+            if ($row === null || $row->outer_type === 'POINT') {
+                return 'skipped';
+            }
+            if (!(int) $row->missing && (float) $row->ratio >= $minRatio) {
+                return 'kept';
+            }
+        } catch (\Throwable) {
+            // ST_Area can throw on invalid stored geometry; an unmeasurable inner is a
+            // suspect inner, so fall through and re-derive it.
+        }
+
+        try {
+            // keep-raw: embeds the innerExpr GIS derivation; updated_at preserved deliberately.
+            // The POINT guard repeats here because the check above can be skipped by its
+            // catch: a degraded completed-post row must never get an inner resurrected.
+            DB::update(
+                'UPDATE rippling_reach
+                    SET inner_bound = ' . self::innerExpr('polygon') . ',
+                        updated_at = updated_at
+                  WHERE msgid = ? AND ST_GeometryType(outer_bound) <> \'POINT\'',
+                [$msgid]
+            );
+        } catch (\Throwable $e) {
+            Log::warning("ripple: inner bound derivation failed for msg {$msgid}: {$e->getMessage()}");
+            $this->nullInner($msgid);
+
+            return 'nulled';
+        }
+
+        [, $innerOk] = $this->verifySandwich($msgid);
+        if ($innerOk !== 1) {
+            $this->nullInner($msgid);
+
+            return 'nulled';
+        }
+
+        return 'derived';
     }
 
     /**

--- a/iznik-batch/tests/Feature/Ripple/BackfillInnerBoundsCommandTest.php
+++ b/iznik-batch/tests/Feature/Ripple/BackfillInnerBoundsCommandTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature\Ripple;
+
+use App\Models\Message;
+use App\Services\Ripple\ReachBoundsService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * ripple:backfill-inner-bounds — the one-shot repair for rows whose inner bound is
+ * missing or uselessly small (the town-core-fragment inners behind the Aug 2026 db3
+ * saturation). Dry-run reports without touching rows; a real run re-derives the inner
+ * from the stored polygon, one row at a time, and leaves useful inners and degraded
+ * (completed-post) rows alone.
+ */
+class BackfillInnerBoundsCommandTest extends TestCase
+{
+    // Comfortably larger than the ±0.002° derivation tolerance.
+    private const WKT = 'POLYGON((-0.2 51.4, 0.0 51.4, 0.0 51.6, -0.2 51.6, -0.2 51.4))';
+
+    // ~0.002° square in the middle of WKT: correct (⊆ polygon) but useless (~0.01% area).
+    private const TINY_INNER = 'POLYGON((-0.101 51.499, -0.099 51.499, -0.099 51.501, -0.101 51.501, -0.101 51.499))';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DB::statement('DELETE FROM rippling_reach');
+    }
+
+    /** Seed a message + reach row with the given inner bound state; returns the msgid. */
+    private function seedReach(?string $innerWkt): int
+    {
+        $user = $this->createTestUser();
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: inner bounds fixture (London)',
+            'textbody' => 'Inner bounds fixture.',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+        DB::statement(
+            'INSERT INTO rippling_reach (msgid, lat, lng, polygon, outer_bound, inner_bound, arrival, mode, tick,
+                total_ticks, total_freeglers, max_drive_min, schedule, next_expansion_at, status, created_at, updated_at)
+             VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), ' . ReachBoundsService::outerExpr('ST_GeomFromText(?, 3857)') . ', '
+                . ($innerWkt !== null ? 'ST_GeomFromText(?, 3857)' : 'NULL') . ",
+                NOW(), 'drive', 1, 3, 90, 30, NULL, NULL, 'done', NOW(), NOW())",
+            $innerWkt !== null
+                ? [$message->id, self::WKT, self::WKT, $innerWkt]
+                : [$message->id, self::WKT, self::WKT]
+        );
+
+        return (int) $message->id;
+    }
+
+    private function innerRatio(int $msgid): float
+    {
+        return (float) DB::selectOne(
+            'SELECT COALESCE(ST_Area(inner_bound) / NULLIF(ST_Area(polygon), 0), 0) AS r
+               FROM rippling_reach WHERE msgid = ?',
+            [$msgid]
+        )->r;
+    }
+
+    public function test_dry_run_reports_candidates_without_changing_rows(): void
+    {
+        $tiny = $this->seedReach(self::TINY_INNER);
+        $missing = $this->seedReach(null);
+
+        $this->artisan('ripple:backfill-inner-bounds', ['--dry-run' => true])
+            ->expectsOutputToContain('DRY RUN')
+            ->assertExitCode(0);
+
+        $this->assertLessThan(0.5, $this->innerRatio($tiny), 'dry-run leaves the tiny inner in place');
+        $this->assertSame(0.0, $this->innerRatio($missing), 'dry-run leaves the missing inner NULL');
+    }
+
+    public function test_execute_fixes_bad_rows_and_leaves_good_and_degraded_rows_alone(): void
+    {
+        $tiny = $this->seedReach(self::TINY_INNER);
+        $missing = $this->seedReach(null);
+
+        $good = $this->seedReach(null);
+        (new ReachBoundsService())->syncFromPolygon($good);
+        $goodBefore = DB::selectOne(
+            'SELECT ST_AsBinary(inner_bound) AS b FROM rippling_reach WHERE msgid = ?',
+            [$good]
+        )->b;
+
+        $degraded = $this->seedReach(null);
+        (new ReachBoundsService())->degradeForCompleted($degraded);
+
+        $this->artisan('ripple:backfill-inner-bounds')->assertExitCode(0);
+
+        $this->assertGreaterThan(0.5, $this->innerRatio($tiny), 'tiny inner is re-derived from the polygon');
+        $this->assertGreaterThan(0.5, $this->innerRatio($missing), 'missing inner is derived from the polygon');
+
+        $goodAfter = DB::selectOne(
+            'SELECT ST_AsBinary(inner_bound) AS b FROM rippling_reach WHERE msgid = ?',
+            [$good]
+        )->b;
+        $this->assertSame($goodBefore, $goodAfter, 'a useful inner is not rewritten');
+
+        $deg = DB::selectOne(
+            'SELECT ST_GeometryType(outer_bound) AS ot, inner_bound IS NULL AS inner_null
+               FROM rippling_reach WHERE msgid = ?',
+            [$degraded]
+        );
+        $this->assertSame('POINT', $deg->ot, 'completed-post degraded outer stays a point');
+        $this->assertSame(1, (int) $deg->inner_null, 'completed-post inner stays NULL');
+    }
+
+    public function test_limit_bounds_the_number_of_fixes(): void
+    {
+        $first = $this->seedReach(self::TINY_INNER);
+        $second = $this->seedReach(self::TINY_INNER);
+
+        $this->artisan('ripple:backfill-inner-bounds', ['--limit' => 1])->assertExitCode(0);
+
+        $ratios = [$this->innerRatio($first), $this->innerRatio($second)];
+        sort($ratios);
+        $this->assertLessThan(0.5, $ratios[0], 'the row beyond --limit is untouched');
+        $this->assertGreaterThan(0.5, $ratios[1], 'exactly one row is fixed under --limit=1');
+    }
+
+    public function test_nothing_to_do_is_a_clean_noop(): void
+    {
+        $good = $this->seedReach(null);
+        (new ReachBoundsService())->syncFromPolygon($good);
+
+        $this->artisan('ripple:backfill-inner-bounds')->assertExitCode(0);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/Ripple/ReachBoundsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ReachBoundsServiceTest.php
@@ -190,28 +190,6 @@ class ReachBoundsServiceTest extends TestCase
         $this->assertSame(1, (int) $check->ie, 'verified provided inner is stored verbatim');
     }
 
-    public function test_sync_with_bad_provided_inner_nulls_it(): void
-    {
-        // A provided inner that pokes outside the stored polygon (possible after clips, or
-        // a routing bug) must fail write-time verification and be dropped — never shipped
-        // as a cheap-accept.
-        $msgid = $this->seedReach(self::WKT);
-        $outer = 'POLYGON((-0.21 51.39, 0.01 51.39, 0.01 51.61, -0.21 51.61, -0.21 51.39))';
-        $badInner = 'POLYGON((-0.3 51.3, 0.1 51.3, 0.1 51.7, -0.3 51.7, -0.3 51.3))'; // ⊃ polygon
-
-        $this->service()->sync($msgid, $outer, $badInner);
-
-        $row = $this->boundsRow($msgid);
-        $this->assertNotNull($row);
-        $this->assertSame(1, (int) $row->inner_null, 'unverifiable provided inner is NULLed');
-        $ok = DB::selectOne(
-            'SELECT ST_Contains(outer_bound, polygon) AS o
-               FROM rippling_reach WHERE msgid = ?',
-            [$msgid]
-        );
-        $this->assertSame(1, (int) $ok->o, 'the good provided outer is kept');
-    }
-
     public function test_sync_with_bad_provided_outer_falls_back_safely(): void
     {
         // A provided outer that does NOT contain the stored polygon (e.g. the polygon was
@@ -316,8 +294,11 @@ class ReachBoundsServiceTest extends TestCase
 
     public function test_sync_derives_inner_after_nulling_unverifiable_provided_inner(): void
     {
-        // An inner that pokes outside the polygon is dropped (correctness), and the
+        // An inner that pokes outside the polygon (possible after clips, or a routing
+        // bug) must fail write-time verification and never ship as a cheap-accept; the
         // replacement is derived from the polygon rather than left NULL (usefulness).
+        // Replaces the pre-guard test_sync_with_bad_provided_inner_nulls_it, whose
+        // "ends as NULL" assertion described the behaviour this guard exists to remove.
         $msgid = $this->seedReach(self::WKT);
         $outer = 'POLYGON((-0.21 51.39, 0.01 51.39, 0.01 51.61, -0.21 51.61, -0.21 51.39))';
         $badInner = 'POLYGON((-0.3 51.3, 0.1 51.3, 0.1 51.7, -0.3 51.7, -0.3 51.3))'; // ⊃ polygon
@@ -326,12 +307,16 @@ class ReachBoundsServiceTest extends TestCase
 
         $check = DB::selectOne(
             'SELECT inner_bound IS NULL AS inner_null,
-                    (inner_bound IS NULL OR ST_Contains(polygon, inner_bound)) AS i
+                    (inner_bound IS NULL OR ST_Contains(polygon, inner_bound)) AS i,
+                    ST_Equals(inner_bound, ST_GeomFromText(?, 3857)) AS still_bad,
+                    ST_Contains(outer_bound, polygon) AS o
                FROM rippling_reach WHERE msgid = ?',
-            [$msgid]
+            [$badInner, $msgid]
         );
         $this->assertSame(0, (int) $check->inner_null, 'a safe inner is derived to replace the rejected one');
         $this->assertSame(1, (int) $check->i, 'the derived inner satisfies inner ⊆ polygon');
+        $this->assertSame(0, (int) $check->still_bad, 'the rejected provided inner is not what is stored');
+        $this->assertSame(1, (int) $check->o, 'the good provided outer is kept');
     }
 
     public function test_ensure_useful_inner_keeps_a_good_inner_untouched(): void

--- a/iznik-batch/tests/Unit/Services/Ripple/ReachBoundsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ReachBoundsServiceTest.php
@@ -258,4 +258,112 @@ class ReachBoundsServiceTest extends TestCase
         $this->assertNotNull($row);
         $this->assertNotSame('POINT', $row->outer_type, 'reopened post gets real bounds back');
     }
+
+    /** The area the stored inner bound covers, as a share of the polygon's area. */
+    private function innerRatio(int $msgid): float
+    {
+        return (float) DB::selectOne(
+            'SELECT COALESCE(ST_Area(inner_bound) / NULLIF(ST_Area(polygon), 0), 0) AS r
+               FROM rippling_reach WHERE msgid = ?',
+            [$msgid]
+        )->r;
+    }
+
+    public function test_sync_replaces_uselessly_small_provided_inner(): void
+    {
+        // A provided inner can be CORRECT (⊆ polygon) yet useless: the routing grid's
+        // 3-cell erosion disintegrates ribbon-shaped rural reaches, leaving a town-core
+        // fragment covering 1–2% of the polygon. Every viewer between that fragment and
+        // the outer bound then pays the full 178KB polygon test — the db3 CPU saturation
+        // of Aug 2026. Verified-but-tiny inners must be replaced by one derived from the
+        // stored polygon.
+        $msgid = $this->seedReach(self::WKT);
+        $outer = 'POLYGON((-0.21 51.39, 0.01 51.39, 0.01 51.61, -0.21 51.61, -0.21 51.39))';
+        $tinyInner = 'POLYGON((-0.101 51.499, -0.099 51.499, -0.099 51.501, -0.101 51.501, -0.101 51.499))';
+
+        $this->service()->sync($msgid, $outer, $tinyInner);
+
+        $this->assertGreaterThan(
+            0.5,
+            $this->innerRatio($msgid),
+            'a verified-but-tiny provided inner is replaced by a polygon-derived one'
+        );
+        $check = DB::selectOne(
+            'SELECT ST_Contains(polygon, inner_bound) AS i,
+                    ST_Contains(outer_bound, polygon) AS o
+               FROM rippling_reach WHERE msgid = ?',
+            [$msgid]
+        );
+        $this->assertSame(1, (int) $check->i, 'the replacement inner still satisfies inner ⊆ polygon');
+        $this->assertSame(1, (int) $check->o, 'the verified provided outer is kept');
+    }
+
+    public function test_sync_derives_inner_when_none_provided(): void
+    {
+        // Routing ships no inner when erosion leaves nothing usable. Previously that
+        // stored NULL (no cheap accept, full polygon test for every in-outer viewer);
+        // now the inner is derived from the stored polygon instead.
+        $msgid = $this->seedReach(self::WKT);
+        $outer = 'POLYGON((-0.21 51.39, 0.01 51.39, 0.01 51.61, -0.21 51.61, -0.21 51.39))';
+
+        $this->service()->sync($msgid, $outer, null);
+
+        $row = $this->boundsRow($msgid);
+        $this->assertNotNull($row);
+        $this->assertSame(0, (int) $row->inner_null, 'missing provided inner is derived from the polygon');
+        $this->assertGreaterThan(0.5, $this->innerRatio($msgid), 'the derived inner is useful, not a sliver');
+    }
+
+    public function test_sync_derives_inner_after_nulling_unverifiable_provided_inner(): void
+    {
+        // An inner that pokes outside the polygon is dropped (correctness), and the
+        // replacement is derived from the polygon rather than left NULL (usefulness).
+        $msgid = $this->seedReach(self::WKT);
+        $outer = 'POLYGON((-0.21 51.39, 0.01 51.39, 0.01 51.61, -0.21 51.61, -0.21 51.39))';
+        $badInner = 'POLYGON((-0.3 51.3, 0.1 51.3, 0.1 51.7, -0.3 51.7, -0.3 51.3))'; // ⊃ polygon
+
+        $this->service()->sync($msgid, $outer, $badInner);
+
+        $check = DB::selectOne(
+            'SELECT inner_bound IS NULL AS inner_null,
+                    (inner_bound IS NULL OR ST_Contains(polygon, inner_bound)) AS i
+               FROM rippling_reach WHERE msgid = ?',
+            [$msgid]
+        );
+        $this->assertSame(0, (int) $check->inner_null, 'a safe inner is derived to replace the rejected one');
+        $this->assertSame(1, (int) $check->i, 'the derived inner satisfies inner ⊆ polygon');
+    }
+
+    public function test_ensure_useful_inner_keeps_a_good_inner_untouched(): void
+    {
+        $msgid = $this->seedReach(self::WKT);
+        $this->service()->syncFromPolygon($msgid);
+        $before = DB::selectOne(
+            'SELECT ST_AsBinary(inner_bound) AS b FROM rippling_reach WHERE msgid = ?',
+            [$msgid]
+        )->b;
+
+        $this->assertSame('kept', $this->service()->ensureUsefulInner($msgid));
+
+        $after = DB::selectOne(
+            'SELECT ST_AsBinary(inner_bound) AS b FROM rippling_reach WHERE msgid = ?',
+            [$msgid]
+        )->b;
+        $this->assertSame($before, $after, 'a useful inner is not rewritten');
+    }
+
+    public function test_ensure_useful_inner_skips_degraded_completed_rows(): void
+    {
+        // degradeForCompleted deliberately collapses the bounds to prune the post from
+        // the browse R-tree; the usefulness guard must never resurrect an inner there.
+        $msgid = $this->seedReach(self::WKT);
+        $this->service()->syncFromPolygon($msgid);
+        $this->service()->degradeForCompleted($msgid);
+
+        $this->assertSame('skipped', $this->service()->ensureUsefulInner($msgid));
+
+        $row = $this->boundsRow($msgid);
+        $this->assertSame('POINT', $row->outer_type, 'degraded outer stays a point');
+        $this->assertSame(1, (int) $row->inner_null, 'degraded inner stays NULL');
+    }
 }


### PR DESCRIPTION
## Summary

- **What was wrong**: the sandwich-bounds optimisation for reach containment (shipped July, plan `plans/2026-07-17-db3-cpu-reach-sql-prefilter.md`) is being defeated by its own inner bounds. The routing grid closes the road network by one cell, but `IsochroneBounds` erodes by three — ribbon-shaped rural reaches disintegrate under erosion and the largest surviving fragment (a town-core blob covering **1–2% of the polygon**) ships as the inner bound. It passes the write-time correctness check (it *is* a subset) and sticks forever.
- **Measured live on db3 (10 Aug)**: the "band" of viewers needing the full ~178KB polygon test ran at **58% of candidates vs the designed 7–19%**; the browse count query alone held ~4.25 cores at 347 calls/min; polygon BLOB re-reads (~150MB/s sustained) thrashed the 16GB buffer pool into swap. Full investigation: db3 session notes (findings doc shared separately).
- **Fix**: `ReachBoundsService::sync()` now ends with `ensureUsefulInner()` — an inner covering less than `INNER_MIN_AREA_RATIO` (0.5) of the polygon's area, or missing, or just NULLed by verification, is replaced by the SQL derivation from the stored polygon (~90% coverage). Degraded completed-post rows (POINT outer) are never touched.
- **Backfill**: `ripple:backfill-inner-bounds` repairs the ~20–30k existing bad rows — PK-chunked, one row at a time, paced both for Galera and for the polygon BLOB reads its own scan incurs, idempotent, `--dry-run` first.
- Docs: `docs/developers/reference/rippling-algorithm.md` sandwich-bounds section updated in the same PR.

## User impact

**No behaviour change in which posts members see.** The inner bound is a pure query optimisation: it can only cheap-accept viewers who are *provably inside* the exact polygon (verified at write time; the fallback ladder on any failure is NULL, which is slow-but-correct). What members should notice:

- **Faster Browse**: the browse feed and count queries stop fetching ~178KB polygons for more than half their candidates. At the measured hotspot, 96% (115/120) of the rows currently paying the full test would cheap-accept instead. Expect the ~730ms count query to drop to roughly 150–250ms.
- **Fewer site-wide slowdowns and timeouts**: db3 has been running saturated through the day (load 30–105, worst queries 40–73s — beyond the 50s load-balancer timeout, so members saw failed/hung requests during pile-ups). Cutting the dominant query's cost and its BLOB traffic relieves CPU, buffer pool and swap pressure for *everything* sharing the cluster — digests, rippling ticks, API traffic.
- **Rural members benefit most**: the useless inners are concentrated outside cities, so semi-rural and rural browsing is exactly where the slow queries live today.

## Deploy / operational notes

1. Merge deploys the guard for **new** rows via the normal batch path (bind mount — no restart needed).
2. Then run the backfill on batch-prod, dry-run first:
   `php artisan ripple:backfill-inner-bounds --dry-run` (counts candidates, changes nothing)
   `php artisan ripple:backfill-inner-bounds` (expect a few hours at default pacing; idempotent, safe to stop/re-run)
3. Optional follow-up (separate PR if wanted): routing-side fix to erode less / ship multi-fragment inners — with this guard in place it is a refinement, not a requirement.

## Code Quality Review

- Guard is one public method on the existing service, reusing the established verify/fallback ladder (`verifySandwich` → `nullInner`); no duplication with `syncFromPolygon` (which already derives from the polygon and needs no usefulness pass).
- Every GIS call is wrapped: an exception can only ever degrade to NULL inner (slow-but-correct), never abort a tick — consistent with the file's existing invariants.
- Completed-post degradation (POINT outer) is guarded twice: in the usefulness check and again in the derive UPDATE's WHERE, so a throwing area-check cannot resurrect a pruned post's bounds.
- Backfill does no bulk GIS: PK-only chunks, single-row checks, paced scan (the check itself reads the polygon BLOB, so even a fix-nothing pass is throttled).

## Test Plan

- New unit tests: verified-but-tiny provided inner is replaced; missing inner is derived; rejected (unverifiable) inner is derived rather than left NULL; useful inner left byte-identical; degraded rows skipped.
- New feature tests for the command: dry-run counts without changing rows; execute fixes tiny+missing, leaves good and degraded rows alone; `--limit` respected; clean no-op.
- Existing ReachBoundsService tests unchanged and still meaningful (the verbatim-store test uses a ~0.81-ratio inner, above the usefulness bar).
- Tests run in CI (per project practice, suites are not run on the shared dev host).