### PR TITLE
fix(browse): load the posts the new-post count is promising

### DIFF
--- a/iznik-nuxt3/components/MessageList.vue
+++ b/iznik-nuxt3/components/MessageList.vue
@@ -17,8 +17,14 @@
         initialFetchDone && selectedSort === 'Unseen' && showCountsUnseen && me
       "
     >
+      <!-- Only announce new posts we can actually show. The count comes from the server
+           and is polled independently of the feed, so it can run ahead of the loaded list
+           (a post arriving after this page was fetched). Announcing it then puts "N new
+           post" directly above "YOU'RE UP TO DATE" with nothing in between - a promise the
+           page cannot keep. useFeedCountSync pulls the feed on a rise, so the usual case is
+           that the posts arrive a moment later and the banner appears with them. -->
       <MessageListCounts
-        v-if="browseCount && !search"
+        v-if="browseCount && unseenMessages.length && !search"
         :count="browseCount"
         @mark-seen="markSeen"
       />
@@ -155,6 +161,7 @@ import { useNearbyStore } from '~/stores/nearby'
 import { throttleFetches } from '~/composables/useThrottle'
 import { useMe } from '~/composables/useMe'
 import { useScrollDepth } from '~/composables/useScrollDepth'
+import { useFeedCountSync } from '~/composables/useFeedCountSync'
 import {
   deduplicateMessages,
   findDuplicates,
@@ -559,6 +566,17 @@ function visibilityChanged(visible) {
     emit('update:visible', visible)
   }
 }
