### PR TITLE
feat(rippling): restore the users_approxlocs writer, unported since V1 (34% of active members missing)

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -165,6 +165,17 @@ the nearest road is on the wrong bank - a postcode centre sits on its own street
 are assumed not to span rivers or similar barriers. This is all server-side; only group ids
 ever leave the server.
 
+**The candidate members come from `users_approxlocs`** - the query in
+`iznik-routing-go/reachable_groups.go` drives off that table's spatial index and joins
+outwards, so a member with no row there is invisible to targeting whatever their postcode
+says. That table is a cache, refreshed nightly by `users:update-approx-locs`
+(`UserApproxLocService`), holding one ~400m-blurred point per member active in the last six
+months. Nothing else notices when the refresh stops: reach still computes, still looks
+plausible, and just quietly stops seeing newer members. It went unwritten from V1's removal
+until 2026-08-10, by which point 38,325 of 112,548 active members (34%) had no row. If reach
+ever looks like it is under-targeting, check `MAX(timestamp)` on that table first - and the
+job's row on the SysAdmin cron dashboard, where a missed run shows as overdue.
+
 The same decision is computed **per tick**: every entry in the ripple schedule carries
 `reachable_group_ids` for its drive-time (a threshold over the already-computed member
 drive-times - no extra routing). The Rippling Explorer tints groups from exactly this field,

--- a/docs/developers/reference/worktrees.md
+++ b/docs/developers/reference/worktrees.md
@@ -130,6 +130,14 @@ If you see one, check which ports are in use:
 docker ps --format '{{.Ports}}' | grep -oP '0\.0\.0\.0:\d+' | sort | uniq -d
 ```
 
+### `spatial` / `spatial-live` exited immediately
+
+They need `iznik-routing-go/data/uk-latest.osm.pbf`, a 2.5GB gitignored download that
+`git worktree add` cannot bring across. `freegle worktree create` hardlinks it from the main
+checkout (one inode, so no extra disk per worktree) and prints `Shared iznik-routing-go/...`
+when it does. If the main checkout has never downloaded it, the two containers will exit(1) and
+everything that does not need the routing graph still works.
+
 ### CRLF line endings in worktree (WSL)
 If Docker builds fail with "not found" errors on shell scripts, fix line endings:
 ```bash

--- a/freegle
+++ b/freegle
@@ -49,6 +49,32 @@ _next_free_ports() {
     (( n == count ))
 }
 
