### PR TITLE
fix(stories): keep our own notification links inside the app, and ask for a login before the story form

### DIFF
--- a/iznik-nuxt3/components/NewsStory.vue
+++ b/iznik-nuxt3/components/NewsStory.vue
@@ -94,7 +94,11 @@
       imgflag="story"
       @hidden="showNewsPhotoModal = false"
     />
-    <StoryAddModal v-if="showAdd" @hidden="showAdd = false" />
+    <StoryAddModal
+      v-if="showAdd"
+      @login-required="loginRequired"
+      @hidden="showAdd = false"
+    />
     <StoryShareModal
       v-if="showNewsShareModal"
       :id="newsfeed.storyid"
@@ -110,6 +114,7 @@ import ReadMore from '~/components/ReadMore'
 import { twem } from '~/composables/useTwem'
 import NewsUserIntro from '~/components/NewsUserIntro'
 import NewsLoveComment from '~/components/NewsLoveComment'
+import { useStoryAdd } from '~/composables/useStoryAdd'
 
 const props = defineProps({
   id: {
@@ -154,7 +159,11 @@ try {
   console.log('Error fetching story:', e)
 }
 
-const showAdd = ref(false)
+const {
+  showStoryAddModal: showAdd,
+  showAddModal,
+  loginRequired,
+} = useStoryAdd()
 
 const story = computed(() => {
   return storyStore?.byId(newsfeed.value?.storyid)
@@ -177,10 +186,6 @@ function share() {
 
 function showPhotoModal() {
   showNewsPhotoModal.value = true
-}
-
-function showAddModal() {
-  showAdd.value = true
 }
 </script>
 <style scoped lang="scss">

--- a/iznik-nuxt3/components/NotificationOne.vue
+++ b/iznik-nuxt3/components/NotificationOne.vue
@@ -40,7 +40,7 @@
 </template>
 <script setup>
 import { defineAsyncComponent } from 'vue'
-import { useRouter } from '#imports'
+import { useRouter, useRuntimeConfig } from '#imports'
 import { setupNotification } from '~/composables/useNotification'
 
 const NotificationGiftAid = defineAsyncComponent(() =>
@@ -80,6 +80,7 @@ const props = defineProps({
 
 const emit = defineEmits(['showModal'])
 const router = useRouter()
+const runtimeConfig = useRuntimeConfig()
 
 // Setup notification
 const { notification, notificationStore, newsfeed } = await setupNotification(
@@ -92,11 +93,66 @@ function markSeen() {
   }
 }
 
+function originOf(url) {
+  try {
+    return url ? new URL(url).origin : null
+  } catch (e) {
+    return null
+  }
+}
+
+// Some notifications store a full URL rather than a router path - the stories
+// exhort is scheduled with https://www.ilovefreegle.org/stories.  Opening one of
+// those with window.open() launches the system browser, which in the app throws
+// the freegler out of the app into a session where they're not logged in, so
+// whatever the notification asked them to do then fails.  The push side already
+// strips our own site off the front (PushNotificationService::notificationRoute)
+// and this is the equivalent for the in-app notification list.  Returns the path
+// to route to, or null if the URL really is somewhere else.
+function internalPath(url) {
+  const trimmed = (url || '').trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  if (trimmed.startsWith('/')) {
+    // Already a router path.
+    return trimmed
+  }
+
+  let parsed = null
+
+  try {
+    parsed = new URL(trimmed)
+  } catch (e) {
+    // Not something we can pick apart - leave it to window.open().
+    return null
+  }
+
+  const ours = [
+    originOf(runtimeConfig.public.USER_SITE),
+    typeof window === 'undefined' ? null : window.location.origin,
+  ].filter(Boolean)
+
+  return ours.includes(parsed.origin)
+    ? parsed.pathname + parsed.search + parsed.hash
+    : null
+}
+
 function click() {
   markSeen()
 
-  if (notification.value?.url) {
-    window.open(notification.value.url)
+  const url = notification.value?.url
+
+  if (url) {
+    const path = internalPath(url)
+
+    if (path) {
+      router.push(path)
+    } else {
+      window.open(url)
+    }
   } else if (newsfeed?.value) {
     router.push('/chitchat/' + newsfeed.value.id)
   }

--- a/iznik-nuxt3/components/StoryAddModal.vue
+++ b/iznik-nuxt3/components/StoryAddModal.vue
@@ -128,7 +128,7 @@
           variant="white"
           :disabled="uploadingPhoto"
           class="me-2"
-          @click="hide"
+          @click="cancel"
         >
           Cancel
         </b-button>
@@ -146,15 +146,19 @@ import { useStoryStore } from '~/stores/stories'
 import { useComposeStore } from '~/stores/compose'
 import { useOurModal } from '~/composables/useOurModal'
 import { useImageStore } from '~/stores/image'
+import { useAuthStore } from '~/stores/auth'
 
 const OurUploader = defineAsyncComponent(() =>
   import('~/components/OurUploader')
 )
 
+const emit = defineEmits(['login-required'])
+
 // Store instances
 const storyStore = useStoryStore()
 const composeStore = useComposeStore()
 const imageStore = useImageStore()
+const authStore = useAuthStore()
 
 // Modal control
 const { modal, hide } = useOurModal()
@@ -176,6 +180,8 @@ const noStory = ref(false)
 const uploadingPhoto = computed(() => {
   return composeStore?.uploading
 })
+
+const loggedIn = computed(() => Boolean(authStore.user))
 
 // Watchers
 watch(
@@ -227,9 +233,20 @@ function rotateRight() {
 
 function onShow() {
   thankyou.value = false
-  story.value.headline = null
-  story.value.story = null
-  story.value.image = null
+
+  // If we had to interrupt them to log in, pick up where they left off rather
+  // than making them type their story out again.
+  const draft = composeStore.storyDraft
+
+  story.value.headline = draft?.headline ?? null
+  story.value.story = draft?.story ?? null
+  story.value.image = draft?.image ?? null
+}
+
+function cancel() {
+  // They've decided against it, so don't hang on to what they typed.
+  composeStore.clearStoryDraft()
+  hide()
 }
 
 async function submit() {
@@ -237,6 +254,21 @@ async function submit() {
   noStory.value = false
 
   if (story.value.headline && story.value.story) {
+    if (!loggedIn.value) {
+      // Adding a story needs a login. Ask for one, keeping what they've typed -
+      // logging in rebuilds the app and takes this modal with it, so the draft
+      // has to live outside it.
+      composeStore.saveStoryDraft({
+        headline: story.value.headline,
+        story: story.value.story,
+        image: story.value.image,
+      })
+
+      emit('login-required')
+      authStore.forceLogin = true
+      return
+    }
+
     await storyStore.add(
       story.value.headline,
       story.value.story,
@@ -244,6 +276,7 @@ async function submit() {
       true
     )
 
+    composeStore.clearStoryDraft()
     thankyou.value = true
   } else {
     if (!story.value.headline) {

--- a/iznik-nuxt3/composables/useStoryAdd.js
+++ b/iznik-nuxt3/composables/useStoryAdd.js
@@ -1,0 +1,53 @@
+import { ref } from 'vue'
+import { useAuthStore } from '~/stores/auth'
+import { useStoryStore } from '~/stores/stories'
+
+/**
+ * Shared "Tell us your story!" button behaviour.
+ *
+ * Adding a story needs a login, so if they're not logged in when they ask to
+ * tell us their story we get that out of the way before showing them the form.
+ * Otherwise they type the whole thing out and the submit fails - which is what
+ * happened to the freegler who followed the stories notification out of the app
+ * into a browser where she wasn't logged in.
+ *
+ * app.vue keys the whole app on loginCount, so logging in throws away every
+ * component and builds it again. That means the fact that they asked for the
+ * form has to be remembered in the store, and picked up by the fresh instance
+ * as it sets up - watching for the login here would only ever be seen by the
+ * instance that's about to be discarded.
+ *
+ * StoryAddModal also checks at submit time, in case the login lapses while
+ * they're typing. It saves the draft and emits login-required; call
+ * loginRequired() from that so we reopen the modal (with their story still in
+ * it) once they're back in.
+ */
+export function useStoryAdd() {
+  const authStore = useAuthStore()
+  const storyStore = useStoryStore()
+
+  const showStoryAddModal = ref(false)
+
+  function showAddModal() {
+    if (authStore.user) {
+      showStoryAddModal.value = true
+    } else {
+      loginRequired()
+    }
+  }
+
+  function loginRequired() {
+    storyStore.addWanted = true
+    authStore.forceLogin = true
+  }
+
+  // Pick up where they left off if we sent them away to log in. Claim the flag
+  // so that on a page with several of these (the ChitChat feed has one per
+  // story) we only open one form.
+  if (authStore.user && storyStore.addWanted) {
+    storyStore.addWanted = false
+    showStoryAddModal.value = true
+  }
+
+  return { showStoryAddModal, showAddModal, loginRequired }
+}

--- a/iznik-nuxt3/pages/stories/[[groupid]].vue
+++ b/iznik-nuxt3/pages/stories/[[groupid]].vue
@@ -53,6 +53,7 @@
             <template #footer>
               <StoryAddModal
                 v-if="showStoryAddModal"
+                @login-required="loginRequired"
                 @hidden="showStoryAddModal = false"
               />
             </template>
@@ -70,6 +71,7 @@ import { useAuthStore } from '~/stores/auth'
 import GroupSelect from '~/components/GroupSelect'
 import StoryOne from '~/components/StoryOne'
 import ScrollGrid from '~/components/ScrollGrid'
+import { useStoryAdd } from '~/composables/useStoryAdd'
 import { useRoute, useRouter, computed } from '#imports'
 
 const StoryAddModal = defineAsyncComponent(() =>
@@ -123,11 +125,7 @@ useHead(
   )
 )
 
-const showStoryAddModal = ref(false)
-
-const showAddModal = function () {
-  showStoryAddModal.value = true
-}
+const { showStoryAddModal, showAddModal, loginRequired } = useStoryAdd()
 
 const stories = computed(() => {
   return storyStore.recent

--- a/iznik-nuxt3/pages/stories/authority/[id].vue
+++ b/iznik-nuxt3/pages/stories/authority/[id].vue
@@ -30,6 +30,7 @@
       </b-row>
       <StoryAddModal
         v-if="showStoryAddModal"
+        @login-required="loginRequired"
         @hidden="showStoryAddModal = false"
       />
     </div>
@@ -41,6 +42,7 @@ import { useRoute } from '#imports'
 import { buildHead } from '~/composables/useBuildHead'
 import { useAuthorityStore } from '~/stores/authority'
 import StoryOne from '~/components/StoryOne'
+import { useStoryAdd } from '~/composables/useStoryAdd'
 const StoryAddModal = defineAsyncComponent(() =>
   import('~/components/StoryAddModal')
 )
@@ -79,9 +81,5 @@ const sortedStories = computed(() => {
   })
 })
 
-const showStoryAddModal = ref(false)
-
-const showAddModal = () => {
-  showStoryAddModal.value = true
-}
+const { showStoryAddModal, showAddModal, loginRequired } = useStoryAdd()
 </script>

--- a/iznik-nuxt3/pages/story/[id].vue
+++ b/iznik-nuxt3/pages/story/[id].vue
@@ -30,6 +30,7 @@
       </b-row>
       <StoryAddModal
         v-if="showStoryAddModal"
+        @login-required="loginRequired"
         @hidden="showStoryAddModal = false"
       />
     </div>
@@ -47,6 +48,7 @@ import {
 } from '#imports'
 import NoticeMessage from '~/components/NoticeMessage'
 import StoryOne from '~/components/StoryOne'
+import { useStoryAdd } from '~/composables/useStoryAdd'
 
 const StoryAddModal = defineAsyncComponent(() =>
   import('~/components/StoryAddModal')
@@ -83,9 +85,5 @@ if (invalid.value) {
   )
 }
 
-const showStoryAddModal = ref(false)
-
-function showAddModal() {
-  showStoryAddModal.value = true
-}
+const { showStoryAddModal, showAddModal, loginRequired } = useStoryAdd()
 </script>

--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -46,6 +46,10 @@ export const useComposeStore = defineStore({
     // survives a refresh via this store's localStorage persistence — a clearance
     // holds far more (many items + photos) than a normal post, so losing it hurts.
     clearanceDraft: null,
+    // In-progress story (components/StoryAddModal.vue). Held here for the same
+    // reason: if we have to interrupt them to log in, app.vue rebuilds the whole
+    // app and the modal goes with it, so without this what they typed is gone.
+    storyDraft: null,
   }),
   actions: {
     init(config) {
@@ -58,6 +62,13 @@ export const useComposeStore = defineStore({
     },
     clearClearanceDraft() {
       this.clearanceDraft = null
+    },
+    // Save / clear the in-progress story draft (persisted to localStorage).
+    saveStoryDraft(draft) {
+      this.storyDraft = draft
+    },
+    clearStoryDraft() {
+      this.storyDraft = null
     },
     calculateSteps(type) {
       let steps = 0

--- a/iznik-nuxt3/stores/stories.js
+++ b/iznik-nuxt3/stores/stories.js
@@ -7,6 +7,10 @@ export const useStoryStore = defineStore({
   state: () => ({
     list: {},
     recent: [],
+    // Set when we've sent someone off to log in before they can tell us their
+    // story (see composables/useStoryAdd.js). Logging in re-runs the setup of
+    // the page they were on, so this can't live in the page.
+    addWanted: false,
   }),
   actions: {
     init(config) {

--- a/iznik-nuxt3/tests/unit/components/NewsStory.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsStory.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent, h, Suspense } from 'vue'
 import NewsStory from '~/components/NewsStory.vue'
@@ -47,6 +47,11 @@ describe('NewsStory', () => {
     mockNewsfeedStore.byId.mockReturnValue({ ...mockNewsfeed })
     mockStoryStore.byId.mockReturnValue({ ...mockStory })
     mockStoryStore.fetch.mockResolvedValue({ ...mockStory })
+    globalThis.__mockAuthStore = { user: { id: 42 }, forceLogin: false }
+  })
+
+  afterEach(() => {
+    delete globalThis.__mockAuthStore
   })
 
   async function createWrapper(props = {}) {
@@ -259,6 +264,18 @@ describe('NewsStory', () => {
         .find((b) => b.text().includes('Tell your story!'))
       await tellButton.trigger('click')
       expect(wrapper.find('.story-add-modal').exists()).toBe(true)
+    })
+
+    it('asks for a login first when logged out', async () => {
+      globalThis.__mockAuthStore = { user: null, forceLogin: false }
+      const wrapper = await createWrapper()
+      const tellButton = wrapper
+        .findAll('.b-button')
+        .find((b) => b.text().includes('Tell your story!'))
+      await tellButton.trigger('click')
+
+      expect(wrapper.find('.story-add-modal').exists()).toBe(false)
+      expect(globalThis.__mockAuthStore.forceLogin).toBe(true)
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/NotificationOne.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NotificationOne.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent, h, Suspense } from 'vue'
 import NotificationOne from '~/components/NotificationOne.vue'
@@ -47,6 +47,8 @@ vi.mock('#imports', async () => {
 
 globalThis.__testUseRouter = () => mockRouter
 
+const USER_SITE = 'https://www.ilovefreegle.org'
+
 describe('NotificationOne', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -57,6 +59,11 @@ describe('NotificationOne', () => {
       url: null,
     }
     mockNewsfeed.value = { id: 456 }
+    globalThis.__testRuntimeConfig = () => ({ public: { USER_SITE } })
+  })
+
+  afterEach(() => {
+    delete globalThis.__testRuntimeConfig
   })
 
   async function createWrapper(props = {}) {
@@ -243,6 +250,84 @@ describe('NotificationOne', () => {
       await wrapper.find('.notification__wrapper').trigger('click')
 
       expect(openSpy).toHaveBeenCalledWith('https://example.com/notification')
+      expect(mockRouter.push).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
+    // The stories exhort is scheduled with a full https://www.ilovefreegle.org
+    // URL. window.open() on that launches the system browser, which in the app
+    // means leaving the app for a session where you're not logged in.
+    it('routes internally for a url on our own site', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+      mockNotification.value.url = USER_SITE + '/stories'
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.notification__wrapper').trigger('click')
+
+      expect(mockRouter.push).toHaveBeenCalledWith('/stories')
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
+    it('keeps the query and hash when routing internally', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+      mockNotification.value.url = USER_SITE + '/stories?src=exhort#top'
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.notification__wrapper').trigger('click')
+
+      expect(mockRouter.push).toHaveBeenCalledWith('/stories?src=exhort#top')
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
+    it('routes internally for a url on the site we are being served from', async () => {
+      // Dev and the app are served from somewhere other than USER_SITE.
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+      mockNotification.value.url = window.location.origin + '/stories'
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.notification__wrapper').trigger('click')
+
+      expect(mockRouter.push).toHaveBeenCalledWith('/stories')
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
+    it('routes internally for a url that is already a path', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+      mockNotification.value.url = '/stories'
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.notification__wrapper').trigger('click')
+
+      expect(mockRouter.push).toHaveBeenCalledWith('/stories')
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
+    it('opens externally when we have no site configured to compare against', async () => {
+      globalThis.__testRuntimeConfig = () => ({ public: {} })
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+      mockNotification.value.url = USER_SITE + '/stories'
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.notification__wrapper').trigger('click')
+
+      expect(openSpy).toHaveBeenCalledWith(USER_SITE + '/stories')
+      expect(mockRouter.push).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
+    it('opens externally for a url we cannot parse', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+      mockNotification.value.url = 'not a url'
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.notification__wrapper').trigger('click')
+
+      expect(openSpy).toHaveBeenCalledWith('not a url')
+      expect(mockRouter.push).not.toHaveBeenCalled()
       openSpy.mockRestore()
     })
 

--- a/iznik-nuxt3/tests/unit/components/StoryAddModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/StoryAddModal.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { ref } from 'vue'
 import StoryAddModal from '~/components/StoryAddModal.vue'
@@ -11,7 +11,16 @@ const mockStoryStore = {
 
 const mockComposeStore = {
   uploading: false,
+  storyDraft: null,
+  saveStoryDraft: vi.fn(function (draft) {
+    mockComposeStore.storyDraft = draft
+  }),
+  clearStoryDraft: vi.fn(function () {
+    mockComposeStore.storyDraft = null
+  }),
 }
+
+const mockHide = vi.fn()
 
 const mockImageStore = {
   post: vi.fn().mockResolvedValue(undefined),
@@ -32,7 +41,7 @@ vi.mock('~/stores/image', () => ({
 vi.mock('~/composables/useOurModal', () => ({
   useOurModal: () => ({
     modal: mockModal,
-    hide: vi.fn(),
+    hide: mockHide,
   }),
 }))
 
@@ -40,7 +49,27 @@ describe('StoryAddModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockComposeStore.uploading = false
+    mockComposeStore.storyDraft = null
+    globalThis.__mockAuthStore = { user: { id: 42 }, forceLogin: false }
   })
+
+  afterEach(() => {
+    delete globalThis.__mockAuthStore
+  })
+
+  function fillIn(wrapper, headline, story) {
+    return Promise.all([
+      wrapper.find('.b-form-input').setValue(headline),
+      wrapper.find('.b-form-textarea').setValue(story),
+    ])
+  }
+
+  function clickButton(wrapper, text) {
+    return wrapper
+      .findAll('.b-button')
+      .find((b) => b.text().includes(text))
+      .trigger('click')
+  }
 
   function createWrapper() {
     return mount(StoryAddModal, {
@@ -51,6 +80,11 @@ describe('StoryAddModal', () => {
               '<div class="b-modal"><slot /><slot name="footer" /></div>',
             props: ['scrollable', 'title', 'size', 'noStacking'],
             emits: ['shown'],
+            // useOurModal shows the modal as soon as it mounts, so shown fires
+            // right away in real life too.
+            mounted() {
+              this.$emit('shown')
+            },
             methods: {
               show() {},
               hide() {},
@@ -262,6 +296,112 @@ describe('StoryAddModal', () => {
       await flushPromises()
 
       expect(wrapper.text()).toContain('grateful')
+    })
+  })
+
+  describe('login required', () => {
+    beforeEach(() => {
+      globalThis.__mockAuthStore = { user: null, forceLogin: false }
+    })
+
+    it('does not try to add the story when logged out', async () => {
+      const wrapper = createWrapper()
+      await fillIn(wrapper, 'Test Headline', 'Test Story Content')
+
+      await clickButton(wrapper, 'Add Your Story')
+      await flushPromises()
+
+      expect(mockStoryStore.add).not.toHaveBeenCalled()
+    })
+
+    it('asks for a login when logged out', async () => {
+      const wrapper = createWrapper()
+      await fillIn(wrapper, 'Test Headline', 'Test Story Content')
+
+      await clickButton(wrapper, 'Add Your Story')
+      await flushPromises()
+
+      expect(globalThis.__mockAuthStore.forceLogin).toBe(true)
+      expect(wrapper.emitted('login-required')).toHaveLength(1)
+    })
+
+    it('saves what they typed so the login modal closing it does not lose it', async () => {
+      const wrapper = createWrapper()
+      await fillIn(wrapper, 'Test Headline', 'Test Story Content')
+
+      await clickButton(wrapper, 'Add Your Story')
+      await flushPromises()
+
+      expect(mockComposeStore.saveStoryDraft).toHaveBeenCalledWith({
+        headline: 'Test Headline',
+        story: 'Test Story Content',
+        image: null,
+      })
+    })
+
+    it('still complains about an empty story rather than asking for a login', async () => {
+      const wrapper = createWrapper()
+
+      await clickButton(wrapper, 'Add Your Story')
+      await flushPromises()
+
+      expect(globalThis.__mockAuthStore.forceLogin).toBe(false)
+      expect(mockComposeStore.saveStoryDraft).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('draft', () => {
+    it('picks up a saved draft when shown', async () => {
+      mockComposeStore.storyDraft = {
+        headline: 'Saved Headline',
+        story: 'Saved Story',
+        image: null,
+      }
+
+      const wrapper = createWrapper()
+      await flushPromises()
+
+      expect(wrapper.find('.b-form-input').element.value).toBe('Saved Headline')
+      expect(wrapper.find('.b-form-textarea').element.value).toBe('Saved Story')
+    })
+
+    it('submits the restored draft once they are logged back in', async () => {
+      mockComposeStore.storyDraft = {
+        headline: 'Saved Headline',
+        story: 'Saved Story',
+        image: null,
+      }
+
+      const wrapper = createWrapper()
+      await clickButton(wrapper, 'Add Your Story')
+      await flushPromises()
+
+      expect(mockStoryStore.add).toHaveBeenCalledWith(
+        'Saved Headline',
+        'Saved Story',
+        null,
+        true
+      )
+    })
+
+    it('clears the draft once the story is added', async () => {
+      const wrapper = createWrapper()
+      await fillIn(wrapper, 'Test Headline', 'Test Story Content')
+
+      await clickButton(wrapper, 'Add Your Story')
+      await flushPromises()
+
+      expect(mockComposeStore.clearStoryDraft).toHaveBeenCalled()
+    })
+
+    it('clears the draft if they cancel', async () => {
+      const wrapper = createWrapper()
+      await fillIn(wrapper, 'Test Headline', 'Test Story Content')
+
+      await clickButton(wrapper, 'Cancel')
+
+      expect(mockComposeStore.clearStoryDraft).toHaveBeenCalled()
+      expect(mockHide).toHaveBeenCalled()
     })
   })
 

--- a/iznik-nuxt3/tests/unit/composables/useStoryAdd.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useStoryAdd.spec.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useStoryAdd } from '~/composables/useStoryAdd'
+
+const mockStoryStore = {
+  addWanted: false,
+}
+
+vi.mock('~/stores/stories', () => ({
+  useStoryStore: () => mockStoryStore,
+}))
+
+describe('useStoryAdd', () => {
+  beforeEach(() => {
+    mockStoryStore.addWanted = false
+    globalThis.__mockAuthStore = { user: null, forceLogin: false }
+  })
+
+  afterEach(() => {
+    delete globalThis.__mockAuthStore
+  })
+
+  function logIn() {
+    globalThis.__mockAuthStore.user = { id: 42 }
+  }
+
+  it('opens the form straight away when logged in', () => {
+    logIn()
+    const { showStoryAddModal, showAddModal } = useStoryAdd()
+
+    showAddModal()
+
+    expect(showStoryAddModal.value).toBe(true)
+    expect(globalThis.__mockAuthStore.forceLogin).toBe(false)
+    expect(mockStoryStore.addWanted).toBe(false)
+  })
+
+  it('asks for a login instead of showing the form when logged out', () => {
+    const { showStoryAddModal, showAddModal } = useStoryAdd()
+
+    showAddModal()
+
+    expect(showStoryAddModal.value).toBe(false)
+    expect(globalThis.__mockAuthStore.forceLogin).toBe(true)
+    expect(mockStoryStore.addWanted).toBe(true)
+  })
+
+  it('opens the form on the instance the login rebuilt', () => {
+    // Logging in re-keys app.vue, so the component that asked for the login is
+    // thrown away and a new one set up in its place.
+    const first = useStoryAdd()
+    first.showAddModal()
+    expect(first.showStoryAddModal.value).toBe(false)
+
+    logIn()
+    const second = useStoryAdd()
+
+    expect(second.showStoryAddModal.value).toBe(true)
+  })
+
+  it('only opens one form when several are set up at once', () => {
+    // The ChitChat feed has one of these per story.
+    useStoryAdd().showAddModal()
+    logIn()
+
+    const opened = [useStoryAdd(), useStoryAdd(), useStoryAdd()].filter(
+      (s) => s.showStoryAddModal.value
+    )
+
+    expect(opened).toHaveLength(1)
+    expect(mockStoryStore.addWanted).toBe(false)
+  })
+
+  it('does not open the form on a login we did not ask for', () => {
+    logIn()
+
+    const { showStoryAddModal } = useStoryAdd()
+
+    expect(showStoryAddModal.value).toBe(false)
+  })
+
+  it('does not open the form while they are still logged out', () => {
+    mockStoryStore.addWanted = true
+
+    const { showStoryAddModal } = useStoryAdd()
+
+    expect(showStoryAddModal.value).toBe(false)
+    expect(mockStoryStore.addWanted).toBe(true)
+  })
+
+  it('remembers the intent when the modal itself asks for a login', () => {
+    // StoryAddModal emits login-required if the login lapses while they're
+    // typing, so the form comes back (with their story in it) afterwards.
+    const { loginRequired } = useStoryAdd()
+
+    loginRequired()
+
+    expect(globalThis.__mockAuthStore.forceLogin).toBe(true)
+    expect(mockStoryStore.addWanted).toBe(true)
+
+    logIn()
+    expect(useStoryAdd().showStoryAddModal.value).toBe(true)
+  })
+})


### PR DESCRIPTION
Liz tapped the "tell us your story" notification in the app, was taken out of the app into the system browser, wrote her story, and lost it to a 401.

## The notification took her out of the app

`NotificationOne.vue` treated any notification with a `url` as external and `window.open()`ed it. The stories exhort is scheduled with a full `https://www.ilovefreegle.org/stories` (`ExhortUsersCommand.php`), so in the app that launches the system browser, where she has no session.

The push side already had this fix - `PushNotificationService::notificationRoute()` strips our own site off the front so the app gets a router path. The in-app notification list never got the equivalent. It has it now: a notification url on our own site (matching `USER_SITE` or the origin we're served from), or one that is already a path, is `router.push()`ed; only genuinely external urls get `window.open()`.

That also fixes the `MatchedPost` and microvolunteering notifications, which store bare paths like `/message/123` and so were being `window.open()`ed into a new tab.

## Nothing asked her to log in until it was too late

Adding a story needs a login, but the only thing that noticed was the API call at the end. The "Tell us your story!" button now asks for the login first, so nobody types into a form that can't be submitted.

That behaviour is shared by the four places that offer the button (`pages/stories`, `pages/stories/authority`, `pages/story`, `NewsStory` in the ChitChat feed) via a new `useStoryAdd` composable. `app.vue` keys the whole app on `loginCount`, so logging in throws away and rebuilds every component - the "they asked for the form" flag therefore lives in the story store, where the rebuilt instance picks it up and opens the form.

`StoryAddModal` also checks at submit time, in case the login lapses while they're typing. It saves what they wrote to the compose store (which persists to localStorage, as the clearance draft already does) so it survives the rebuild, and restores it when the form comes back.

## Verified

Local JS unit suite against this branch: 725 files, 15280 tests, all pass.

In the real app on `freegle-dev-local`:

- Logged out, "Tell us your story!" now opens the login modal instead of the story form; after logging in the story form opens by itself.
- A `users_notifications` row pointing at our own site navigates in-app - the url changes, no new tab. One pointing somewhere else still opens a new tab, as before.

## Not in this PR

- `file-sync.sh` does not route `iznik-nuxt3/pages/` to the vitest runner container, so page specs run locally against the copy baked into the image. I `docker cp`'d the pages in for the runs above.
- The stories-ask email (`emails/mjml/stories/ask.blade.php`) lands people on `/stories` with no autologin token. The login gate catches them now, but a token would save them the step.
