### PR TITLE
reach: the travel-time cap belongs to the recipient, not the post

### DIFF
--- a/docs/developers/01-architecture.md
+++ b/docs/developers/01-architecture.md
@@ -60,7 +60,11 @@ and per-group membership and roles are the ones you will meet first.
   and the rejected alternatives are in [./reference/rippling-algorithm.md](./reference/rippling-algorithm.md);
   the member and moderator behaviour is in
   [../members/rippling-out.md](../members/rippling-out.md) and
-  [../moderators/rippling-out.md](../moderators/rippling-out.md).
+  [../moderators/rippling-out.md](../moderators/rippling-out.md). The one structural thing
+  to know before reading any of it: the travel-time cap belongs to the RECIPIENT, not the
+  post. Every ripple grows to the same ceiling, and each member is then admitted on the
+  budget their own local freegler density justifies - so a rural member can reach the town
+  they already drive to, while a city member is not mailed things nobody would travel for.
 - **Getting a first reply in** sits alongside rippling and attacks the 44% of rippled posts
   that get no reply at all: a passthrough for a silent post's first reply, individual mail to
   the members who have asked for that specific item (an open post of the opposite type, or a

--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -3,7 +3,10 @@ last_reviewed: 2026-08-11
 covers:
   - iznik-batch/app/Services/Ripple/**
   - iznik-batch/app/Console/Commands/Ripple/**
+  - iznik-batch/app/Console/Commands/Browse/**
   - iznik-server-go/rippling/**
+  - iznik-server-go/density/**
+  - iznik-nuxt3/composables/useReachDistance.js
   - iznik-nuxt3/modtools/components/ModSysAdminRipplingDensity.vue
   - iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
 ---
@@ -145,10 +148,10 @@ ceiling applies unchanged. Two further stops:
   Interested repliers stops expanding - it has plenty of interest already.
 - **Outcome.** A taken, withdrawn or received post stops immediately.
 
-### 3a. The time budget is chosen from local density
+### 3a. The time budget belongs to the traveller, not to the post
 
-The governor normalises the AUDIENCE. The drive-time ceiling on top of it (`max_minutes`) is
-the other half, and a single national figure for it is wrong in both directions.
+The governor normalises the AUDIENCE. The drive-time ceiling on top of it is the other half,
+and a single national figure for it is wrong in both directions.
 
 Measured on live, conversion by drive-time behaves completely differently by place: in dense
 areas it collapses past about 20-25 minutes, and in sparse ones it does not fall at all out to
@@ -157,11 +160,11 @@ and too tight in the country, where the people who would come are still outside 
 
 `App\Services\Ripple\DensityService` measures the density directly rather than inferring it
 from the group or a population dataset: it asks the spatial KNN service for the **nearest K
-freeglers** (`RIPPLE_DENSITY_K`, default 400) to the post's blurred origin and takes the radius
-that contains them. That is the quantity the reach actually cares about - how far you have to
-go to find people - rather than a proxy for it.
+freeglers** (`RIPPLE_DENSITY_K`, default 400) to a point and takes the radius that contains
+them. That is the quantity the reach actually cares about - how far you have to go to find
+people - rather than a proxy for it.
 
-| Band | Nearest 400 within | `max_minutes` |
+| Band | Nearest 400 within | Travel-time budget |
 |---|---|---|
 | `dense` | ≤ 1.6 mi | 20 |
 | `medium` | ≤ 3.1 mi | 30 |
@@ -170,18 +173,51 @@ go to find people - rather than a proxy for it.
 The thresholds are the terciles of the live distribution, so the bands are roughly equal in
 posts to begin with. Per-band caps live in `freegle.ripple.density.max_minutes`.
 
-Two edge cases, both of which would otherwise size a post wrongly and silently:
+**Whose density decides.** Read the measurement again and it is about the person who would
+make the journey, not the item: it is the REPLIER's drive-time and the REPLIER's surroundings
+that predict a collection. Applying the cap at the post's origin gets that right only when both
+ends sit in the same kind of place, and where they differ it fails exactly backwards - on the
+commonest case there is. A rural member's nearest town is the town they already drive to, and
+its posts are the ones they most want. Measured on live for a member outside Spalding (nearest
+400 freeglers 16.1 miles out, so definitively sparse):
+
+- Peterborough, their nearest big town, is `medium` and so would cap at 30 minutes. They are
+  **38 minutes** from it, so sizing at the origin means the town's posts could never reach them
+  however far they were willing to go.
+- Of 191 posts within 21.6 miles of them over 14 days, **2** were inside a 30-minute drive.
+  **110** are inside 45 minutes. Their local supply sits almost entirely in the band a flat or
+  origin-sized cap cuts off.
+
+So the cap is applied to the RECIPIENT:
+
+1. **Every ripple grows to `DensityService::ceiling()`** - the widest budget any band earns
+   (45 by default; taken as the max over the configured bands so re-tuning one cannot leave the
+   ripple too small to serve it). A post cannot know which bands the members around it fall in,
+   only that the sparse ones travel furthest.
+2. **Each member is admitted on their own band**, through the travel-time preference that
+   already gates browse and mail - `settings.browseMaxMinutes` and the radius derived from it,
+   `browseMaxDistance` (§8). Their band is the DEFAULT for that preference, so a city member is
+   still not shown or mailed a post 40 minutes away, while the rural member finally gets the
+   town.
+
+The dense saving is therefore preserved while the rural gap closes: what changed is which end
+of the journey the number describes.
+
+Two edge cases, both of which would otherwise size a member wrongly and silently:
 
 - **Fewer than K found** inside the KNN service's search ceiling is *definitively* sparse -
   there genuinely are not 400 freeglers within reach - so the band is `sparse`, not unknown.
-- **Zero found**, or the service unreachable, is `unknown`, and an `unknown` post runs on the
-  flat cap. An empty or broken index must not stretch a London post to 45 minutes.
+- **Zero found**, or the service unreachable, is `unknown`, which keeps the flat cap and leaves
+  a member's stored preference untouched. An empty or broken index must not stretch a London
+  member to 45 minutes.
 
-The decision is stored on the post: `rippling_reach.density_band`, `density_radius_miles` and
-`max_minutes_cap`. Schedule reuse is cap-aware - a co-located earlier post computed under a
-different cap is not reused - so one post can never fix the budget for later ones.
+The origin's own band is still measured and stored on the post - `rippling_reach.density_band`
+and `density_radius_miles` - because it is what the density analytics read rows back by. It is
+a description of where the post is, not a limit on where it goes; `max_minutes_cap` records the
+ceiling the schedule was built under, and schedule reuse is cap-aware, so changing the ceiling
+takes effect everywhere rather than only where nobody had posted before.
 
-Killswitch `RIPPLE_DENSITY_ENABLED=false` reverts every post to the flat cap.
+Killswitch `RIPPLE_DENSITY_ENABLED=false` reverts every post and every member to the flat cap.
 
 **Instrumentation, because a lever nobody can read is a lever nobody can turn back.**
 `GET /rippling/density` (Support/Admin, `iznik-server-go/rippling/density.go`) reports per band:
@@ -313,6 +349,46 @@ retracted, so re-approval restores the copy without re-rippling.
   own distance) and OUTBOUND (a post is only shown/mailed to people within the *poster's*
   distance of it - the author-side cap in `isochrone/message.go`'s `authorReachCapWhere` and
   the digest's `DistancePreferenceFilter::passesBothPreferences`).
+
+  Since the ripple grows to the ceiling rather than to the origin's band (§3a), **this
+  preference is what holds each member to their own band** - it is no longer only a narrowing
+  the member opted into. A member who has never touched the slider must therefore still have
+  one, which is what `browse:backfill-max-distance` materialises: their band's cap in
+  `browseMaxMinutes`, and the routing-derived radius for it in `browseReachMaxDistance`. On
+  live only 2,900 of 121,000 recently-active members had ever set one, so without that pass
+  the wider ripple would reach a city member with everything inside 45 minutes of a post.
+
+  **`browseReachMaxDistance` is a separate key from `browseMaxDistance`, and the split is
+  load-bearing.** `browseMaxDistance` is the member's own choice and applies in BOTH
+  directions, so writing a band default into it would silently cap how far away other people
+  see that member's posts: a city member's band radius is ~4.8 miles, so their giveaways would
+  stop travelling almost immediately - the exact opposite of growing the ripple to the ceiling.
+  How far someone will travel to collect is not the same question as how far their own post
+  should travel to find a taker. So:
+
+  | Key | Set by | Inbound | Outbound |
+  |---|---|---|---|
+  | `browseMaxDistance` | the member, via the slider | yes | yes |
+  | `browseReachMaxDistance` | the backfill, from their band | yes (only when the member has not chosen) | **never** |
+
+  Readers: `DistancePreferenceFilter::maxDistanceMiles` (inbound, falls back to the default)
+  and `authorMaxDistanceMiles` (outbound, own choice only); Go `isochrone.resolveMaxDistance`
+  (inbound, same fallback) and `utils.AuthorReachCapWhere` (outbound, own choice only).
+
+  The command also RESCALES an explicit choice rather than carrying it across. The old slider
+  was a fixed 5-30, so a stored value said what FRACTION of the range the member wanted, not an
+  absolute travel time: 15 was two fifths of the way up, and two fifths of a rural member's 5-45
+  is 20. It rescales proportionally and snaps to the slider's 5-minute step, and at or above the
+  old top stop the member lands on their new cap. No location, or a failed density or routing
+  lookup, means the member is skipped and left untouched.
+
+  **The unlimited sentinel is no longer safe below the ceiling.** It means "defer to the
+  server's own reach", and the server's own reach is now the ceiling - so it only says "as far
+  as my band goes" for a member whose band earns it. A medium-band member left on the sentinel
+  would silently gain the widest band's reach (measured on live: a 33-mile radius around
+  Peterborough against the 30-minute band they should have). Below the ceiling, both the
+  backfill and the slider store a real derived radius at the top stop; only at the ceiling is
+  the sentinel written.
 
   **The viewer's own posts always come first.** A member's own open posts are included in the
   feed regardless of reach (`isochrone/message.go` own-posts arm) and flagged with `mine`

--- a/docs/members/04-your-account.md
+++ b/docs/members/04-your-account.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-05
+last_reviewed: 2026-08-11
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/pages/settings/**
@@ -48,6 +48,12 @@ There is also a weekly **Community Event Roundup** email (sent Thursdays) listin
 events. It is on by default and can be turned off in Settings.
 
 If you are in the app, you can also turn on a **daily push notification** of new posts.
+
+Above the email settings there is a **Feed** section with a "How far away" slider, marked
+Nearer at one end and Further at the other. It changes both what you see when browsing and
+what we email you about. How far "Further" actually reaches depends on how spread out
+freeglers are around your postcode, so it goes further in the countryside than in a city -
+[rippling out](rippling-out.md) explains why.
 
 ## Your communities
 

--- a/docs/members/rippling-out.md
+++ b/docs/members/rippling-out.md
@@ -155,12 +155,33 @@ how far you would like posts to come from. It starts set to "Further", which mea
 limit beyond the posts that have naturally reached you. If you would rather only see things
 from close by, drag it towards "Nearer" at any time; drag it back whenever you like.
 
+**"Further" means further in the countryside than it does in a city**, because it should. If
+you live somewhere with few people nearby, the nearest town is probably somewhere you already
+drive to, and its posts are the ones most worth showing you - so the slider reaches further out
+for you, and the "Max ... miles by road" note under it will say a bigger number than it would
+for someone in a city centre. In a busy area there is usually someone much closer, so reaching
+half an hour across town mostly means being emailed about things you would not travel for.
+Freegle works out which of these applies to you from how spread out other freeglers are around
+your postcode; you do not have to tell it anything.
+
 The same setting works **both ways**. As well as narrowing which posts you see and get
 emailed about, moving it towards "Nearer" also limits **how far away other people see your
 own posts** - handy if you would rather only hear from people who can easily get to you.
 Left at "Further", your posts reach as far as rippling naturally takes them. (It measures
 distance by road distance and travel time, not a straight line, so it follows real geography
 like estuaries and coastlines.)
+
+That both-ways rule applies to the slider **when you move it yourself**. It is your decision
+about how far you are willing to go, so it seems only fair that it says how far your own
+offers travel too.
+
+The starting position Freegle works out for you is different, and it only affects **what you
+see**. It never shortens how far your own posts go. That is deliberate, and the reason is that
+the two are not really the same question. Working out that you have plenty of freeglers close
+by is a statement about your neighbourhood, not a promise from you about how far you would
+drive. Using it to stop your spare sofa reaching somebody twenty minutes away would just mean
+one less thing gets reused, and it would not help anybody. So Freegle only holds your own
+posts back when you have actually asked it to.
 
 Freegle remembers your choice, along with your other filters (which posts, which communities,
 and sort order), so you do not need to set them again next time you visit.

--- a/docs/moderators/02-moderating-posts.md
+++ b/docs/moderators/02-moderating-posts.md
@@ -68,7 +68,11 @@ ModTools tells you *why* a post needs a look, right on the post:
 - **Rippling banners** explain when a post has rippled in from a neighbouring community
   ("do not reject just for being out of area"), or has rippled out to several communities
   (so approving here affects only your community). A **View rippling reach** map shows
-  where the post is or will be visible.
+  where the post is or will be visible. The map is the post's full reach; an individual
+  member inside it still only sees the post if it is within the travel time their own
+  area justifies, which is further in the countryside than in a city - so "it is on the
+  reach map" and "everyone in that area saw it" are not the same thing. See
+  [rippling out](rippling-out.md).
 - **Bulk clearance** posts show an item count and a "see how members see it" preview.
 
 ## Standard messages

--- a/docs/moderators/rippling-out.md
+++ b/docs/moderators/rippling-out.md
@@ -124,6 +124,15 @@ section above Email Settings. It is a **personal preference each member sets for
 themselves** - by default it is left at "Further" (no extra limit beyond their normal
 rippling reach), and moving it towards "Nearer" narrows how far away posts can be.
 
+**"Further" is not the same distance for everyone**, and this is deliberate. How far the slider
+reaches at its "Further" end depends on how spread out freeglers are around that member's
+postcode: in the countryside it goes further than in a city. The reason is that a rural
+member's nearest town is usually somewhere they already drive to, so its posts are exactly the
+ones worth showing them - whereas in a busy area there is nearly always someone closer, and
+reaching across town mostly generates email for journeys nobody makes. So if a rural member
+and a city member both say they are set to "Further", they are correctly seeing different
+distances, and the "Max ... miles by road" note under the slider will differ between them.
+
 Importantly, this preference now applies in **three** ways:
 
 - **What they see when browsing** - moving it "Nearer" hides posts from further away.
@@ -135,6 +144,26 @@ Importantly, this preference now applies in **three** ways:
 
 It still has **no effect on the rippling engine itself** (what it approves or joins, or how far
 it carries a post) **or on moderation**, and their choice is remembered between visits.
+
+**The third one only applies when the member moved the slider themselves.** This catches people
+out, so it is worth being clear about:
+
+| | What they see and are emailed | How far their own posts go |
+|---|---|---|
+| Member moved the slider | limited by their choice | limited by their choice |
+| Member never touched it | limited by the starting position Freegle works out for them | not limited |
+
+The starting position is Freegle's reading of the member's *area* - how spread out freeglers
+are around their postcode - not something the member has told us about themselves. So we use it
+to decide what is worth putting in front of them, but not to hold their own offers back. If we
+did, a member in a busy town would find their posts stopping a few miles out simply because
+they have a lot of neighbours, which would mean fewer things getting reused and would help
+nobody.
+
+So if a member asks "why do people further away see my post when I only see nearby ones?", the
+answer is that they have never set the slider: Freegle narrowed what it shows them, and left
+their giving alone. If they would rather their posts stayed local too, moving the slider to
+"Nearer" does exactly that, in both directions.
 
 A practical consequence worth knowing: a rippled-in post is shown to the members of your
 community who are **closest to the poster, whose own distance preference reaches that far, and

--- a/iznik-batch/app/Console/Commands/Browse/BackfillBrowseMaxDistanceCommand.php
+++ b/iznik-batch/app/Console/Commands/Browse/BackfillBrowseMaxDistanceCommand.php
@@ -3,13 +3,15 @@
 namespace App\Console\Commands\Browse;
 
 use App\Models\User;
+use App\Services\Ripple\DensityService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 /**
- * Reconcile settings.browseMaxDistance with settings.browseMaxMinutes.
+ * Put every member on the travel-time budget their own surroundings justify, and
+ * keep settings.browseMaxDistance consistent with it.
  *
  * The "How far away" slider stores a travel-time budget in minutes (the source
  * of truth) and a derived crow-flies mile radius that the fast Haversine feed
@@ -18,25 +20,71 @@ use Illuminate\Support\Facades\Log;
  * pair could diverge: seen live as a slider showing 25 minutes while the feed
  * stayed capped at a stale 1 mile, which the member experienced as "I only see
  * old posts". The slider now fails open, but every already-diverged pair stays
- * wrong until recomputed - which is this command's job.
+ * wrong until recomputed - which is part of this command's job.
  *
- * For each user with browseMaxMinutes set:
- *   - minutes at the no-limit stop (>= 30): distance must be the shared
- *     unlimited sentinel.
- *   - minutes below it: distance is recomputed from the same routing-backed
- *     endpoint the slider uses (town/near reach_radius_miles) at the user's
- *     location, and corrected when it differs by more than --epsilon-miles.
- *   - no known location, or the routing call fails: SKIPPED, never clobbered -
- *     a batch job must not loosen or tighten someone's feed on a lookup blip.
+ * The other part is the reason it now has to run for members who never touched
+ * the slider at all. A post's ripple grows to the widest budget any band earns
+ * (DensityService::ceiling()), because the cap belongs to the person who would
+ * travel rather than to the item - see DensityService's docblock. That is only
+ * safe if each member is then admitted on their OWN band, and the thing that
+ * admits them is exactly this preference. On live only 2,900 of 121,000 recently
+ * active members have ever set one, so without a materialised default the wider
+ * ripple would show and mail a city member posts 45 minutes away. A member's
+ * default is therefore their band's cap:
  *
- * Users with a distance but NO minutes are pre-2026-07-10 miles-slider writes.
+ *   dense  -> 20 min      medium -> 30 min      sparse -> 45 min
+ *
+ * with the radius derived from real routing at that travel time.
+ *
+ * That default is written to settings.browseReachMaxDistance, NOT browseMaxDistance.
+ * The latter is the member's own choice and ALSO caps how far away other people see
+ * their posts, so a default written there would stop a city member's posts travelling
+ * past their ~4.8 mile band radius - the exact opposite of the intent, which is to let
+ * posts travel while holding each RECIPIENT to what their own surroundings justify. A
+ * member who has set browseMaxDistance keeps having that key reconciled; nobody has one
+ * created for them.
+ *
+ * An explicit narrower choice is kept, not overwritten - but it is RESCALED onto
+ * the member's new range, because the old slider's positions meant a fixed 5-30. A
+ * stored value said what FRACTION of the range the member wanted, not an absolute
+ * travel time they would recognise: 15 was two fifths of the way up the old scale, and
+ * two fifths of a rural member's 5-45 is 20. The rescale is proportional and snapped to
+ * the slider's 5-minute step:
+ *
+ *   f = (old - 5) / (30 - 5), clamped to [0,1]
+ *   new = round_to_5(5 + f * (cap - 5)), clamped to [5, cap]
+ *
+ * At or above the old top stop, f = 1 and the member lands on their new cap.
+ *
+ * The unlimited sentinel means "defer to the server's own reach", and that reach is
+ * now the ceiling - so it only says "as far as my band goes" for a member whose band
+ * earns it. Below the ceiling the top stop stores a real derived radius instead, or a
+ * medium-band member would silently gain the widest band's reach.
+ *
+ * Never guesses: no known location, or a failed routing/density lookup, means
+ * SKIPPED and untouched. A batch job must not loosen or tighten someone's feed on
+ * a lookup blip.
+ *
+ * Users with a browseMaxDistance but NO minutes are pre-2026-07-10 miles-slider writes.
  * Since the slider went time-based it has shown them "no limit" while their old
- * cap silently kept filtering - so their stored state is overridden to the
- * unlimited sentinel to match what the UI has been telling them (explicitly
- * decided 2026-08-04). An old app bundle that still runs the miles slider may
- * re-write a cap; that re-write is a current, deliberate act and stands.
+ * cap silently kept filtering, so they are treated as being at the top stop and
+ * land on their band's cap (decided 2026-08-04; the same rule, now band-aware).
+ * An old app bundle that still runs the miles slider may re-write a cap; that
+ * re-write is a current, deliberate act and stands.
  *
- * Chunked by id and re-runnable: it only ever moves a pair TOWARDS the
+ * Cost. Both lookups are memoized on a ROUNDED location, so a street of members
+ * costs one spatial call and one routing call between them rather than one each -
+ * without which a 121,000-member pass would be a quarter of a million calls.
+ * Neither density nor a travel-time radius varies meaningfully within the
+ * rounding, and the density memo matches the 4dp key DensityService already uses.
+ *
+ * The selection is a full walk of users (~2.9M rows on live): neither the JSON_EXTRACT
+ * predicates nor lastaccess is indexed, so chunkById pages by primary key and evaluates
+ * the filter per row. That is acceptable for a manual, occasional pass and is why this is
+ * not scheduled - run it off-peak, --dry-run first, and use --since-days to bound how many
+ * members it will actually touch.
+ *
+ * Chunked by id and re-runnable: it only ever moves a member towards the
  * invariant, so stopping and re-running is safe.
  */
 class BackfillBrowseMaxDistanceCommand extends Command
@@ -49,21 +97,60 @@ class BackfillBrowseMaxDistanceCommand extends Command
      */
     private const DISTANCE_UNLIMITED = 9007199254740991;
 
-    private const MINUTES_NO_LIMIT = 30;
+    /**
+     * The INBOUND-ONLY band default. Separate from browseMaxDistance because that key is
+     * the member's own choice AND caps how far away other people see their posts - so a
+     * default written there would stop a city member's posts travelling past their ~4.8
+     * mile band radius, which is the opposite of the intent. Must stay in step with
+     * DistancePreferenceFilter::maxDistanceMiles and the Go resolveMaxDistance.
+     */
+    private const DEFAULT_KEY = 'browseReachMaxDistance';
+
+    /**
+     * The bounds the time-based slider had before it became band-aware. The old top
+     * stop is what a stored value has to be read against to know what fraction of
+     * their range the member was asking for. Must stay in step with
+     * iznik-nuxt3/constants.js BROWSE_MINUTES_MIN / BROWSE_MINUTES_STEP.
+     */
+    private const MINUTES_MIN = 5;
+
+    private const MINUTES_OLD_MAX = 30;
+
+    private const MINUTES_STEP = 5;
+
+    /** ~11m of latitude: far finer than density or a travel-time radius can resolve. */
+    private const DENSITY_MEMO_DP = 4;
+
+    /** ~110m: a radius in miles cannot tell two members this close apart. */
+    private const RADIUS_MEMO_DP = 3;
 
     protected $signature = 'browse:backfill-max-distance
                             {--chunk=200 : Users per DB chunk}
                             {--limit=0 : Stop after this many corrections (0 = no limit)}
+                            {--since-days=90 : Also give a default to members active within this many days (0 = only those who already have a setting)}
                             {--epsilon-miles=0.5 : Leave pairs alone when the recomputed radius is within this of the stored one}
                             {--dry-run : Report what would change without writing}';
 
-    protected $description = 'Reconcile stale settings.browseMaxDistance values with the browseMaxMinutes source of truth';
+    protected $description = 'Put each member on their own density band travel-time budget, and reconcile the derived browseMaxDistance';
+
+    /** Memo: rounded "lat,lng" => density cap. */
+    private array $capMemo = [];
+
+    /** Memo: "lat,lng,minutes" => derived radius, or false when the lookup failed. */
+    private array $radiusMemo = [];
+
+    public function __construct(private ?DensityService $density = null)
+    {
+        parent::__construct();
+        $this->density ??= new DensityService();
+    }
 
     public function handle(): int
     {
         $dryRun = (bool) $this->option('dry-run');
         $chunk = max(1, (int) $this->option('chunk'));
         $limit = max(0, (int) $this->option('limit'));
+        $sinceDays = max(0, (int) $this->option('since-days'));
         $epsilon = max(0.0, (float) $this->option('epsilon-miles'));
         $apiBase = rtrim(config('freegle.town_near_url'), '/');
 
@@ -75,9 +162,7 @@ class BackfillBrowseMaxDistanceCommand extends Command
             'lookup_failed' => 0,
         ];
 
-        User::query()
-            ->whereNull('deleted')
-            ->whereRaw("(JSON_EXTRACT(settings, '$.browseMaxMinutes') IS NOT NULL OR JSON_EXTRACT(settings, '$.browseMaxDistance') IS NOT NULL)")
+        $this->selection($sinceDays)
             ->orderBy('id')
             ->chunkById($chunk, function ($users) use ($dryRun, $limit, $epsilon, $apiBase, &$stats) {
                 foreach ($users as $user) {
@@ -86,38 +171,7 @@ class BackfillBrowseMaxDistanceCommand extends Command
                     }
 
                     $stats['scanned']++;
-                    $settings = $user->settings ?? [];
-                    $minutes = isset($settings['browseMaxMinutes'])
-                        ? (int) $settings['browseMaxMinutes']
-                        : null;
-                    $current = $settings['browseMaxDistance'] ?? null;
-
-                    $desired = $this->desiredDistance($user, $minutes, $apiBase, $stats);
-                    if ($desired === null) {
-                        continue;
-                    }
-
-                    if ($this->consistent($current, $desired, $epsilon)) {
-                        $stats['already_consistent']++;
-
-                        continue;
-                    }
-
-                    $this->line(sprintf(
-                        '%suser %d: minutes=%d distance %s -> %s',
-                        $dryRun ? '[dry-run] ' : '',
-                        $user->id,
-                        $minutes,
-                        $current === null ? 'NULL' : (string) $current,
-                        (string) $desired,
-                    ));
-
-                    if (! $dryRun) {
-                        $settings['browseMaxDistance'] = $desired;
-                        $user->settings = $settings;
-                        $user->save();
-                    }
-                    $stats['corrected']++;
+                    $this->reconcile($user, $dryRun, $epsilon, $apiBase, $stats);
                 }
             });
 