+# _share_gitignored_data MAIN_REPO WORKTREE_DIR
+#   Give a new worktree the large gitignored downloads its containers need to boot. These are
+#   not in git, so `git worktree add` leaves them behind and the spatial containers exit(1) on
+#   a missing OSM extract — which looks like a broken worktree rather than a missing file.
+#
+#   Shared by hardlink, not copied: the UK extract is 2.5GB, it is an immutable download, and
+#   every container mounts its directory read-only, so one inode can back every worktree. The
+#   link survives removal of the main checkout (it is a reference to the inode, not to the path).
+#   Falls back to a copy if the two checkouts are on different filesystems.
+_share_gitignored_data() {
+    local main_repo="$1" worktree_dir="$2"
+    local rel
+    for rel in iznik-routing-go/data/uk-latest.osm.pbf; do
+        local src="$main_repo/$rel" dst="$worktree_dir/$rel"
+        [[ -f "$src" ]] || continue
+        [[ -e "$dst" ]] && continue
+        mkdir -p "$(dirname "$dst")"
+        ln "$src" "$dst" 2>/dev/null || cp "$src" "$dst" || {
+            echo "  Warning: could not share $rel; spatial containers will not start." >&2
+            continue
+        }
+        echo "  Shared $rel from the main checkout."
+    done
+    return 0
+}
+
 # Get the root of the main git repo (not a worktree)
 get_main_repo() {
     local gitdir
@@ -303,6 +329,10 @@ cmd_worktree_create() {
             sed -i -E "s|^(${live_key}=http://apiv2-live\.localhost)(:[0-9]+)?(/.*)?\$|\\1:${wt_traefik_port}\\3|" "$worktree_dir/.env"
         done
     fi
+
+    # Hand over the large gitignored downloads before starting containers, or the spatial
+    # services exit(1) on a missing OSM extract.
+    _share_gitignored_data "$main_repo" "$worktree_dir"
 
     # Start the containers immediately so the worktree is ready to use
     echo ""

--- a/iznik-batch/app/Console/Commands/User/UpdateApproxLocsCommand.php
+++ b/iznik-batch/app/Console/Commands/User/UpdateApproxLocsCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands\User;
+
+use App\Services\UserApproxLocService;
+use App\Traits\LogsBatchJob;
+use Illuminate\Console\Command;
+
+/**
+ * No GracefulShutdown: the refresh takes seconds (5,000 members in ~1s locally, so the ~112k
+ * active members on live are well inside a minute) and is fully idempotent, so there is nothing
+ * for a shutdown handler to protect — being killed mid-run just means tonight's run redoes it.
+ */
+class UpdateApproxLocsCommand extends Command
+{
+    use LogsBatchJob;
+
+    protected $signature = 'users:update-approx-locs
+                            {--dry-run : Report what would change without writing}
+                            {--limit= : Stop after considering this many members}';
+
+    protected $description = 'Refresh users_approxlocs, the blurred point cloud of active members that drives rippling reach';
+
+    public function handle(UserApproxLocService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $limit = $this->option('limit') !== null ? (int) $this->option('limit') : null;
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no changes will be made.');
+        }
+
+        return $this->runWithLogging(function () use ($service, $dryRun, $limit) {
+            $stats = $service->updateLocations($dryRun, $limit);
+
+            $this->info(sprintf(
+                'Approx locations: considered %d, upserted %d, no location %d, pruned %d.',
+                $stats['considered'],
+                $stats['upserted'],
+                $stats['no_location'],
+                $stats['pruned']
+            ));
+
+            return Command::SUCCESS;
+        });
+    }
+}

--- a/iznik-batch/app/Services/UserApproxLocService.php
+++ b/iznik-batch/app/Services/UserApproxLocService.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace App\Services;
+
+use App\Support\GreatCircle;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Maintains users_approxlocs — the privacy-blurred point cloud of recently-active members.
+ *
+ * Ported from V1 Nearby::updateLocations() (iznik-server/include/user/Nearby.php), which was
+ * deleted with the rest of V1 in c14a7125b without a Laravel equivalent, leaving the table with
+ * readers but no writer. Its readers are:
+ *
+ *   - iznik-routing-go/reachable_groups.go — the table is the driving side of the STRAIGHT_JOIN
+ *     that decides which groups a ripple can reach, so a member absent here is invisible to reach
+ *   - iznik-spatial-go/dataset_userapproxlocs.go — point dataset served by the spatial API
+ *   - iznik-routing-go/cmd/rippleextract — ripple simulator extract
+ *   - iznik-server-go/userdump — GDPR user dump
+ *
+ * Each row is a member's location blurred by ~400m, so nothing here is precise enough to identify
+ * a household; the readers treat it as an approximate point cloud, not an address book.
+ */
+class UserApproxLocService
+{
+    /**
+     * V1 Engage::USER_INACTIVE — half a year in seconds. A member who has not accessed the site
+     * within this window is "inactive" and drops out of the point cloud.
+     */
+    public const USER_INACTIVE_SECONDS = 365 * 24 * 60 * 60 / 2;
+
+    /** V1 Utils::BLUR_USER — metres to blur a member's location by. */
+    public const BLUR_USER = 400;
+
+    /** Members read per SELECT. */
+    private const READ_CHUNK = 2000;
+
+    /** Rows per bulk upsert statement. */
+    private const WRITE_CHUNK = 500;
+
+    /** Rows per DELETE when pruning, so a big catch-up prune can't stall Galera replication. */
+    private const PRUNE_CHUNK = 5000;
+
+    /**
+     * The inactivity cutoff, V1-style: date-granular, ~181.5 days ago
+     * (now - USER_INACTIVE + 1 day, formatted as a date). Members whose lastaccess predates it
+     * are not written, and rows whose timestamp predates it are pruned.
+     */
+    public function cutoff(): string
+    {
+        return Carbon::now()
+            ->subSeconds((int) self::USER_INACTIVE_SECONDS)
+            ->addDay()
+            ->format('Y-m-d');
+    }
+
+    /**
+     * Refresh the point cloud: upsert a blurred point for every recently-active member whose
+     * location we can resolve, then prune rows that have aged out.
+     *
+     * @param  bool  $dryRun  Count what would change without writing.
+     * @param  int|null  $limit  Stop after considering this many members (for a bounded manual run).
+     * @return array{considered:int,upserted:int,no_location:int,pruned:int}
+     */
+    public function updateLocations(bool $dryRun = false, ?int $limit = null): array
+    {
+        $cutoff = $this->cutoff();
+        $stats = ['considered' => 0, 'upserted' => 0, 'no_location' => 0, 'pruned' => 0];
+
+        $lastId = 0;
+
+        while (true) {
+            $take = self::READ_CHUNK;
+
+            if ($limit !== null) {
+                $remaining = $limit - $stats['considered'];
+
+                if ($remaining <= 0) {
+                    break;
+                }
+
+                $take = min($take, $remaining);
+            }
+
+            $members = $this->readMembers($cutoff, $lastId, $take);
+
+            if ($members->isEmpty()) {
+                break;
+            }
+
+            $pending = [];
+
+            foreach ($members as $member) {
+                $stats['considered']++;
+                $lastId = (int) $member->id;
+
+                $point = $this->resolvePoint($member);
+
+                if ($point === null) {
+                    $stats['no_location']++;
+
+                    continue;
+                }
+
+                // V1's `if ($lat || $lng)` guard. 0,0 is missing data, not a place in the
+                // Atlantic — 1,629 locations on live sit there. Note it takes BOTH coordinates
+                // being falsy: the Greenwich meridian runs through east London, so lng exactly
+                // 0 alongside a real lat is a genuine location.
+                if (!$point[0] && !$point[1]) {
+                    $stats['no_location']++;
+
+                    continue;
+                }
+
+                [$lat, $lng] = $this->blur($point[0], $point[1]);
+                $pending[] = [(int) $member->id, $lat, $lng, $member->lastaccess];
+                $stats['upserted']++;
+            }
+
+            if (!$dryRun) {
+                foreach (array_chunk($pending, self::WRITE_CHUNK) as $chunk) {
+                    $this->upsert($chunk);
+                }
+            }
+        }
+
+        if (!$dryRun) {
+            $stats['pruned'] = $this->prune($cutoff);
+        }
+
+        Log::info('users_approxlocs refreshed', $stats + ['cutoff' => $cutoff, 'dry_run' => $dryRun]);
+
+        return $stats;
+    }
+
+    /**
+     * One page of members to consider: anyone with a membership whose lastaccess is inside the
+     * cutoff, walked by ascending id so a long run pages without OFFSET.
+     *
+     * V1 used `INNER JOIN memberships ... DISTINCT`; whereExists is the same set without the join
+     * fan-out. Like V1 this deliberately does not filter on membership collection or on
+     * users.deleted — the readers apply their own filters (reachable_groups.go, for instance,
+     * requires collection='Approved' and lastaccess within 90 days).
+     *
+     * @return \Illuminate\Support\Collection<int, object>
+     */
+    private function readMembers(string $cutoff, int $afterId, int $take): \Illuminate\Support\Collection
+    {
+        return DB::table('users as u')
+            ->leftJoin('locations as l', 'l.id', '=', 'u.lastlocation')
+            ->whereExists(function ($query) {
+                $query->select(DB::raw(1))
+                    ->from('memberships as m')
+                    ->whereColumn('m.userid', 'u.id');
+            })
+            ->where('u.id', '>', $afterId)
+            ->where('u.lastaccess', '>=', $cutoff)
+            ->orderBy('u.id')
+            ->limit($take)
+            ->select('u.id', 'u.lastaccess', 'l.lat as loc_lat', 'l.lng as loc_lng')
+            // keep-raw: JSON path extraction, which the builder has no expression for. Read as raw
+            // JSON text rather than CAST to DECIMAL because a JSON null casts to 0.000000, not
+            // NULL, which would silently place the member in the Atlantic.
+            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(u.settings, '$.mylocation.lat')) AS myloc_lat")
+            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(u.settings, '$.mylocation.lng')) AS myloc_lng")
+            ->get();
+    }
+
+    /**
+     * A member's raw point, resolved the way V1 getLatLng(usedef=FALSE, usegroup=FALSE) did:
+     * settings.mylocation first, else their lastlocation, else nothing. There is deliberately no
+     * fallback to their last posted message, their group's centre, or the centre of Britain —
+     * a member whose location we don't know stays out of the cloud rather than being planted
+     * somewhere they aren't.
+     *
+     * V1 accepted mylocation when only its lat was set, then tried to insert a NULL lng into a
+     * NOT NULL column; here both coordinates must be present for mylocation to win, matching
+     * UnifiedDigestService::resolveUserLatLng.
+     *
+     * @return array{0:float,1:float}|null
+     */
+    private function resolvePoint(object $member): ?array
+    {
+        if (is_numeric($member->myloc_lat) && is_numeric($member->myloc_lng)) {
+            return [(float) $member->myloc_lat, (float) $member->myloc_lng];
+        }
+
+        if ($member->loc_lat !== null && $member->loc_lng !== null) {
+            return [(float) $member->loc_lat, (float) $member->loc_lng];
+        }
+
+        return null;
+    }
+
+    /**
+     * Blur a point by BLUR_USER metres, V1 Utils::blur: the direction is derived from the
+     * coordinates themselves so it is deterministic (the point must not jitter between runs,
+     * or members would appear to move around the map), and the result is rounded to 4 dp.
+     *
+     * The same algorithm lives in Go as utils.Blur and in ExpandService::blurOrigin for the
+     * poster's origin; all three must agree, so change them together.
+     *
+     * @return array{0:float,1:float}
+     */
+    private function blur(float $lat, float $lng): array
+    {
+        $dir = ($lat * 1000 + $lng * 1000) % 360;
+        $pos = GreatCircle::getPositionByDistance(self::BLUR_USER, $dir, $lat, $lng);
+
+        return [round($pos['lat'], 4), round($pos['lng'], 4)];
+    }
+
+    /**
+     * Bulk upsert.
+     *
+     * timestamp is set explicitly to the member's lastaccess (V1 parity): the column is
+     * ON UPDATE CURRENT_TIMESTAMP, so leaving it out would stamp it with the run time and the
+     * prune below could then never age anybody out.
+     *
+     * position is SRID 3857 in POINT(lng lat) order — the axis order reachable_groups.go and the
+     * spatial dataset read it back in.
+     *
+     * @param  list<array{0:int,1:float,2:float,3:string}>  $rows
+     */
+    private function upsert(array $rows): void
+    {
+        $srid = (int) config('freegle.srid', 3857);
+
+        $placeholders = implode(', ', array_fill(0, count($rows), '(?, ?, ?, ST_SRID(POINT(?, ?), ?), ?)'));
+
+        $bindings = [];
+
+        foreach ($rows as [$userid, $lat, $lng, $lastaccess]) {
+            array_push($bindings, $userid, $lat, $lng, $lng, $lat, $srid, $lastaccess);
+        }
+
+        // keep-raw: the builder's upsert() binds column values only, so it cannot put the
+        // ST_SRID(POINT(...)) spatial constructor in the VALUES list, and the SPATIAL index on
+        // position means the geometry has to be built in the same statement.
+        DB::statement(
+            "INSERT INTO users_approxlocs (userid, lat, lng, position, timestamp)
+             VALUES $placeholders AS new
+             ON DUPLICATE KEY UPDATE
+               lat = new.lat,
+               lng = new.lng,
+               position = new.position,
+               timestamp = new.timestamp",
+            $bindings
+        );
+    }
+
+    /**
+     * Drop members who have gone inactive. Chunked: after a long gap in the schedule the cutoff
+     * jumps forward and this can be a large delete, which as a single statement would hold a long
+     * transaction and risk Galera flow control on the live cluster.
+     */
+    private function prune(string $cutoff): int
+    {
+        $pruned = 0;
+
+        do {
+            $deleted = DB::table('users_approxlocs')
+                ->where('timestamp', '<', $cutoff)
+                ->limit(self::PRUNE_CHUNK)
+                ->delete();
+            $pruned += $deleted;
+        } while ($deleted === self::PRUNE_CHUNK);
+
+        return $pruned;
+    }
+}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -898,6 +898,17 @@ Schedule::command('users:update-engagement')
     ->sendOutputTo(cronLog('users:update-engagement'))
     ->runInBackground();
 
+// Refresh users_approxlocs, the blurred point cloud of active members. It is the driving table
+// of the rippling reach query, so while it is not being written new members are invisible to
+// reach - which is what happened between V1's removal and this port (34% of active members were
+// missing by 2026-08-10).
+// V1: cron/nearby.php -> Nearby::updateLocations() (daily)
+Schedule::command('users:update-approx-locs')
+    ->dailyAt('04:45')
+    ->withoutOverlapping(360)
+    ->sendOutputTo(cronLog('users:update-approx-locs'))
+    ->runInBackground();
+
 // Remove search index entries for messages older than 30 days.
 // V1: cron/message_deindex.php (daily at 01:00)
 Schedule::command('messages:deindex')

