### PR TITLE
fix(ci): stop the Coveralls gate flapping - duplicate Go coverage paths and a raced dynamic import

### DIFF
--- a/iznik-nuxt3/tests/unit/components/PostMap.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostMap.spec.js
@@ -126,6 +126,29 @@ vi.mock('nuxt/app', () => ({
 // Mock leaflet imports
 vi.mock('leaflet/dist/leaflet-src.esm', () => ({}))
 
+// ready() dynamically imports the geocoder control and the Photon geocoder. Left
+// unmocked they load the real modules, and whether that resolves before the test ends
+// is a race against real module-load time — so lines 700-753 of PostMap.vue were hit in
+// some runs and not others. That made this file's covered-line count vary between runs
+// of an IDENTICAL tree (559 vs 530 of 866), moving whole-repo coverage by ~0.024pp and
+// flapping the Coveralls gate on PRs that touch no frontend code at all. Mocking them —
+// as every other external in this file already is — makes the geocoder path resolve
+// deterministically. Verified by diffing two lcov reports from the same tree.
+vi.mock('leaflet-control-geocoder/src/control', () => ({
+  Geocoder: vi.fn().mockImplementation(() => {
+    // ready() chains .on('markgeocode', ...).addTo(map), so both must be chainable.
+    const control = {
+      on: vi.fn(() => control),
+      addTo: vi.fn(() => control),
+    }
+    return control
+  }),
+}))
+
+vi.mock('leaflet-control-geocoder/src/geocoders/photon', () => ({
+  Photon: vi.fn().mockImplementation(() => ({})),
+}))
+
 // Mock vue-leaflet components
 vi.mock('@vue-leaflet/vue-leaflet', () => ({
   LGeoJson: {

--- a/iznik-nuxt3/tests/unit/components/PostMap.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostMap.spec.js
@@ -454,6 +454,36 @@ describe('PostMap', () => {
       await createWrapper()
       expect(loadLeaflet).toHaveBeenCalled()
     })
+
+    // ready() wraps its geocoder setup in try/catch precisely because leaflet throws
+    // here in practice. That containment is what keeps a geocoder failure from taking
+    // the whole map down, and it was only ever covered by accident — before the two
+    // dynamic imports above were mocked, the real modules threw in jsdom and hit this
+    // catch as a side effect. Asserted deliberately now.
+    it('keeps working when the geocoder fails to construct', async () => {
+      const { Geocoder } = await import('leaflet-control-geocoder/src/control')
+      Geocoder.mockImplementationOnce(() => {
+        throw new Error('leaflet not ready')
+      })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      const wrapper = await createWrapper()
+      const map = wrapper.findComponent({ name: 'LMap' })
+      await map.vm.$emit('ready')
+      await flushPromises()
+
+      // Swallowed, not propagated...
+      expect(
+        logSpy.mock.calls.some((c) => String(c[0]).includes('Ignore leaflet exception'))
+      ).toBe(true)
+
+      // ...and the map is still live: it framed itself and the parent was told it is ready.
+      const component = wrapper.findComponent(PostMap)
+      expect(component.emitted('update:ready')).toBeTruthy()
+      expect(map.vm.leafletObject.fitBounds).toHaveBeenCalled()
+
+      logSpy.mockRestore()
+    })
   })
 
   describe('map hidden behavior', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModEmailDateFilter.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModEmailDateFilter.spec.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import ModEmailDateFilter from '~/modtools/components/ModEmailDateFilter.vue'
+
+/**
+ * This filter decides the time window every incoming-email panel queries with. The
+ * distinction that matters is precision: the short presets carry a time of day, the
+ * multi-day ones are date-only. If "last hour" degraded to a date-only range it would
+ * silently become "since midnight" — a much wider window that still looks plausible.
+ */
+describe('ModEmailDateFilter', () => {
+  function fetchPayload(defaultPreset) {
+    const wrapper = mount(ModEmailDateFilter, { props: { defaultPreset } })
+    const events = wrapper.emitted('fetch')
+    expect(events, 'the panel fetches on mount, without waiting for a click').toBeTruthy()
+    return events[0][0]
+  }
+
+  it('fetches on mount so the panel arrives populated', () => {
+    const wrapper = mount(ModEmailDateFilter)
+
+    expect(wrapper.emitted('fetch')).toHaveLength(1)
+  })
+
+  describe('short presets keep the time of day', () => {
+    it('hour asks for a window one hour wide, not since midnight', () => {
+      const p = fetchPayload('hour')
+
+      expect(p.start).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)
+      expect(p.end).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)
+
+      const widthMs = new Date(p.end) - new Date(p.start)
+      expect(widthMs).toBeGreaterThan(59 * 60 * 1000)
+      expect(widthMs).toBeLessThan(61 * 60 * 1000)
+    })
+
+    it('day asks for a window 24 hours wide', () => {
+      const p = fetchPayload('day')
+
+      expect(p.start).toMatch(/T\d{2}:\d{2}:\d{2}$/)
+      const widthMs = new Date(p.end) - new Date(p.start)
+      expect(widthMs).toBeGreaterThan(23.5 * 3600 * 1000)
+      expect(widthMs).toBeLessThan(24.5 * 3600 * 1000)
+    })
+  })
+
+  describe('multi-day presets are date-only', () => {
+    it.each(['7days', '30days', '90days'])('%s sends bare dates', (preset) => {
+      const p = fetchPayload(preset)
+
+      expect(p.start).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(p.end).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(p.start).not.toContain('T')
+    })
+
+    it('7days spans a week', () => {
+      const p = fetchPayload('7days')
+
+      const days = (new Date(p.end) - new Date(p.start)) / 86400000
+      expect(days).toBe(7)
+    })
+  })
+
+  describe('lokiRange', () => {
+    it.each([
+      ['hour', '1h'],
+      ['day', '24h'],
+      ['7days', '7d'],
+      ['30days', '30d'],
+      ['90days', '90d'],
+    ])('maps %s to %s', (preset, expected) => {
+      expect(fetchPayload(preset).lokiRange).toBe(expected)
+    })
+
+    it('is null for custom dates, so the consumer must use the explicit range', () => {
+      expect(fetchPayload('custom').lokiRange).toBeNull()
+    })
+  })
+
+  it('reports which preset produced the window', () => {
+    expect(fetchPayload('30days').preset).toBe('30days')
+  })
+
+  it('defaults to the last 7 days', () => {
+    const wrapper = mount(ModEmailDateFilter)
+
+    expect(wrapper.emitted('fetch')[0][0].preset).toBe('7days')
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/modtools/ModEmailDateFilter.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModEmailDateFilter.spec.js
@@ -87,4 +87,42 @@ describe('ModEmailDateFilter', () => {
 
     expect(wrapper.emitted('fetch')[0][0].preset).toBe('7days')
   })
+
+  it('falls back to a week for a preset it does not recognise', () => {
+    // The window is what the panel queries with, so an unknown preset must land on a
+    // sane range rather than an empty or undefined one.
+    const p = fetchPayload('sometime-last-tuesday')
+
+    expect(p.start).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect((new Date(p.end) - new Date(p.start)) / 86400000).toBe(7)
+  })
+
+  describe('changing the dropdown', () => {
+    async function selectPreset(wrapper, value) {
+      const select = wrapper.find('select.form-select')
+      await select.setValue(value)
+      return wrapper
+    }
+
+    it('refetches immediately for a fixed preset', async () => {
+      const wrapper = mount(ModEmailDateFilter)
+      expect(wrapper.emitted('fetch')).toHaveLength(1) // the mount fetch
+
+      await selectPreset(wrapper, 'day')
+
+      expect(wrapper.emitted('fetch')).toHaveLength(2)
+      expect(wrapper.emitted('fetch')[1][0].preset).toBe('day')
+    })
+
+    it('waits for the Fetch button when custom dates are chosen', async () => {
+      // Auto-fetching on 'custom' would fire with both date fields still empty, so the
+      // early return is what lets the moderator fill them in first.
+      const wrapper = mount(ModEmailDateFilter)
+      expect(wrapper.emitted('fetch')).toHaveLength(1)
+
+      await selectPreset(wrapper, 'custom')
+
+      expect(wrapper.emitted('fetch')).toHaveLength(1)
+    })
+  })
 })

--- a/iznik-nuxt3/tests/unit/setup.ts
+++ b/iznik-nuxt3/tests/unit/setup.ts
@@ -189,6 +189,13 @@ config.global.stubs = {
       '<label class="form-check"><input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked); $emit(\'change\', $event.target.checked)" /><slot /></label>',
     props: ['modelValue'],
   },
+  // b-form wraps the *-input/-select stubs below. Without it here, any component
+  // laying its controls out in a <b-form> logs "Failed to resolve component",
+  // which this file turns into a test failure.
+  'b-form': {
+    template: '<form @submit.prevent="$emit(\'submit\')"><slot /></form>',
+    props: ['inline'],
+  },
   'b-form-group': {
     template: '<div class="form-group"><slot /></div>',
     props: ['label', 'labelFor'],

--- a/iznik-nuxt3/tests/unit/setup.ts
+++ b/iznik-nuxt3/tests/unit/setup.ts
@@ -174,10 +174,37 @@ config.global.stubs = {
     template:
       '<div class="card"><slot /><slot name="header" /><slot name="footer" /></div>',
   },
+  // Renders the `options` prop as real <option>s. Without them the stubbed <select> has
+  // no matching option for any value, so setValue('x') lands as '' and a test cannot
+  // drive the control at all — it silently exercises the wrong branch instead of the one
+  // it names. The <slot> is kept for components that pass options as slot content.
+  // Declares `change` and emits it with the VALUE, as bootstrap-vue-next does. Without
+  // that declaration a parent's @change is treated as a native listener on the <select>
+  // and receives an Event object instead, so a handler like
+  // `onPresetChange(p) { if (p === 'custom') return }` can never take its early return in
+  // tests — it silently runs the other branch.
   'b-form-select': {
     template:
-      '<select class="form-select" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+      '<select class="form-select" :value="modelValue" @change="onStubChange">' +
+      '<option v-for="o in stubOptions" :key="o.value" :value="o.value">{{ o.text }}</option>' +
+      '<slot /></select>',
     props: ['modelValue', 'id', 'options'],
+    emits: ['update:modelValue', 'change'],
+    methods: {
+      onStubChange(e: { target: { value: unknown } }) {
+        this.$emit('update:modelValue', e.target.value)
+        this.$emit('change', e.target.value)
+      },
+    },
+    computed: {
+      stubOptions() {
+        return (this.options || []).map((o) =>
+          o !== null && typeof o === 'object'
+            ? { value: o.value, text: o.text ?? o.value }
+            : { value: o, text: o }
+        )
+      },
+    },
   },
   'b-form-input': {
     template:

--- a/iznik-server-go/build.sh
+++ b/iznik-server-go/build.sh
@@ -89,9 +89,8 @@ echo "✅ Swagger specification validation passed"
 # directory at runtime, so the file-based detection in status.go's init() cannot
 # work there. ldflags is the only reliable way to make /api/version report the
 # live Go deploy (consumed by the monitor-fsm verified-live reply gate). The
-# import path here must match how packages are imported (via the
-# `replace github.com/freegle/iznik-server-go => ./` directive in go.mod), not
-# the bare module name.
+# import path here is the module path declared in go.mod, which is also how
+# every package imports its siblings.
 echo "Building application..."
 BUILD_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')

--- a/iznik-server-go/go.mod
+++ b/iznik-server-go/go.mod
@@ -1,4 +1,4 @@
-module iznik-server-go
+module github.com/freegle/iznik-server-go
 
 go 1.23.0
 
@@ -74,8 +74,6 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
-
-replace github.com/freegle/iznik-server-go => ./
 
 // Fix for dockertest v3.3.5 incompatibility with modern runc
 replace github.com/ory/dockertest => github.com/ory/dockertest/v3 v3.10.0

--- a/iznik-server-go/message/postmatches_pure_test.go
+++ b/iznik-server-go/message/postmatches_pure_test.go
@@ -1,0 +1,28 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// oppositeType decides what the matched-posts email searches for. Only the Offer
+// branch was exercised; the other two matter just as much:
+//
+//   - if Wanted stopped mapping to Offer, a wanted post would be matched against
+//     other wanted posts, pairing a request with a request
+//   - if the default stopped returning "", a type that has no opposite (Taken,
+//     Received, Admin...) would enter matching and pull in arbitrary candidates
+func TestOppositeTypeOfferIsWanted(t *testing.T) {
+	assert.Equal(t, "Wanted", oppositeType("Offer"))
+}
+
+func TestOppositeTypeWantedIsOffer(t *testing.T) {
+	assert.Equal(t, "Offer", oppositeType("Wanted"))
+}
+
+func TestOppositeTypeOfAnythingElseIsEmptySoMatchingIsSkipped(t *testing.T) {
+	for _, in := range []string{"Taken", "Received", "Admin", "", "offer", "OFFER"} {
+		assert.Equal(t, "", oppositeType(in), "type %q has no opposite and must not match", in)
+	}
+}

--- a/iznik-server-go/partnerships/stats_filename_test.go
+++ b/iznik-server-go/partnerships/stats_filename_test.go
@@ -1,0 +1,58 @@
+package partnerships
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// sanitiseFilename exists to stop a crafted authority name breaking out of a
+// Content-Disposition header. Only its pass-through path was covered, so the
+// sanitising it is named for — the whole point of the function — was untested.
+
+func TestSanitiseFilenameLeavesAnOrdinaryNameAlone(t *testing.T) {
+	assert.Equal(t, "Bristol City Council.xlsx", sanitiseFilename("Bristol City Council.xlsx"))
+}
+
+func TestSanitiseFilenameReplacesTheQuoteThatWouldCloseTheHeader(t *testing.T) {
+	// A bare double quote would terminate filename="..." and let the rest be
+	// read as further header parameters.
+	got := sanitiseFilename(`evil".xlsx`)
+
+	assert.NotContains(t, got, `"`)
+	assert.Equal(t, "evil_.xlsx", got)
+}
+
+func TestSanitiseFilenameReplacesPathSeparatorsAndBackslashes(t *testing.T) {
+	got := sanitiseFilename(`../../etc/passwd`)
+
+	assert.NotContains(t, got, "/")
+	assert.NotContains(t, got, `\`)
+	// Each separator becomes one underscore; the dots are left alone.
+	assert.Equal(t, ".._.._etc_passwd", got)
+	assert.Equal(t, `a_b`, sanitiseFilename(`a\b`))
+}
+
+func TestSanitiseFilenameReplacesControlCharacters(t *testing.T) {
+	// CR/LF are the header-injection characters: they would let a crafted name
+	// append an entirely new header.
+	got := sanitiseFilename("stats\r\nX-Injected: 1.xlsx")
+
+	assert.NotContains(t, got, "\r")
+	assert.NotContains(t, got, "\n")
+	assert.False(t, strings.Contains(got, "\r\n"))
+}
+
+func TestSanitiseFilenameFallsBackWhenNothingIsLeft(t *testing.T) {
+	// An empty name would produce filename="" — the fallback keeps the download
+	// usable instead.
+	assert.Equal(t, "statistics.xlsx", sanitiseFilename(""))
+}
+
+func TestSanitiseFilenameKeepsNonAsciiNames(t *testing.T) {
+	// Only control characters and the three delimiters are replaced, so an
+	// accented or non-Latin authority name survives intact.
+	assert.Equal(t, "Sirhowy Ystrad Mynach.xlsx", sanitiseFilename("Sirhowy Ystrad Mynach.xlsx"))
+	assert.Equal(t, "Powys–Gwynedd.xlsx", sanitiseFilename("Powys–Gwynedd.xlsx"))
+}

--- a/iznik-server-go/user/auth.go
+++ b/iznik-server-go/user/auth.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/freegle/iznik-server-go/auth"
 	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/location"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
-	"iznik-server-go/location"
 )
 
 // WhoAmI returns the authenticated user ID from the request, or 0 if not logged in.

--- a/status-nuxt/server/api/tests/vitest.post.ts
+++ b/status-nuxt/server/api/tests/vitest.post.ts
@@ -7,6 +7,13 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event).catch(() => ({}))
   const filter = body?.filter || ''
 
+  // ?coverage=true writes coverage/lcov.info inside the container, mirroring the Go
+  // endpoint. Needed to diagnose coverage locally at all: CI archives a Go profile
+  // but no frontend one, so without this the only way to see a frontend coverage
+  // number is to push and read Coveralls.
+  const query = getQuery(event)
+  const withCoverage = query.coverage === 'true'
+
   if (isTestRunning('vitest')) {
     throw createError({
       statusCode: 409,
@@ -41,7 +48,8 @@ export default defineEventHandler(async (event) => {
   })
 
   const filterArg = filter ? ` --reporter=verbose "${filter}"` : ' --reporter=verbose'
-  const testCmd = `cd /app && npx vitest run${filterArg} 2>&1`
+  const coverageArg = withCoverage ? ' --coverage' : ''
+  const testCmd = `cd /app && npx vitest run${filterArg}${coverageArg} 2>&1`
 
   const testProcess = spawn('sh', ['-c', `
     docker exec -w /app ${container} sh -c '${testCmd}'


### PR DESCRIPTION
## Symptom

The `Coveralls - go` and `Coveralls - vitest` gates fail PRs on deltas of ±0.01% that no code change explains. Recent **master** commits, with no PR involved:

| commit | apiv2 | frontend |
|---|---|---|
| 0ad1dc5ac | remained the same at 85.769% | **decreased -0.007%** |
| 89c72e5b6 | 85.774% | 73.108% |
| 23d54e98c | 85.760% | 73.108% |
| f3244ae32 | **increased +0.009%** | increased +0.009% |
| 518447381 | 85.775% | 73.095% |

apiv2 wanders over 85.760-85.775% and the frontend over 73.095-73.137% unaided, one master commit reporting a decrease against its own parent. Any PR whose true delta is smaller than that band fails or passes at random.

## Cause

`go.mod` declared `module iznik-server-go`, but all **305** files that import a sibling package import it as `github.com/freegle/iznik-server-go/...`, bridged by a self-replace: `replace github.com/freegle/iznik-server-go => ./`.

Go treats the two spellings as separate packages built from the same source, so:

1. `-coverpkg ./...` instruments packages under the **declared** path, while the test binaries link and execute the **imported** path — different instances of the same code.
2. **69 of 75 packages** appeared in `coverage.out` under both spellings with independent hit counts: 556,688 profile lines under `iznik-server-go/` plus 73,509 under `github.com/freegle/iznik-server-go/`.
3. `gcov2lcov` resolves both spellings back to the same `/app/<pkg>/<file>.go`, so the two count sets are **merged per file**. The order in which test binaries write their profiles is not stable, so a line hit only in the executed copy can be zeroed by the unexecuted one.

Step 3 is the flapping: the reported percentage depends on profile write order, not on the code.

## Fix

Declare the module as the path the code actually imports, and drop the self-replace, so `./...` enumerates the same package instances the tests execute. Three lines:

- `go.mod`: `module github.com/freegle/iznik-server-go`, self-replace removed
- `user/auth.go`: held the last bare import (`location`) and now matches its 305 siblings
- `build.sh`: already had to spell its ldflags with the long path and carried a comment explaining the mismatch. The workaround is now simply the module path, so the comment goes.

This removes a workaround rather than adding one.

## Verification

Coverage run in a worktree, before and after:

```
before  84.973%  17987/21168 stmts  12317 blocks  (both prefixes merged)
after   84.958%  17984/21168 stmts  12317 blocks  (single prefix, 0 duplicates)
```

Identical denominator and block count, so the same code is measured. The 3-statement (0.015%) difference **is** the jitter — after the fix there is only one copy, so nothing can vary between runs. The profile went from 630,197 lines across two prefixes to 556,688 under one, with zero bare-prefix entries.

`gcov2lcov` still emits 173 `SF:` entries, all under `/app/`, so the orb's `sed 's|^SF:/app/|SF:iznik-server-go/|'` matches all of them and the reporting pipeline is unchanged.

Go suite green: **4065 passed** (master's 4056 plus the 9 offset tests below). Frontend suite **15177** (master's 15158, plus 18 for the date filter and 1 for the geocoder containment).

Expect a **one-off baseline correction** on the build that lands this, of roughly the jitter's own size, after which the number should hold still.

## Getting this branch's own gate green

Correcting the measurement makes the reported number drop, so the gate reads the fix itself as a regression. Both failing flags, and what each actually is:

- **apiv2 -0.009% to 85.76%** — this is the fix working. 85.76% is the true single-copy figure; master's 85.769% is the merge-inflated one.
- **frontend -0.02%/-0.03%** — could not be this branch either (it touches nothing under `iznik-nuxt3/`). That was a **second, independent** jitter source, now also fixed here — see below.

Offsets picked by parsing the corrected profile for pure functions that are mostly covered but have a real untested branch, so each is worth pinning on its own merits:

- `oppositeType()` had only its Offer branch exercised. If Wanted stopped mapping to Offer, a wanted post would be matched against other wanted posts - pairing a request with a request. If the default stopped returning `""`, a type with no opposite (Taken, Received, Admin) would enter matching and pull in arbitrary candidates.
- `sanitiseFilename()` stops a crafted authority name breaking out of a `Content-Disposition` header, and only its pass-through path was covered - **the sanitising it is named for was entirely untested**. Now covers the quote that would close the header, path separators and backslashes, CR/LF injection, the empty-name fallback, and that non-ASCII names survive.
- `ModEmailDateFilter.vue` had no spec and sits in an included coverage glob. Its load-bearing distinction is precision: `hour`/`day` carry a time of day while the multi-day presets are date-only, so a regression turns "last hour" into "since midnight" - wider, and still plausible-looking.

### Closing the last of the gap, and two harness bugs behind it

With the jitter gone the branch still read 0.005% below master, which made no sense for a branch that only *adds* a spec. Measuring master with the same tooling settled it: master covers `ModEmailDateFilter.vue` **144/144** (incidentally, via a parent's spec) while this branch's own narrower spec covered **134/144** — 10 lines, exactly the reported gap. The missing ranges were the `default:` fallback in `resolvePresetDates` and `onPresetChange` itself, and they were unreachable because of two fidelity bugs in the shared `b-form-select` stub:

1. It rendered `<slot />` only, ignoring the `options` **prop** every caller uses — so the stubbed `<select>` had no matching `<option>` for any value and `setValue('day')` landed as `''`. Tests drove the control to empty string while appearing to select a preset.
2. It never declared or emitted `change`, so a parent's `@change` became a **native** listener and received an Event object instead of the value. A handler like `onPresetChange(p) { if (p === 'custom') return }` could not take its early return in tests at all.

Neither surfaced as a failure before, because nothing drove a select. Both are fixed, and the spec now asserts those paths directly: an unrecognised preset falls back to a week rather than an empty range, a fixed preset refetches at once, and `custom` does not — that early return is what lets a moderator fill in both date fields before anything fires.

Branch coverage now equals master **exactly and deterministically**: 71.3220%, 84707/118767, twice identical, 0 files differing.

### Incidental harness fix

`b-form` was absent from the global bootstrap stubs in `tests/unit/setup.ts`, so any component laying its controls out in a `<b-form>` logs "Failed to resolve component", which that file escalates to a test failure. Stubbed globally rather than locally, since the next such component would hit it too. The full frontend suite confirms the shared change is safe.

## The frontend half of the flapping

Same class of bug, different mechanism, and it needed the tooling in this branch to see at all: CI archives a Go coverage profile but no frontend one, so the only feedback loop was push and read Coveralls. Added `?coverage=true` to the frontend test endpoint (mirroring the Go one), then diffed two full runs of an **identical tree**:

```
run1  71.3136%   84697/118767
run2  71.2892%   84668/118767      -0.0244pp, and exactly ONE file differing
```

The file was `components/PostMap.vue`, covered lines flipping 559 <-> 530 of 866 with its total fixed. A per-line hit-status diff named the range: 700-725 and 748-753 — `ready()`'s dynamically imported geocoder:

```js
const { Geocoder } = await import('leaflet-control-geocoder/src/control')
const { Photon }   = await import('.../geocoders/photon')
```

Those two were the only externals in `PostMap.spec.js` left unmocked, so they loaded the real modules and whether that resolved before the test ended was a race against real module-load time, won or lost by machine load under `pool: 'forks'`. Mocking them — as every other external in that file already is — makes the path deterministic. Four consecutive full coverage runs of the same tree:

```
71.3111%   84694/118767   x4, 0 files differing in any pair
```

That settled 3 lines below the luckiest pre-fix run (84697), and those 3 turned out to be `PostMap.vue` 751-753 — the `catch` around `ready()`'s geocoder setup. They had only ever been covered *by accident*: the real `leaflet-control-geocoder` throws in jsdom, so the unmocked imports hit that catch as a side effect of failing. So a further test asserts that containment deliberately — make the `Geocoder` constructor throw, then check the exception is swallowed rather than propagated, the parent is still told the map is ready, and the map still framed itself. A geocoder failure should lose the search box, not the map. Final state:

```
71.3136%   84697/118767   x3, 0 files differing in any pair
```

Deterministic **and** at the higher value, so this lands no coverage loss at all.

**A wrong turn worth recording:** PostMap also arms a 200ms fit debounce and a 500ms marker-fix interval, and fake timers *looked* like the fix because two runs then agreed. The per-line diff showed the timers were never among the racing lines — two agreeing runs were luck, not evidence. Reverted in favour of the actual cause.

## Hazards checked first

- **Import cycle**: `location` does not import `user`, so routing that import through the module path creates no cycle. `auth.go`'s comment about avoiding `user -> location -> auth` is satisfied by delegating to `auth.WhoAmI`, not by the import spelling.
- **Non-Go references to the bare module name**: none. The two `monitor-fsm` matches on `iznik-server-go/` are repo-relative diff paths, not import paths, and the orb keys on `/app/`.

## Note for reviewers

Found while investigating why #1303 failed this gate with zero frontend changes. That PR carries its own genuine-test offset to get green; this is the underlying cause. Whichever lands second may need the trivial import-path touch-up if it adds a bare `iznik-server-go/...` import in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Sd6Y1n3DAveUTkcTEwUpt