### PR TITLE
feat(chitchat): let ChitChat moderators review newsletter posts from every area

### DIFF
--- a/iznik-nuxt3/api/NewsAPI.js
+++ b/iznik-nuxt3/api/NewsAPI.js
@@ -5,12 +5,15 @@ export default class NewsAPI extends BaseAPI {
     return this.$getv2('/newsfeed', params)
   }
 
-  async fetch(id, distance, lovelist, logError) {
+  // newsletters: 'all' asks for the Community News posts from every area rather
+  // than just our own. The server honours it only for ChitChat moderators.
+  async fetch(id, distance, lovelist, logError, newsletters) {
     return await this.$getv2(
       id ? '/newsfeed/' + id : '/newsfeed',
       {
         distance,
         lovelist,
+        newsletters,
       },
       logError
     )

--- a/iznik-nuxt3/components/NewsAlert.vue
+++ b/iznik-nuxt3/components/NewsAlert.vue
@@ -12,6 +12,11 @@
         <br />
         <span class="text-muted small ps-2">
           {{ addedago }}
+          <!-- Community News posts are targeted at one area. Reviewing them from
+               all over the country is meaningless without knowing which. -->
+          <span v-if="chitChatMod && newsfeed.location">
+            · {{ newsfeed.location }}
+          </span>
         </span>
       </div>
     </div>
@@ -60,6 +65,7 @@ import { defineAsyncComponent, ref, computed } from 'vue'
 import { useNewsfeedStore } from '~/stores/newsfeed'
 import { twem } from '~/composables/useTwem'
 import { timeago } from '~/composables/useTimeFormat'
+import { useMe } from '~/composables/useMe'
 import { URL_REGEX } from '~/constants'
 import NewsLoveComment from '~/components/NewsLoveComment'
 import ProfileImage from '~/components/ProfileImage'
@@ -81,6 +87,7 @@ const props = defineProps({
 const emit = defineEmits(['focus-comment'])
 
 const newsfeedStore = useNewsfeedStore()
+const { chitChatMod } = useMe()
 
 // Data properties
 const showNewsPhotoModal = ref(false)

--- a/iznik-nuxt3/pages/chitchat/[[id]].vue
+++ b/iznik-nuxt3/pages/chitchat/[[id]].vue
@@ -122,6 +122,16 @@
                   class="filter-select"
                   size="sm"
                 />
+                <!-- Community News posts are targeted at one area and capped in
+                     any one feed, so there is otherwise no way to review what is
+                     going out nationally. -->
+                <b-form-checkbox
+                  v-if="chitChatMod"
+                  v-model="allNewsletters"
+                  class="filter-newsletters"
+                >
+                  All newsletter posts
+                </b-form-checkbox>
               </div>
             </div>
           </div>
@@ -194,6 +204,7 @@ import { useMiscStore } from '~/stores/misc'
 import { useNewsfeedStore } from '~/stores/newsfeed'
 import { useAuthStore } from '~/stores/auth'
 import { useLocationStore } from '~/stores/location'
+import { useTeamStore } from '~/stores/team'
 import NewsCommunityEventVolunteerSummary from '~/components/NewsCommunityEventVolunteerSummary'
 import { useMe } from '~/composables/useMe'
 import VisibleWhen from '~/components/VisibleWhen'
@@ -258,6 +269,7 @@ const miscStore = useMiscStore()
 const newsfeedStore = useNewsfeedStore()
 const authStore = useAuthStore()
 const locationStore = useLocationStore()
+const teamStore = useTeamStore()
 
 // We want this to be our next home page.
 const existingHomepage = miscStore.get('lasthomepage')
@@ -270,7 +282,20 @@ if (existingHomepage !== 'news') {
 }
 
 // Use me computed property from useMe composable for consistency
-const { me } = useMe()
+const { me, chitChatMod } = useMe()
+
+// chitChatMod resolves team membership through the team store, so the team has
+// to be loaded before the review filter can appear. The session already tells us
+// which teams we are in, so ordinary members cost no extra request.
+if (
+  me.value &&
+  (me.value.systemrole === 'Moderator' ||
+    me.value.systemrole === 'Support' ||
+    me.value.systemrole === 'Admin' ||
+    me.value.teams?.includes('ChitChat Moderation'))
+) {
+  teamStore.fetch('ChitChat Moderation')
+}
 const mod = computed(
   () =>
     me.value &&
@@ -326,6 +351,21 @@ const selectedArea = computed({
 
     await authStore.saveAndGet({
       settings,
+    })
+  },
+})
+
+// A reviewing tool rather than a preference, so it lives in local state rather
+// than the profile settings - no server round-trip, and it doesn't follow the
+// moderator onto their phone.
+const allNewsletters = computed({
+  get() {
+    return Boolean(miscStore.get('chitchatallnewsletters'))
+  },
+  set(newval) {
+    miscStore.set({
+      key: 'chitchatallnewsletters',
+      value: newval,
     })
   },
 })
@@ -505,7 +545,8 @@ function loadMore($state) {
 async function areaChange() {
   const newDistance = me.value?.settings?.newsfeedarea || 0
   await newsfeedStore.reset()
-  await newsfeedStore.fetchFeed(newDistance)
+  // reset() clears the store's memory of the flag, so pass it explicitly.
+  await newsfeedStore.fetchFeed(newDistance, allNewsletters.value)
   infiniteId.value++
   show.value = 0
 }
@@ -620,6 +661,16 @@ watch(selectedArea, async () => {
   await areaChange()
 })
 
+// Turning the newsletter review filter on or off rebuilds the feed the same way
+// a distance change does.
+watch(allNewsletters, async () => {
+  if (!me.value) {
+    return
+  }
+
+  await areaChange()
+})
+
 // Initialize location data if needed
 const initializeLocation = async () => {
   if (!areaname.value && areaid.value) {
@@ -696,7 +747,7 @@ if (me.value) {
       }
     })
   } else {
-    newsfeedStore.fetchFeed(distance.value).then(() => {
+    newsfeedStore.fetchFeed(distance.value, allNewsletters.value).then(() => {
       // Fetch the first few threads in parallel so that they are in the store.
       const feed = newsfeedStore.feed
 
@@ -889,6 +940,15 @@ if (me.value) {
     border-color: $color-green-background;
     box-shadow: 0 0 0 2px rgba($color-green-background, 0.1);
   }
+}
+
+/* Moderator-only, so it must not squeeze the distance filter - it keeps its
+   natural width and wraps to its own line when the row runs out of room. */
+.filter-newsletters {
+  flex: 0 0 auto;
+  font-size: 0.9rem;
+  color: $color-gray--darker;
+  white-space: nowrap;
 }
 
 // Events section

--- a/iznik-nuxt3/stores/newsfeed.js
+++ b/iznik-nuxt3/stores/newsfeed.js
@@ -21,6 +21,10 @@ export const useNewsfeedStore = defineStore({
     // Most recently used distance.
     lastDistance: 0,
 
+    // Whether the last feed fetch asked for every area's newsletter posts
+    // (ChitChat moderators only).
+    lastAllNewsletters: false,
+
     // Track what was seen before visiting ChitChat page (for "you're up to date" divider).
     seenBeforeVisit: null,
 
@@ -167,10 +171,20 @@ export const useNewsfeedStore = defineStore({
       this.delayedSeenMode = false
       this.seenBeforeVisit = null
     },
-    async fetchFeed(distance) {
+    // allNewsletters defaults to whatever was last asked for so that a refetch
+    // triggered by something else - posting, for instance - doesn't silently
+    // drop a moderator out of the review view.
+    async fetchFeed(distance, allNewsletters = this.lastAllNewsletters) {
       this.lastDistance = distance
+      this.lastAllNewsletters = allNewsletters
       distance = distance || 'anywhere'
-      this.feed = await api(this.config).news.fetch(null, distance)
+      this.feed = await api(this.config).news.fetch(
+        null,
+        distance,
+        undefined,
+        undefined,
+        allNewsletters ? 'all' : undefined
+      )
       return this.feed
     },
     async fetch(id, force, lovelist) {

--- a/iznik-nuxt3/tests/unit/components/NewsAlert.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsAlert.spec.js
@@ -1,8 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
 import NewsAlert from '~/components/NewsAlert.vue'
 
 const mockById = vi.fn()
+const mockChitChatMod = ref(false)
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({
+    chitChatMod: mockChitChatMod,
+  }),
+}))
 
 vi.mock('~/stores/newsfeed', () => ({
   useNewsfeedStore: () => ({
@@ -30,6 +38,7 @@ describe('NewsAlert', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockChitChatMod.value = false
     mockById.mockReturnValue(mockNewsfeed)
   })
 
@@ -103,6 +112,21 @@ describe('NewsAlert', () => {
     it('shows news love comment component', () => {
       const wrapper = createWrapper()
       expect(wrapper.find('.news-love-comment').exists()).toBe(true)
+    })
+
+    it('does not show the area to an ordinary member', () => {
+      // Members see the alerts for their own area, so naming it adds nothing.
+      mockById.mockReturnValue({ ...mockNewsfeed, location: 'Penzance' })
+      const wrapper = createWrapper()
+      expect(wrapper.text()).not.toContain('Penzance')
+    })
+
+    it('shows the area to a ChitChat moderator', () => {
+      // Reviewing posts from all over the country is meaningless without it.
+      mockChitChatMod.value = true
+      mockById.mockReturnValue({ ...mockNewsfeed, location: 'Penzance' })
+      const wrapper = createWrapper()
+      expect(wrapper.text()).toContain('Penzance')
     })
   })
 

--- a/iznik-nuxt3/tests/unit/pages/chitchat/id.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/chitchat/id.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import { ref } from 'vue'
+import { ref, reactive } from 'vue'
 
 import ChitchatPage from '~/pages/chitchat/[[id]].vue'
 
@@ -66,11 +66,28 @@ vi.mock('~/stores/newsfeed', () => ({
   useNewsfeedStore: () => mockNewsfeedStore,
 }))
 
-vi.mock('~/stores/misc', () => ({
-  useMiscStore: () => ({
-    get: vi.fn(),
-    set: vi.fn(),
+// Stateful AND reactive, because the newsletter review filter round-trips
+// through it: the real store is a Pinia getter over reactive state, so a plain
+// object here would leave the computed with nothing to track.
+const mockMiscState = reactive({})
+const mockMiscStore = {
+  get: vi.fn((key) => mockMiscState[key]),
+  set: vi.fn(({ key, value }) => {
+    mockMiscState[key] = value
   }),
+}
+
+vi.mock('~/stores/misc', () => ({
+  useMiscStore: () => mockMiscStore,
+}))
+
+const mockTeamStore = {
+  fetch: vi.fn().mockResolvedValue({}),
+  getTeam: vi.fn(),
+}
+
+vi.mock('~/stores/team', () => ({
+  useTeamStore: () => mockTeamStore,
 }))
 
 vi.mock('~/stores/location', () => ({
@@ -81,11 +98,13 @@ vi.mock('~/stores/location', () => ({
 
 // Mock useMe
 const mockMe = ref({ id: 1, displayname: 'Test User', settings: {} })
+const mockChitChatMod = ref(false)
 
 vi.mock('~/composables/useMe', () => ({
   useMe: () => ({
     me: mockMe,
     myGroups: ref([]),
+    chitChatMod: mockChitChatMod,
   }),
 }))
 
@@ -152,6 +171,12 @@ describe('chitchat/[[id]].vue loadMore', () => {
             template: '<select />',
             props: ['modelValue', 'options'],
           },
+          'b-form-checkbox': {
+            template:
+              '<label class="form-check"><input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)"><slot /></label>',
+            props: ['modelValue'],
+            emits: ['update:modelValue'],
+          },
           'b-spinner': { template: '<span />' },
           'v-icon': { template: '<i />' },
           OurUploader: { template: '<div />' },
@@ -170,6 +195,8 @@ describe('chitchat/[[id]].vue loadMore', () => {
     vi.clearAllMocks()
     setActivePinia(createPinia())
     mockMe.value = { id: 1, displayname: 'Test User', settings: {} }
+    mockChitChatMod.value = false
+    Object.keys(mockMiscState).forEach((k) => delete mockMiscState[k])
     mockNewsfeedStore.feed = []
     routeState.params = {}
   })
@@ -260,7 +287,86 @@ describe('chitchat/[[id]].vue loadMore', () => {
     await flushPromises()
 
     expect(mockNewsfeedStore.reset).toHaveBeenCalled()
-    expect(mockNewsfeedStore.fetchFeed).toHaveBeenCalledWith(12345)
+    expect(mockNewsfeedStore.fetchFeed).toHaveBeenCalledWith(12345, false)
+  })
+
+  describe('newsletter review filter', () => {
+    // Community News drips posts to one area at a time and the feed caps them,
+    // so support and the ChitChat Moderation team had no way to see what was
+    // going out nationally.
+    const checkbox = () => wrapper.find('.filter-newsletters input')
+
+    it('is not offered to an ordinary member', async () => {
+      mockChitChatMod.value = false
+      mountComponent()
+      await flushPromises()
+
+      expect(checkbox().exists()).toBe(false)
+    })
+
+    it('is offered to a ChitChat moderator', async () => {
+      mockChitChatMod.value = true
+      mountComponent()
+      await flushPromises()
+
+      expect(checkbox().exists()).toBe(true)
+    })
+
+    it('rebuilds the feed with the flag when switched on', async () => {
+      mockChitChatMod.value = true
+      mockMe.value = {
+        id: 1,
+        displayname: 'Test User',
+        settings: { newsfeedarea: 8046 },
+      }
+      mountComponent()
+      await flushPromises()
+      vi.clearAllMocks()
+
+      await checkbox().setValue(true)
+      await flushPromises()
+
+      expect(mockNewsfeedStore.reset).toHaveBeenCalled()
+      expect(mockNewsfeedStore.fetchFeed).toHaveBeenCalledWith(8046, true)
+    })
+
+    it('starts from the remembered setting on the next visit', async () => {
+      mockChitChatMod.value = true
+      mockMiscState.chitchatallnewsletters = true
+      mountComponent()
+      await flushPromises()
+
+      expect(mockNewsfeedStore.fetchFeed).toHaveBeenCalledWith(
+        expect.anything(),
+        true
+      )
+    })
+
+    it('fetches the moderation team so the filter can appear for a plain member of it', async () => {
+      mockMe.value = {
+        id: 1,
+        displayname: 'Test User',
+        settings: {},
+        teams: ['ChitChat Moderation'],
+      }
+      mountComponent()
+      await flushPromises()
+
+      expect(mockTeamStore.fetch).toHaveBeenCalledWith('ChitChat Moderation')
+    })
+
+    it('does not fetch the moderation team for an ordinary member', async () => {
+      mockMe.value = {
+        id: 1,
+        displayname: 'Test User',
+        settings: {},
+        teams: [],
+      }
+      mountComponent()
+      await flushPromises()
+
+      expect(mockTeamStore.fetch).not.toHaveBeenCalled()
+    })
   })
 
   it('does not hide consecutive posts from same user when message field is missing', () => {
@@ -342,7 +448,9 @@ describe('chitchat/[[id]].vue loadMore', () => {
       mountComponent()
       await flushPromises()
 
-      expect(mockNewsfeedStore.ensureSeenBaselineForThreadView).toHaveBeenCalled()
+      expect(
+        mockNewsfeedStore.ensureSeenBaselineForThreadView
+      ).toHaveBeenCalled()
       expect(mockNewsfeedStore.fetch).toHaveBeenCalled()
       // Order matters: delayedSeenMode must be on before the fetch's addItems
       // could fire an instant Seen POST for everything in the thread.

--- a/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
@@ -464,14 +464,56 @@ describe('newsfeed store', () => {
       expect(result).toEqual(feedData)
       expect(store.feed).toEqual(feedData)
       expect(store.lastDistance).toBe('nearby')
-      expect(mockFetchNews).toHaveBeenCalledWith(null, 'nearby')
+      expect(mockFetchNews).toHaveBeenCalledWith(
+        null,
+        'nearby',
+        undefined,
+        undefined,
+        undefined
+      )
     })
 
     it('defaults distance to anywhere when falsy', async () => {
       mockFetchNews.mockResolvedValue([])
 
       await store.fetchFeed(0)
-      expect(mockFetchNews).toHaveBeenCalledWith(null, 'anywhere')
+      expect(mockFetchNews).toHaveBeenCalledWith(
+        null,
+        'anywhere',
+        undefined,
+        undefined,
+        undefined
+      )
+    })
+
+    it('asks for every area when all newsletters are wanted', async () => {
+      mockFetchNews.mockResolvedValue([])
+
+      await store.fetchFeed('nearby', true)
+      expect(mockFetchNews).toHaveBeenCalledWith(
+        null,
+        'nearby',
+        undefined,
+        undefined,
+        'all'
+      )
+    })
+
+    it('keeps the newsletter flag across a refetch that does not pass it', async () => {
+      // Posting refetches the feed with no arguments; a moderator must not be
+      // silently dropped back to their own area.
+      mockFetchNews.mockResolvedValue([])
+
+      await store.fetchFeed('nearby', true)
+      await store.fetchFeed()
+
+      expect(mockFetchNews).toHaveBeenLastCalledWith(
+        null,
+        'anywhere',
+        undefined,
+        undefined,
+        'all'
+      )
     })
   })
 
@@ -603,7 +645,13 @@ describe('newsfeed store', () => {
         imageid: null,
       })
       // Should fetch feed for new thread
-      expect(mockFetchNews).toHaveBeenCalledWith(null, 'anywhere')
+      expect(mockFetchNews).toHaveBeenCalledWith(
+        null,
+        'anywhere',
+        undefined,
+        undefined,
+        undefined
+      )
     })
 
     it('sends reply and fetches threadhead', async () => {

--- a/iznik-server-go/newsfeed/newsfeed.go
+++ b/iznik-server-go/newsfeed/newsfeed.go
@@ -269,7 +269,13 @@ func Feed(c *fiber.Ctx) error {
 		}
 	}
 
-	ret := getFeed(myid, gotDistance, distance)
+	// ChitChat moderators can ask to see the Community News drip posts from all
+	// over the country rather than just their own area, so that what goes out
+	// nationally can be reviewed. Silently ignored for anyone else - it must not
+	// become a way for a member to widen their feed.
+	allNewsletters := c.Query("newsletters") == "all" && auth.IsChitChatMod(myid)
+
+	ret := getFeed(myid, gotDistance, distance, allNewsletters)
 	if len(ret) == 0 {
 		// Force [] rather than null to be returned.
 		return c.JSON(make([]string, 0))
@@ -278,8 +284,19 @@ func Feed(c *fiber.Ctx) error {
 	}
 }
 
-func getFeed(myid uint64, gotDistance bool, distance uint64) []NewsfeedSummary {
+// allNewsletters lifts the geographic filter and the flood cap on unpinned
+// Alerts (Community News). Callers must already have established that the user
+// is a ChitChat moderator - this function does not re-check.
+func getFeed(myid uint64, gotDistance bool, distance uint64, allNewsletters bool) []NewsfeedSummary {
 	db := database.DBConn
+
+	// The flood cap exists to stop a news run crowding out members' own ChitChat.
+	// A moderator reviewing the drip wants the opposite, so raise it to the same
+	// 100 the whole feed is capped at.
+	alertsPerFeed := utils.NEWSFEED_ALERTS_PER_FEED
+	if allNewsletters {
+		alertsPerFeed = 100
+	}
 
 	var gotLatLng bool
 
@@ -383,6 +400,26 @@ func getFeed(myid uint64, gotDistance bool, distance uint64) []NewsfeedSummary {
 	// Use a backstop timestamp so we can index better.
 	start := time.Now().AddDate(0, 0, -utils.OPEN_AGE_CHITCHAT).Format("2006-01-02")
 
+	// The alert arm normally leans on the spatial index to find posts inside the
+	// member's alert box. Reviewing all newsletters drops that predicate, so the
+	// timestamp index is the one that serves it.
+	alertArmIndex := "position"
+	alertArmGeo := "MBRContains(ST_SRID(POLYGON(LINESTRING(POINT(?, ?), POINT(?, ?), POINT(?, ?), POINT(?, ?), POINT(?, ?))), ?), position) AND "
+	alertArmGeoArgs := []interface{}{
+		alertSwlng, alertSwlat,
+		alertSwlng, alertNelat,
+		alertNelng, alertNelat,
+		alertNelng, alertSwlat,
+		alertSwlng, alertSwlat,
+		utils.SRID,
+	}
+
+	if allNewsletters {
+		alertArmIndex = "timestamp"
+		alertArmGeo = ""
+		alertArmGeoArgs = nil
+	}
+
 	if gotLatLng {
 		// Four-way UNION:
 		// 1. Regular posts (non-event, non-alert types) in the user's geographic area, capped at 100.
@@ -390,7 +427,8 @@ func getFeed(myid uint64, gotDistance bool, distance uint64) []NewsfeedSummary {
 		//    flood of these cannot push regular posts out of the feed (Discourse #9624).
 		// 3. Alerts in the user's ALERT box (fixed NEWSFEED_ALERT_RADIUS_KM), capped at
 		//    NEWSFEED_ALERTS_PER_FEED. Community News drip-posts as type Alert, so this is
-		//    the same flood guard as #2.
+		//    the same flood guard as #2. Both the box and the cap come off for a ChitChat
+		//    mod who asked for all newsletters.
 		// 4. PINNED alerts (any location), capped at 5. Only pinned alerts - central Freegle
 		//    announcements - are allowed to escape the geographic filter.
 		db.Raw(
@@ -437,14 +475,14 @@ func getFeed(myid uint64, gotDistance bool, distance uint64) []NewsfeedSummary {
 					"(CASE WHEN communityevents.id IS NOT NULL AND communityevents.pending THEN 1 ELSE 0 END) AS eventpending,"+
 					"(CASE WHEN volunteering.id IS NOT NULL AND volunteering.pending THEN 1 ELSE 0 END) AS volunteeringpending, "+
 					"(CASE WHEN users_stories.id IS NOT NULL AND (users_stories.public = 0 OR users_stories.reviewed = 0) THEN 1 ELSE 0 END) AS storypending "+
-					"FROM newsfeed FORCE INDEX (position) "+
+					"FROM newsfeed FORCE INDEX (%s) "+
 					"LEFT JOIN users ON users.id = newsfeed.userid "+
 					"LEFT JOIN spam_users ON spam_users.userid = newsfeed.userid AND collection IN (?, ?) "+
 					"LEFT JOIN newsfeed_unfollow ON newsfeed.id = newsfeed_unfollow.newsfeedid AND newsfeed_unfollow.userid = ? "+
 					"LEFT JOIN communityevents ON newsfeed.eventid = communityevents.id "+
 					"LEFT JOIN volunteering ON newsfeed.volunteeringid = volunteering.id "+
 					"LEFT JOIN users_stories ON newsfeed.storyid = users_stories.id "+
-					"WHERE MBRContains(ST_SRID(POLYGON(LINESTRING(POINT(?, ?), POINT(?, ?), POINT(?, ?), POINT(?, ?), POINT(?, ?))), ?), position) AND "+
+					"WHERE %s"+
 					"newsfeed.timestamp >= ? AND replyto IS NULL AND newsfeed.deleted IS NULL AND reviewrequired = 0 "+
 					"AND users.deleted IS NULL "+
 					"AND spam_users.id IS NULL "+
@@ -473,52 +511,50 @@ func getFeed(myid uint64, gotDistance bool, distance uint64) []NewsfeedSummary {
 					"ORDER BY pinned DESC, timestamp DESC "+
 					"LIMIT 5) "+
 					"ORDER BY pinned DESC, timestamp DESC LIMIT 100;",
-				utils.NEWSFEED_EVENTS_PER_FEED, utils.NEWSFEED_ALERTS_PER_FEED),
-			// UNION 1: regular posts in geographic area
-			utils.NEWSFEED_MODSTATUS_SUPPRESSED,
-			utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER,
-			myid,
-			swlng, swlat,
-			swlng, nelat,
-			nelng, nelat,
-			nelng, swlat,
-			swlng, swlat,
-			utils.SRID,
-			start,
-			utils.NEWSFEED_TYPE_COMMUNITY_EVENT, utils.NEWSFEED_TYPE_VOLUNTEER_OPPORTUNITY, utils.NEWSFEED_TYPE_ALERT,
-			// UNION 2: event/volunteering posts in geographic area (flood-capped, proximity-sorted)
-			utils.NEWSFEED_MODSTATUS_SUPPRESSED,
-			utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER,
-			myid,
-			swlng, swlat,
-			swlng, nelat,
-			nelng, nelat,
-			nelng, swlat,
-			swlng, swlat,
-			utils.SRID,
-			start,
-			utils.NEWSFEED_TYPE_COMMUNITY_EVENT, utils.NEWSFEED_TYPE_VOLUNTEER_OPPORTUNITY,
-			userLng, userLat, utils.SRID,
-			// UNION 3: alerts in the ALERT box (flood-capped) - Community News posts here.
-			// The alert box, not the feed box: the feed's density-derived radius can be
-			// far smaller than the ~20-mile scale news areas are clustered at.
-			utils.NEWSFEED_MODSTATUS_SUPPRESSED,
-			utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER,
-			myid,
-			alertSwlng, alertSwlat,
-			alertSwlng, alertNelat,
-			alertNelng, alertNelat,
-			alertNelng, alertSwlat,
-			alertSwlng, alertSwlat,
-			utils.SRID,
-			start,
-			utils.NEWSFEED_TYPE_ALERT,
-			// UNION 4: pinned alerts only (any location)
-			utils.NEWSFEED_MODSTATUS_SUPPRESSED,
-			utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER,
-			myid,
-			start,
-			utils.NEWSFEED_TYPE_ALERT,
+				utils.NEWSFEED_EVENTS_PER_FEED, alertArmIndex, alertArmGeo, alertsPerFeed),
+			append(append([]interface{}{
+				// UNION 1: regular posts in geographic area
+				utils.NEWSFEED_MODSTATUS_SUPPRESSED,
+				utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER,
+				myid,
+				swlng, swlat,
+				swlng, nelat,
+				nelng, nelat,
+				nelng, swlat,
+				swlng, swlat,
+				utils.SRID,
+				start,
+				utils.NEWSFEED_TYPE_COMMUNITY_EVENT, utils.NEWSFEED_TYPE_VOLUNTEER_OPPORTUNITY, utils.NEWSFEED_TYPE_ALERT,
+				// UNION 2: event/volunteering posts in geographic area (flood-capped, proximity-sorted)
+				utils.NEWSFEED_MODSTATUS_SUPPRESSED,
+				utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER,
+				myid,
+				swlng, swlat,
+				swlng, nelat,
+				nelng, nelat,
+				nelng, swlat,
+				swlng, swlat,
+				utils.SRID,
+				start,
+				utils.NEWSFEED_TYPE_COMMUNITY_EVENT, utils.NEWSFEED_TYPE_VOLUNTEER_OPPORTUNITY,
+				userLng, userLat, utils.SRID,
+				// UNION 3: alerts in the ALERT box (flood-capped) - Community News posts here.
+				// The alert box, not the feed box: the feed's density-derived radius can be
+				// far smaller than the ~20-mile scale news areas are clustered at. A ChitChat
+				// mod reviewing all newsletters gets no box at all - see alertArmGeo.
+				utils.NEWSFEED_MODSTATUS_SUPPRESSED,
+				utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER,
+				myid,
+			}, alertArmGeoArgs...), []interface{}{
+				start,
+				utils.NEWSFEED_TYPE_ALERT,
+				// UNION 4: pinned alerts only (any location)
+				utils.NEWSFEED_MODSTATUS_SUPPRESSED,
+				utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER,
+				myid,
+				start,
+				utils.NEWSFEED_TYPE_ALERT,
+			}...)...,
 		).Scan(&newsfeed)
 	} else {
 		// Three-way UNION for the "everywhere" path:
@@ -528,11 +564,16 @@ func getFeed(myid uint64, gotDistance bool, distance uint64) []NewsfeedSummary {
 		//    announcements) come from anywhere; unpinned ones - Community News - only from
 		//    inside the user's own alert box, so "everywhere" (the default feed setting)
 		//    doesn't serve somebody in Cornwall news about Yorkshire. With no known
-		//    location only pinned alerts are served.
+		//    location only pinned alerts are served. A ChitChat mod who asked for all
+		//    newsletters gets the lot, uncapped by geography.
 		alertGeo := "AND newsfeed.pinned = 1 "
 		var alertGeoArgs []interface{}
 
-		if gotAlertBox {
+		if allNewsletters {
+			// A ChitChat mod reviewing the drip wants every area's posts, so the
+			// arm carries no geographic condition at all.
+			alertGeo = ""
+		} else if gotAlertBox {
 			alertGeo = "AND (newsfeed.pinned = 1 OR MBRContains(ST_SRID(POLYGON(LINESTRING(POINT(?, ?), POINT(?, ?), POINT(?, ?), POINT(?, ?), POINT(?, ?))), ?), position)) "
 			alertGeoArgs = []interface{}{
 				alertSwlng, alertSwlat,
@@ -601,7 +642,7 @@ func getFeed(myid uint64, gotDistance bool, distance uint64) []NewsfeedSummary {
 					"%s"+
 					"ORDER BY pinned DESC, newsfeed.timestamp DESC LIMIT %d "+
 					") ORDER BY pinned DESC, timestamp DESC LIMIT 100;",
-				utils.NEWSFEED_EVENTS_PER_FEED, alertGeo, utils.NEWSFEED_ALERTS_PER_FEED),
+				utils.NEWSFEED_EVENTS_PER_FEED, alertGeo, alertsPerFeed),
 			append([]interface{}{
 				// UNION 1: regular posts
 				utils.NEWSFEED_MODSTATUS_SUPPRESSED,
@@ -923,8 +964,11 @@ func fetchSingle(id uint64, myid uint64, lovelist bool) (Newsfeed, bool) {
 			Scan(&areaname)
 		if areaname != "" {
 			newsfeed.Location = areaname
-		} else if len(newsfeed.Location) > 2 {
-			// Fallback to truncated postcode if no area name found.
+		} else if newsfeed.Type != utils.NEWSFEED_TYPE_ALERT && len(newsfeed.Location) > 2 {
+			// Fallback to truncated postcode if no area name found. Alerts are
+			// exempt: Community News stores the news AREA NAME there, and the
+			// system account that posts them has no lastlocation, so without this
+			// they would come back as "Edinbur" or "Weston-super-Ma".
 			newsfeed.Location = strings.TrimSpace(newsfeed.Location[:len(newsfeed.Location)-2])
 		}
 
@@ -1046,7 +1090,9 @@ func Count(c *fiber.Ctx) error {
 
 	go func() {
 		defer wg.Done()
-		ret = getFeed(myid, gotDistance, distance)
+		// Always the normal feed: the unread count is about what the member has
+		// to read, not what a moderator has asked to review.
+		ret = getFeed(myid, gotDistance, distance, false)
 	}()
 
 	wg.Add(1)

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -1212,6 +1212,8 @@ func SetupRoutes(app *fiber.App) {
 		// @Description Returns newsfeed items
 		// @Tags newsfeed
 		// @Produce json
+		// @Param distance query string false "Feed radius in metres, or 'nearby'/'anywhere'"
+		// @Param newsletters query string false "Set to 'all' to see Community News posts from every area. ChitChat moderators only; ignored for anyone else."
 		// @Success 200 {array} newsfeed.Item
 		rg.Get("/newsfeed", newsfeed.Feed)
 		rg.Post("/newsfeed", newsfeed.Post)

--- a/iznik-server-go/test/newsfeed_newsletters_test.go
+++ b/iznik-server-go/test/newsfeed_newsletters_test.go
@@ -1,0 +1,162 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	newsfeed2 "github.com/freegle/iznik-server-go/newsfeed"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// Community News drip-posts to ChitChat as unpinned Alerts placed at the centre
+// of a news area. The feed serves those only from inside the member's own alert
+// box, capped at NEWSFEED_ALERTS_PER_FEED, so nobody can review what is going out
+// nationally. `newsletters=all` lifts both limits for ChitChat moderators only.
+
+// createTestAlertAt inserts an unpinned Alert at a point, with the area name in
+// `location` the way CommunityNewsChitChatService writes it.
+func createTestAlertAt(t *testing.T, userID uint64, lat float64, lng float64, message string, location string) uint64 {
+	db := database.DBConn
+
+	result := db.Exec(fmt.Sprintf("INSERT INTO newsfeed (userid, message, type, timestamp, deleted, reviewrequired, position, hidden, pinned, location) "+
+		"VALUES (?, ?, 'Alert', NOW(), NULL, 0, ST_GeomFromText(?, %d), NULL, 0, ?)", utils.SRID),
+		userID, message, fmt.Sprintf("POINT(%f %f)", lng, lat), location)
+
+	if result.Error != nil {
+		t.Fatalf("ERROR: Failed to create test alert: %v", result.Error)
+	}
+
+	var id uint64
+	db.Raw("SELECT id FROM newsfeed WHERE userid = ? AND message = ? ORDER BY id DESC LIMIT 1",
+		userID, message).Scan(&id)
+
+	if id == 0 {
+		t.Fatalf("ERROR: Alert was created but ID not found")
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM newsfeed WHERE id = ?", id)
+	})
+
+	return id
+}
+
+// feedContains reports whether a feed response includes a newsfeed id.
+func feedContains(t *testing.T, token string, query string, wanted uint64) bool {
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed?jwt="+token+query, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var feed []newsfeed2.Newsfeed
+	json2.Unmarshal(rsp(resp), &feed)
+
+	for _, item := range feed {
+		if item.ID == wanted {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Test users sit at Edinburgh (CreateTestUser settings mylocation). Cornwall is
+// far outside NEWSFEED_ALERT_RADIUS_KM of that, so an alert there is only ever
+// visible because the flag lifted the geographic filter, never by accident.
+const farAwayLat = 50.2660
+const farAwayLng = -5.0527
+
+func TestFeedAllNewslettersVisibleToChitChatMod(t *testing.T) {
+	prefix := uniquePrefix("nlmod")
+	userID, token := CreateFullTestUser(t, prefix)
+	makeChitChatMod(t, userID)
+
+	poster := CreateTestUser(t, prefix+"_poster", "User")
+	alertID := createTestAlertAt(t, poster, farAwayLat, farAwayLng, "Newsletter far away "+prefix, "Penzance")
+
+	// Without the flag the alert is out of area, on both feed paths.
+	assert.False(t, feedContains(t, token, "&distance=0", alertID),
+		"an out-of-area newsletter post must not reach the everywhere feed unasked")
+	assert.False(t, feedContains(t, token, "&distance=10000", alertID),
+		"an out-of-area newsletter post must not reach the distance-filtered feed unasked")
+
+	// With it, a ChitChat mod sees it on both.
+	assert.True(t, feedContains(t, token, "&distance=0&newsletters=all", alertID),
+		"a ChitChat mod asking for all newsletters must see an out-of-area one")
+	assert.True(t, feedContains(t, token, "&distance=10000&newsletters=all", alertID),
+		"the distance-filtered feed path must honour the flag too")
+}
+
+func TestFeedAllNewslettersIgnoredForOrdinaryMember(t *testing.T) {
+	prefix := uniquePrefix("nlmember")
+	_, token := CreateFullTestUser(t, prefix)
+
+	poster := CreateTestUser(t, prefix+"_poster", "User")
+	alertID := createTestAlertAt(t, poster, farAwayLat, farAwayLng, "Newsletter far away "+prefix, "Penzance")
+
+	// The param is not a way for a member to escape the geographic filter.
+	assert.False(t, feedContains(t, token, "&distance=0&newsletters=all", alertID),
+		"an ordinary member must not be able to widen the feed with the flag")
+	assert.False(t, feedContains(t, token, "&distance=10000&newsletters=all", alertID),
+		"an ordinary member must not be able to widen the distance-filtered feed either")
+}
+
+func TestFeedAllNewslettersLeavesOrdinaryPostsAlone(t *testing.T) {
+	// The flag widens the alert arm only - it must not drag in out-of-area
+	// member chat, which would be a privacy change rather than a review tool.
+	prefix := uniquePrefix("nlchat")
+	userID, token := CreateFullTestUser(t, prefix)
+	makeChitChatMod(t, userID)
+
+	poster := CreateTestUser(t, prefix+"_poster", "User")
+	chatID := CreateTestNewsfeed(t, poster, farAwayLat, farAwayLng, "Far away chatter "+prefix)
+	t.Cleanup(func() {
+		database.DBConn.Exec("DELETE FROM newsfeed WHERE id = ?", chatID)
+	})
+
+	assert.False(t, feedContains(t, token, "&distance=10000&newsletters=all", chatID),
+		"the flag must not widen the feed for ordinary ChitChat posts")
+}
+
+func TestNewsfeedAlertLocationIsNotTruncated(t *testing.T) {
+	// Alert posts store the news AREA NAME in `location`, not a postcode, so the
+	// "trim the last two characters off the postcode" fallback mangles them
+	// ("Edinburgh" -> "Edinbur"). The Freegle system account that posts them has
+	// no lastlocation, so that fallback is exactly the path they take.
+	prefix := uniquePrefix("nlloc")
+	poster := CreateTestUser(t, prefix+"_poster", "User")
+	alertID := createTestAlertAt(t, poster, 55.9533, -3.1883, "Newsletter local "+prefix, "Edinburgh")
+
+	id := strconv.FormatUint(alertID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var single newsfeed2.Newsfeed
+	json2.Unmarshal(rsp(resp), &single)
+	assert.Equal(t, "Edinburgh", single.Location,
+		"an Alert's area name must be returned intact, not treated as a postcode")
+}
+
+func TestNewsfeedMessageLocationStillTruncated(t *testing.T) {
+	// The postcode fallback must survive for ordinary posts, which is what it
+	// was written for.
+	prefix := uniquePrefix("nlloc2")
+	poster := CreateTestUser(t, prefix+"_poster", "User")
+	nfID := CreateTestNewsfeed(t, poster, 55.9533, -3.1883, "Ordinary post "+prefix)
+	database.DBConn.Exec("UPDATE newsfeed SET location = ? WHERE id = ?", "EH3 9DR", nfID)
+	t.Cleanup(func() {
+		database.DBConn.Exec("DELETE FROM newsfeed WHERE id = ?", nfID)
+	})
+
+	id := strconv.FormatUint(nfID, 10)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed/"+id, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var single newsfeed2.Newsfeed
+	json2.Unmarshal(rsp(resp), &single)
+	assert.Equal(t, "EH3 9", single.Location,
+		"an ordinary post's postcode must still be truncated for privacy")
+}


### PR DESCRIPTION
## Summary

- Community News drip-posts to ChitChat as unpinned `Alert` rows placed at the centre of a news area (`CommunityNewsChitChatService`). The feed serves those only from inside the member's own 32km alert box (`NEWSFEED_ALERT_RADIUS_KM`) and caps them at `NEWSFEED_ALERTS_PER_FEED` = 5, so support and the ChitChat Moderation team had no way to review what was going out nationally. Live that is 239 areas, 469 posts so far, 56-112 on an active day.
- `GET /newsfeed` takes a new `newsletters=all`. It drops the geographic predicate on the unpinned-Alert arm and raises that arm's cap to 100. The whole feed's outer `LIMIT 100` is unchanged, so with the filter on you see roughly the last day's national drip alongside whatever ChitChat fits.
- Honoured only for ChitChat moderators, via the existing `auth.IsChitChatMod()` - the ChitChat Moderation team, or Support/Admin. For anyone else the parameter is silently ignored, so it cannot be used to widen a member's own feed. The unread count endpoint always uses the normal feed.
- A checkbox, "All newsletter posts", sits on the same row as the distance filter for those moderators only. It lives in local state rather than profile settings: it is a reviewing tool, not a preference, so it costs no server round-trip and does not follow the moderator onto their phone.
- Alert posts now show their area name next to the byline, for ChitChat moderators only. Reviewing posts from all over the country is meaningless without knowing which area each was aimed at.

## Bug found and fixed on the way

`fetchSingle` overwrites `location` with the poster's area name, and when the poster has no `lastlocation` it falls back to `location[:len-2]` on the assumption the value is a postcode. The Freegle system account that posts Community News has no `lastlocation`, and Alert rows hold the news **area name** in that column. The API has therefore been returning `Edinbur`, `Dumfrie` and `Weston-super-Ma` for all 469 of these posts. It went unnoticed because `NewsAlert.vue` never rendered the field - which this PR changes, so the fix belongs here. Ordinary posts still get the postcode truncation, and there is a test pinning each side.

## Code Quality Review

- No new permission concept: both the Go gate and the client gate already existed and are reused unchanged.
- The `IsChitChatMod` lookup is behind a short-circuit on the query parameter, so ordinary feed requests do not gain a database round-trip.
- Dropping `MBRContains` from the alert arm makes `FORCE INDEX (position)` the wrong hint, so that arm switches to the `timestamp` index when the filter is on.
- The store remembers the flag, so a refetch triggered by something else - posting, for instance - does not silently drop a moderator back to their own area.
- The four-way UNION's arguments moved to the same `append`-built slice style the three-way UNION already used, so the geographic arguments can be omitted along with the predicate.

## Future Improvements

- The feed has no paging, so even with the filter on a moderator sees only the newest ~100 items - under two days of the national drip. Working through the whole backlog would need a paged ModTools page rather than a feed filter.
- With the drip at its current rate the filter leaves little room for real ChitChat in the outer 100. If that proves annoying, lowering the arm cap trades review depth for feed balance.

## Test Plan

- Go, 5 new tests in `test/newsfeed_newsletters_test.go`: an out-of-area newsletter post is absent from both feed paths without the flag and present with it for a ChitChat mod; absent on both paths for an ordinary member using the same flag; the flag does not widen the feed for ordinary ChitChat posts; an Alert's area name survives intact; an ordinary post's postcode is still truncated. Each carries its own before-state control, so it fails without the change.
- Vitest: page tests for the checkbox being hidden from members and offered to moderators, the toggle rebuilding the feed with the flag, the setting being remembered, and the moderation team being fetched only when it can matter. Store tests for the parameter and for the flag surviving a bare refetch. Component tests for the area name being moderator-only.
- Full suites, Go re-run against this branch tip: Go 4061 passed, 0 failed. Vitest 719 files, 15,168 passed.
- Browser-verified on `freegle-dev-local` as a plain `User` who is in the ChitChat Moderation team: with the filter off only the local Edinburgh alert appears; with it on a Cornwall alert appears too, labelled "· Penzance". The row keeps the distance filter full width and wraps the checkbox onto its own line at 375px.