+
+// The count is polled every 60s; the feed is not. When the count RISES, pull the feed so the
+// posts behind it actually load - otherwise the page announces "1 new post" while the list it
+// is showing predates that post, and the member sees a count with nothing to open.
+useFeedCountSync(browseCount, async () => {
+  if (me.value?.settings?.browseView === 'mygroups') {
+    await messageStore.fetchMyGroups()
+  } else {
+    await nearbyStore.fetchMessages(true)
+  }
+})
 
 function markSeen() {
   // Mark the whole list the count is computed over (the full nearby/mygroups response),

--- a/iznik-nuxt3/composables/useFeedCountSync.js
+++ b/iznik-nuxt3/composables/useFeedCountSync.js
@@ -1,0 +1,55 @@
+import { watch } from 'vue'
+
+// Keep the browse feed in step with the badge count.
+//
+// The count is polled every 60 seconds (useNavbar's getCounts -> messageStore.fetchCount).
+// The FEED is not on that timer - it is fetched on navigation, on a filter change, and after
+// "Mark seen". So a post arriving after the page loaded raises the count while the loaded list
+// still predates it: the page says "1 new post" and has nothing unseen to show for it, sitting
+// directly above "YOU'RE UP TO DATE". A count is a promise that there is something to see, and
+// the page could not keep it.
+//
+// So when the count RISES, pull the feed. Only on a rise:
+//   - unchanged is the common case (the poll fires every minute regardless), and refetching
+//     then would put every browsing member's reach query back on the server every minute;
+//   - falling is what "Mark seen" does, and that path refreshes the feed itself.
+//
+// `count` is a ref/computed of the server's unseen count; `refresh` reloads the feed for the
+// current browse view. Returns the watch handle so a caller can stop it.
+export function useFeedCountSync(count, refresh) {
+  // The value present at setup came back alongside the feed we already have, so the posts
+  // behind it are loaded. Only what happens AFTER that is news.
+  let previous = numeric(count.value)
+  let fetching = false
+
+  return watch(count, (raw) => {
+    const now = numeric(raw)
+    const rose = now > previous
+    previous = now
+
+    // A poll can fire again while a slow reach query is still running. Fetching the same feed
+    // twice concurrently is wasted work on a query the server is already busy with, and the
+    // second answer would only overwrite the first.
+    if (!rose || fetching) {
+      return
+    }
+
+    fetching = true
+    Promise.resolve()
+      .then(refresh)
+      .catch(() => {
+        // Best-effort: a failed refresh leaves the count where it is, and the next rise (or
+        // the member's own navigation) tries again. Swallowing it here keeps a network blip
+        // from wedging the sync permanently.
+      })
+      .finally(() => {
+        fetching = false
+      })
+  })
+}
+
+// fetchCount can resolve to null/undefined before the first real answer arrives, and a
+// non-numeric value must never read as a rise.
+function numeric(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}

--- a/iznik-nuxt3/tests/unit/composables/useFeedCountSync.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useFeedCountSync.spec.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { useFeedCountSync } from '~/composables/useFeedCountSync'
+
+// The browse badge count is polled every 60 seconds (useNavbar getCounts -> messageStore
+// .fetchCount). The FEED is not on that timer, so a post that arrives after the page loaded
+// makes the count say "1 new post" while the loaded list has nothing unseen to show for it -
+// which is what members see as a count with no item behind it.
+describe('useFeedCountSync', () => {
+  let refresh
+
+  beforeEach(() => {
+    refresh = vi.fn().mockResolvedValue(undefined)
+  })
+
+  it('pulls the feed when the count rises', async () => {
+    const count = ref(0)
+    useFeedCountSync(count, refresh)
+
+    count.value = 1
+    await nextTick()
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not pull the feed when the count falls', async () => {
+    // Falling is what "Mark seen" does, and it already refreshes the feed itself.
+    const count = ref(3)
+    useFeedCountSync(count, refresh)
+
+    count.value = 0
+    await nextTick()
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('does not pull the feed when the count is re-reported unchanged', async () => {
+    // The poll fires every 60s whether or not anything changed; refetching the feed on
+    // every tick would put every browsing member's reach query back on the server.
+    const count = ref(2)
+    useFeedCountSync(count, refresh)
+
+    count.value = 2
+    await nextTick()
+    count.value = 2
+    await nextTick()
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('treats the value present at setup as already accounted for', async () => {
+    // The feed was fetched alongside this count, so the posts behind it are already loaded.
+    const count = ref(4)
+    useFeedCountSync(count, refresh)
+    await nextTick()
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('pulls again on each subsequent rise', async () => {
+    const count = ref(0)
+    useFeedCountSync(count, refresh)
+
+    count.value = 1
+    await nextTick()
+    // Let the first refresh settle - two rises that overlap are covered separately below.
+    await flushPromises()
+    count.value = 2
+    await nextTick()
+
+    expect(refresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('rises again correctly after a fall', async () => {
+    // Mark seen drops it to 0; the next arrival must still pull the feed.
+    const count = ref(2)
+    useFeedCountSync(count, refresh)
+
+    count.value = 0
+    await nextTick()
+    count.value = 1
+    await nextTick()
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('survives a null or undefined count without pulling', async () => {
+    // fetchCount can resolve to nothing before the first real answer arrives.
+    const count = ref(null)
+    useFeedCountSync(count, refresh)
+
+    count.value = undefined
+    await nextTick()
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('does not stack refreshes while one is still in flight', async () => {
+    // The poll can fire again before a slow reach query returns; a second concurrent
+    // fetch of the same feed is wasted work on a query the server is already running.
+    let release
+    refresh = vi.fn(() => new Promise((resolve) => (release = resolve)))
+    const count = ref(0)
+    useFeedCountSync(count, refresh)
+
+    count.value = 1
+    await nextTick()
+    count.value = 2
+    await nextTick()
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    release()
+    await flushPromises()
+
+    // Once it settles, a later rise is honoured again.
+    count.value = 3
+    await nextTick()
+    expect(refresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not wedge permanently when a refresh rejects', async () => {
+    refresh = vi.fn().mockRejectedValue(new Error('network'))
+    const count = ref(0)
+    useFeedCountSync(count, refresh)
+
+    count.value = 1
+    await nextTick()
+    await flushPromises()
+
+    count.value = 2
+    await nextTick()
+
+    expect(refresh).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary

Browse could show "1 new post / Mark seen" directly above "YOU'RE UP TO DATE", with nothing in between. A count with no item behind it.

**Root cause is cadence, not a query mismatch.** The count is polled every 60 seconds (`useNavbar.js:363` re-arms `getCounts`, which calls `messageStore.fetchCount`). The feed is not on that timer: `nearbyStore.messageList` is a session-lifetime cache refetched only on navigation, on a filter change, or after Mark seen. So a post arriving after the page loaded raises the count while the list on screen still predates it. The banner announces something the page has no way to display, and the two banners cannot correct each other — `MessageListCounts` reads the **server** count, `MessageListUpToDate` reads the **local** seen split.

## The fix

`composables/useFeedCountSync.js`: when the count **rises**, pull the feed.

Only on a rise, deliberately:
- **unchanged** is the common case — the poll fires every minute whether or not anything happened, and refetching then would put every browsing member's reach query back on the server every minute;
- **falling** is Mark seen, which already refreshes the feed itself.

Concurrent rises collapse to a single fetch (a slow reach query can outlast the next poll), and a failed refresh does not wedge the sync.

The banner additionally requires an unseen post to actually be loaded. In the moment before the refetch lands there is no banner rather than a false one, and if the count and feed ever genuinely disagree the page stays quiet instead of promising a post it cannot show.

## What this is NOT

This is the same symptom as the `mygroups` divergence fixed in 0f8d58241 and c55007424, but a different mechanism, so it is not a third pass at membership predicates. Before changing anything I checked the count and feed queries against each other for the default `nearby` view:

- They share their predicates **by construction** — successful/held/promised, `AuthorReachCapWhere`, the sandwich-bounds/exact-polygon test, and unseen semantics all come from shared functions.
- There is **no LIMIT or pagination** in either path.
- The differences that do exist push the count **down**, not up: `COUNT(DISTINCT ms.msgid)` in the count vs an un-deduplicated per-row scan in the feed, and the feed's viewer's-own-posts arm which the count has no equivalent of.
- The raster containment path (`SPATIAL_REACH_MODE`) is **off in every environment this repo defines**.

Cadence was the only mechanism left that produces exactly the reported state: count 1, zero unseen rendered, seen posts present.

## Related, deliberately not fixed here

`spatialReachIDs` (dark-launched in f21160920) is wired into `nearbyCount` **only**, never the feed — so once `SPATIAL_REACH_MODE=on`, any raster/SQL disagreement becomes a badge-vs-feed divergence by construction. There is also a concrete gap: ids classified as definite `in` get no held-status recheck, only `partial` ids do, so a reach held within the last delta cycle is counted but correctly excluded from the feed. Dormant while the flag is off; worth closing before that rollout.

## Test Plan

- vitest 15,318 pass, including 9 new cases in `tests/unit/composables/useFeedCountSync.spec.js`: pulls on a rise, does not pull on a fall or on an unchanged re-report, treats the setup value as already accounted for, pulls again on each subsequent rise, rises correctly after a fall, tolerates a null/undefined count, collapses concurrent rises to one fetch, and does not wedge when a refresh rejects.
- No e2e spec asserts on the banner text, so nothing there depends on the old behaviour.
- Go and Laravel untouched.