@@ -139,33 +193,183 @@ class BackfillBrowseMaxDistanceCommand extends Command
     }
 
     /**
-     * The distance the invariant wants for this user, or null when it cannot be
-     * determined honestly (no location / lookup failure) and the pair must be
-     * left alone.
+     * Members needing a preference: anyone who already has one (to reconcile or
+     * rescale), plus - unless --since-days=0 - anyone active recently enough to be
+     * shown or mailed a post, who needs the band default materialised before the
+     * wider ripple reaches them.
      */
-    private function desiredDistance(User $user, ?int $minutes, string $apiBase, array &$stats): int|float|null
+    private function selection(int $sinceDays)
     {
-        // No minutes at all: a pre-2026-07-10 miles-slider write. The time-based
-        // slider shows these members "no limit", so storage is overridden to
-        // match the UI (see class docblock). No routing call needed.
-        if ($minutes === null) {
-            return self::DISTANCE_UNLIMITED;
+        $query = User::query()->whereNull('deleted');
+
+        // keep-raw: JSON_EXTRACT path predicates have no query-builder equivalent;
+        // whereJsonContains tests containment, not presence of a key.
+        $hasSetting = "(JSON_EXTRACT(settings, '$.browseMaxMinutes') IS NOT NULL OR JSON_EXTRACT(settings, '$.browseMaxDistance') IS NOT NULL)";
+
+        if ($sinceDays === 0) {
+            return $query->whereRaw($hasSetting);
         }
 
-        if ($minutes >= self::MINUTES_NO_LIMIT) {
-            return self::DISTANCE_UNLIMITED;
+        return $query->where(function ($q) use ($hasSetting, $sinceDays) {
+            $q->whereRaw($hasSetting)
+                ->orWhere('lastaccess', '>=', now()->subDays($sinceDays));
+        });
+    }
+
+    /** Move one member onto their band's budget, or leave them alone and say why. */
+    private function reconcile(User $user, bool $dryRun, float $epsilon, string $apiBase, array &$stats): void
+    {
+        $settings = $user->settings ?? [];
+        $minutes = isset($settings['browseMaxMinutes'])
+            ? (int) $settings['browseMaxMinutes']
+            : null;
+
+        // A member who has set browseMaxDistance chose it, and that key also caps how far
+        // away other people see THEIR posts. We reconcile it when they have one; we never
+        // create one, because a created value would silently shrink their outbound reach.
+        $chose = array_key_exists('browseMaxDistance', $settings);
+        $targetKey = $chose ? 'browseMaxDistance' : self::DEFAULT_KEY;
+        $current = $settings[$targetKey] ?? null;
+
+        $loc = $this->location($user);
+        if ($loc === null) {
+            $stats['no_location']++;
+
+            return;
+        }
+
+        $cap = $this->capFor($loc);
+        if ($cap['band'] === DensityService::BAND_UNKNOWN) {
+            // Density could not be measured. Their band is precisely what this command
+            // exists to apply, so a guess here is the one thing worse than leaving them
+            // alone - it would be a cap nobody chose.
+            $stats['lookup_failed']++;
+
+            return;
+        }
+
+        $capMinutes = (int) round($cap['max_minutes']);
+        $desiredMinutes = $this->rescale($minutes, $capMinutes);
+        $desired = $this->desiredDistance($loc, $desiredMinutes, $capMinutes, $apiBase);
+        if ($desired === null) {
+            $stats['lookup_failed']++;
+
+            return;
+        }
+
+        if ($desiredMinutes === $minutes && $this->consistent($current, $desired, $epsilon)) {
+            $stats['already_consistent']++;
+
+            return;
+        }
+
+        $this->line(sprintf(
+            '%suser %d: %s band, minutes %s -> %d (cap %d), %s %s -> %s',
+            $dryRun ? '[dry-run] ' : '',
+            $user->id,
+            $cap['band'],
+            $minutes === null ? 'NULL' : (string) $minutes,
+            $desiredMinutes,
+            $capMinutes,
+            $targetKey,
+            $current === null ? 'NULL' : (string) $current,
+            (string) $desired,
+        ));
+
+        if (! $dryRun) {
+            $settings['browseMaxMinutes'] = $desiredMinutes;
+            $settings[$targetKey] = $desired;
+            $user->settings = $settings;
+            $user->save();
+        }
+        $stats['corrected']++;
+    }
+
+    /**
+     * Where the member's stored position lands on their own range.
+     *
+     * The stored minutes were chosen against a fixed 5-30 slider, so they say what
+     * FRACTION of the available range the member wanted, not an absolute travel time
+     * they would recognise. Carrying the number across unchanged would silently narrow
+     * a rural member (25 of 30 was near their maximum; 25 of 45 is barely past the
+     * middle) and would leave a city member above a cap the reach engine no longer
+     * honours.
+     *
+     * No stored minutes means the top stop - see the class docblock.
+     */
+    public function rescale(?int $minutes, int $capMinutes): int
+    {
+        if ($minutes === null || $minutes >= self::MINUTES_OLD_MAX) {
+            return $capMinutes;
+        }
+
+        $fraction = ($minutes - self::MINUTES_MIN) / (self::MINUTES_OLD_MAX - self::MINUTES_MIN);
+        $fraction = max(0.0, min(1.0, $fraction));
+
+        $scaled = self::MINUTES_MIN + $fraction * ($capMinutes - self::MINUTES_MIN);
+        $snapped = (int) (round($scaled / self::MINUTES_STEP) * self::MINUTES_STEP);
+
+        return max(self::MINUTES_MIN, min($capMinutes, $snapped));
+    }
+
+    /** The member's location, or null when there isn't one to work from. */
+    private function location(User $user): ?object
+    {
+        if ($user->lastlocation === null) {
+            return null;
         }
 
         $loc = DB::table('locations')
             ->where('id', $user->lastlocation)
             ->select('lat', 'lng')
             ->first();
-        if (! $loc || $loc->lat === null || $loc->lng === null) {
-            $stats['no_location']++;
 
+        if (! $loc || $loc->lat === null || $loc->lng === null) {
             return null;
         }
 
+        return $loc;
+    }
+
+    /** The band cap here, memoized so neighbours share one spatial call. */
+    private function capFor(object $loc): array
+    {
+        $key = round((float) $loc->lat, self::DENSITY_MEMO_DP)
+            . ',' . round((float) $loc->lng, self::DENSITY_MEMO_DP);
+
+        return $this->capMemo[$key] ??= $this->density->capFor((float) $loc->lat, (float) $loc->lng);
+    }
+
+    /**
+     * The distance the invariant wants, or null when it cannot be determined
+     * honestly (a routing failure) and the member must be left alone.
+     */
+    private function desiredDistance(object $loc, int $minutes, int $capMinutes, string $apiBase): int|float|null
+    {
+        // The "no limit" sentinel defers to the server's own reach, and the server's
+        // own reach is now the CEILING - so it only means "my band's worth" for a
+        // member whose band earns the ceiling. For anyone below it, storing the
+        // sentinel would hand them the widest band's reach: a Peterborough member
+        // would go from 30 minutes to everything within 45 minutes of a post, which
+        // on live is a 33-mile radius. Below the ceiling the band cap has to be a real
+        // derived radius, which is exactly what holds each member to their own band.
+        if ($minutes >= $capMinutes && $capMinutes >= (int) round(DensityService::ceiling())) {
+            return self::DISTANCE_UNLIMITED;
+        }
+
+        $key = round((float) $loc->lat, self::RADIUS_MEMO_DP)
+            . ',' . round((float) $loc->lng, self::RADIUS_MEMO_DP) . ',' . $minutes;
+
+        if (! array_key_exists($key, $this->radiusMemo)) {
+            $this->radiusMemo[$key] = $this->lookupRadius($loc, $minutes, $apiBase);
+        }
+
+        return $this->radiusMemo[$key] === false ? null : $this->radiusMemo[$key];
+    }
+
+    /** One town/near call: the crow-flies radius this travel time reaches, or false. */
+    private function lookupRadius(object $loc, int $minutes, string $apiBase): float|false
+    {
         try {
             $response = Http::timeout(10)->get($apiBase, [
                 'lat' => $loc->lat,
@@ -177,13 +381,7 @@ class BackfillBrowseMaxDistanceCommand extends Command
             $radius = null;
         }
 
-        if (! is_numeric($radius) || $radius <= 0) {
-            $stats['lookup_failed']++;
-
-            return null;
-        }
-
-        return $radius;
+        return is_numeric($radius) && $radius > 0 ? (float) $radius : false;
     }
 
     private function consistent(mixed $current, int|float $desired, float $epsilon): bool

--- a/iznik-batch/app/Services/Ripple/DensityService.php
+++ b/iznik-batch/app/Services/Ripple/DensityService.php
@@ -7,8 +7,8 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 /**
- * How thinly freeglers are spread around a post, and therefore how far its ripple
- * should be allowed to grow.
+ * How thinly freeglers are spread around a point, and therefore how far someone
+ * there would travel for a free item.
  *
  * A single flat drive-time cap cannot fit the whole country. The chance that a
  * reply from drive-time D goes on to collect, measured over 887 posts split by
@@ -28,10 +28,34 @@ use Illuminate\Support\Facades\Log;
  * almost nothing but costs mail and crossposting) and too tight in the country (it
  * cuts off people who demonstrably do collect).
  *
+ * WHOSE density decides. Read the table again by row and it is about the person
+ * who would make the journey, not the item: it is the REPLIER's drive-time and
+ * the REPLIER's surroundings that predict a collection. Applying the cap at the
+ * post's origin gets this right only when both ends sit in the same kind of
+ * place. Where they differ it fails exactly backwards, and the case it fails on
+ * is the common one: a rural member's nearest town is the town they already
+ * drive to, and its posts are the ones they most want. A member outside Spalding
+ * (nearest 400 freeglers 16 miles out - definitively sparse) sits 38 minutes from
+ * Peterborough, which is medium and so caps at 30. Sizing at the origin means
+ * they can never be reached by the town's posts however far they would travel,
+ * while a Peterborough member who would not leave the city is reached by
+ * everything within 30 minutes of it.
+ *
+ * So the cap is applied to the RECIPIENT: a post's ripple grows to the widest
+ * budget any member might justify (Ceiling()), and each member is then admitted
+ * on their OWN band, via the travel-time preference that already gates browse and
+ * mail: settings.browseMaxMinutes, plus the radius in browseReachMaxDistance - an
+ * INBOUND-ONLY key, because browseMaxDistance also caps how far away others see the
+ * member's OWN posts and defaulting it would stop a city member's posts travelling.
+ *
+ * The dense saving is preserved - a city member is still not shown or mailed a post
+ * 40 minutes away, because their own band says 20 - while the rural member finally
+ * gets the town. See docs/developers/reference/rippling-algorithm.md.
+ *
  * Density is the radius of the circle that holds the nearest K freeglers (K=400)
- * to the post's origin. Distance is great-circle miles, computed here rather than
- * taken from the spatial server's `distance` field, which is a Euclidean distance
- * in DEGREES and so understates east-west separation by about a third at UK
+ * to the point. Distance is great-circle miles, computed here rather than taken
+ * from the spatial server's `distance` field, which is a Euclidean distance in
+ * DEGREES and so understates east-west separation by about a third at UK
  * latitudes.
  *
  * Fails soft in every direction: an unreachable spatial server, an empty result or
@@ -58,8 +82,35 @@ class DensityService
     }
 
     /**
-     * The reach budget for a post at this origin, plus the measurement behind it so
-     * every reach row can be read back against the decision that shaped it.
+     * The widest budget any band can earn. A ripple grows to this, because the cap
+     * belongs to the recipient and a post cannot know in advance which bands the
+     * members around it fall in - only that the sparse ones travel furthest. Members
+     * nearer the middle are then held to their own band on the way out.
+     *
+     * Taken as the max over the configured bands rather than hardcoding 'sparse', so
+     * re-tuning a band cannot silently leave the ripple too small to serve it.
+     */
+    public static function ceiling(): float
+    {
+        $flat = (float) config('freegle.ripple.max_minutes', 30);
+
+        if (!config('freegle.ripple.density.enabled', true)) {
+            return $flat;
+        }
+
+        $bands = (array) config('freegle.ripple.density.max_minutes', []);
+
+        return max($flat, ...array_map('floatval', array_values($bands) ?: [$flat]));
+    }
+
+    /**
+     * The travel-time budget someone at this point would justify, plus the
+     * measurement behind it so every decision can be read back against its reason.
+     *
+     * Used for the RECIPIENT (their slider default and the reach they are admitted
+     * on) and, for the post's origin, recorded on the reach row as the local
+     * description - not as its growth limit, which is ceiling(). See the class
+     * docblock for why the cap belongs to the traveller.
      *
      * @return array{band:string, radius_miles:?float, max_minutes:float}
      */

--- a/iznik-batch/app/Services/Ripple/DistancePreferenceFilter.php
+++ b/iznik-batch/app/Services/Ripple/DistancePreferenceFilter.php
@@ -41,13 +41,21 @@ class DistancePreferenceFilter
     public const DISTANCE_UNLIMITED = 9007199254740991;
 
     /**
-     * Resolve a member's configured max distance in miles from
-     * settings.browseMaxDistance.
+     * Resolve a member's INBOUND max distance in miles: their own
+     * settings.browseMaxDistance if they have set one, else the band default in
+     * settings.browseReachMaxDistance.
      *
      * Absent, null, non-numeric, <= 0, or >= the sentinel all mean "no
      * limit" and collapse to DISTANCE_UNLIMITED so callers can short-circuit
-     * with a single comparison — this is the fast path that the overwhelming
-     * majority of members (who have never touched the slider) take.
+     * with a single comparison.
+     *
+     * The band default is a SEPARATE key on purpose. browseMaxDistance is the
+     * member's own choice and also caps how far away other people see THEIR
+     * posts (authorMaxDistanceMiles / the Go AuthorReachCapWhere clause), so
+     * writing a default into it would silently stop a city member's posts
+     * travelling beyond their ~4.8-mile band radius. The point of the band is
+     * to hold each RECIPIENT to the distance their own surroundings justify
+     * while posts still travel — see App\Services\Ripple\DensityService.
      */
     public function maxDistanceMiles(User $user): float
     {
@@ -55,19 +63,55 @@ class DistancePreferenceFilter
         if (is_string($settings)) {
             $settings = json_decode($settings, true) ?: [];
         }
+        if (!is_array($settings)) {
+            return (float) self::DISTANCE_UNLIMITED;
+        }
+
+        // An explicit choice always wins, including a wider one: a member who moved
+        // the slider has said what they want.
+        foreach (['browseMaxDistance', 'browseReachMaxDistance'] as $key) {
+            $value = $settings[$key] ?? null;
+            if (!is_numeric($value)) {
+                continue;
+            }
+
+            $value = (float) $value;
+
+            return $value <= 0 || $value >= self::DISTANCE_UNLIMITED
+                ? (float) self::DISTANCE_UNLIMITED
+                : $value;
+        }
+
+        return (float) self::DISTANCE_UNLIMITED;
+    }
+
+    /**
+     * A member's OUTBOUND cap in miles: how far away other people may see the posts they
+     * write. Reads ONLY settings.browseMaxDistance - the key the member set themselves.
+     *
+     * The band default (browseReachMaxDistance) is deliberately NOT consulted here. It says
+     * how far this member will travel to collect, which is a different question from how far
+     * their giveaway should travel to find a taker; applying it outbound would stop a city
+     * member's posts leaving their ~4.8-mile band radius and undo the reason the ripple grows
+     * to the ceiling at all.
+     */
+    public function authorMaxDistanceMiles(User $user): float
+    {
+        $settings = $user->settings;
+        if (is_string($settings)) {
+            $settings = json_decode($settings, true) ?: [];
+        }
 
         $value = is_array($settings) ? ($settings['browseMaxDistance'] ?? null) : null;
-
         if (!is_numeric($value)) {
             return (float) self::DISTANCE_UNLIMITED;
         }
 
         $value = (float) $value;
-        if ($value <= 0 || $value >= self::DISTANCE_UNLIMITED) {
-            return (float) self::DISTANCE_UNLIMITED;
-        }
 
-        return $value;
+        return $value <= 0 || $value >= self::DISTANCE_UNLIMITED
+            ? (float) self::DISTANCE_UNLIMITED
+            : $value;
     }
 
     /**

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -781,13 +781,22 @@ class ExpandService
             $distinctOrigins[$lat . ',' . $lng] = ['lat' => $lat, 'lng' => $lng];
         }
 
-        // How far each origin's reach is allowed to grow. A function of the origin
-        // alone, like the schedule itself, so it is measured once per DISTINCT origin
-        // and memoized inside DensityService for the run.
+        // Every reach grows to the SAME budget: the widest any band earns. The cap
+        // belongs to the person who would travel, not to the item (DensityService
+        // docblock), and a post cannot know which bands the members around it fall
+        // in - so it must reach far enough for the sparse ones and let each member be
+        // admitted on their own band on the way out. Sizing this at the origin
+        // instead is what left a rural member permanently unable to see their nearest
+        // town's posts.
+        //
+        // The origin's own band is still measured and stored: it is what the row is
+        // read back by, and the density analytics compare bands against each other.
+        // It is a description of where the post is, not the limit on where it goes.
+        $ceiling = DensityService::ceiling();
         $capByKey = [];
         foreach ($distinctOrigins as $k => $o) {
             $capByKey[$k] = $this->density->capFor($o['lat'], $o['lng']);
-            $distinctOrigins[$k]['max_minutes'] = $capByKey[$k]['max_minutes'];
+            $distinctOrigins[$k]['max_minutes'] = $ceiling;
         }
 
         $scheduleByKey = []; // "lat,lng" => parsed schedule | null
@@ -824,14 +833,13 @@ class ExpandService
                     continue; // not one of this batch's origins, or already reused
                 }
                 // A stored schedule computed under a DIFFERENT reach budget is not this
-                // post's schedule, however co-located the two posts are. Without this the
-                // first post at an origin would fix the cap for everything that followed,
-                // and changing a band's minutes would take effect only where nobody had
-                // posted before - the density change would look far weaker than it is.
+                // post's schedule, however co-located the two posts are. Every reach now
+                // grows to the ceiling, so this mostly guards the rows written before
+                // that - and it is what makes a change to the ceiling take effect
+                // everywhere rather than only where nobody had posted before.
                 if ($capCol !== '') {
                     $storedCap = $e->max_minutes_cap === null ? null : (float) $e->max_minutes_cap;
-                    $wantCap = (float) ($capByKey[$k]['max_minutes'] ?? 0);
-                    if ($storedCap === null || abs($storedCap - $wantCap) > 0.001) {
+                    if ($storedCap === null || abs($storedCap - $ceiling) > 0.001) {
                         continue;
                     }
                 }
@@ -889,11 +897,8 @@ class ExpandService
                     // against a 30-min drive isochrone (the innermost tick is already km-scale), so
                     // this does not meaningfully reduce origin privacy - it only rescues the posts
                     // the blur would otherwise lose. Costs one extra routing call per stranded post.
-                    // Same reach budget as the blurred origin would have had: 400m cannot
-                    // move a post between density bands, so re-measuring would only add a
-                    // spatial call to the recovery path for the stranded posts.
                     $schedule = $this->reach->computeSchedule(
-                        (float) $row->lat, (float) $row->lng, $cap['max_minutes']
+                        (float) $row->lat, (float) $row->lng, $ceiling
                     );
                     if ($schedule !== null) {
                         $lat = (float) $row->lat;
@@ -975,7 +980,7 @@ class ExpandService
                         json_encode($schedule['ticks']),
                         json_encode($this->tickReachableIds($entry, $schedule)),
                         $next, $status,
-                    ], $withDensity ? [$cap['band'], $cap['radius_miles'], $cap['max_minutes']] : []);
+                    ], $withDensity ? [$cap['band'], $cap['radius_miles'], $ceiling] : []);
                     $initStore = function (string $wkt) use ($initSql, $initTail, $row, $lat, $lng, $ready, $poly): void {
                         $head = [$row->msgid, $lat, $lng, $wkt];
                         try {

--- a/iznik-batch/app/Services/Ripple/ReachService.php
+++ b/iznik-batch/app/Services/Ripple/ReachService.php
@@ -119,8 +119,10 @@ class ReachService
      * is deterministic per origin, so de-duplicating origins before calling this turns
      * O(posts) routing calls into O(distinct origins).
      *
-     * Each origin may carry its own `max_minutes` (the density-conditional cap); absent
-     * means the configured flat cap.
+     * Each origin may carry its own `max_minutes`; absent means the configured flat cap.
+     * ExpandService passes DensityService::ceiling() - the widest budget any band earns -
+     * because the cap belongs to the recipient rather than the post, and each member is held
+     * to their own band on the way out (see DensityService's docblock).
      *
      * @param array<int,array{lat:float,lng:float,max_minutes?:float}> $origins
      * @return array<int,?array>

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -1854,6 +1854,10 @@ class UnifiedDigestService
      * memoised per author id so repeated posts by the same freegler — across
      * recipients and groups within a run — cost a single lookup. Absent author or
      * absent/sentinel setting resolves to DISTANCE_UNLIMITED (no outbound cap).
+     *
+     * Uses authorMaxDistanceMiles, NOT maxDistanceMiles: the latter falls back to the
+     * member's density band default, which describes how far THEY would travel to collect
+     * and must never become a cap on how far their own posts may go.
      */
     private array $authorMaxMilesCache = [];
 
@@ -1862,7 +1866,7 @@ class UnifiedDigestService
         if (!array_key_exists($fromuser, $this->authorMaxMilesCache)) {
             $author = User::select('id', 'settings')->find($fromuser);
             $this->authorMaxMilesCache[$fromuser] = $author
-                ? app(DistancePreferenceFilter::class)->maxDistanceMiles($author)
+                ? app(DistancePreferenceFilter::class)->authorMaxDistanceMiles($author)
                 : (float) DistancePreferenceFilter::DISTANCE_UNLIMITED;
         }
 

--- a/iznik-batch/tests/Feature/Browse/BackfillBrowseMaxDistanceCommandTest.php
+++ b/iznik-batch/tests/Feature/Browse/BackfillBrowseMaxDistanceCommandTest.php
@@ -7,17 +7,62 @@ use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 /**
- * The backfill reconciles settings.browseMaxDistance (the derived cap the feed
- * and digest filters read) with settings.browseMaxMinutes (the slider's source
- * of truth). It must recompute stale caps from the routing endpoint, honour the
- * unlimited sentinel at the no-limit stop, and never touch a pair it cannot
- * recompute honestly.
+ * The backfill puts each member on the travel-time budget their own density band
+ * justifies, and keeps settings.browseMaxDistance (the derived cap the feed and
+ * digest filters read) consistent with settings.browseMaxMinutes (the slider's
+ * source of truth).
+ *
+ * Both halves matter. The reconciliation stops a stale radius filtering to a cap
+ * the slider no longer shows; the band default is what admits each member to the
+ * wider ripple on their OWN terms, without which a city member would start being
+ * mailed posts 45 minutes away.
  */
 class BackfillBrowseMaxDistanceCommandTest extends TestCase
 {
     private const UNLIMITED = 9007199254740991;
 
-    private function userWith(array $settings, ?float $lat = 53.4, ?float $lng = -1.3): int
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'freegle.ripple.max_minutes' => 30,
+            'freegle.ripple.density.enabled' => true,
+            'freegle.ripple.density.k' => 400,
+            'freegle.ripple.density.dense_max_miles' => 1.6,
+            'freegle.ripple.density.medium_max_miles' => 3.1,
+            'freegle.ripple.density.max_minutes.dense' => 20,
+            'freegle.ripple.density.max_minutes.medium' => 30,
+            'freegle.ripple.density.max_minutes.sparse' => 45,
+        ]);
+    }
+
+    /**
+     * Fake both endpoints the command uses: the spatial KNN behind the density band,
+     * and the routing-backed town/near behind the derived radius. $count freeglers
+     * with the furthest $miles away (due north, so the great-circle conversion is
+     * the unambiguous one) decides the band.
+     */
+    private function fakeLookups(int $count, float $miles, float $radiusMiles = 8.5, float $lat = 53.4, float $lng = -1.3): void
+    {
+        $results = [];
+        for ($i = 0; $i < $count; $i++) {
+            $offset = ($miles * ($i + 1) / $count) / 69.05;
+            $results[] = ['id' => $i + 1, 'extra' => ['lat' => $lat + $offset, 'lng' => $lng]];
+        }
+
+        Http::fake([
+            '*userapproxlocs*' => Http::response(['results' => $results]),
+            '*town/near*' => Http::response(['reach_radius_miles' => $radiusMiles]),
+        ]);
+    }
+
+    /** A member in a medium band: 30-minute cap, so stored minutes carry across unchanged. */
+    private function fakeMedium(float $radiusMiles = 8.5): void
+    {
+        $this->fakeLookups(400, 2.5, $radiusMiles);
+    }
+
+    private function userWith(array $settings, ?float $lat = 53.4, ?float $lng = -1.3, ?string $lastaccess = null): int
     {
         $locationId = null;
         if ($lat !== null) {
@@ -29,24 +74,58 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
             ]);
         }
 
-        return (int) DB::table('users')->insertGetId([
+        $row = [
             'fullname' => 'Backfill Test '.uniqid(),
             'systemrole' => 'User',
             'lastlocation' => $locationId,
             'settings' => json_encode($settings),
-        ]);
+        ];
+        if ($lastaccess !== null) {
+            $row['lastaccess'] = $lastaccess;
+        }
+
+        return (int) DB::table('users')->insertGetId($row);
     }
 
+    private function settingsOf(int $id): array
+    {
+        return json_decode(DB::table('users')->where('id', $id)->value('settings'), true) ?: [];
+    }
+
+    /** The inbound cap actually in force: their own choice if they made one, else the band default. */
     private function distanceOf(int $id): mixed
     {
-        $settings = json_decode(DB::table('users')->where('id', $id)->value('settings'), true);
+        $s = $this->settingsOf($id);
 
-        return $settings['browseMaxDistance'] ?? null;
+        return $s['browseMaxDistance'] ?? $s['browseReachMaxDistance'] ?? null;
+    }
+
+    /** browseMaxDistance ONLY - the key that also caps how far away others see their posts. */
+    private function chosenDistanceOf(int $id): mixed
+    {
+        return $this->settingsOf($id)['browseMaxDistance'] ?? null;
+    }
+
+    private function minutesOf(int $id): mixed
+    {
+        return $this->settingsOf($id)['browseMaxMinutes'] ?? null;
+    }
+
+    private function townNearCalls(): int
+    {
+        $n = 0;
+        foreach (Http::recorded() as [$request]) {
+            if (str_contains($request->url(), 'town/near')) {
+                $n++;
+            }
+        }
+
+        return $n;
     }
 
     public function testRecomputesAStaleCapFromTheRoutingEndpoint(): void
     {
-        Http::fake(['*' => Http::response(['reach_radius_miles' => 8.5])]);
+        $this->fakeMedium();
         // The live case: slider at 25 minutes, cap stuck at a stale 1 mile.
         $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 1]);
 