--- a/iznik-batch/tests/Feature/User/UpdateApproxLocsCommandTest.php
+++ b/iznik-batch/tests/Feature/User/UpdateApproxLocsCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class UpdateApproxLocsCommandTest extends TestCase
+{
+    protected Group $group;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->group = $this->createTestGroup();
+    }
+
+    private function activeMemberAt(float $lat, float $lng): User
+    {
+        $user = $this->createTestUser();
+        $this->createMembership($user, $this->group);
+        DB::table('users')->where('id', $user->id)->update([
+            'lastaccess' => now()->subDay(),
+            'settings' => json_encode(['mylocation' => ['lat' => $lat, 'lng' => $lng]]),
+        ]);
+
+        return $user->fresh();
+    }
+
+    public function test_command_writes_a_point_for_an_active_member(): void
+    {
+        $user = $this->activeMemberAt(51.5010, -0.1416);
+
+        $this->artisan('users:update-approx-locs')
+            ->assertExitCode(0);
+
+        $this->assertNotNull(DB::table('users_approxlocs')->where('userid', $user->id)->first());
+    }
+
+    public function test_command_reports_what_it_did(): void
+    {
+        $this->activeMemberAt(51.5010, -0.1416);
+
+        $this->artisan('users:update-approx-locs')
+            ->expectsOutputToContain('upserted')
+            ->assertExitCode(0);
+    }
+
+    public function test_dry_run_reports_without_writing(): void
+    {
+        $user = $this->activeMemberAt(51.5010, -0.1416);
+
+        $this->artisan('users:update-approx-locs', ['--dry-run' => true])
+            ->assertExitCode(0);
+
+        $this->assertNull(DB::table('users_approxlocs')->where('userid', $user->id)->first());
+    }
+
+    /**
+     * Asserted on the reported count rather than on which rows appeared: the test database is
+     * shared, so --limit 1 may well pick an active member committed by an earlier test rather
+     * than one of ours.
+     */
+    public function test_limit_bounds_how_many_members_are_considered(): void
+    {
+        $this->activeMemberAt(51.5010, -0.1416);
+        $this->activeMemberAt(53.4084, -2.9916);
+
+        $this->artisan('users:update-approx-locs', ['--limit' => 1])
+            ->expectsOutputToContain('considered 1')
+            ->assertExitCode(0);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/UserApproxLocServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UserApproxLocServiceTest.php
@@ -1,0 +1,384 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Group;
+use App\Models\User;
+use App\Services\UserApproxLocService;
+use App\Support\GreatCircle;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Port of V1 Nearby::updateLocations() (iznik-server/include/user/Nearby.php, deleted in
+ * c14a7125b). users_approxlocs is the privacy-blurred point cloud that drives the rippling
+ * reach query, so these tests pin the two things its readers depend on: which members get a
+ * row, and that the row's geometry is SRID 3857 in POINT(lng lat) order.
+ */
+class UserApproxLocServiceTest extends TestCase
+{
+    protected UserApproxLocService $service;
+
+    protected Group $group;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new UserApproxLocService();
+        $this->group = $this->createTestGroup();
+    }
+
+    /**
+     * An active member: has a membership and a lastaccess inside the cutoff. Returns the user.
+     */
+    private function activeMember(array $attributes = []): User
+    {
+        $user = $this->createTestUser();
+        $this->createMembership($user, $this->group);
+        DB::table('users')->where('id', $user->id)->update(array_merge([
+            'lastaccess' => now()->subDay(),
+        ], $attributes));
+
+        return $user->fresh();
+    }
+
+    private function makeLocation(float $lat, float $lng): int
+    {
+        return DB::table('locations')->insertGetId([
+            'name' => 'TestLoc '.uniqid('', true),
+            'type' => 'Postcode',
+            'lat' => $lat,
+            'lng' => $lng,
+        ]);
+    }
+
+    private function setMyLocation(User $user, array $myLocation): void
+    {
+        DB::table('users')->where('id', $user->id)->update([
+            'settings' => json_encode(['mylocation' => $myLocation]),
+        ]);
+    }
+
+    private function row(User $user): ?object
+    {
+        return DB::table('users_approxlocs')->where('userid', $user->id)->first();
+    }
+
+    // --- Which members get a row ---
+
+    public function test_writes_a_blurred_row_for_an_active_member_from_mylocation(): void
+    {
+        $user = $this->activeMember();
+        $this->setMyLocation($user, ['id' => 1, 'name' => 'SW1A 1AA', 'lat' => 51.5010, 'lng' => -0.1416]);
+
+        $this->service->updateLocations();
+
+        $row = $this->row($user);
+        $this->assertNotNull($row, 'active member with a resolvable location should get a row');
+
+        // Blurred, so not the raw point - but within a few hundred metres of it.
+        $this->assertNotEquals(51.5010, (float) $row->lat);
+        $this->assertLessThan(0.01, abs((float) $row->lat - 51.5010));
+    }
+
+    public function test_falls_back_to_lastlocation_when_there_is_no_mylocation(): void
+    {
+        $user = $this->activeMember();
+        $locationId = $this->makeLocation(53.4084, -2.9916);
+        DB::table('users')->where('id', $user->id)->update(['lastlocation' => $locationId]);
+
+        $this->service->updateLocations();
+
+        $row = $this->row($user);
+        $this->assertNotNull($row);
+        [$expectedLat, $expectedLng] = $this->blurred(53.4084, -2.9916);
+        $this->assertEquals($expectedLat, (float) $row->lat);
+        $this->assertEquals($expectedLng, (float) $row->lng);
+    }
+
+    public function test_mylocation_wins_over_lastlocation(): void
+    {
+        $user = $this->activeMember();
+        $locationId = $this->makeLocation(53.4084, -2.9916);
+        DB::table('users')->where('id', $user->id)->update(['lastlocation' => $locationId]);
+        $this->setMyLocation($user, ['id' => 2, 'name' => 'Elsewhere', 'lat' => 51.5010, 'lng' => -0.1416]);
+
+        $this->service->updateLocations();
+
+        [$expectedLat, $expectedLng] = $this->blurred(51.5010, -0.1416);
+        $row = $this->row($user);
+        $this->assertEquals($expectedLat, (float) $row->lat);
+        $this->assertEquals($expectedLng, (float) $row->lng);
+    }
+
+    public function test_mylocation_with_only_one_coordinate_falls_through_to_lastlocation(): void
+    {
+        $user = $this->activeMember();
+        $locationId = $this->makeLocation(53.4084, -2.9916);
+        DB::table('users')->where('id', $user->id)->update(['lastlocation' => $locationId]);
+        $this->setMyLocation($user, ['id' => 3, 'name' => 'Half a point', 'lat' => 51.5010, 'lng' => null]);
+
+        $this->service->updateLocations();
+
+        [$expectedLat, $expectedLng] = $this->blurred(53.4084, -2.9916);
+        $row = $this->row($user);
+        $this->assertNotNull($row);
+        $this->assertEquals($expectedLat, (float) $row->lat);
+        $this->assertEquals($expectedLng, (float) $row->lng);
+    }
+
+    public function test_skips_a_member_with_no_resolvable_location(): void
+    {
+        $user = $this->activeMember();
+
+        $this->service->updateLocations();
+
+        $this->assertNull($this->row($user));
+    }
+
+    /**
+     * 1,629 locations on live sit at 0,0 — that is missing data, not a place in the Atlantic.
+     * V1 guarded against it (`if ($lat || $lng)`) and so must this.
+     */
+    public function test_skips_a_member_whose_location_is_zero_zero(): void
+    {
+        $user = $this->activeMember();
+        $locationId = $this->makeLocation(0, 0);
+        DB::table('users')->where('id', $user->id)->update(['lastlocation' => $locationId]);
+
+        $this->service->updateLocations();
+
+        $this->assertNull($this->row($user));
+    }
+
+    /**
+     * The guard is "both coordinates falsy", not "either coordinate is zero": the Greenwich
+     * meridian runs through east London, so lng exactly 0 is a real place.
+     */
+    public function test_writes_a_member_on_the_greenwich_meridian(): void
+    {
+        $user = $this->activeMember();
+        $locationId = $this->makeLocation(51.4934, 0);
+        DB::table('users')->where('id', $user->id)->update(['lastlocation' => $locationId]);
+
+        $this->service->updateLocations();
+
+        $this->assertNotNull($this->row($user), 'lng 0 with a real lat is Greenwich, not missing data');
+    }
+
+    public function test_skips_a_member_whose_mylocation_is_zero_zero(): void
+    {
+        $user = $this->activeMember();
+        $this->setMyLocation($user, ['lat' => 0, 'lng' => 0]);
+
+        $this->service->updateLocations();
+
+        $this->assertNull($this->row($user));
+    }
+
+    public function test_skips_a_user_with_no_membership(): void
+    {
+        $user = $this->createTestUser();
+        DB::table('users')->where('id', $user->id)->update([
+            'lastaccess' => now()->subDay(),
+            'settings' => json_encode(['mylocation' => ['lat' => 51.5010, 'lng' => -0.1416]]),
+        ]);
+
+        $this->service->updateLocations();
+
+        $this->assertNull($this->row($user));
+    }
+
+    public function test_skips_a_member_whose_lastaccess_predates_the_cutoff(): void
+    {
+        $user = $this->activeMember(['lastaccess' => now()->subDays(200)]);
+        $this->setMyLocation($user, ['lat' => 51.5010, 'lng' => -0.1416]);
+
+        $this->service->updateLocations();
+
+        $this->assertNull($this->row($user));
+    }
+
+    // --- Row contents ---
+
+    public function test_timestamp_is_the_users_lastaccess_not_now(): void
+    {
+        $lastaccess = now()->subDays(30)->startOfSecond();
+        $user = $this->activeMember(['lastaccess' => $lastaccess]);
+        $this->setMyLocation($user, ['lat' => 51.5010, 'lng' => -0.1416]);
+
+        $this->service->updateLocations();
+
+        $this->assertEquals(
+            $lastaccess->format('Y-m-d H:i:s'),
+            $this->row($user)->timestamp,
+            'timestamp carries lastaccess - the prune and the readers key off it'
+        );
+    }
+
+    public function test_position_is_srid_3857_in_lng_lat_order(): void
+    {
+        $user = $this->activeMember();
+        $this->setMyLocation($user, ['lat' => 51.5010, 'lng' => -0.1416]);
+
+        $this->service->updateLocations();
+
+        $geom = DB::table('users_approxlocs')
+            ->where('userid', $user->id)
+            ->selectRaw('ST_SRID(position) AS srid, ST_X(position) AS x, ST_Y(position) AS y, lat, lng')
+            ->first();
+
+        $this->assertEquals(3857, (int) $geom->srid);
+        $this->assertEquals((float) $geom->lng, round((float) $geom->x, 4), 'ST_X must be lng');
+        $this->assertEquals((float) $geom->lat, round((float) $geom->y, 4), 'ST_Y must be lat');
+    }
+
+    public function test_rerunning_updates_the_existing_row_rather_than_duplicating(): void
+    {
+        $user = $this->activeMember();
+        $this->setMyLocation($user, ['lat' => 51.5010, 'lng' => -0.1416]);
+        $this->service->updateLocations();
+
+        // Member moves.
+        $this->setMyLocation($user, ['lat' => 53.4084, 'lng' => -2.9916]);
+        $this->service->updateLocations();
+
+        $this->assertEquals(1, DB::table('users_approxlocs')->where('userid', $user->id)->count());
+        [$expectedLat] = $this->blurred(53.4084, -2.9916);
+        $this->assertEquals($expectedLat, (float) $this->row($user)->lat);
+    }
+
+    // --- Blur parity with V1 Utils::blur ---
+
+    public function test_blur_offsets_the_point_by_about_400_metres(): void
+    {
+        $user = $this->activeMember();
+        $this->setMyLocation($user, ['lat' => 51.5010, 'lng' => -0.1416]);
+
+        $this->service->updateLocations();
+
+        $row = $this->row($user);
+        $metres = $this->distanceMetres(51.5010, -0.1416, (float) $row->lat, (float) $row->lng);
+        $this->assertGreaterThan(350, $metres);
+        $this->assertLessThan(450, $metres);
+    }
+
+    public function test_blur_is_deterministic_so_the_point_does_not_jitter(): void
+    {
+        $user = $this->activeMember();
+        $this->setMyLocation($user, ['lat' => 51.5010, 'lng' => -0.1416]);
+
+        $this->service->updateLocations();
+        $first = $this->row($user);
+        $this->service->updateLocations();
+        $second = $this->row($user);
+
+        $this->assertEquals($first->lat, $second->lat);
+        $this->assertEquals($first->lng, $second->lng);
+    }
+
+    public function test_blur_rounds_to_four_decimal_places(): void
+    {
+        $user = $this->activeMember();
+        $this->setMyLocation($user, ['lat' => 51.5010, 'lng' => -0.1416]);
+
+        $this->service->updateLocations();
+
+        $row = $this->row($user);
+        $this->assertEquals(round((float) $row->lat, 4), (float) $row->lat);
+        $this->assertEquals(round((float) $row->lng, 4), (float) $row->lng);
+    }
+
+    // --- Prune ---
+
+    public function test_prunes_rows_whose_timestamp_predates_the_cutoff(): void
+    {
+        $stale = $this->activeMember();
+        DB::table('users_approxlocs')->insert([
+            'userid' => $stale->id,
+            'lat' => 51.5,
+            'lng' => -0.1,
+            'position' => DB::raw("ST_SRID(POINT(-0.1, 51.5), 3857)"),
+            'timestamp' => now()->subDays(250),
+        ]);
+
+        $stats = $this->service->updateLocations();
+
+        $this->assertNull($this->row($stale), 'row older than the inactivity cutoff should be pruned');
+        $this->assertGreaterThanOrEqual(1, $stats['pruned']);
+    }
+
+    public function test_keeps_rows_inside_the_cutoff(): void
+    {
+        $fresh = $this->activeMember();
+        DB::table('users_approxlocs')->insert([
+            'userid' => $fresh->id,
+            'lat' => 51.5,
+            'lng' => -0.1,
+            'position' => DB::raw("ST_SRID(POINT(-0.1, 51.5), 3857)"),
+            'timestamp' => now()->subDays(30),
+        ]);
+
+        $this->service->updateLocations();
+
+        $this->assertNotNull($this->row($fresh));
+    }
+
+    // --- Dry run ---
+
+    public function test_dry_run_writes_nothing(): void
+    {
+        $user = $this->activeMember();
+        $this->setMyLocation($user, ['lat' => 51.5010, 'lng' => -0.1416]);
+
+        $stats = $this->service->updateLocations(true);
+
+        $this->assertNull($this->row($user));
+        // Not an exact count: the suite shares a database, so earlier tests may have left their
+        // own active members behind.
+        $this->assertGreaterThanOrEqual(1, $stats['upserted'], 'dry run still reports what it would have written');
+    }
+
+    public function test_dry_run_does_not_prune(): void
+    {
+        $stale = $this->activeMember();
+        DB::table('users_approxlocs')->insert([
+            'userid' => $stale->id,
+            'lat' => 51.5,
+            'lng' => -0.1,
+            'position' => DB::raw("ST_SRID(POINT(-0.1, 51.5), 3857)"),
+            'timestamp' => now()->subDays(250),
+        ]);
+
+        $this->service->updateLocations(true);
+
+        $this->assertNotNull($this->row($stale));
+    }
+
+    // --- Helpers ---
+
+    /**
+     * The expected blurred point, derived the V1 way: deterministic direction from the raw
+     * coordinates, 400 m along a great circle, rounded to 4 dp.
+     *
+     * @return array{0:float,1:float}
+     */
+    private function blurred(float $lat, float $lng): array
+    {
+        $dir = ($lat * 1000 + $lng * 1000) % 360;
+        $pos = GreatCircle::getPositionByDistance(UserApproxLocService::BLUR_USER, $dir, $lat, $lng);
+
+        return [round($pos['lat'], 4), round($pos['lng'], 4)];
+    }
+
+    private function distanceMetres(float $lat1, float $lng1, float $lat2, float $lng2): float
+    {
+        $r = 6371000;
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLng = deg2rad($lng2 - $lng1);
+        $a = sin($dLat / 2) ** 2
+            + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLng / 2) ** 2;
+
+        return $r * 2 * atan2(sqrt($a), sqrt(1 - $a));
+    }
+}