@@ -57,7 +136,7 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
 
     public function testLeavesAConsistentPairAlone(): void
     {
-        Http::fake(['*' => Http::response(['reach_radius_miles' => 8.5])]);
+        $this->fakeMedium();
         $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 8.2]);
 
         // 0.3 miles inside the default 0.5 epsilon - not worth churning.
@@ -68,7 +147,7 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
 
     public function testFillsAMissingCapForACapWantingSlider(): void
     {
-        Http::fake(['*' => Http::response(['reach_radius_miles' => 3.7])]);
+        $this->fakeMedium(3.7);
         $id = $this->userWith(['browseMaxMinutes' => 10]);
 
         $this->artisan('browse:backfill-max-distance')->assertSuccessful();
@@ -76,20 +155,28 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
         $this->assertSame(3.7, $this->distanceOf($id));
     }
 
-    public function testNoLimitStopGetsTheSharedSentinelWithoutARoutingCall(): void
+    public function testTopStopBelowTheCeilingStoresARealRadiusNotTheSentinel(): void
     {
-        Http::fake(['*' => Http::response(['reach_radius_miles' => 99])]);
+        // The sentinel defers to the server's own reach, which now grows to the
+        // CEILING - so for a band below it the sentinel would hand this member the
+        // widest band's reach instead of their own.
+        $this->fakeMedium(13.2);
         $id = $this->userWith(['browseMaxMinutes' => 30, 'browseMaxDistance' => 12]);
 
         $this->artisan('browse:backfill-max-distance')->assertSuccessful();
 
-        $this->assertSame(self::UNLIMITED, $this->distanceOf($id));
-        Http::assertNothingSent();
+        $this->assertSame(13.2, $this->distanceOf($id));
+        $this->assertSame(30, $this->minutesOf($id));
     }
 
     public function testSkipsWhenTheRoutingLookupFails(): void
     {
-        Http::fake(['*' => Http::response(null, 500)]);
+        Http::fake([
+            '*userapproxlocs*' => Http::response(['results' => [
+                ['id' => 1, 'extra' => ['lat' => 53.43, 'lng' => -1.3]],
+            ]]),
+            '*town/near*' => Http::response(null, 500),
+        ]);
         $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 1]);
 
         $this->artisan('browse:backfill-max-distance')->assertSuccessful();
@@ -99,9 +186,26 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
         $this->assertSame(1, $this->distanceOf($id));
     }
 
+    public function testSkipsWhenDensityCannotBeMeasured(): void
+    {
+        // An empty spatial index and a genuinely empty area look identical from here.
+        // Guessing a band would hand the member a cap nobody chose.
+        Http::fake([
+            '*userapproxlocs*' => Http::response(['results' => []]),
+            '*town/near*' => Http::response(['reach_radius_miles' => 8.5]),
+        ]);
+        $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 1]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame(1, $this->distanceOf($id));
+        $this->assertSame(25, $this->minutesOf($id));
+        $this->assertSame(0, $this->townNearCalls());
+    }
+
     public function testSkipsUsersWithNoKnownLocation(): void
     {
-        Http::fake(['*' => Http::response(['reach_radius_miles' => 8.5])]);
+        $this->fakeMedium();
         $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 1], null, null);
 
         $this->artisan('browse:backfill-max-distance')->assertSuccessful();
@@ -110,33 +214,49 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
         Http::assertNothingSent();
     }
 
-    public function testOverridesALegacyMilesOnlyCapToUnlimited(): void
+    public function testOverridesALegacyMilesOnlyCapToTheBandCap(): void
     {
-        Http::fake(['*' => Http::response(['reach_radius_miles' => 8.5])]);
+        $this->fakeMedium();
         // Pre-2026-07-10 miles-slider write: distance set, no minutes. The
         // time-based slider shows this member "no limit" - storage must match.
         $id = $this->userWith(['browseMaxDistance' => 5]);
 
         $this->artisan('browse:backfill-max-distance')->assertSuccessful();
 
-        $this->assertSame(self::UNLIMITED, $this->distanceOf($id));
-        Http::assertNothingSent();
+        $this->assertSame(8.5, $this->distanceOf($id));
+        $this->assertSame(30, $this->minutesOf($id));
     }
 
-    public function testLeavesALegacyAlreadyUnlimitedRowAlone(): void
+    public function testALegacyUnlimitedRowBelowTheCeilingIsBroughtBackToItsBand(): void
     {
-        Http::fake(['*' => Http::response(['reach_radius_miles' => 8.5])]);
-        $id = $this->userWith(['browseMaxDistance' => self::UNLIMITED]);
+        // 'Unlimited' used to mean the flat 30 the ripple grew to. It now means the
+        // ceiling, so a medium-band member left on it would quietly gain the widest
+        // band's reach - the exact flooding the recipient cap exists to prevent.
+        $this->fakeMedium(13.2);
+        $id = $this->userWith(['browseMaxMinutes' => 30, 'browseMaxDistance' => self::UNLIMITED]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame(13.2, $this->distanceOf($id));
+        $this->assertSame(30, $this->minutesOf($id));
+    }
+
+    public function testASparseRowAtTheCeilingKeepsTheSentinel(): void
+    {
+        // At the ceiling 'defer to the server's own reach' is exactly right: the
+        // ripple grows no further than this member is willing to travel.
+        $this->fakeLookups(400, 16.1);
+        $id = $this->userWith(['browseMaxMinutes' => 45, 'browseMaxDistance' => self::UNLIMITED]);
 
         $this->artisan('browse:backfill-max-distance')->assertSuccessful();
 
         $this->assertSame(self::UNLIMITED, $this->distanceOf($id));
-        Http::assertNothingSent();
+        $this->assertSame(0, $this->townNearCalls());
     }
 
     public function testDryRunWritesNothing(): void
     {
-        Http::fake(['*' => Http::response(['reach_radius_miles' => 8.5])]);
+        $this->fakeMedium();
         $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 1]);
 
         $this->artisan('browse:backfill-max-distance --dry-run')->assertSuccessful();
@@ -146,7 +266,7 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
 
     public function testPreservesUnrelatedSettingsKeys(): void
     {
-        Http::fake(['*' => Http::response(['reach_radius_miles' => 8.5])]);
+        $this->fakeMedium();
         $id = $this->userWith([
             'browseMaxMinutes' => 25,
             'browseMaxDistance' => 1,
@@ -156,9 +276,162 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
 
         $this->artisan('browse:backfill-max-distance')->assertSuccessful();
 
-        $settings = json_decode(DB::table('users')->where('id', $id)->value('settings'), true);
+        $settings = $this->settingsOf($id);
         $this->assertSame(8.5, $settings['browseMaxDistance']);
         $this->assertSame('mygroups', $settings['browseView']);
         $this->assertSame('Newest', $settings['browseSort']);
+    }
+
+    /**
+     * The case that started this: a rural member at the old top stop. Their band
+     * earns 45 minutes, so the top stop now means 45 - and still means "no limit",
+     * deferring to the server's own reach rather than a radius that would narrow it.
+     */
+    public function testARuralMemberAtTheOldTopStopMovesUpToTheirBandCap(): void
+    {
+        $this->fakeLookups(400, 16.1);
+        $id = $this->userWith(['browseMaxMinutes' => 30, 'browseMaxDistance' => self::UNLIMITED]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame(45, $this->minutesOf($id));
+        $this->assertSame(self::UNLIMITED, $this->distanceOf($id));
+    }
+
+    /**
+     * A city member at the old top stop lands on 20, not 30. Without this the wider
+     * ripple would reach them with everything inside 45 minutes of a post.
+     */
+    public function testACityMemberAtTheOldTopStopComesDownToTheirBandCap(): void
+    {
+        $this->fakeLookups(400, 0.9, 7.4);
+        $id = $this->userWith(['browseMaxMinutes' => 30, 'browseMaxDistance' => self::UNLIMITED]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame(20, $this->minutesOf($id));
+        $this->assertSame(7.4, $this->distanceOf($id));
+    }
+
+    /**
+     * A member who never touched the slider has no preference to reconcile, but they
+     * are exactly who needs the default: the ripple now grows past what their band
+     * justifies, and this is what holds them to it.
+     */
+    public function testGivesAnUntouchedActiveMemberTheirBandDefault(): void
+    {
+        $this->fakeLookups(400, 0.9, 7.4);
+        $id = $this->userWith([], 53.4, -1.3, now()->subDays(3)->toDateTimeString());
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame(20, $this->minutesOf($id));
+        $this->assertSame(7.4, $this->distanceOf($id));
+    }
+
+    public function testLeavesLongDormantMembersAlone(): void
+    {
+        $this->fakeLookups(400, 0.9);
+        $id = $this->userWith([], 53.4, -1.3, now()->subDays(400)->toDateTimeString());
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertNull($this->minutesOf($id));
+    }
+
+    public function testSinceDaysZeroTouchesOnlyMembersWhoAlreadyChose(): void
+    {
+        $this->fakeLookups(400, 0.9);
+        $untouched = $this->userWith([], 53.4, -1.3, now()->subDays(3)->toDateTimeString());
+
+        $this->artisan('browse:backfill-max-distance --since-days=0')->assertSuccessful();
+
+        $this->assertNull($this->minutesOf($untouched));
+    }
+
+    /**
+     * An explicit narrower choice is a fraction of the range the member was shown, not
+     * an absolute travel time they would recognise. 15 was two fifths of the way up the
+     * old 5-30; two fifths of a rural 5-45 is 20. Carrying 15 across unchanged would
+     * quietly narrow them at the moment the reach engine got wider.
+     */
+    public function testRescalesAnExplicitChoiceOntoTheNewRange(): void
+    {
+        $this->fakeLookups(400, 16.1, 12.4);
+        $id = $this->userWith(['browseMaxMinutes' => 15, 'browseMaxDistance' => 6]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame(20, $this->minutesOf($id));
+        $this->assertSame(12.4, $this->distanceOf($id));
+    }
+
+    public function testRescalingSnapsToTheSlidersStep(): void
+    {
+        $command = app(\App\Console\Commands\Browse\BackfillBrowseMaxDistanceCommand::class);
+
+        // Rural range 5-45: the ends pin, the interior snaps to fives.
+        $this->assertSame(5, $command->rescale(5, 45));
+        $this->assertSame(45, $command->rescale(30, 45));
+        $this->assertSame(20, $command->rescale(15, 45));
+        $this->assertSame(30, $command->rescale(20, 45));
+
+        // City range 5-20: every position lands at or below the cap.
+        $this->assertSame(5, $command->rescale(5, 20));
+        $this->assertSame(15, $command->rescale(20, 20));
+        $this->assertSame(20, $command->rescale(30, 20));
+
+        // A stored value past the old top (an older bundle, a hand-edited setting)
+        // is still just "as far as I can".
+        $this->assertSame(45, $command->rescale(60, 45));
+
+        // No stored value at all means the top stop.
+        $this->assertSame(45, $command->rescale(null, 45));
+    }
+
+    /**
+     * A street of members must not cost a spatial call and a routing call each: on
+     * live this pass covers 121,000 people.
+     */
+    public function testMemoizesLookupsAcrossCoLocatedMembers(): void
+    {
+        $this->fakeLookups(400, 16.1, 12.4);
+        $this->userWith(['browseMaxMinutes' => 15, 'browseMaxDistance' => 6]);
+        $this->userWith(['browseMaxMinutes' => 15, 'browseMaxDistance' => 6]);
+        $this->userWith(['browseMaxMinutes' => 15, 'browseMaxDistance' => 6]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame(1, $this->townNearCalls());
+    }
+
+    /**
+     * The outbound half of the preference. browseMaxDistance also caps how far away other
+     * people see a member's OWN posts, so the band default must never be written there:
+     * a city member's ~4.8-mile radius would stop their posts travelling at all, which is
+     * the opposite of what growing the ripple to the ceiling is for.
+     */
+    public function testTheBandDefaultNeverCreatesAnOutboundCap(): void
+    {
+        $this->fakeLookups(400, 0.9, 7.4);
+        $id = $this->userWith([], 53.4, -1.3, now()->subDays(3)->toDateTimeString());
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertNull($this->chosenDistanceOf($id), 'no outbound cap may be invented');
+        $this->assertSame(7.4, $this->settingsOf($id)['browseReachMaxDistance']);
+    }
+
+    public function testAnExplicitChoiceKeepsBeingTheOutboundCap(): void
+    {
+        // Someone who moved the slider chose both halves; we reconcile that key rather
+        // than leaving it stale beside a new default.
+        $this->fakeMedium(8.5);
+        $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 1]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame(8.5, $this->chosenDistanceOf($id));
+        $this->assertArrayNotHasKey('browseReachMaxDistance', $this->settingsOf($id));
     }
 }

--- a/iznik-batch/tests/Unit/Services/Ripple/DensityServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/DensityServiceTest.php
@@ -149,4 +149,40 @@ class DensityServiceTest extends TestCase
         $this->assertSame(DensityService::BAND_SPARSE, DensityService::band(400, 400, 3.11));
         $this->assertSame(DensityService::BAND_UNKNOWN, DensityService::band(0, 400, null));
     }
+
+    /**
+     * A ripple grows to the ceiling, not to its origin's band, because the cap
+     * belongs to whoever would make the journey. If the ceiling were ever below a
+     * band's cap, members in that band could never be reached at the distance their
+     * own band says they would travel - which is the failure this replaced.
+     */
+    public function test_the_ceiling_covers_the_widest_band(): void
+    {
+        $this->assertSame(45.0, DensityService::ceiling());
+    }
+
+    public function test_the_ceiling_follows_a_retuned_band(): void
+    {
+        config(['freegle.ripple.density.max_minutes.sparse' => 50]);
+
+        $this->assertSame(50.0, DensityService::ceiling());
+    }
+
+    public function test_the_ceiling_never_drops_below_the_flat_cap(): void
+    {
+        config([
+            'freegle.ripple.density.max_minutes.dense' => 10,
+            'freegle.ripple.density.max_minutes.medium' => 15,
+            'freegle.ripple.density.max_minutes.sparse' => 20,
+        ]);
+
+        $this->assertSame(30.0, DensityService::ceiling());
+    }
+
+    public function test_the_killswitch_puts_the_ceiling_back_on_the_flat_cap(): void
+    {
+        config(['freegle.ripple.density.enabled' => false]);
+
+        $this->assertSame(30.0, DensityService::ceiling());
+    }
 }

--- a/iznik-batch/tests/Unit/Services/Ripple/DistancePreferenceFilterTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/DistancePreferenceFilterTest.php
@@ -176,4 +176,56 @@ class DistancePreferenceFilterTest extends TestCase
         $miles = $this->filter()->distanceMiles(51.5074, -0.1278, 48.8566, 2.3522);
         $this->assertEqualsWithDelta(213.0, $miles, 5.0);
     }
+
+    /**
+     * The band default (browse:backfill-max-distance) is INBOUND only. It lives in its own
+     * key because browseMaxDistance also caps how far away other people see the member's
+     * posts - see DensityService for why the cap belongs to the recipient.
+     */
+    public function test_band_default_applies_when_the_member_has_not_chosen(): void
+    {
+        $user = $this->userWithSettings(['browseReachMaxDistance' => 7.4]);
+        $this->assertSame(7.4, $this->filter()->maxDistanceMiles($user));
+    }
+
+    public function test_an_explicit_choice_beats_the_band_default_even_when_wider(): void
+    {
+        // Someone who moved the slider has said what they want; the default is only a default.
+        $user = $this->userWithSettings([
+            'browseMaxDistance' => 22.0,
+            'browseReachMaxDistance' => 7.4,
+        ]);
+        $this->assertSame(22.0, $this->filter()->maxDistanceMiles($user));
+    }
+
+    public function test_an_explicit_unlimited_choice_beats_a_narrower_band_default(): void
+    {
+        $user = $this->userWithSettings([
+            'browseMaxDistance' => DistancePreferenceFilter::DISTANCE_UNLIMITED,
+            'browseReachMaxDistance' => 7.4,
+        ]);
+        $this->assertSame(
+            (float) DistancePreferenceFilter::DISTANCE_UNLIMITED,
+            $this->filter()->maxDistanceMiles($user)
+        );
+    }
+
+    public function test_a_junk_band_default_is_no_limit_not_a_guess(): void
+    {
+        $user = $this->userWithSettings(['browseReachMaxDistance' => 'nonsense']);
+        $this->assertSame(
+            (float) DistancePreferenceFilter::DISTANCE_UNLIMITED,
+            $this->filter()->maxDistanceMiles($user)
+        );
+    }
+
+    public function test_the_band_default_is_not_an_outbound_cap(): void
+    {
+        // authorMaxDistanceMiles must read ONLY the member's own choice.
+        $user = $this->userWithSettings(['browseReachMaxDistance' => 4.8]);
+        $this->assertSame(
+            (float) DistancePreferenceFilter::DISTANCE_UNLIMITED,
+            $this->filter()->authorMaxDistanceMiles($user)
+        );
+    }
 }

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -118,11 +118,13 @@ class ExpandServiceTest extends TestCase
         return null;
     }
 