--- a/iznik-nuxt3/tests/unit/api/LocationAPI.spec.js
+++ b/iznik-nuxt3/tests/unit/api/LocationAPI.spec.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { captureMessage } from '@sentry/vue'
+
+vi.mock('~/stores/auth', () => ({
+  useAuthStore: () => ({
+    auth: { jwt: 'test-jwt', persistent: 'test-persistent' },
+    user: { id: 123 },
+  }),
+}))
+
+vi.mock('~/stores/misc', () => ({
+  useMiscStore: () => ({
+    modtools: false,
+    api: vi.fn(),
+    waitForOnline: vi.fn().mockResolvedValue(),
+  }),
+}))
+
+vi.mock('~/stores/loggingContext', () => ({
+  useLoggingContextStore: () => ({
+    getHeaders: () => ({}),
+  }),
+}))
+
+vi.mock('~/composables/useTrace', () => ({
+  getTraceHeaders: () => ({}),
+}))
+
+vi.mock('@sentry/vue', () => ({
+  captureMessage: vi.fn(),
+}))
+
+const mockFetch = vi.fn()
+vi.mock('~/composables/useFetchRetry', () => ({
+  fetchRetry: () => mockFetch,
+}))
+
+let LocationAPI
+
+describe('LocationAPI', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    const mod = await import('~/api/LocationAPI.js')
+    LocationAPI = mod.default
+  })
+
+  function createApi() {
+    return new LocationAPI({
+      public: { APIv2: 'https://api.test.com' },
+    })
+  }
+
+  /** The URL passed to fetch for the first (only) call. */
+  function calledUrl() {
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    return mockFetch.mock.calls[0][0]
+  }
+
+  /** The JSON-decoded request body for the first (only) call. */
+  function calledBody() {
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    return JSON.parse(mockFetch.mock.calls[0][1].body)
+  }
+
+  describe('typeahead', () => {
+    it('URL-encodes the query so punctuation cannot split the query string', async () => {
+      mockFetch.mockResolvedValue([200, []])
+
+      await createApi().typeahead('sofa & chair #2')
+
+      const url = calledUrl()
+      // An unencoded & would start a bogus parameter and truncate the search term;
+      // an unencoded # would drop everything after it.
+      expect(url).toContain('q=sofa%20%26%20chair%20%232')
+      expect(url).not.toContain('q=sofa & chair')
+    })
+
+    it('targets the v2 typeahead endpoint', async () => {
+      mockFetch.mockResolvedValue([200, []])
+
+      await createApi().typeahead('bristol')
+
+      expect(calledUrl()).toContain('https://api.test.com/location/typeahead')
+    })
+  })
+
+  describe('resolve', () => {
+    it('does not report a 404 to Sentry, because an unknown place name is an expected outcome', async () => {
+      // resolve() passes logError=false precisely so that "no such place" does not
+      // become Sentry noise - it is how the caller decides whether to offer
+      // "search near <place>". Asserting the decision, not just the argument.
+      mockFetch.mockResolvedValue([404, null])
+
+      await expect(createApi().resolve('Nowheresville')).rejects.toThrow()
+
+      expect(captureMessage).not.toHaveBeenCalled()
+    })
+
+    it('still reports a 404 for a call that has not opted out of logging', async () => {
+      // Contrast case: without this, the test above would also pass if logError
+      // were ignored everywhere.
+      mockFetch.mockResolvedValue([404, null])
+
+      await expect(createApi().fetchv2(12345)).rejects.toThrow()
+
+      expect(captureMessage).toHaveBeenCalled()
+    })
+  })
+
+  describe('endpoint paths', () => {
+    it('fetchAddresses targets the addresses sub-resource of the location', async () => {
+      mockFetch.mockResolvedValue([200, []])
+
+      await createApi().fetchAddresses(4567)
+
+      expect(calledUrl()).toContain('https://api.test.com/location/4567/addresses')
+    })
+
+    it('latlng passes both coordinates', async () => {
+      mockFetch.mockResolvedValue([200, {}])
+
+      await createApi().latlng(51.5074, -0.1278)
+
+      const url = calledUrl()
+      expect(url).toContain('https://api.test.com/location/latlng')
+      expect(url).toContain('lat=51.5074')
+      expect(url).toContain('lng=-0.1278')
+    })
+  })
+
+  describe('del', () => {
+    it('excludes the location rather than deleting it, by id not by name', async () => {
+      mockFetch.mockResolvedValue([200, {}])
+
+      await createApi().del(999, 42)
+
+      const body = calledBody()
+      // 'Exclude' removes the location from a group's coverage; a different action
+      // value here would be a destructive change to a shared locations table.
+      expect(body.action).toBe('Exclude')
+      expect(body.byname).toBe(false)
+      expect(body.id).toBe(999)
+      expect(body.groupid).toBe(42)
+    })
+  })
+
+  describe('convertKML', () => {
+    it('sends the KML with the ConvertKML action', async () => {
+      mockFetch.mockResolvedValue([200, {}])
+
+      await createApi().convertKML('<kml/>')
+
+      const body = calledBody()
+      expect(body.action).toBe('ConvertKML')
+      expect(body.kml).toBe('<kml/>')
+    })
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/PostMap.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostMap.spec.js
@@ -126,6 +126,29 @@ vi.mock('nuxt/app', () => ({
 // Mock leaflet imports
 vi.mock('leaflet/dist/leaflet-src.esm', () => ({}))
 
+// ready() dynamically imports the geocoder control and the Photon geocoder. Left
+// unmocked they load the real modules, and whether that resolves before the test ends
+// is a race against real module-load time — so lines 700-753 of PostMap.vue were hit in
+// some runs and not others. That made this file's covered-line count vary between runs
+// of an IDENTICAL tree (559 vs 530 of 866), moving whole-repo coverage by ~0.024pp and
+// flapping the Coveralls gate on PRs that touch no frontend code at all. Mocking them —
+// as every other external in this file already is — makes the geocoder path resolve
+// deterministically. Verified by diffing two lcov reports from the same tree.
+vi.mock('leaflet-control-geocoder/src/control', () => ({
+  Geocoder: vi.fn().mockImplementation(() => {
+    // ready() chains .on('markgeocode', ...).addTo(map), so both must be chainable.
+    const control = {
+      on: vi.fn(() => control),
+      addTo: vi.fn(() => control),
+    }
+    return control
+  }),
+}))
+
+vi.mock('leaflet-control-geocoder/src/geocoders/photon', () => ({
+  Photon: vi.fn().mockImplementation(() => ({})),
+}))
+
 // Mock vue-leaflet components
 vi.mock('@vue-leaflet/vue-leaflet', () => ({
   LGeoJson: {

--- a/iznik-nuxt3/tests/unit/components/PostMap.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostMap.spec.js
@@ -454,6 +454,36 @@ describe('PostMap', () => {
       await createWrapper()
       expect(loadLeaflet).toHaveBeenCalled()
     })
+
+    // ready() wraps its geocoder setup in try/catch precisely because leaflet throws
+    // here in practice. That containment is what keeps a geocoder failure from taking
+    // the whole map down, and it was only ever covered by accident — before the two
+    // dynamic imports above were mocked, the real modules threw in jsdom and hit this
+    // catch as a side effect. Asserted deliberately now.
+    it('keeps working when the geocoder fails to construct', async () => {
+      const { Geocoder } = await import('leaflet-control-geocoder/src/control')
+      Geocoder.mockImplementationOnce(() => {
+        throw new Error('leaflet not ready')
+      })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      const wrapper = await createWrapper()
+      const map = wrapper.findComponent({ name: 'LMap' })
+      await map.vm.$emit('ready')
+      await flushPromises()
+
+      // Swallowed, not propagated...
+      expect(
+        logSpy.mock.calls.some((c) => String(c[0]).includes('Ignore leaflet exception'))
+      ).toBe(true)
+
+      // ...and the map is still live: it framed itself and the parent was told it is ready.
+      const component = wrapper.findComponent(PostMap)
+      expect(component.emitted('update:ready')).toBeTruthy()
+      expect(map.vm.leafletObject.fitBounds).toHaveBeenCalled()
+
+      logSpy.mockRestore()
+    })
   })
 
   describe('map hidden behavior', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/RipplingLegend.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/RipplingLegend.spec.js
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import RipplingLegend from '~/modtools/components/RipplingLegend.vue'
+
+/**
+ * The legend is the only thing telling a moderator what the colours on the rippling
+ * map mean, so a wrong mapping here misreads the map rather than looking broken. The
+ * catchment key in particular is documented as deriving from the bands actually drawn
+ * ("so the key always matches"), which only holds while it renders from the prop.
+ */
+describe('RipplingLegend', () => {
+  const bands = [
+    { color: '#ff0000', label: '10 minutes', sub: '2 hours' },
+    { color: '#00ff00', label: '20 minutes' },
+  ]
+
+  function mountLegend(props) {
+    return mount(RipplingLegend, { props })
+  }
+
+  describe('catchment mode', () => {
+    it('takes its swatch colours from the bands drawn on the map, not a hardcoded list', () => {
+      const wrapper = mountLegend({ mode: 'catchment', bands })
+
+      const swatches = wrapper.findAll('.rpl-leg-swatch')
+      const styles = swatches.map((s) => s.attributes('style') || '')
+
+      expect(styles.some((s) => s.includes('rgb(255, 0, 0)') || s.includes('#ff0000'))).toBe(true)
+      expect(styles.some((s) => s.includes('rgb(0, 255, 0)') || s.includes('#00ff00'))).toBe(true)
+    })
+
+    it('renders one entry per band, plus the group-area key', () => {
+      const wrapper = mountLegend({ mode: 'catchment', bands })
+
+      // One item per band + the trailing "Group area" entry.
+      expect(wrapper.findAll('.rpl-leg-item')).toHaveLength(bands.length + 1)
+      expect(wrapper.text()).toContain('Group area')
+    })
+
+    it('labels each band with the band label', () => {
+      const wrapper = mountLegend({ mode: 'catchment', bands })
+
+      expect(wrapper.text()).toContain('10 minutes')
+      expect(wrapper.text()).toContain('20 minutes')
+    })
+
+    it('explains the delay only for bands that carry one', () => {
+      const wrapper = mountLegend({ mode: 'catchment', bands })
+
+      // The first band has sub: '2 hours'; the second has none, so exactly one
+      // "reached ... after posting" line should appear.
+      expect(wrapper.text()).toContain('reached 2 hours after posting')
+      expect(wrapper.text().match(/after posting/g)).toHaveLength(1)
+    })
+
+    it('renders no band entries when the map drew no bands', () => {
+      const wrapper = mountLegend({ mode: 'catchment', bands: [] })
+
+      // Only the group-area key remains.
+      expect(wrapper.findAll('.rpl-leg-item')).toHaveLength(1)
+      expect(wrapper.text()).toContain('Group area')
+    })
+  })
+
+  describe('inbound mode', () => {
+    it('explains that the number on a pin is its digest position', () => {
+      const wrapper = mountLegend({ mode: 'inbound' })
+
+      expect(wrapper.text()).toContain('number = digest position')
+    })
+
+    it('distinguishes a rippled-in group from the home group', () => {
+      const wrapper = mountLegend({ mode: 'inbound' })
+
+      expect(wrapper.text()).toContain('Active home-group')
+      expect(wrapper.text()).toContain('Active rippled in')
+      expect(wrapper.text()).toContain('Home-group area')
+    })
+
+    it('is not the catchment key', () => {
+      const wrapper = mountLegend({ mode: 'inbound' })
+
+      expect(wrapper.text()).not.toContain('Ripples in within')
+    })
+  })
+
+  describe('outbound mode', () => {
+    it('keys the deprivation quintiles shown outside the boundary', () => {
+      const wrapper = mountLegend({ mode: 'outbound' })
+
+      expect(wrapper.text()).toContain('Q1 — most deprived')
+      expect(wrapper.text()).toContain('Q5 — least deprived')
+      expect(wrapper.text()).toContain('Travel time boundary')
+    })
+
+    it('omits the deprivation quintiles when minimal, because that view does not draw them', () => {
+      const wrapper = mountLegend({ mode: 'outbound', minimal: true })
+
+      expect(wrapper.text()).not.toContain('most deprived')
+      expect(wrapper.text()).not.toContain('least deprived')
+      expect(wrapper.text()).toContain('Current reach boundary')
+    })
+  })
+
+  describe('minimal precedence', () => {
+    it('is ignored in catchment mode, which keeps its own key', () => {
+      // minimal is only checked after mode, so a catchment map still gets the
+      // heatmap key rather than the per-post modal's reduced legend.
+      const wrapper = mountLegend({ mode: 'catchment', bands, minimal: true })
+
+      expect(wrapper.text()).toContain('Ripples in within')
+      expect(wrapper.text()).not.toContain('Current reach boundary')
+    })
+  })
+
+  describe('mode prop', () => {
+    it('accepts only the three modes the map can be in', () => {
+      const { validator } = RipplingLegend.props.mode
+
+      expect(validator('outbound')).toBe(true)
+      expect(validator('inbound')).toBe(true)
+      expect(validator('catchment')).toBe(true)
+      expect(validator('sideways')).toBe(false)
+    })
+  })
+})

--- a/iznik-server-go/housekeeper/housekeeper.go
+++ b/iznik-server-go/housekeeper/housekeeper.go
@@ -368,6 +368,11 @@ var cronJobs = []CronJob{
 	{Command: "users:remap-locations", Name: "Remap Locations", Description: "Updates cached location names in user settings when the canonical name has changed", Schedule: "Daily at 5am", IntervalMinutes: 1440, Category: "User Management", Active: true},
 	{Command: "users:process-exports", Name: "GDPR Exports", Description: "Processes pending GDPR data export requests; purges export data older than 7 days", Schedule: "Every minute", IntervalMinutes: 1, Category: "User Management", Active: true},
 	{Command: "users:update-engagement", Name: "Engagement Classification", Description: "Updates user engagement classifications (New / Occasional / Frequent / Obsessed / Inactive / Dormant) based on recent activity", Schedule: "Daily at 3am", IntervalMinutes: 1440, Category: "User Management", Active: true},
+	// Worth watching: this is the only writer of users_approxlocs, and the rippling reach query
+	// drives off that table, so a silently-stopped run makes new members invisible to reach
+	// without anything else going red. That is exactly what happened between V1's removal and
+	// the Laravel port.
+	{Command: "users:update-approx-locs", Name: "Approx Locations", Description: "Refreshes users_approxlocs, the ~400m-blurred point cloud of recently-active members that drives the rippling reach query; prunes members inactive for 6 months", Schedule: "Daily at 4:45am", IntervalMinutes: 1440, Category: "User Management", Active: true},
 	{Command: "users:cleanup", Name: "User Cleanup", Description: "Cleans up Yahoo Groups users, inactive users, GDPR forgets, and fully forgotten users", Schedule: "Daily (6am)", IntervalMinutes: 1440, Category: "User Management", Active: true},
 	{Command: "users:fix-tn-names", Name: "Fix TN Names", Description: "Extracts display names from TrashNothing email addresses (firstname-groupid@trashnothing.com) for users with no first/last name", Schedule: "Daily at 6:30am", IntervalMinutes: 1440, Category: "User Management", Active: true},
 

--- a/iznik-server-go/housekeeper/housekeeper_test.go
+++ b/iznik-server-go/housekeeper/housekeeper_test.go
@@ -193,3 +193,28 @@ func TestCronJobStructFields(t *testing.T) {
 		t.Errorf("queue:background-tasks Category = %q, want System", queueJob.Category)
 	}
 }
+
+// The users_approxlocs refresh is the only writer of the point cloud that drives rippling reach,
+// so if it silently stops running nothing else notices - it must be visible on the SysAdmin cron
+// dashboard where an overdue run shows up.
+func TestCronJobsIncludesApproxLocsRefresh(t *testing.T) {
+	const command = "users:update-approx-locs"
+
+	for _, j := range cronJobs {
+		if j.Command != command {
+			continue
+		}
+		if !j.Active {
+			t.Errorf("%s: Active = false, want true", command)
+		}
+		if j.IntervalMinutes != 1440 {
+			t.Errorf("%s: IntervalMinutes = %d, want 1440 (daily)", command, j.IntervalMinutes)
+		}
+		if j.Category != "User Management" {
+			t.Errorf("%s: Category = %q, want %q", command, j.Category, "User Management")
+		}
+		return
+	}
+
+	t.Errorf("cronJobs is missing %q - it would not appear in SysAdmin > Cron Jobs", command)
+}

--- a/iznik-server-go/systemlogs/systemlogs_test.go
+++ b/iznik-server-go/systemlogs/systemlogs_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"iznik-server-go/utils"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -701,4 +703,38 @@ func TestBuildSingleTraceSummary_SingleLog(t *testing.T) {
 	assert.Equal(t, 1, summary.ChildCount)
 	assert.Equal(t, "2026-01-01T10:00:00Z", summary.FirstTimestamp)
 	assert.Equal(t, "2026-01-01T10:00:00Z", summary.LastTimestamp)
+}
+
+// ---------------------------------------------------------------------------
+// canViewGroupLogs — Support/Admin branches only. Those return before touching
+// database.DBConn, which is nil in this package's tests; the moderates-the-group
+// branch is covered by the DB-backed suite in test/.
+// ---------------------------------------------------------------------------
+
+func TestCanViewGroupLogs_SupportSeesAnyGroup(t *testing.T) {
+	assert.True(t, canViewGroupLogs(0, 12345, utils.SYSTEMROLE_SUPPORT))
+}
+
+func TestCanViewGroupLogs_AdminSeesAnyGroup(t *testing.T) {
+	assert.True(t, canViewGroupLogs(0, 12345, utils.SYSTEMROLE_ADMIN))
+}
+
+// ---------------------------------------------------------------------------
+// parseTimeRange — the 30-day clamp
+// ---------------------------------------------------------------------------
+
+// Production Loki 400-rejects a query range wider than 30d1h, so an over-wide
+// request returns NOTHING rather than less. The clamp is what keeps a "1000d"
+// request useful, and a regression in it would look like "logs have vanished".
+func TestParseTimeRange_ClampsRangeWiderThanThirtyDays(t *testing.T) {
+	startTs, endTs := parseTimeRange("1000d", "now")
+
+	assert.Equal(t, int64(30*24*time.Hour), endTs-startTs,
+		"a start older than 30 days must be clamped to exactly 30 days before the end")
+}
+
+func TestParseTimeRange_DoesNotClampRangeInsideThirtyDays(t *testing.T) {
+	startTs, endTs := parseTimeRange("29d", "now")
+
+	assert.Equal(t, int64(29*24*time.Hour), endTs-startTs, "29 days is inside the limit and must be left alone")
 }

--- a/iznik-server-go/systemlogs/systemlogs_test.go
+++ b/iznik-server-go/systemlogs/systemlogs_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"iznik-server-go/utils"
-
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/plans/active/users-approxlocs-laravel-port.md
+++ b/plans/active/users-approxlocs-laravel-port.md
@@ -1,0 +1,109 @@
+# Port `users_approxlocs` maintenance from V1 PHP to Laravel
+
+## Why
+
+`users_approxlocs` is a privacy-blurred point cloud of active members. It has **readers but no
+writer**:
+
+| Reader | Use |
+|---|---|
+| `iznik-routing-go/reachable_groups.go` | drives the *entire* "which groups are reachable" query for rippling (STRAIGHT_JOIN leads from its SPATIAL index) |
+| `iznik-spatial-go/dataset_userapproxlocs.go` | point dataset served to the spatial API |
+| `iznik-routing-go/cmd/rippleextract` | ripple simulator extract |
+| `iznik-server-go/userdump/collect_db.go` | GDPR user dump |
+
+The writer was V1 `Nearby::updateLocations()` (`iznik-server/include/user/Nearby.php`), called from
+`scripts/cron/nearby.php`. V1 was deleted in `c14a7125b` (2026-07-09) and that method was never
+ported.
+
+**Live evidence (prod, 2026-08-10):**
+
+```
+rows_total = 171,799   min_ts = 2025-12-12   max_ts = 2026-06-11
+```
+
+`timestamp` holds `users.lastaccess`, so `max_ts` dates the last run: **2026-06-11, ~2 months
+stale**. The blind spot:
+
+```
+active members (Approved membership, lastaccess >= 90d) = 112,548
+  with a users_approxlocs row                          =  74,223
+  MISSING                                              =  38,325  (34%)
+```
+
+So a third of active freeglers are currently invisible to rippling reach, and the share grows daily.
+
+## V1 behaviour to preserve
+
+`Nearby::updateLocations()`:
+
+1. `cutoff = date('Y-m-d', now - Engage::USER_INACTIVE + 1 day)`, where
+   `USER_INACTIVE = 365*24*60*60/2` (182.5 days) → cutoff is **date-granular, ~181.5 days ago**.
+2. `SELECT DISTINCT users.id, users.lastaccess FROM users INNER JOIN memberships ON ... WHERE
+   users.lastaccess >= cutoff` — any membership row, no `collection` filter, no `deleted` filter.
+3. Per user, `getLatLng(usedef=FALSE, usegroup=FALSE, BLUR_USER)`, i.e. resolution order:
+   - `settings.mylocation.lat/lng`
+   - else `users.lastlocation` → `locations.lat/lng`
+   - else **nothing** (no last-message fallback, no group fallback, no Dunsop Bridge default)
+4. `Utils::blur($lat, $lng, 400)`: deterministic direction `($lat*1000 + $lng*1000) % 360`,
+   `GreatCircle::getPositionByDistance(400, dir, lat, lng)`, then `round(.., 4)`.
+5. Upsert `users_approxlocs (userid, lat, lng, position, timestamp)` with
+   `position = ST_GeomFromText('POINT(lng lat)', 3857)` and **`timestamp = users.lastaccess`**
+   (explicitly, so the column's `ON UPDATE CURRENT_TIMESTAMP` doesn't hijack it).
+6. `DELETE FROM users_approxlocs WHERE timestamp < cutoff`.
+
+## Deliberate divergences
+
+| V1 | Here | Why |
+|---|---|---|
+| per-user PHP loop, one `getLatLng` + one upsert each | resolution in one SQL projection, chunked reads, bulk upserts | 112k users; the loop was the reason V1's run was slow enough to be dropped. Measured: 5,000 members in ~1.1s |
+| `mylocation.lat` used even when `mylocation.lng` is NULL (would insert NULL into a NOT NULL column) | both coords required before `mylocation` wins | matches `UnifiedDigestService::resolveUserLatLng`, the house pattern; V1's path was a latent insert failure |
+
+Two traps found while building, both now pinned by tests:
+
+- `CAST(JSON_EXTRACT(settings, '$.mylocation.lat') AS DECIMAL)` yields **0.000000** for a JSON
+  null, not NULL — the obvious SQL-side resolution would have silently moved members to Null
+  Island. mylocation is read as raw JSON text and validated in PHP instead.
+- V1's `if ($lat || $lng)` guard is load-bearing: 1,629 `locations` rows on live sit at 0,0. The
+  guard needs *both* coordinates falsy, because the Greenwich meridian runs through east London.
+
+Everything else is kept, including the absent `collection`/`deleted` filters (readers do their own
+filtering — `reachable_groups` requires `collection='Approved'` and `lastaccess >= 90d`).
+
+## Shape
+
+- `app/Services/UserApproxLocService.php` — `updateLocations(bool $dryRun, ?int $limit): array`
+- `app/Console/Commands/User/UpdateApproxLocsCommand.php` — `users:update-approx-locs`
+- `routes/console.php` — `dailyAt('04:45')` (free slot; V1 cadence class was daily)
+- `iznik-server-go/housekeeper/housekeeper.go` — registry entry so it shows in SysAdmin → Cron Jobs
+
+## Test plan (TDD, RED first)
+
+`tests/Unit/Services/UserApproxLocServiceTest.php` — 20 tests: resolution order (mylocation,
+lastlocation, one-coord fall-through, 0,0 rejected on both paths, Greenwich accepted), membership
+and cutoff filtering, `timestamp` = `lastaccess`, upsert not duplicate, SRID 3857 / `POINT(lng lat)`,
+blur distance + determinism + 4-dp rounding, prune, and dry-run for both write and prune.
+
+`tests/Feature/User/UpdateApproxLocsCommandTest.php` — 4 tests: writes, reports, `--dry-run`,
+`--limit`.
+
+`iznik-server-go/housekeeper/housekeeper_test.go` — registry contains
+`users:update-approx-locs`, active, daily, under User Management.
+
+`test-freegle-worktree-data.sh` — 6 tests for the `freegle` CLI change below.
+
+## Side fix: `freegle worktree create` and the OSM extract
+
+A fresh worktree's `spatial` / `spatial-live` containers exit(1) because
+`iznik-routing-go/data/uk-latest.osm.pbf` (2.5GB, gitignored) only exists in the main checkout.
+`_share_gitignored_data` now hardlinks it in before starting containers — one inode, so N
+worktrees cost no extra disk, and it survives removal of the main checkout.
+
+## Verified end to end
+
+Seeded 5,000 synthetic members in the worktree dev DB (half via `settings.mylocation`, half via
+`lastlocation`), ran the command, then ran the **real** `reachable_groups.go` query against the
+result: 4,500 in-bbox member rows made the group reachable (the 500 excluded were seeded 90+ days
+stale, exactly as its `lastaccess >= NOW() - 90 DAY` filter requires). Both resolution paths landed
+in their own seeded coordinate boxes; SRID uniformly 3857 with `ST_X` = lng. Aging 100 members to
+300 days back dropped them from the refresh and pruned their rows.

--- a/test-freegle-worktree-data.sh
+++ b/test-freegle-worktree-data.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Tests for the freegle CLI's shared-data helper (_share_gitignored_data), which gives a new
+# worktree the large gitignored downloads (the UK OSM extract) that its containers need to boot.
+# Run: bash test-freegle-worktree-data.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/freegle"
+
+# Source the CLI without triggering its command dispatch.
+FREEGLE_LIB_ONLY=1 source "$SCRIPT"
+set +e
+
+fails=0
+check() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc"
+        echo "      expected: [$expected]"
+        echo "      actual:   [$actual]"
+        fails=$(( fails + 1 ))
+    fi
+}
+
+tmproot=$(mktemp -d)
+trap 'rm -rf "$tmproot"' EXIT
+
+# Build a fake main checkout with the gitignored extract, and an empty fake worktree.
+setup_pair() {
+    local name="$1"
+    local main="$tmproot/$name-main" wt="$tmproot/$name-wt"
+    rm -rf "$main" "$wt"
+    mkdir -p "$main/iznik-routing-go/data" "$wt/iznik-routing-go/data"
+    echo "$name-pbf-contents" > "$main/iznik-routing-go/data/uk-latest.osm.pbf"
+    echo "$main" "$wt"
+}
+
+# 1. The extract is absent from the worktree → it gets it.
+read -r main wt < <(setup_pair copies)
+_share_gitignored_data "$main" "$wt" >/dev/null 2>&1
+check "copies the OSM extract into a fresh worktree" \
+    "copies-pbf-contents" "$(cat "$wt/iznik-routing-go/data/uk-latest.osm.pbf" 2>/dev/null)"
+
+# 2. It is shared by hardlink, so N worktrees do not cost N x 2.5GB of disk.
+read -r main wt < <(setup_pair links)
+_share_gitignored_data "$main" "$wt" >/dev/null 2>&1
+main_inode=$(stat -c %i "$main/iznik-routing-go/data/uk-latest.osm.pbf" 2>/dev/null)
+wt_inode=$(stat -c %i "$wt/iznik-routing-go/data/uk-latest.osm.pbf" 2>/dev/null)
+check "shares the extract by hardlink rather than duplicating 2.5GB" "$main_inode" "$wt_inode"
+
+# 3. A worktree that already has its own extract keeps it untouched.
+read -r main wt < <(setup_pair keeps)
+echo "worktree-own-pbf" > "$wt/iznik-routing-go/data/uk-latest.osm.pbf"
+_share_gitignored_data "$main" "$wt" >/dev/null 2>&1
+check "leaves an extract the worktree already has alone" \
+    "worktree-own-pbf" "$(cat "$wt/iznik-routing-go/data/uk-latest.osm.pbf")"
+
+# 4. No extract in the main checkout is not an error - a machine that never downloaded it should
+#    still get a working worktree for everything that does not need the routing graph.
+read -r main wt < <(setup_pair missing)
+rm -f "$main/iznik-routing-go/data/uk-latest.osm.pbf"
+_share_gitignored_data "$main" "$wt" >/dev/null 2>&1
+check "succeeds when the main checkout has no extract" "0" "$?"
+check "and creates no bogus file" \
+    "absent" \
+    "$([[ -e "$wt/iznik-routing-go/data/uk-latest.osm.pbf" ]] && echo present || echo absent)"
+
+# 5. Works when the worktree data directory does not exist yet.
+read -r main wt < <(setup_pair nodir)
+rm -rf "$wt/iznik-routing-go"
+_share_gitignored_data "$main" "$wt" >/dev/null 2>&1
+check "creates the data directory when missing" \
+    "nodir-pbf-contents" "$(cat "$wt/iznik-routing-go/data/uk-latest.osm.pbf" 2>/dev/null)"
+
+echo
+if (( fails > 0 )); then
+    echo "$fails test(s) failed"
+    exit 1
+fi
+echo "All shared-data tests passed"


### PR DESCRIPTION
## The gap this closes

`users_approxlocs` holds one ~400m privacy-blurred point per recently-active member. V1's `Nearby::updateLocations()` was its **only writer**, and it went away with the rest of V1 in `c14a7125b` without a Laravel equivalent. The table has four readers and, until this branch, no writer:

| Reader | Use |
|---|---|
| `iznik-routing-go/reachable_groups.go` | drives the **entire** "which groups can this post reach" query off this table's spatial index |
| `iznik-spatial-go/dataset_userapproxlocs.go` | point dataset served by the spatial API |
| `iznik-routing-go/cmd/rippleextract` | ripple simulator extract |
| `iznik-server-go/userdump` | GDPR user dump |

Because reach *drives off* this table, a member with no row is invisible to targeting whatever their postcode says. State on live at time of writing:

```
users_approxlocs:  171,799 rows   min_ts 2025-12-12   max_ts 2026-06-11
```

`timestamp` carries `users.lastaccess`, so `max_ts` dates the last write: 2026-06-11, two months stale. The resulting blind spot:

```
active members (Approved membership, lastaccess >= 90d) = 112,548
  with a users_approxlocs row                          =  74,223
  MISSING                                              =  38,325   (34%)
```

The failure mode is silent by construction: reach still computes and still returns plausible targets, so nothing errors. The candidate set simply omits newer members, and the omitted share grows daily.

## What the branch adds

`UserApproxLocService` + `users:update-approx-locs`, scheduled `dailyAt('04:45')`.

V1 semantics preserved:

- cutoff is date-granular at `now - USER_INACTIVE + 1 day` (~181.5 days)
- candidates are members with any membership whose `lastaccess` is inside the cutoff — no `collection` or `deleted` filter, as the readers apply their own
- the point is `settings.mylocation` else `lastlocation`, with **no** fallback to last-posted-message, group centre, or the centre of Britain: a member whose location is unknown stays out rather than being planted somewhere they aren't
- blur is a deterministic-direction 400m offset rounded to 4dp, so points do not jitter between runs
- `timestamp` carries `lastaccess`, set explicitly — the column is `ON UPDATE CURRENT_TIMESTAMP`, and omitting it would stamp the run time and permanently defeat the prune
- rows outside the cutoff are pruned

Two deliberate divergences from V1:

- **Set-based rather than per-user.** V1 ran `getLatLng` and an upsert per user. Resolution now happens in SQL, with chunked keyset reads and bulk upserts: 5,000 members in ~1.1s, so live's ~112k is well inside a minute.
- **`mylocation` requires both coordinates** before it wins. V1 accepted a lone `lat` and then attempted to insert a NULL `lng` into a NOT NULL column. Matches `UnifiedDigestService::resolveUserLatLng`.

## Two constraints the tests pin

- `CAST(JSON_EXTRACT(settings, '$.mylocation.lat') AS DECIMAL)` yields **`0.000000`** for a JSON null, not NULL. SQL-side resolution would therefore place members with a null coordinate on Null Island. `mylocation` is read as raw JSON text and validated in PHP instead.
- V1's `if ($lat || $lng)` guard is load-bearing: 1,629 `locations` rows on live sit at 0,0. Without it, a member resolving to 0,0 is written as a blurred point ~400m off Null Island. The guard requires *both* coordinates falsy, because the Greenwich meridian runs through east London — `lng` exactly 0 alongside a real lat is a genuine place.

## Visible on the cron dashboard

Registered in `housekeeper.go`, so it appears under SysAdmin → Cron Jobs (User Management, daily). `ListCronJobs` returns every registry entry with DB status merged, so a job that has never run still appears, and the dashboard's never-run/overdue count is what surfaces a silently-stopped refresh. A Go test pins the entry rather than trusting a hand-maintained list.

## Verification

24 new PHP tests (20 unit, 4 feature) covering resolution order, the 0,0 guard on both paths, Greenwich acceptance, membership and cutoff filtering, `timestamp` provenance, upsert-not-duplicate, SRID 3857 with `POINT(lng lat)` axis order, blur distance/determinism/rounding, prune, and dry-run for both write and prune.

End-to-end check that the output is consumable: 5,000 synthetic members seeded across both resolution paths, command run, then the **real** `reachable_groups.go` query run against the result — 4,500 in-bbox member rows made the group reachable, the 500 excluded being exactly those seeded past its `lastaccess >= NOW() - 90 DAY` filter. Both resolution paths landed in their own seeded coordinate boxes; SRID uniformly 3857 with `ST_X` = lng. 100 members aged to 300 days back were dropped from the refresh and their rows pruned.

| Suite | Result |
|---|---|
| Laravel (full) | 5413 passed |
| Go (full) | 4061 passed |
| Frontend (full) | 15202 passed |
| `test-freegle-worktree-data.sh` | 6 passed |
| `test-freegle-ports.sh` | passed (unchanged) |

First live run will upsert ~112k rows and prune ~35,726, both chunked (5,000 per DELETE, 500 per upsert) so a catch-up run cannot hold a long transaction on the Galera cluster.

## Second commit: the OSM extract for new worktrees

A fresh `freegle worktree create` leaves `spatial` and `spatial-live` in `Exited(1)`: they need `iznik-routing-go/data/uk-latest.osm.pbf`, a 2.5GB gitignored download only the main checkout has. The symptom presents as a broken worktree rather than a missing file. The extract is now hardlinked in before containers start — one inode, so N worktrees cost no extra disk, and the link survives removal of the main checkout. Falls back to a copy across filesystems; a machine that never downloaded the extract still gets a worktree that works for everything not needing the routing graph.

## Third commit: coverage-gate offset

The Coveralls gate fails this branch on -0.009% (apiv2) and -0.002% (frontend). Neither is attributable to the branch: the frontend delta appears with **zero** frontend files changed, and the apiv2 change is four comment lines plus one struct-literal element that runs at package init. Recent master commits wander over 85.760-85.775% and 73.095-73.137% unaided, one reporting "decreased -0.007%" against its own parent, so this branch's 85.76% is a value master itself has reported. Root cause is the duplicate module paths in the Go coverage profile (every file listed under both `iznik-server-go/...` and `github.com/freegle/iznik-server-go/...` with independent counts), which is worth fixing in its own right but not from inside a rippling change.

Offset with tests that are worth pinning on their own merits, picked by parsing the real profile from the CI artifact:

- `canViewGroupLogs()` was 6/6 statements uncovered - it decides who may read another group's logs. Its Support/Admin branches return before touching `database.DBConn`, so they suit this package's DB-free test file; the moderates-the-group branch stays for the DB-backed suite.
- `parseTimeRange()`'s one uncovered branch was the **30-day clamp**. Production Loki 400-rejects a range wider than 30d1h, so an over-wide query returns nothing rather than less, and a regression would present as "the logs have vanished". Both sides asserted.
- `LocationAPI` had no spec (4 of 51 `api/*API.js` wrappers did). Pins the v2 endpoint each method targets, that `typeahead` URL-encodes its query so `&` or `#` cannot truncate the search, and that `del()` sends `Exclude` rather than a destructive action. `resolve()` passes `logError=false`, so the test asserts what that *decides* - no Sentry report on a 404 - with a contrast case that fails if `logError` were ignored anywhere. **Note:** genuine as a test but *not* a coverage offset - `coverage.include` in `vitest.config.mts` does not list `api/`, so the frontend percentage did not move by a thousandth.
- `modtools/components/RipplingLegend.vue` (197 lines) is inside an included glob and had no spec. It is the only thing telling a moderator what the map's colours mean. The load-bearing assertion is that the catchment key takes its colours and labels from the `bands` prop - the bands actually drawn - which is what makes its own comment "so the key always matches" true; a regression to a hardcoded palette would silently misreport drive-time bands. Also covers the `minimal` precedence rule (ignored in catchment mode, since `minimal` is only checked after `mode`).

Not padded: the only remaining uncovered pure functions are trivial `TableName()` one-liners, and testing those would cheat the gate rather than test anything.

### The frontend flag jittered independently - now fixed, and carried here

The frontend flag moved without any frontend change: #1305 touches zero files under `iznik-nuxt3/` and still reported -0.02%/-0.03%. Cause, found by diffing two full coverage runs of an identical tree: `components/PostMap.vue`'s `ready()` dynamically imports the leaflet geocoder, those two imports were the only unmocked externals in its spec, and whether they resolved before the test ended was a race against real module-load time. Four consecutive runs are now byte-identical (71.3111%, 84694/118767, 0 files differing in any pair) against 84697/84668 alternating before.

Mocking them alone settled coverage 3 lines below the luckiest pre-fix run, and those 3 were the `catch` around the geocoder setup — covered until now only *by accident*, because the real module throws in jsdom. A second test asserts that containment deliberately (a geocoder failure should lose the search box, not the map), which brings it to a deterministic 84697/118767 — the higher value, so no coverage is lost.

Both fixes (`f165f55d1`, `8a9de2c38`) are cherry-picked onto this branch too, so **this PR's gate does not depend on merge order**. Both branches carry the identical commits; whichever merges second, git resolves them without conflict.

### Digest mock-up assertions

`RipplingDigestModal.vue` builds its body as raw HTML from post data and injects it with `v-html`, so member-supplied subject and group name pass through `escapeHTML` on the way — and nothing asserted that. The file already ran at 100% *line* coverage, exercised incidentally by its parent; executed is not asserted. 23 tests now cover the escaping (by asserting no such element exists in the DOM, not just that the string looks escaped), the `OFFER:`/`WANTED:` prefix stripping, `< 1 mile` vs rounded miles, `Posted to:` only for a genuine cross-post, the header count being the full deduped total while only the capped set is listed, and `openPost`'s rank offset, singular view/reply, score breakdown and group-name fallback chain.

Coverage-neutral by construction: a first version covering only `openDigest`/`openCluster` *dropped* whole-repo coverage by 44 lines, because v8's per-file result is not unioned across forks and a narrower direct view wins over the incidental 225/225. Covering `openPost` — exactly those 44 lines — restores it, verified at 84707/118767 twice identical, 0 files differing against master.

### On the residual `Coveralls - vitest` -0.001%

Left deliberately, having measured it three ways. Master's branch protection requires exactly one check — `ci/circleci: build-and-test` — which is green here, and the aggregate `coverage/coveralls` is green too (+0.009%). This branch measures **byte-identical to master** locally (84707/118767, 0 files differing, deterministic), so there is no missing coverage to add. Applying #1305's harness fixes here changes the number not at all, and adding a spec for an already-fully-covered file can only lose lines, never gain them. The -0.001% is a comparison against master's *recorded* baseline, which came from a pre-fix raced build that landed one line high; it resolves once #1305 makes that baseline deterministic. Closing it any other way would mean padding to beat a number that is about to stop existing.

## Relationship to #1305

The Coveralls jitter described above has its root cause fixed separately in #1305: `go.mod` declared `module iznik-server-go` while every file that imports a sibling (305 of them on master) imports it as `github.com/freegle/iznik-server-go/...` via a self-replace, so `-coverpkg ./...` instrumented different package instances than the tests executed.

The new Go test here imports `utils` by the module path rather than the bare spelling, so these two branches compose in either merge order. `user/auth.go` holds the last remaining bare import and is fixed in #1305, not here.

## Out of scope

Two other V1 `Nearby` methods are also unported and remain so:

- `Nearby::messages()` — the "nearby relevant" mails. `users_nearby` has a purge (`purgeUsersNearby`) but no writer, so the feature is dead. Restarting it is a product decision about sending more mail, not table maintenance.
- `getUsersNear()` — the moderators' map of nearby mods. No Go equivalent exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Sd6Y1n3DAveUTkcTEwUpt