-    public function test_a_city_post_is_given_a_shorter_reach_budget_than_the_countryside(): void
+    public function test_a_city_post_still_ripples_to_the_ceiling_so_rural_members_can_reach_it(): void
     {
-        // The flat 30 minutes came from a pooled bullseye that turned out to be city
-        // behaviour. Dense conversion collapses past 20-25 min; sparse does not fall at
-        // all out to 45. One cap cannot be right for both.
+        // The cap belongs to the person who would travel, not to the item. Sizing a city
+        // post at its own 20 minutes means a rural member 38 minutes away can NEVER see
+        // their nearest town's posts, at any setting - measured on live for member 488811
+        // and Peterborough. So every post ripples to the ceiling and each member is held
+        // to their own band by their travel-time preference on the way out.
         config(['freegle.ripple.density.enabled' => true, 'freegle.ripple.density.k' => 400]);
         $this->fakeDensity(400, 1.0);   // 400 freeglers within a mile: a city
         $this->fakeRouting(3);
@@ -130,14 +132,16 @@ class ExpandServiceTest extends TestCase
 
         $this->service()->process(false, 500);
 
-        $this->assertSame('20', $this->requestedMaxMinutes(), 'the routing server is asked for the city budget');
+        $this->assertSame('45', $this->requestedMaxMinutes(), 'the routing server is asked for the ceiling');
         $row = DB::table('rippling_reach')->where('msgid', $msgid)->first();
+        // The origin band is still recorded - the density analytics read rows back by it -
+        // but it describes where the post IS, not how far it goes.
         $this->assertSame('dense', $row->density_band);
-        $this->assertSame(20.0, (float) $row->max_minutes_cap);
+        $this->assertSame(45.0, (float) $row->max_minutes_cap);
         $this->assertEqualsWithDelta(1.0, (float) $row->density_radius_miles, 0.05);
     }
 
-    public function test_a_countryside_post_is_given_a_longer_reach_budget(): void
+    public function test_a_countryside_post_ripples_to_the_ceiling_too(): void
     {
         config(['freegle.ripple.density.enabled' => true, 'freegle.ripple.density.k' => 400]);
         $this->fakeDensity(400, 6.0);   // it takes six miles to find 400 people
@@ -152,10 +156,16 @@ class ExpandServiceTest extends TestCase
         $this->assertSame(45.0, (float) $row->max_minutes_cap);
     }
 
-    public function test_an_unmeasurable_origin_keeps_the_flat_cap_and_says_so_on_the_row(): void
+    public function test_the_density_killswitch_puts_every_post_back_on_the_flat_cap(): void
     {
-        config(['freegle.ripple.density.enabled' => true, 'freegle.ripple.max_minutes' => 30]);
-        Http::fake(['*userapproxlocs/knn*' => Http::response('boom', 500)]);
+        // One switch has to undo the whole scheme: with density off there are no bands to
+        // hold a member to, so a ripple grown to the ceiling would reach people nothing
+        // narrows again.
+        config([
+            'freegle.ripple.density.enabled' => false,
+            'freegle.ripple.max_minutes' => 30,
+        ]);
+        $this->fakeDensity(400, 6.0);
         $this->fakeRouting(3);
         $msgid = $this->seedSpatialPost(now()->subMinutes(90));
 
@@ -163,16 +173,32 @@ class ExpandServiceTest extends TestCase
 
         $this->assertSame('30', $this->requestedMaxMinutes());
         $row = DB::table('rippling_reach')->where('msgid', $msgid)->first();
+        $this->assertSame('unknown', $row->density_band);
+    }
+
+    public function test_an_unmeasurable_origin_still_reaches_the_ceiling_and_says_so_on_the_row(): void
+    {
+        // The measurement decides how the row READS, not how far it goes: an unreachable
+        // spatial server must not shrink a post's reach, only leave its band unrecorded.
+        config(['freegle.ripple.density.enabled' => true, 'freegle.ripple.max_minutes' => 30]);
+        Http::fake(['*userapproxlocs/knn*' => Http::response('boom', 500)]);
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(90));
+
+        $this->service()->process(false, 500);
+
+        $this->assertSame('45', $this->requestedMaxMinutes());
+        $row = DB::table('rippling_reach')->where('msgid', $msgid)->first();
         $this->assertSame('unknown', $row->density_band, 'the row records that no measurement was made');
         $this->assertNull($row->density_radius_miles);
     }
 
     public function test_a_co_located_post_does_not_inherit_a_schedule_sized_under_a_different_cap(): void
     {
-        // Schedule reuse is keyed on the blurred origin, which is not enough on its own
-        // once the budget varies by density: the first post at an origin would fix the
-        // cap for everything that followed there, and retuning a band would only take
-        // effect where nobody had posted before.
+        // Schedule reuse is keyed on the blurred origin, which is not enough on its own:
+        // the first post at an origin would fix the budget for everything that followed
+        // there, and retuning the ceiling would only take effect where nobody had posted
+        // before.
         config([
             'freegle.ripple.density.enabled' => true,
             'freegle.ripple.density.k' => 400,
@@ -183,15 +209,15 @@ class ExpandServiceTest extends TestCase
         $this->seedSpatialPost(now()->subMinutes(90));
         $this->service()->process(false, 500);
 
-        // The band's budget is retuned; a new post at the SAME origin must be recomputed.
-        config(['freegle.ripple.density.max_minutes.dense' => 25]);
+        // The ceiling is retuned; a new post at the SAME origin must be recomputed.
+        config(['freegle.ripple.density.max_minutes.sparse' => 50]);
         $this->fakeDensity(400, 1.0);
         $this->fakeRouting(3);
         $msgid2 = $this->seedSpatialPost(now()->subMinutes(90));
         $this->service()->process(false, 500);
 
         $row = DB::table('rippling_reach')->where('msgid', $msgid2)->first();
-        $this->assertSame(25.0, (float) $row->max_minutes_cap, 'recomputed under the new budget, not reused');
+        $this->assertSame(50.0, (float) $row->max_minutes_cap, 'recomputed under the new ceiling, not reused');
     }
 
     /** Like fakeRouting(), but the schedule response also carries reachable_group_ids. */

--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -48,7 +48,7 @@
             id="distanceSlider"
             v-model="sliderValue"
             :min="BROWSE_MINUTES_MIN"
-            :max="BROWSE_MINUTES_MAX"
+            :max="maxMinutes"
             :step="BROWSE_MINUTES_STEP"
             left-label="Nearer"
             right-label="Further"
@@ -150,7 +150,6 @@ import { useMe } from '~/composables/useMe'
 import {
   BROWSE_DISTANCE_UNLIMITED,
   BROWSE_MINUTES_MIN,
-  BROWSE_MINUTES_MAX,
   BROWSE_MINUTES_STEP,
 } from '~/constants'
 import { useReachDistance } from '~/composables/useReachDistance'
@@ -399,10 +398,14 @@ const maxDistance = computed(
 
 // The time-based slider position + its persistence live in the shared composable. When a change is
 // saved it re-emits the derived mile cap (so parent feeds re-filter) and refreshes the unseen count.
-const { sliderValue, onSliderChange } = useReachDistance((miles) => {
-  emit('update:selectedMaxDistance', miles)
-  refetchCount()
-})
+// maxMinutes is the member's own density-sized reach cap, so the slider's top stop is the furthest
+// travel the reach engine will actually honour for them - not a fixed 30 minutes.
+const { sliderValue, maxMinutes, onSliderChange } = useReachDistance(
+  (miles) => {
+    emit('update:selectedMaxDistance', miles)
+    refetchCount()
+  }
+)
 
 // "Filters active" badge (#G): lights for ANY control that differs from its default -
 // not just narrowing ones - so members always have a quick visual cue that the feed

--- a/iznik-nuxt3/components/settings/FeedSettingsSection.vue
+++ b/iznik-nuxt3/components/settings/FeedSettingsSection.vue
@@ -22,7 +22,7 @@
         <RangeSlider
           v-model="sliderValue"
           :min="BROWSE_MINUTES_MIN"
-          :max="BROWSE_MINUTES_MAX"
+          :max="maxMinutes"
           :step="BROWSE_MINUTES_STEP"
           left-label="Nearer"
           right-label="Further"
@@ -39,11 +39,7 @@
 import { defineEmits } from 'vue'
 import RangeSlider from '~/components/RangeSlider.vue'
 import NearbyTowns from '~/components/NearbyTowns.vue'
-import {
-  BROWSE_MINUTES_MIN,
-  BROWSE_MINUTES_MAX,
-  BROWSE_MINUTES_STEP,
-} from '~/constants'
+import { BROWSE_MINUTES_MIN, BROWSE_MINUTES_STEP } from '~/constants'
 import { useReachDistance } from '~/composables/useReachDistance'
 
 const emit = defineEmits(['update'])
@@ -52,8 +48,11 @@ const emit = defineEmits(['update'])
 // miles. The shared composable persists both the chosen minutes (so the slider restores) and the
 // routing-derived crow-flies mile radius (settings.browseMaxDistance, for the fast feed filter). The
 // far-right stop means "no limit". Deliberately no numeric readout - Nearer/Further is enough, and a
-// per-tick readout made the drag janky. Only persists on release (RangeSlider's `change`).
-const { sliderValue, onSliderChange } = useReachDistance(() => emit('update'))
+// per-tick readout made the drag janky. Only persists on release (RangeSlider's `change`). The top
+// of the slider is the member's own density-sized reach cap, not a fixed 30 minutes.
+const { sliderValue, maxMinutes, onSliderChange } = useReachDistance(() =>
+  emit('update')
+)
 </script>
 
 <style scoped lang="scss">

--- a/iznik-nuxt3/composables/useReachDistance.js
+++ b/iznik-nuxt3/composables/useReachDistance.js
@@ -1,4 +1,4 @@
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, getCurrentInstance, onMounted } from 'vue'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
 import api from '~/api'
@@ -6,29 +6,42 @@ import {
   BROWSE_DISTANCE_UNLIMITED,
   BROWSE_MINUTES_MIN,
   BROWSE_MINUTES_MAX,
+  BROWSE_MINUTES_FALLBACK_MAX,
 } from '~/constants'
 
 // Shared logic for the TIME-based "How far away" slider (browse filter + Feed settings). The slider
 // is a travel-time budget in MINUTES - matching the reach system (drive-time isochrones) rather than
 // miles. On change we convert the chosen minutes to a crow-flies mile radius via real routing
 // (location-aware, no hardcoded miles<->minutes constant) and persist BOTH:
-//   - settings.browseMaxMinutes: the source of truth, so the slider restores to the right position.
-//   - settings.browseMaxDistance: the derived radius the fast Haversine feed filter reads unchanged.
-// The far-right (MAX) stop means "no limit": it stores BROWSE_DISTANCE_UNLIMITED so the server's own
+//   - settings.browseMaxMinutes: the source of truth, so the slider restores.
+//   - settings.browseMaxDistance: the derived radius the fast Haversine feed filter reads.
+// The far-right stop means "no limit": it stores BROWSE_DISTANCE_UNLIMITED so the server's own
 // reach keeps governing. `onPersisted(miles)` runs after a successful save (emit / refetch count).
+//
+// The far-right stop is NOT a fixed 30 minutes. The reach engine sizes each post's budget from how
+// thinly freeglers are spread around it (20 dense / 30 medium / 45 sparse), so the slider asks the
+// server for this member's own cap and tops out there. Until that answer arrives - and whenever
+// density cannot be measured - the flat cap applies, so the slider is never wider than something
+// the server will honour.
 export function useReachDistance(onPersisted) {
   const authStore = useAuthStore()
   const { me } = useMe()
   const runtimeConfig = useRuntimeConfig()
   const apiInstance = api(runtimeConfig)
 
-  // Slider position comes from the saved travel-time budget; default (unset) is the max = "no limit".
+  // The top of the slider for this member. Starts at the flat cap and narrows or widens once the
+  // server reports the band. BROWSE_MINUTES_MAX is the ceiling across all bands: a server that
+  // reports something larger (a future band, a misconfigured env) must not stretch the UI past a
+  // travel time we are willing to offer.
+  const maxMinutes = ref(BROWSE_MINUTES_FALLBACK_MAX)
+
+  // Slider position comes from the saved travel-time budget; default (unset) is the top = "no limit".
   const savedMinutes = computed(
-    () => me.value?.settings?.browseMaxMinutes ?? BROWSE_MINUTES_MAX
+    () => me.value?.settings?.browseMaxMinutes ?? maxMinutes.value
   )
 
   function positionFor(minutes) {
-    if (minutes >= BROWSE_MINUTES_MAX) return BROWSE_MINUTES_MAX
+    if (minutes >= maxMinutes.value) return maxMinutes.value
     if (minutes < BROWSE_MINUTES_MIN) return BROWSE_MINUTES_MIN
     return minutes
   }
@@ -41,19 +54,43 @@ export function useReachDistance(onPersisted) {
     sliderValue.value = positionFor(m)
   })
 
-  // The crow-flies radius the chosen travel time reaches, from the routing-backed /town/near. Null
-  // if there's no known location or the call fails (best-effort - we then leave the cap unchanged).
-  async function reachRadiusFor(minutes) {
+  // One call to /town/near answers both questions: the member's cap (which describes their location,
+  // not the chosen time) and the radius for a given travel time. Null if there's no known location
+  // or the call fails - best-effort, we then leave the cap and the radius unchanged.
+  async function fetchNear(minutes) {
     const lat = me.value?.lat
     const lng = me.value?.lng
     if (!lat && !lng) return null
     try {
       const r = await apiInstance.town.fetchNear(lat, lng, minutes)
-      return typeof r?.reach_radius_miles === 'number'
-        ? r.reach_radius_miles
-        : null
+      if (typeof r?.cap_minutes === 'number' && r.cap_minutes > 0) {
+        maxMinutes.value = Math.min(r.cap_minutes, BROWSE_MINUTES_MAX)
+      }
+      return r
     } catch (e) {
       return null
+    }
+  }
+
+  // The crow-flies radius the chosen travel time reaches, from the routing-backed /town/near.
+  async function reachRadiusFor(minutes) {
+    const r = await fetchNear(minutes)
+    return typeof r?.reach_radius_miles === 'number'
+      ? r.reach_radius_miles
+      : null
+  }
+
+  // Learn this member's cap, and reconcile a saved position that now sits above it. A position above
+  // the cap is one the reach engine no longer honours: leaving it saved would show the slider at the
+  // top ("no limit") while the stored radius kept filtering to the old, narrower travel time - the
+  // same divergence that had members seeing only old posts. So we persist the correction once,
+  // rather than displaying one thing and filtering by another.
+  async function loadCap() {
+    await fetchNear(savedMinutes.value)
+
+    const saved = me.value?.settings?.browseMaxMinutes
+    if (typeof saved === 'number' && saved > maxMinutes.value) {
+      await onSliderChange(maxMinutes.value)
     }
   }
 
@@ -61,10 +98,18 @@ export function useReachDistance(onPersisted) {
     const settings = me.value?.settings
     if (!settings) return
 
-    if (minutes >= BROWSE_MINUTES_MAX) {
-      // Far right = "no limit": defer to the server's own reach extent.
-      settings.browseMaxMinutes = BROWSE_MINUTES_MAX
+    const atTop = minutes >= maxMinutes.value
+    if (atTop) minutes = maxMinutes.value
+
+    // "No limit" defers to the server's own reach, and the server grows every post's
+    // reach to the widest budget ANY band earns (BROWSE_MINUTES_MAX). So the sentinel
+    // only means "as far as my own band goes" for a member whose band earns that
+    // ceiling. Below it - a city or middling area - the top stop still needs a real
+    // derived radius, or the member would silently inherit the widest band's reach.
+    if (atTop && maxMinutes.value >= BROWSE_MINUTES_MAX) {
+      settings.browseMaxMinutes = minutes
       settings.browseMaxDistance = BROWSE_DISTANCE_UNLIMITED
+      sliderValue.value = minutes
       await authStore.saveAndGet({ settings })
       if (onPersisted) onPersisted(BROWSE_DISTANCE_UNLIMITED)
       return
@@ -72,6 +117,7 @@ export function useReachDistance(onPersisted) {
 
     const radius = await reachRadiusFor(minutes)
     settings.browseMaxMinutes = minutes
+    if (atTop) sliderValue.value = minutes
     if (radius !== null) {
       settings.browseMaxDistance = radius
     } else {
@@ -89,5 +135,11 @@ export function useReachDistance(onPersisted) {
       onPersisted(settings.browseMaxDistance ?? BROWSE_DISTANCE_UNLIMITED)
   }
 
-  return { sliderValue, onSliderChange }
+  // Components get the cap without asking; the composable is also called directly in tests, where
+  // there is no instance to mount into and loadCap() is driven explicitly.
+  if (getCurrentInstance()) {
+    onMounted(loadCap)
+  }
+
+  return { sliderValue, maxMinutes, onSliderChange, loadCap }
 }

--- a/iznik-nuxt3/constants.js
+++ b/iznik-nuxt3/constants.js
@@ -77,13 +77,23 @@ export const GROUP_REPOSTS = { offer: 3, wanted: 14, max: 10, chaseups: 2 }
 export const BROWSE_DISTANCE_UNLIMITED = Number.MAX_SAFE_INTEGER
 
 // The "How far away" slider is TIME-based: a travel-time budget in MINUTES, matching the reach
-// system (drive-time isochrones), not miles. The far-right (MAX) stop means "no limit" - it stores
-// BROWSE_DISTANCE_UNLIMITED, deferring to the server's own reach (default 30-min budget). The chosen
-// minutes are converted to a crow-flies mile radius by real routing (location-aware) and stored as
+// system (drive-time isochrones), not miles. The far-right stop means "no limit" - it stores
+// BROWSE_DISTANCE_UNLIMITED, deferring to the server's own reach. The chosen minutes are converted
+// to a crow-flies mile radius by real routing (location-aware) and stored as
 // settings.browseMaxDistance for the fast distance filter; the minutes themselves are stored as
 // settings.browseMaxMinutes so the slider restores.
+//
+// The TOP of the slider is not fixed: the reach engine sizes a post's budget from how thinly
+// freeglers are spread around it (20 minutes dense, 30 medium, 45 sparse), so the slider asks the
+// server for the member's own cap (town/near cap_minutes) and uses that. A fixed 5-30 was too short
+// in the country, where a member could not ask for the 45 minutes they now receive, and too long in
+// the city, where the last stops described travel the reach engine no longer honours.
+//   MIN          the closest anyone can ask for.
+//   FALLBACK_MAX the flat cap, used until the server answers or when density cannot be measured.
+//   MAX          the ceiling across all bands - the widest the slider can ever go.
 export const BROWSE_MINUTES_MIN = 5
-export const BROWSE_MINUTES_MAX = 30
+export const BROWSE_MINUTES_FALLBACK_MAX = 30
+export const BROWSE_MINUTES_MAX = 45
 export const BROWSE_MINUTES_STEP = 5
 
 // Colour for the reach/isochrone-style map polygons (the former per-user

--- a/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
@@ -49,7 +49,8 @@ const { mockNearbyMessageList, mockMyGroupsList, mockWhichPostsShow } =
 vi.mock('~/constants', () => ({
   BROWSE_DISTANCE_UNLIMITED: Number.MAX_SAFE_INTEGER,
   BROWSE_MINUTES_MIN: 5,
-  BROWSE_MINUTES_MAX: 30,
+  BROWSE_MINUTES_FALLBACK_MAX: 30,
+  BROWSE_MINUTES_MAX: 45,
   BROWSE_MINUTES_STEP: 5,
 }))
 
@@ -504,10 +505,11 @@ describe('PostFilters', () => {
       expect(wrapper.find('.range-slider-stub').exists()).toBe(true)
     })
 
-    // The slider is a fixed TRAVEL-TIME range in MINUTES (5-30, matching the reach system), not a
-    // miles scale tied to the feed - so the "Max X-Y miles by road" reach hint stays stable instead
-    // of jumping as the feed reloads (Discourse 9808).
-    it('is a fixed 5-30 minute travel-time range with 5-minute steps', () => {
+    // The slider is a TRAVEL-TIME range in MINUTES, not a miles scale tied to the feed - so the
+    // "Max X-Y miles by road" reach hint stays stable instead of jumping as the feed reloads
+    // (Discourse 9808). Its top is the member's own density-sized reach cap; until the server
+    // answers, the flat cap applies.
+    it('starts on the flat travel-time cap with 5-minute steps', () => {
       const wrapper = createWrapper({ forceShowFilters: true })
       const input = wrapper.find('.range-slider-stub')
       expect(Number(input.attributes('min'))).toBe(5)
@@ -546,20 +548,32 @@ describe('PostFilters', () => {
       expect(Number(input.element.value)).toBe(10)
     })
 
-    it('stores BROWSE_DISTANCE_UNLIMITED (and skips routing) when dragged to the rightmost stop', async () => {
+    // The sentinel defers to the server's own reach, which grows every post to the
+    // widest band's budget - so it only means "as far as I would go" for a member whose
+    // own band earns that ceiling. A sparse member at their top stop is exactly that case.
+    it('stores BROWSE_DISTANCE_UNLIMITED (and skips routing) at the top stop when the band is the ceiling', async () => {
+      mockFetchNear.mockResolvedValue({
+        cap_minutes: 45,
+        density_band: 'sparse',
+        reach_radius_miles: 4,
+        towns: [],
+      })
       const wrapper = createWrapper({ forceShowFilters: true })
+      await flushPromises()
+      mockFetchNear.mockClear()
+
       const input = wrapper.find('.range-slider-stub')
-      input.element.value = 30 // the max = "no limit"
+      input.element.value = 45 // their own max = "no limit"
       await input.trigger('change')
       await flushPromises()
-      expect(mockMe.value.settings.browseMaxMinutes).toBe(30)
+
+      expect(mockMe.value.settings.browseMaxMinutes).toBe(45)
       expect(mockMe.value.settings.browseMaxDistance).toBe(
         Number.MAX_SAFE_INTEGER
       )
-      expect(mockFetchNear).not.toHaveBeenCalled() // far right needs no reach lookup
-      expect(wrapper.emitted('update:selectedMaxDistance')[0]).toEqual([
-        Number.MAX_SAFE_INTEGER,
-      ])
+      expect(mockFetchNear).not.toHaveBeenCalled() // the top stop needs no reach lookup
+      const emitted = wrapper.emitted('update:selectedMaxDistance')
+      expect(emitted[emitted.length - 1]).toEqual([Number.MAX_SAFE_INTEGER])
     })
 
     // For any position left of max, the chosen MINUTES are stored (so the slider restores) and the

--- a/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
+++ b/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
@@ -9,7 +9,8 @@ import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
 vi.mock('~/constants', () => ({
   BROWSE_DISTANCE_UNLIMITED: Number.MAX_SAFE_INTEGER,
   BROWSE_MINUTES_MIN: 5,
-  BROWSE_MINUTES_MAX: 30,
+  BROWSE_MINUTES_FALLBACK_MAX: 30,
+  BROWSE_MINUTES_MAX: 45,
   BROWSE_MINUTES_STEP: 5,
 }))
 
@@ -54,7 +55,12 @@ function mountWith(settings = {}) {
 const slider = (wrapper) => wrapper.findComponent({ name: 'RangeSlider' })
 
 describe('FeedSettingsSection', () => {
-  beforeEach(() => vi.clearAllMocks())
+  // clearAllMocks wipes call history but NOT implementations, so a test that overrides
+  // fetchNear (to fake a density band) would otherwise leak its response into the next.
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchNear.mockResolvedValue({ reach_radius_miles: 4 })
+  })
 
   it('renders the Feed section with a slider', () => {
     const wrapper = mountWith()
@@ -77,12 +83,30 @@ describe('FeedSettingsSection', () => {
     expect(wrapper.text()).not.toContain('any distance')
   })
 
-  it('is a fixed 5-30 minute travel-time range', () => {
+  // The top of the range is the member's own density-sized reach cap, not a fixed 30: the
+  // reach engine grows a post to the widest band's budget and holds each member to their
+  // own, so the slider must offer exactly what it will honour for them. Until the server
+  // answers, the flat cap applies.
+  it('starts on the flat cap in 5-minute steps', () => {
     const wrapper = mountWith()
     const s = slider(wrapper)
     expect(Number(s.props('min'))).toBe(5)
     expect(Number(s.props('max'))).toBe(30)
     expect(Number(s.props('step'))).toBe(5)
+  })
+
+  it("opens the range to a rural member's own cap", async () => {
+    mockFetchNear.mockResolvedValue({ cap_minutes: 45, density_band: 'sparse' })
+    const wrapper = mountWith()
+    await flushPromises()
+    expect(Number(slider(wrapper).props('max'))).toBe(45)
+  })
+
+  it("closes the range to a city member's own cap", async () => {
+    mockFetchNear.mockResolvedValue({ cap_minutes: 20, density_band: 'dense' })
+    const wrapper = mountWith()
+    await flushPromises()
+    expect(Number(slider(wrapper).props('max'))).toBe(20)
   })
 
   // Left of max: persist the chosen MINUTES (so the slider restores) and the routing-derived
@@ -97,11 +121,14 @@ describe('FeedSettingsSection', () => {
     expect(me.value.settings.browseMaxDistance).toBe(4)
   })
 
-  it('stores the unlimited sentinel (and skips routing) when dragged to the far end', async () => {
+  it('stores the unlimited sentinel at the far end when the cap is the ceiling', async () => {
+    mockFetchNear.mockResolvedValue({ cap_minutes: 45, density_band: 'sparse' })
     const wrapper = mountWith({ browseMaxMinutes: 10 })
-    await slider(wrapper).vm.$emit('change', 30)
     await flushPromises()
-    expect(me.value.settings.browseMaxMinutes).toBe(30)
+    mockFetchNear.mockClear()
+    await slider(wrapper).vm.$emit('change', 45)
+    await flushPromises()
+    expect(me.value.settings.browseMaxMinutes).toBe(45)
     expect(me.value.settings.browseMaxDistance).toBe(BROWSE_DISTANCE_UNLIMITED)
     expect(mockFetchNear).not.toHaveBeenCalled()
   })

--- a/iznik-nuxt3/tests/unit/composables/useReachDistance.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useReachDistance.spec.js
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
-import { BROWSE_DISTANCE_UNLIMITED, BROWSE_MINUTES_MAX } from '~/constants'
+import {
+  BROWSE_DISTANCE_UNLIMITED,
+  BROWSE_MINUTES_MAX,
+  BROWSE_MINUTES_FALLBACK_MAX,
+} from '~/constants'
 
 // The slider persists BOTH settings.browseMaxMinutes (source of truth) and
 // settings.browseMaxDistance (the derived radius the fast feed/digest filters
@@ -79,14 +83,198 @@ describe('useReachDistance onSliderChange', () => {
     expect(mockFetchNear).not.toHaveBeenCalled()
   })
 
-  it('stores the unlimited sentinel at the far-right stop without a routing call', async () => {
+  // Before the server has answered, the member is on the flat cap - which is BELOW the
+  // ceiling the ripple grows to, so the top stop has to be a real radius. Storing the
+  // sentinel here would hand an unmeasured member the widest band's reach.
+  it('derives a radius at the far-right stop while still on the flat cap', async () => {
+    mockFetchNear.mockResolvedValue({ reach_radius_miles: 11.3 })
     const { onSliderChange } = useReachDistance()
 
-    await onSliderChange(BROWSE_MINUTES_MAX)
+    await onSliderChange(BROWSE_MINUTES_FALLBACK_MAX)
 
     const saved = mockSaveAndGet.mock.calls[0][0].settings
-    expect(saved.browseMaxMinutes).toBe(BROWSE_MINUTES_MAX)
+    expect(saved.browseMaxMinutes).toBe(BROWSE_MINUTES_FALLBACK_MAX)
+    expect(saved.browseMaxDistance).toBe(11.3)
+  })
+})
+
+// The reach engine sizes a post's travel-time budget from local freegler density
+// (20 dense / 30 medium / 45 sparse), so the top of the slider has to follow the
+// member's own band. A fixed top left rural members unable to ask for the 45
+// minutes they now actually receive, and told them "Max 10-12 miles by road"
+// while the reach engine was already carrying posts further.
+describe('useReachDistance density-aware maximum', () => {
+  let useReachDistance
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockMe.value = {
+      lat: 53.4,
+      lng: -1.3,
+      settings: { browseMaxMinutes: 15, browseMaxDistance: 6 },
+    }
+    const mod = await import('~/composables/useReachDistance')
+    useReachDistance = mod.useReachDistance
+  })
+
+  it('uses the flat cap until the server answers', () => {
+    const { maxMinutes } = useReachDistance()
+
+    expect(maxMinutes.value).toBe(BROWSE_MINUTES_FALLBACK_MAX)
+  })
+
+  it('opens up to the sparse cap for a rural member', async () => {
+    mockFetchNear.mockResolvedValue({ cap_minutes: 45, density_band: 'sparse' })
+    const { maxMinutes, loadCap } = useReachDistance()
+
+    await loadCap()
+
+    expect(maxMinutes.value).toBe(45)
+  })
+
+  it('closes down to the dense cap for a city member', async () => {
+    mockFetchNear.mockResolvedValue({ cap_minutes: 20, density_band: 'dense' })
+    const { maxMinutes, loadCap } = useReachDistance()
+
+    await loadCap()
+
+    expect(maxMinutes.value).toBe(20)
+  })
+
+  it('treats the cap - not a fixed 30 - as the no-limit stop', async () => {
+    mockFetchNear.mockResolvedValue({ cap_minutes: 45, density_band: 'sparse' })
+    const { onSliderChange, loadCap } = useReachDistance()
+    await loadCap()
+    mockFetchNear.mockClear()
+
+    await onSliderChange(45)
+
+    const saved = mockSaveAndGet.mock.calls[0][0].settings
+    expect(saved.browseMaxMinutes).toBe(45)
     expect(saved.browseMaxDistance).toBe(BROWSE_DISTANCE_UNLIMITED)
     expect(mockFetchNear).not.toHaveBeenCalled()
+  })
+
+  // The server grows every post's reach to the widest band's budget, so the
+  // unlimited sentinel means "the widest band's worth", not "mine". Only a member
+  // whose own band earns the ceiling can safely store it: below the ceiling the
+  // top stop still needs a real radius, or a city member would silently inherit
+  // the countryside's reach (on live, a 33-mile radius around Peterborough).
+  it('stores a real radius at the top stop when the band is below the ceiling', async () => {
+    mockFetchNear.mockResolvedValue({
+      cap_minutes: 20,
+      density_band: 'dense',
+      reach_radius_miles: 7.4,
+    })
+    const { onSliderChange, loadCap } = useReachDistance()
+    await loadCap()
+
+    await onSliderChange(20)
+
+    const saved =
+      mockSaveAndGet.mock.calls[mockSaveAndGet.mock.calls.length - 1][0]
+        .settings
+    expect(saved.browseMaxMinutes).toBe(20)
+    expect(saved.browseMaxDistance).toBe(7.4)
+  })
+
+  it('clamps a drag past the top stop back onto the cap', async () => {
+    mockFetchNear.mockResolvedValue({
+      cap_minutes: 20,
+      density_band: 'dense',
+      reach_radius_miles: 7.4,
+    })
+    const { sliderValue, onSliderChange, loadCap } = useReachDistance()
+    await loadCap()
+
+    await onSliderChange(30)
+
+    const saved =
+      mockSaveAndGet.mock.calls[mockSaveAndGet.mock.calls.length - 1][0]
+        .settings
+    expect(saved.browseMaxMinutes).toBe(20)
+    expect(sliderValue.value).toBe(20)
+  })
+
+  it('still derives a radius below the cap', async () => {
+    mockFetchNear.mockResolvedValue({
+      cap_minutes: 45,
+      density_band: 'sparse',
+      reach_radius_miles: 16.2,
+    })
+    const { onSliderChange, loadCap } = useReachDistance()
+    await loadCap()
+
+    await onSliderChange(35)
+
+    const saved = mockSaveAndGet.mock.calls[0][0].settings
+    expect(saved.browseMaxMinutes).toBe(35)
+    expect(saved.browseMaxDistance).toBe(16.2)
+  })
+
+  it('never offers more than the ceiling, whatever the server says', async () => {
+    mockFetchNear.mockResolvedValue({
+      cap_minutes: 120,
+      density_band: 'sparse',
+    })
+    const { maxMinutes, loadCap } = useReachDistance()
+
+    await loadCap()
+
+    expect(maxMinutes.value).toBe(BROWSE_MINUTES_MAX)
+  })
+
+  it('keeps the flat cap when the server sends no cap at all', async () => {
+    mockFetchNear.mockResolvedValue({ reach_radius_miles: 8 })
+    const { maxMinutes, loadCap } = useReachDistance()
+
+    await loadCap()
+
+    expect(maxMinutes.value).toBe(BROWSE_MINUTES_FALLBACK_MAX)
+  })
+
+  it('pulls a saved position above the new cap down onto the slider, and saves the correction', async () => {
+    // A city member who chose 25 back when the slider went to 30. Their band now
+    // caps at 20, so the reach engine already ignores the last stops - but their
+    // stored radius still filters at 25 minutes' worth. Showing the slider at the
+    // top while a narrower cap kept filtering is exactly the divergence that made
+    // members say "I only see old posts", so the correction is persisted.
+    mockMe.value.settings = { browseMaxMinutes: 25, browseMaxDistance: 9 }
+    mockFetchNear.mockResolvedValue({
+      cap_minutes: 20,
+      density_band: 'dense',
+      reach_radius_miles: 7.4,
+    })
+    const { sliderValue, loadCap } = useReachDistance()
+
+    await loadCap()
+
+    expect(sliderValue.value).toBe(20)
+    const saved = mockSaveAndGet.mock.calls[0][0].settings
+    expect(saved.browseMaxMinutes).toBe(20)
+    // Below the ceiling the top stop is a real radius, not the sentinel.
+    expect(saved.browseMaxDistance).toBe(7.4)
+  })
+
+  it('leaves a saved position inside the new cap alone', async () => {
+    mockMe.value.settings = { browseMaxMinutes: 15, browseMaxDistance: 6 }
+    mockFetchNear.mockResolvedValue({ cap_minutes: 45, density_band: 'sparse' })
+    const { sliderValue, loadCap } = useReachDistance()
+
+    await loadCap()
+
+    expect(sliderValue.value).toBe(15)
+    expect(mockSaveAndGet).not.toHaveBeenCalled()
+  })
+
+  it('does not ask for a cap when the member has no known location', async () => {
+    mockMe.value.lat = null
+    mockMe.value.lng = null
+    const { maxMinutes, loadCap } = useReachDistance()
+
+    await loadCap()
+
+    expect(mockFetchNear).not.toHaveBeenCalled()
+    expect(maxMinutes.value).toBe(BROWSE_MINUTES_FALLBACK_MAX)
   })
 })

--- a/iznik-server-go/density/density.go
+++ b/iznik-server-go/density/density.go
@@ -1,0 +1,193 @@
+// Package density answers "how far is it worth travelling from here", from how
+// thinly freeglers are spread around a point.
+//
+// The reach a POST gets is decided in iznik-batch by
+// App\Services\Ripple\DensityService: dense areas are capped at 20 minutes
+// because conversion collapses past ~20-25 there, sparse ones get 45 because it
+// does not fall at all out to 45, and everything else keeps the flat 30. That
+// decision is what a member actually experiences, so the browse slider has to
+// describe the same thing rather than offering a fixed 5-30 that is too short in
+// the country and too long in the city.
+//
+// This is therefore a deliberate second implementation of one policy. It is kept
+// honest by reading the SAME env var names as
+// iznik-batch/config/freegle.php ripple.density, with the same defaults, and by
+// TestBandMatchesPhpPolicy mirroring DensityService::band()'s cases. Change one,
+// change the other.
+package density
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/freegle/iznik-server-go/spatial"
+	"github.com/freegle/iznik-server-go/utils"
+)
+
+const (
+	BandDense  = "dense"
+	BandMedium = "medium"
+	BandSparse = "sparse"
+
+	// BandUnknown means no usable measurement: the flat cap applies and the
+	// caller says so, rather than guessing a band.
+	BandUnknown = "unknown"
+)
+
+// Result is a cap plus the measurement behind it, so a client (or a support
+// investigation) can read the number back against the reason for it.
+type Result struct {
+	Band        string
+	RadiusMiles *float64
+	MaxMinutes  float64
+}
+
+// knn is the spatial seam, swapped in tests.
+var knn = spatial.KNN
+
+func envFloat(name string, def float64) float64 {
+	if v := os.Getenv(name); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return def
+}
+
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			return i
+		}
+	}
+	return def
+}
+
+// enabled mirrors config('freegle.ripple.density.enabled'), which defaults ON.
+func enabled() bool {
+	v := os.Getenv("RIPPLE_DENSITY_ENABLED")
+	if v == "" {
+		return true
+	}
+	b, err := strconv.ParseBool(v)
+	return err != nil || b
+}
+
+// FlatMinutes is the cap that applies when density sizing is off or cannot
+// measure. Mirrors config('freegle.ripple.max_minutes').
+func FlatMinutes() float64 {
+	return envFloat("RIPPLE_MAX_MINUTES", 30)
+}
+
+// K is how many nearest freeglers define the density radius.
+func K() int {
+	k := envInt("RIPPLE_DENSITY_K", 400)
+	if k < 1 {
+		k = 1
+	}
+	return k
+}
+
+func minutesForBand(band string) float64 {
+	switch band {
+	case BandDense:
+		return envFloat("RIPPLE_DENSITY_MAX_MINUTES_DENSE", 20)
+	case BandMedium:
+		return envFloat("RIPPLE_DENSITY_MAX_MINUTES_MEDIUM", 30)
+	case BandSparse:
+		return envFloat("RIPPLE_DENSITY_MAX_MINUTES_SPARSE", 45)
+	default:
+		return FlatMinutes()
+	}
+}
+
+// Band decides which band a nearest-k measurement falls in. Pure, so the policy
+// is testable without a spatial server.
+//
+// Nothing found (or no answer at all) is unknown, NOT sparse: an empty result
+// and an empty index look identical from here, and quietly stretching a London
+// member's slider because the index was mid-rebuild is a worse failure than
+// leaving them on the flat cap.
+//
+// Some found but fewer than k IS sparse, and confidently so: the KNN buffer
+// ladder sweeps out to its ceiling before giving up, so failing to find k inside
+// that means the true k-radius is past the sparse threshold whatever the exact
+// figure. furthestMiles is then a lower bound rather than the radius, which is
+// why the band is decided by the shortfall and not by the number.
+func Band(found, k int, furthestMiles *float64) string {
+	if found <= 0 || furthestMiles == nil {
+		return BandUnknown
+	}
+	if found < k {
+		return BandSparse
+	}
+
+	if *furthestMiles <= envFloat("RIPPLE_DENSITY_DENSE_MAX_MILES", 1.6) {
+		return BandDense
+	}
+	if *furthestMiles <= envFloat("RIPPLE_DENSITY_MEDIUM_MAX_MILES", 3.1) {
+		return BandMedium
+	}
+	return BandSparse
+}
+
+// CapFor is the travel-time budget worth offering at this point, plus the
+// measurement behind it. Fails soft in every direction: an unreachable spatial
+// server, an empty result or the killswitch all give BandUnknown and the flat
+// cap.
+func CapFor(lat, lng float64) Result {
+	flat := Result{Band: BandUnknown, MaxMinutes: FlatMinutes()}
+
+	if !enabled() {
+		return flat
+	}
+
+	k := K()
+	results, err := knn("userapproxlocs", lng, lat, k, "")
+	if err != nil || len(results) == 0 {
+		return flat
+	}
+
+	// The spatial server ranks by Euclidean degrees, which at UK latitudes
+	// squashes east-west distance by ~cos(lat). The set of k it returns is
+	// therefore a near-miss for the true nearest k, but the RADIUS must still be
+	// honest, so take the furthest of them by great-circle distance.
+	furthest := 0.0
+	for _, r := range results {
+		rLat, okLat := extraFloat(r.Extra, "lat")
+		rLng, okLng := extraFloat(r.Extra, "lng")
+		if !okLat || !okLng {
+			return flat // an older spatial build without coordinates: do not guess
+		}
+		if d := utils.Haversine(lat, lng, rLat, rLng); d > furthest {
+			furthest = d
+		}
+	}
+
+	band := Band(len(results), k, &furthest)
+	if band == BandUnknown {
+		return flat
+	}
+
+	return Result{Band: band, RadiusMiles: &furthest, MaxMinutes: minutesForBand(band)}
+}
+
+// extraFloat reads a coordinate out of the spatial server's untyped extras,
+// which arrive as JSON numbers (float64) but may be absent entirely.
+func extraFloat(extra map[string]any, key string) (float64, bool) {
+	v, ok := extra[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	}
+	return 0, false
+}

--- a/iznik-server-go/density/density_test.go
+++ b/iznik-server-go/density/density_test.go
@@ -1,0 +1,188 @@
+package density
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/spatial"
+)
+
+func f(v float64) *float64 { return &v }
+
+// The band policy must stay byte-identical with
+// iznik-batch App\Services\Ripple\DensityService::band(), because the reach a
+// post actually gets is decided there and the slider only describes it.
+func TestBandMatchesPhpPolicy(t *testing.T) {
+	k := 400
+
+	tests := []struct {
+		name     string
+		found    int
+		furthest *float64
+		want     string
+	}{
+		{"nothing found is unknown, not sparse", 0, nil, BandUnknown},
+		{"no radius is unknown", 400, nil, BandUnknown},
+		{"fewer than k found is definitively sparse", 399, f(21.0), BandSparse},
+		{"fewer than k found is sparse even with a tiny radius", 12, f(0.4), BandSparse},
+		{"at the dense boundary is dense", 400, f(1.6), BandDense},
+		{"just past the dense boundary is medium", 400, f(1.61), BandMedium},
+		{"at the medium boundary is medium", 400, f(3.1), BandMedium},
+		{"past the medium boundary is sparse", 400, f(3.11), BandSparse},
+		{"a city centre is dense", 400, f(0.4), BandDense},
+		{"deep countryside is sparse", 400, f(14.2), BandSparse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Band(tt.found, k, tt.furthest); got != tt.want {
+				t.Errorf("Band(%d, %d, %v) = %q, want %q", tt.found, k, tt.furthest, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMinutesForBand(t *testing.T) {
+	cases := map[string]float64{
+		BandDense:   20,
+		BandMedium:  30,
+		BandSparse:  45,
+		BandUnknown: 30, // the flat cap: a cap must never fail to a value nobody chose
+	}
+
+	for band, want := range cases {
+		if got := minutesForBand(band); got != want {
+			t.Errorf("minutesForBand(%q) = %v, want %v", band, got, want)
+		}
+	}
+}
+
+func TestMinutesForBandHonoursEnv(t *testing.T) {
+	t.Setenv("RIPPLE_DENSITY_MAX_MINUTES_SPARSE", "50")
+
+	if got := minutesForBand(BandSparse); got != 50 {
+		t.Errorf("minutesForBand(sparse) with env override = %v, want 50", got)
+	}
+}
+
+func TestCapForUsesFurthestByGreatCircle(t *testing.T) {
+	// Two members: one ~0.7 miles north, one ~2.4 miles east. The band must come
+	// from the FURTHEST of them, and east-west separation must not be squashed
+	// (the spatial server ranks in degrees, which understates it by ~a third at
+	// UK latitudes).
+	withKNN(t, func(dataset string, lng, lat float64, limit int, typeFilter string) ([]spatial.QueryResult, error) {
+		results := make([]spatial.QueryResult, 0, limit)
+		results = append(results, spatial.QueryResult{ID: 1, Extra: map[string]any{"lat": 53.4, "lng": -2.9}})
+		results = append(results, spatial.QueryResult{ID: 2, Extra: map[string]any{"lat": 53.41, "lng": -2.9}})
+		results = append(results, spatial.QueryResult{ID: 3, Extra: map[string]any{"lat": 53.4, "lng": -2.843}})
+		// Pad out to the full k so the shortfall rule doesn't fire.
+		for len(results) < limit {
+			results = append(results, spatial.QueryResult{ID: int64(len(results) + 1), Extra: map[string]any{"lat": 53.4, "lng": -2.9}})
+		}
+		return results, nil
+	})
+
+	got := CapFor(53.4, -2.9)
+
+	if got.Band != BandMedium {
+		t.Errorf("band = %q, want %q (radius %v)", got.Band, BandMedium, got.RadiusMiles)
+	}
+	if got.MaxMinutes != 30 {
+		t.Errorf("max minutes = %v, want 30", got.MaxMinutes)
+	}
+	if got.RadiusMiles == nil || *got.RadiusMiles < 2.0 || *got.RadiusMiles > 2.8 {
+		t.Errorf("radius = %v, want the ~2.4 mile east member", got.RadiusMiles)
+	}
+}
+
+func TestCapForFailsSoftToTheFlatCap(t *testing.T) {
+	tests := []struct {
+		name string
+		knn  func(string, float64, float64, int, string) ([]spatial.QueryResult, error)
+	}{
+		{
+			name: "spatial server unreachable",
+			knn: func(string, float64, float64, int, string) ([]spatial.QueryResult, error) {
+				return nil, errors.New("connection refused")
+			},
+		},
+		{
+			name: "empty index",
+			knn: func(string, float64, float64, int, string) ([]spatial.QueryResult, error) {
+				return nil, nil
+			},
+		},
+		{
+			name: "an older spatial build with no coordinates",
+			knn: func(_ string, _, _ float64, limit int, _ string) ([]spatial.QueryResult, error) {
+				return []spatial.QueryResult{{ID: 1, Extra: map[string]any{}}}, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withKNN(t, tt.knn)
+
+			got := CapFor(53.4, -2.9)
+
+			if got.Band != BandUnknown {
+				t.Errorf("band = %q, want %q", got.Band, BandUnknown)
+			}
+			if got.MaxMinutes != 30 {
+				t.Errorf("max minutes = %v, want the flat 30", got.MaxMinutes)
+			}
+			if got.RadiusMiles != nil {
+				t.Errorf("radius = %v, want nil", *got.RadiusMiles)
+			}
+		})
+	}
+}
+
+// An empty index and a mid-rebuild index look identical from here, so a lone
+// result must not stretch a London member's slider to the sparse cap.
+func TestCapForSingleResultIsSparseOnlyWhenMeasured(t *testing.T) {
+	withKNN(t, func(string, float64, float64, int, string) ([]spatial.QueryResult, error) {
+		return []spatial.QueryResult{{ID: 1, Extra: map[string]any{"lat": 53.5, "lng": -2.9}}}, nil
+	})
+
+	got := CapFor(53.4, -2.9)
+
+	if got.Band != BandSparse {
+		t.Errorf("band = %q, want %q: a measured shortfall IS sparse", got.Band, BandSparse)
+	}
+	if got.MaxMinutes != 45 {
+		t.Errorf("max minutes = %v, want 45", got.MaxMinutes)
+	}
+}
+
+func TestCapForKillswitch(t *testing.T) {
+	t.Setenv("RIPPLE_DENSITY_ENABLED", "false")
+	withKNN(t, func(string, float64, float64, int, string) ([]spatial.QueryResult, error) {
+		t.Fatal("the killswitch must short-circuit before the spatial call")
+		return nil, nil
+	})
+
+	got := CapFor(53.4, -2.9)
+
+	if got.Band != BandUnknown || got.MaxMinutes != 30 {
+		t.Errorf("killswitch gave %+v, want the flat cap under band %q", got, BandUnknown)
+	}
+}
+
+func TestEnabledDefaultsOn(t *testing.T) {
+	os.Unsetenv("RIPPLE_DENSITY_ENABLED")
+
+	if !enabled() {
+		t.Error("density sizing must default ON, matching config/freegle.php")
+	}
+}
+
+// withKNN swaps the spatial seam for the duration of one test.
+func withKNN(t *testing.T, fn func(string, float64, float64, int, string) ([]spatial.QueryResult, error)) {
+	t.Helper()
+	prev := knn
+	knn = fn
+	t.Cleanup(func() { knn = prev })
+}

--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -691,8 +691,16 @@ func myGroupsCount(db *gorm.DB, myid uint64, maxDistanceMiles float64) uint64 {
 // explicit ?maxDistance= query param wins (so the browse page can force a fresh value right
 // after a slider change), otherwise the viewer's saved settings.browseMaxDistance (so the
 // app-wide navbar badge honours the slider automatically without every call site having to
-// pass it), otherwise BrowseDistanceUnlimited (no limit — the server's own reach extent
-// governs, as before the distance slider existed).
+// pass it), otherwise their band default, otherwise BrowseDistanceUnlimited (no limit — the
+// server's own reach extent governs, as before the distance slider existed).
+//
+// browseReachMaxDistance is the INBOUND-ONLY band default (browse:backfill-max-distance). It is
+// deliberately a separate key from browseMaxDistance, which the member sets themselves and which
+// also caps how far away OTHER people see THEIR posts (utils.AuthorReachCapWhere). Writing a
+// default into that key would silently apply an outbound cap nobody asked for: a city member's
+// band radius is ~4.8 miles, so every post they made would stop reaching anyone beyond it - the
+// opposite of the point, which is to let posts travel while holding each RECIPIENT to the
+// distance their own surroundings justify.
 func resolveMaxDistance(c *fiber.Ctx, db *gorm.DB, myid uint64) float64 {
 	if q := c.Query("maxDistance", ""); q != "" {
 		if v, err := strconv.ParseFloat(q, 64); err == nil {
@@ -700,14 +708,27 @@ func resolveMaxDistance(c *fiber.Ctx, db *gorm.DB, myid uint64) float64 {
 		}
 	}
 
-	var raw string
+	var row struct {
+		Chosen  string `gorm:"column:chosen"`
+		Default string `gorm:"column:banddefault"`
+	}
 	// COALESCE to '' for the same reason as effectiveBrowseView: users who have never set
-	// browseMaxDistance scan cleanly into the non-nullable string instead of erroring.
+	// either key scan cleanly into the non-nullable strings instead of erroring.
 	db.Table("users").
-		Select("COALESCE(JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseMaxDistance')), '')").
+		Select("COALESCE(JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseMaxDistance')), '') AS chosen, "+
+			"COALESCE(JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseReachMaxDistance')), '') AS banddefault").
 		Where("id = ?", myid).
-		Scan(&raw)
-	if raw != "" {
+		Scan(&row)
+
+	// An explicit choice always wins, including one that is wider than the band default:
+	// a member who dragged the slider has said what they want. An unparseable value is
+	// treated as no value and falls through, matching message.go's browse-scoped search
+	// and the Laravel DistancePreferenceFilter - all three must agree or the feed, its
+	// badge and search would disagree about the same member.
+	for _, raw := range []string{row.Chosen, row.Default} {
+		if raw == "" {
+			continue
+		}
 		if v, err := strconv.ParseFloat(raw, 64); err == nil {
 			return v
 		}
@@ -725,8 +746,14 @@ func resolveMaxDistance(c *fiber.Ctx, db *gorm.DB, myid uint64) float64 {
 // SAME blurred-coordinate Haversine distance the feed exposes as `distance`
 // (reachCandidateRow.blurredDistanceMiles) — so the badge matches the client's distance-
 // filtered list exactly at the boundary. Pass BrowseDistanceUnlimited (or anything at or above
-// it) to skip the per-post distance computation entirely and use the original, fast COUNT
-// query — the common case, since most members leave the slider at "no limit".
+// it) to skip the per-post distance computation entirely and use the original, fast COUNT query.
+//
+// The unlimited path used to be the common case, because most members never touched the slider.
+// It no longer is: browse:backfill-max-distance gives every member their density band's radius,
+// and only the sparse band (whose cap IS the reach ceiling) resolves to unlimited — so roughly
+// two thirds of members now take the distance-limited path below. That path deliberately stays
+// in Go rather than SQL: the filter must use the BLURRED coordinates the feed exposes, or the
+// badge and the list would disagree at the boundary, which is the bug class this replaced.
 func nearbyCount(myid uint64, maxDistanceMiles float64) uint64 {
 	db := database.DBConn
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1658,15 +1658,30 @@ func Search(c *fiber.Ctx) error {
 		if ll := user.GetLatLng(myid); ll.Lat != 0 || ll.Lng != 0 {
 			memberLat, memberLng = float64(ll.Lat), float64(ll.Lng)
 		}
-		var rawDist, rawSort string
+		// Same two-key resolution as isochrone.resolveMaxDistance: the member's own
+		// choice, else their density band default (browseReachMaxDistance, written by
+		// browse:backfill-max-distance). Browse-scoped search shares the feed's universe
+		// (Discourse 9933), so missing the fallback here would surface posts in search
+		// that the feed itself hides.
+		var rawDist, rawDefaultDist, rawSort string
 		db.Table("users").
 			Select("COALESCE(JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseMaxDistance')), ''), "+
+				"COALESCE(JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseReachMaxDistance')), ''), "+
 				"COALESCE(JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseSort')), '')").
 			Where("id = ?", myid).
-			Row().Scan(&rawDist, &rawSort)
-		if rawDist != "" {
-			if v, err := strconv.ParseFloat(rawDist, 64); err == nil && v > 0 {
+			Row().Scan(&rawDist, &rawDefaultDist, &rawSort)
+		for _, raw := range []string{rawDist, rawDefaultDist} {
+			if raw == "" {
+				continue
+			}
+			// An unparseable value is treated as no value and falls through to the
+			// next key, matching isochrone.resolveMaxDistance and the Laravel
+			// DistancePreferenceFilter - all three must agree or the feed, its badge
+			// and search would disagree about the same member.
+			if v, err := strconv.ParseFloat(raw, 64); err == nil && v > 0 {
 				browseMaxMiles = v
+
+				break
 			}
 		}
 		browseSort = rawSort

--- a/iznik-server-go/test/mygroups_distance_test.go
+++ b/iznik-server-go/test/mygroups_distance_test.go
@@ -123,4 +123,27 @@ func TestMyGroupsCountDistanceLimit(t *testing.T) {
 	json2.Unmarshal(rsp(settingResp), &settingBody)
 	assert.Equal(t, limitedCount, settingBody["count"].(float64),
 		"settings.browseMaxDistance is honoured for mygroups, matching the explicit query param")
+
+	// The band default (browseReachMaxDistance, written by browse:backfill-max-distance) is
+	// the INBOUND fallback for a member who never touched the slider. It has to bind, because
+	// it is what holds each member to their own density band now that a post's ripple grows to
+	// the ceiling rather than to its own origin's band.
+	db.Exec("UPDATE users SET settings = JSON_REMOVE(COALESCE(settings,'{}'), '$.browseMaxDistance') WHERE id = ?", viewerID)
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.browseReachMaxDistance', 10) WHERE id = ?", viewerID)
+	defaultResp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
+	assert.Equal(t, 200, defaultResp.StatusCode)
+	var defaultBody map[string]interface{}
+	json2.Unmarshal(rsp(defaultResp), &defaultBody)
+	assert.Equal(t, limitedCount, defaultBody["count"].(float64),
+		"the band default narrows the feed for a member who never chose")
+
+	// An explicit choice beats the default, including a WIDER one: a member who moved the
+	// slider has said what they want, and the default is only a default.
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.browseMaxDistance', 9007199254740991) WHERE id = ?", viewerID)
+	chosenResp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
+	assert.Equal(t, 200, chosenResp.StatusCode)
+	var chosenBody map[string]interface{}
+	json2.Unmarshal(rsp(chosenResp), &chosenBody)
+	assert.Equal(t, unlimitedCount, chosenBody["count"].(float64),
+		"an explicit unlimited choice overrides a narrower band default")
 }

--- a/iznik-server-go/test/town_near_test.go
+++ b/iznik-server-go/test/town_near_test.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	json2 "encoding/json"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/freegle/iznik-server-go/town"
@@ -28,4 +30,40 @@ func TestTownSelectNear(t *testing.T) {
 	// None reachable in a tight budget, and empty input.
 	assert.Empty(t, town.SelectNear(cands, 3, 5))
 	assert.Empty(t, town.SelectNear(nil, 30, 5))
+}
+
+// The slider's top stop comes from cap_minutes, so the field has to be on EVERY
+// answer with a usable location - including the ones where the routing server or
+// the towns box gives nothing back and the hint hides. A client that only got it
+// on a lucky call would silently fall back to the flat 30 and go on offering a
+// rural member less than the reach engine now gives them.
+func TestTownNearAlwaysCarriesTheSliderCap(t *testing.T) {
+	// Somewhere real (Edinburgh), so the handler gets past its lat/lng guard.
+	resp, err := getApp().Test(httptest.NewRequest("GET", "/api/town/near?lat=55.9533&lng=-3.1883&minutes=30", nil), 30000)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body map[string]interface{}
+	assert.Nil(t, json2.Unmarshal(rsp(resp), &body))
+
+	capMinutes, ok := body["cap_minutes"].(float64)
+	assert.True(t, ok, "cap_minutes must be present: %v", body)
+	assert.Greater(t, capMinutes, 0.0)
+	// 20/30/45 are the configured bands; anything else means the policy drifted.
+	assert.Contains(t, []float64{20, 30, 45}, capMinutes)
+
+	band, ok := body["density_band"].(string)
+	assert.True(t, ok, "density_band must be present: %v", body)
+	assert.Contains(t, []string{"dense", "medium", "sparse", "unknown"}, band)
+
+	// No location means no cap to describe, and the handler must not invent one.
+	// Decode into a FRESH map: unmarshalling into a populated one merges keys, so
+	// reusing `body` would carry the first response's cap into this assertion.
+	resp, err = getApp().Test(httptest.NewRequest("GET", "/api/town/near?lat=0&lng=0&minutes=30", nil), 30000)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var noLocation map[string]interface{}
+	assert.Nil(t, json2.Unmarshal(rsp(resp), &noLocation))
+	assert.NotContains(t, noLocation, "cap_minutes")
 }

--- a/iznik-server-go/town/town.go
+++ b/iznik-server-go/town/town.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/density"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -122,6 +123,13 @@ type rippleEvalResp struct {
 // roughly the chosen travel time, location-aware, with no hardcoded conversion). Names only, no
 // units. Best-effort: any routing/DB failure returns an empty list (the hint hides).
 //
+// cap_minutes is the top of the slider for THIS member: the reach budget their local freegler
+// density earns (20 dense / 30 medium / 45 sparse), because that is the budget the reach engine
+// gives posts around them. A fixed 5-30 slider is simultaneously too short in the country - where a
+// member cannot ask for the 45 minutes they now actually receive - and too long in the city, where
+// the top stops describe travel the reach engine no longer honours. Always present, so the client
+// never has to guess; it falls back to the flat cap whenever density cannot be measured.
+//
 // @Router /town/near [get]
 // @Summary Up to 5 towns the browse/feed distance slider reaches (by drive-time), names only
 // @Tags location
@@ -135,6 +143,13 @@ func Near(c *fiber.Ctx) error {
 	if (lat == 0 && lng == 0) || minutes <= 0 {
 		return c.JSON(empty)
 	}
+
+	// The cap describes the member's location, not the chosen travel time, so it
+	// rides on every response - including the ones where the town hint gives up.
+	// A client that only learned it on a lucky call would show the wrong slider.
+	reachCap := density.CapFor(lat, lng)
+	empty["cap_minutes"] = reachCap.MaxMinutes
+	empty["density_band"] = reachCap.Band
 	maxMin := minutes
 	if maxMin > 120 {
 		maxMin = 120 // cap so "no limit" never routes the whole country
@@ -189,7 +204,12 @@ func Near(c *fiber.Ctx) error {
 	// The road-distance reach range ("reaches median..max miles by road"), shown alongside the town
 	// list. Comes free from the isochrone, so it's present even when no named town falls inside the
 	// reach.
-	out := fiber.Map{"frontier_median_miles": r.FrontierMedianMiles, "frontier_max_miles": r.FrontierMaxMiles}
+	out := fiber.Map{
+		"frontier_median_miles": r.FrontierMedianMiles,
+		"frontier_max_miles":    r.FrontierMaxMiles,
+		"cap_minutes":           reachCap.MaxMinutes,
+		"density_band":          reachCap.Band,
+	}
 
 	// reach_radius_miles: the mile radius the chosen travel time reaches, for the client to store as
 	// settings.browseMaxDistance. This is a PURE travel-time value from the isochrone frontier -


### PR DESCRIPTION
## Summary

The drive-time reach cap belonged to the post. It should belong to the person who would make the journey, and applying it at the origin fails backwards on the commonest case there is: a rural member's nearest town is the town they already drive to, and its posts are the ones they most want.

Measured on live for the member who reported this (PE12 0PJ, Lincolnshire fens):

- Their band is **sparse** — nearest 400 freeglers **16.11 miles** out, against a 3.1-mile threshold.
- **Peterborough, their nearest big town, is `medium`** and so caps at 30 minutes. They are **38.0 minutes** from it. Sizing at the origin means the town's posts could never reach them, at any setting. #1308 made their situation worse, not better.
- Of 191 posts within 21.6 miles over 14 days, **1** had a reach polygon covering them (4 even at maximum designed extent). Routing from each of the 96 distinct post origins: **2 origins (2 posts) inside 30 minutes, 56 origins (110 posts) inside 45**.
- The slider hint at 30 minutes reads "Max 10-12 miles by road" — their words exactly. At 45 it reads "Max 22-26 miles", and Peterborough appears in the town list.

So the cap moves to the recipient:

1. **Every ripple grows to `DensityService::ceiling()`** — the max over configured bands (45), not the origin's own band. The origin's band is still measured and stored, because the density analytics read rows back by it; it now describes where a post *is*, not how far it goes.
2. **Each member is admitted on their own band**, through the travel-time preference that already gates browse and mail.
3. **`browse:backfill-max-distance` materialises that default.** On live only 2,900 of 121,000 recently-active members had ever set a preference, so without it the wider ripple would reach a city member with everything inside 45 minutes of a post. An explicit choice is rescaled proportionally onto the member's new range rather than carried across, because the old 5-30 slider stored a *fraction* of the range, not an absolute travel time.
4. **The browse slider tops out at the member's own cap**, from a new `cap_minutes` on `/town/near`, backed by a Go `density` package mirroring the PHP band policy (same env vars, same thresholds, same fail-soft behaviour).

## Two traps found while verifying, both fixed

**`browseMaxDistance` is bidirectional.** It also caps how far away other people see the member's own posts. Writing the band default into it would have capped every city member's posts at their ~4.8-mile band radius (measured: a London origin reaches 4.8 miles at 20 minutes vs 21.7 at 45) — gutting city posts and potentially re-excluding the reporting member from Peterborough, while the tests stayed green. The default now lives in a separate **inbound-only** key:

| Key | Set by | Inbound | Outbound |
|---|---|---|---|
| `browseMaxDistance` | the member, via the slider | yes | yes |
| `browseReachMaxDistance` | the backfill, from their band | yes (only when the member has not chosen) | **never** |

Browse-scoped search shares the feed's universe (Discourse 9933), so it needed the same fallback or search would surface posts the feed hides.

The split is deliberate about WHOSE statement each key is. The slider is the member saying how far they are willing to travel, so it is fair that it also says how far their own offers go - that reciprocity is existing behaviour and is unchanged. The band default is Freegle reading their AREA, not a promise from them, so it decides what is worth showing them and leaves their giving alone. Using it outbound would stop a member in a busy town reaching anyone past a few miles simply because they have a lot of neighbours: fewer things reused, nobody better off. Both rules are now written up in plain English for members (docs/members/rippling-out.md) and for moderators (docs/moderators/rippling-out.md), the latter with a table and the answer to "why do people further away see my post when I only see nearby ones?".

**The unlimited sentinel stopped meaning what it used to.** It means "defer to the server's own reach", and that reach is now the ceiling — so it only says "as far as my band goes" for a member whose band earns it. Below the ceiling, both the slider and the backfill now store a real derived radius at the top stop.

## Code Quality Review

- The Go `density` package is a deliberate second implementation of one policy; it reads the same env var names as `config/freegle.php` and its test mirrors `DensityService::band()`'s cases, so the two cannot drift silently.
- Backfill lookups are memoised on a rounded location (4dp density, 3dp radius) — without it a 121,000-member pass is a quarter of a million calls.
- Fail-soft throughout: no location, or a failed density or routing lookup, skips the member untouched rather than writing a cap nobody chose.
- Killswitch `RIPPLE_DENSITY_ENABLED=false` puts every post and every member back on the flat cap, ceiling included.

## Future Improvements

- The density band is recomputed per backfill run. If this pass becomes routine, storing the band alongside `users_approxlocs` would remove the repeated KNN work.
- `browse:backfill-max-distance` is not scheduled; it is a manual pass for now (`--dry-run` first, `--since-days` to bound the population). Its selection is a full walk of `users` (~2.9M rows on live) because neither the JSON_EXTRACT predicates nor `lastaccess` is indexed — fine for an occasional off-peak run, but it is why this is not on a schedule.

## Interaction with the raster badge-count work (f21160920)

Rebasing onto master surfaced one consequence worth a reviewer's attention. `nearbyCount` has a fast path (a single COUNT) for viewers with no inbound limit, and a slower distance-limited path that fetches candidate coordinates and filters in Go. Its comment called the fast path "the common case, since most members leave the slider at no limit".

After `browse:backfill-max-distance` that is no longer true: only the sparse band resolves to unlimited, so roughly two thirds of members move onto the distance-limited path — immediately after master invested in making this query cheaper. The comment is corrected here rather than left to mislead.

That filter deliberately stays in Go rather than moving into SQL: it must use the BLURRED coordinates the feed exposes, or the badge and the list would disagree at the boundary, which is the bug class that path exists to prevent. If the shift is unacceptable, the backfill is the lever to hold back — the reach change alone does not cause it.

## Test Plan

Suites run on the rebased tree (master had moved 8 commits):

- Go 4,098 pass, including new `density` policy tests, `/town/near cap_minutes` presence and absence, and the browse/search inbound fallback.
- Laravel 5,490 pass, including new `ceiling()` tests, rewritten Expand tests asserting the ripple asks for the ceiling, backfill rescale/band-default/outbound-safety tests, and `DistancePreferenceFilter` inbound-vs-outbound tests.
- vitest 15,323 pass, including the density-aware slider maximum, the clamp of a saved position above a narrowed cap, and the sentinel-only-at-the-ceiling rule.
- Reach behaviour verified against the live routing server through the apiv2-live tunnel, not only in unit tests.

Note: `iznik_go_test` needed `./scripts/setup-test-database.sh` to pick up #1308's two migrations before the Go suite would run.

The `ModSupportUser.spec.js` fix that was previously in this branch has been dropped: the same fix landed independently on master as e5ac0fce4, and master's version is used.