### PR TITLE
fix(chitchat): the feed card's last word must be the thread's last word

### DIFF
--- a/iznik-nuxt3/components/NewsReplies.vue
+++ b/iznik-nuxt3/components/NewsReplies.vue
@@ -90,6 +90,10 @@ const HEAD_COUNT = 2
 const TAIL_COUNT = 3
 const COLLAPSE_THRESHOLD = 6
 
+// Consecutive messages from one author inside this window read as one
+// utterance, so they render as a single block.
+const TEN_MINUTES = 10 * 60 * 1000
+
 const props = defineProps({
   id: {
     type: Number,
@@ -114,8 +118,9 @@ const props = defineProps({
     required: true,
   },
   // 'thread' renders the full conversation with head/tail collapsing.
-  // 'feed' keeps cards short: post + the two most recent replies + one
-  // honestly-counted "View all N replies" link to the thread page.
+  // 'feed' keeps cards short: post + the two most recent replies from
+  // anywhere in the thread + one honestly-counted "View all N replies" link
+  // to the thread page.
   context: {
     type: String,
     required: false,
@@ -175,12 +180,15 @@ const visiblereplies = computed(() => {
   return ret
 })
 
-const combinedReplies = computed(() => {
-  const TEN_MINUTES = 10 * 60 * 1000
+// Merge author runs. Serves both the thread's top-level list and the feed
+// card's time-ordered tail, so the same-parent guard matters: in the feed the
+// neighbouring row can be a reply to somebody else entirely, and two answers
+// to different people are not one utterance however close together they land.
+function combineRuns(list) {
   const combined = []
 
-  for (let i = 0; i < filteredReplies.value.length; i++) {
-    const currentReply = filteredReplies.value[i]
+  for (let i = 0; i < list.length; i++) {
+    const currentReply = list[i]
     const currentTime = new Date(currentReply.added).getTime()
     const lastCombined = combined[combined.length - 1]
 
@@ -195,6 +203,7 @@ const combinedReplies = computed(() => {
       !isExpanded &&
       lastCombined &&
       lastCombined.userid === currentReply.userid &&
+      lastCombined.replyto === currentReply.replyto &&
       !currentReply.image &&
       !lastCombined.image &&
       !currentReply.replies?.length &&
@@ -251,7 +260,25 @@ const combinedReplies = computed(() => {
   }
 
   return combined
-})
+}
+
+const combinedReplies = computed(() => combineRuns(filteredReplies.value))
+
+// A double-post says the same thing twice: keep the later one only. Copies the
+// list rather than splicing the caller's, which would corrupt a computed cache.
+function dropRepeatedMessages(list) {
+  const ret = [...list]
+  let lastMessage = null
+  let i = ret.length
+  while (i--) {
+    if (!(ret[i].message || '').localeCompare(lastMessage)) {
+      ret.splice(i, 1)
+    } else {
+      lastMessage = ret[i].message || ''
+    }
+  }
+  return ret
+}
 
 const filteredReplies = computed(() => {
   if (!visiblereplies.value.length) return []
@@ -279,17 +306,7 @@ const filteredReplies = computed(() => {
   }
 
   // Suppress replies where the message is identical to the previous.
-  let lastMessage = null
-  let i = ret.length
-  while (i--) {
-    if (!ret[i].message.localeCompare(lastMessage)) {
-      ret.splice(i, 1)
-    } else {
-      lastMessage = ret[i].message
-    }
-  }
-
-  return ret
+  return dropRepeatedMessages(ret)
 })
 
 // Collapse only at depth 1 (top-level replies), not for nested reply trees.
@@ -389,7 +406,7 @@ const collapsePlan = computed(() => {
 
 // Feed cards must stay short. Above this many replies (counted across the
 // whole tree) the card switches to a view-all link plus the two most recent
-// top-level entries; at or below it, small threads render exactly as before.
+// entries; at or below it, small threads render exactly as before.
 const FEED_TOTAL_THRESHOLD = 3
 const FEED_VISIBLE_TAIL = 2
 
@@ -470,6 +487,41 @@ const replyNames = computed(() => {
   return out
 })
 
+// Every reply in the tree as one list, parents before their children, with the
+// same deleted-unless-a-volunteer filter the top-level list applies.
+function flattenReplies(list, out) {
+  for (const r of list) {
+    const reply = resolveReply(r)
+    if (!reply) continue
+    if (reply.deleted && !mod.value) continue
+    out.push(reply)
+    flattenReplies(reply.replies || [], out)
+  }
+  return out
+}
+
+// The thread in the order things were said. ChitChat nests - 40% of replies are
+// replies-to-replies - so "the most recent replies" cannot be read off the
+// top-level rows: the newest thing anyone said is often a reply to a reply, and
+// a tail taken from top-level rows alone put an older reply forward as the last
+// word with nothing at all to say the newer one existed.
+// `added` is what the card displays; ids break ties so the order is defined even
+// when two replies share a timestamp.
+const chronologicalReplies = computed(() => {
+  const flat = flattenReplies(visiblereplies.value, [])
+  flat.sort(
+    (a, b) => new Date(a.added) - new Date(b.added) || (a.id || 0) - (b.id || 0)
+  )
+  return combineRuns(dropRepeatedMessages(flat))
+})
+
+// A nested reply shown here renders as a row of its own, so its parent must
+// still suppress its inline list or the card would show it twice. Older nested
+// replies stay behind the card's counted view-all link.
+const feedTail = computed(() =>
+  chronologicalReplies.value.slice(-FEED_VISIBLE_TAIL)
+)
+
 const feedMode = computed(() => {
   return (
     props.context === 'feed' &&
@@ -483,16 +535,24 @@ const feedMode = computed(() => {
 // new - not merely the first new top-level reply. Replies to an old comment
 // partway up the thread are new but live under an old parent, so anchoring on
 // the parent keeps that promise true and keeps the parent visible as context.
-const firstNewIndex = computed(() => {
-  if (!seenBeforeVisit.value) return -1
-  return combinedReplies.value.findIndex((r) => subtreeHasNew(r))
+// A feed card renders a slice of the thread, so it anchors on the first row IT
+// shows: an anchor row the card leaves out would take the line with it, and a
+// card showing new replies would carry no sign of where they start.
+const dividerAnchor = computed(() => {
+  if (!seenBeforeVisit.value || props.depth !== 1) return null
+  const rows = feedMode.value ? feedTail.value : combinedReplies.value
+  const anchor = rows.find((r) => subtreeHasNew(r))
+  if (!anchor) return null
+  // The thread opens with new activity: everything there is to see is already
+  // below the line, so there is nothing for the line to divide it from.
+  return anchor.id === combinedReplies.value[0]?.id ? null : anchor
 })
 
 // Every new reply in the thread, nested ones included, so this number agrees
 // with the "View all N replies - M new" link that brought the reader here.
 const newCount = computed(() => treeCounts.value.fresh)
 
-const showDivider = computed(() => props.depth === 1 && firstNewIndex.value > 0)
+const showDivider = computed(() => Boolean(dividerAnchor.value))
 
 const renderEntries = computed(() => {
   let entries
@@ -505,17 +565,15 @@ const renderEntries = computed(() => {
         total: treeCounts.value.total,
         fresh: treeCounts.value.fresh,
       },
-      ...combinedReplies.value
-        .slice(-FEED_VISIBLE_TAIL)
-        .map((r) => ({ reply: r })),
+      ...feedTail.value.map((r) => ({ reply: r })),
     ]
   } else {
     entries = [...collapsePlan.value.entries]
   }
 
   if (showDivider.value) {
-    const first = combinedReplies.value[firstNewIndex.value]
-    const idx = entries.findIndex((e) => e.reply && e.reply.id === first.id)
+    const anchorId = dividerAnchor.value.id
+    const idx = entries.findIndex((e) => e.reply && e.reply.id === anchorId)
     if (idx >= 0) {
       entries.splice(idx, 0, { divider: true, count: newCount.value })
     }

--- a/iznik-nuxt3/components/NewsReply.vue
+++ b/iznik-nuxt3/components/NewsReply.vue
@@ -173,9 +173,9 @@
          depth 2+ replies mounting. When the nested list reports that its
          whole subtree has mounted, this reply's subtree is complete too.
          In the feed the children are suppressed and nothing stands in for
-         them: the card's own "View all N replies" link already counts and
-         names the whole tree, so a second counted link here would only
-         offer a subset of the same conversation under a smaller number. -->
+         them here: recent ones are rows of their own in the card's
+         time-ordered tail, and the card's "View all N replies" link counts
+         and names the rest of the tree. -->
     <NewsReplies
       v-if="reply?.replies?.length && !suppressChildren"
       :id="id"
@@ -390,8 +390,10 @@ const props = defineProps({
     type: Number,
     required: true,
   },
-  // Feed cards keep nested conversations behind a counted link instead of
-  // rendering them inline (set by NewsReplies in feed context).
+  // Feed cards render the recent part of a nested conversation as rows of the
+  // card's own tail rather than inline under the parent, so the inline list is
+  // suppressed to stop those replies appearing twice (set by NewsReplies in
+  // feed context).
   suppressChildren: {
     type: Boolean,
     required: false,

--- a/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
@@ -764,6 +764,116 @@ describe('NewsReplies', () => {
       ).toContain('view-all')
     })
 
+    it('shows the newest reply even when it is a reply to a reply', () => {
+      // ChitChat threads nest, so the newest thing said is often a nested
+      // reply. Picking the tail from top-level rows only left the card
+      // showing an older reply as the last word, with nothing at all to say
+      // the newer one existed.
+      const replies = makeReplies(5, { startId: 10 })
+      replies[4].replies = [200]
+      replies[4].nestedObjects = [
+        {
+          id: 200,
+          userid: 300,
+          displayname: 'Nested Newest',
+          message: 'Newest reply in the thread',
+          added: '2024-01-15T20:00:00Z',
+          deleted: false,
+          type: 'Reply',
+        },
+      ]
+      withReplies(replies)
+
+      const wrapper = createWrapper({ context: 'feed' })
+      const renderedIds = wrapper
+        .findAll('.reply-thread')
+        .map((n) => Number(n.attributes('data-reply-id')))
+      expect(renderedIds).toEqual([14, 200])
+    })
+
+    it('renders a nested reply once when its parent is on the card too', () => {
+      // The parent still suppresses its own nested list - the child is a row
+      // in its own right here, so rendering both would show it twice.
+      const replies = makeReplies(5, { startId: 10 })
+      replies[4].replies = [200]
+      replies[4].nestedObjects = [
+        {
+          id: 200,
+          userid: 300,
+          displayname: 'Nested Newest',
+          message: 'Newest reply in the thread',
+          added: '2024-01-15T20:00:00Z',
+          deleted: false,
+          type: 'Reply',
+        },
+      ]
+      withReplies(replies)
+
+      const wrapper = createWrapper({ context: 'feed' })
+      const rows = wrapper.findAllComponents('.news-reply')
+      expect(rows.length).toBe(2)
+      expect(rows.map((r) => r.props('id'))).toEqual([14, 200])
+      expect(rows.every((r) => r.props('suppressChildren'))).toBe(true)
+    })
+
+    it('marks where the new replies start on the rows it shows', () => {
+      // The divider anchors on a row the card renders. Anchoring on the
+      // top-level parent instead would lose the line whenever that parent is
+      // not one of the rows the card had room for.
+      const replies = makeReplies(6, { startId: 10 })
+      replies[2].replies = [200]
+      replies[2].nestedObjects = [
+        {
+          id: 200,
+          userid: 300,
+          displayname: 'Nested Newest',
+          message: 'The newest thing anyone said',
+          added: '2024-01-15T20:00:00Z',
+          deleted: false,
+          type: 'Reply',
+        },
+      ]
+      withReplies(replies)
+      mockNewsfeedStore.seenBeforeVisit = 199
+
+      const wrapper = createWrapper({ context: 'feed' })
+      expect(
+        wrapper
+          .findAll('.reply-thread')
+          .map((n) => n.attributes('data-reply-id'))
+      ).toEqual(['15', '200'])
+      const divider = wrapper.find('[data-unread-divider]')
+      expect(divider.exists()).toBe(true)
+      expect(
+        divider.element.nextElementSibling.getAttribute('data-reply-id')
+      ).toBe('200')
+    })
+
+    it('keeps the tail in time order, not tree order', () => {
+      // An old nested reply under an early parent must not displace the
+      // genuinely recent top-level replies.
+      const replies = makeReplies(5, { startId: 10 })
+      replies[0].replies = [200]
+      replies[0].nestedObjects = [
+        {
+          id: 200,
+          userid: 300,
+          displayname: 'Nested Old',
+          message: 'Replied ages ago',
+          added: '2024-01-15T10:30:00Z',
+          deleted: false,
+          type: 'Reply',
+        },
+      ]
+      withReplies(replies)
+
+      const wrapper = createWrapper({ context: 'feed' })
+      const renderedIds = wrapper
+        .findAll('.reply-thread')
+        .map((n) => Number(n.attributes('data-reply-id')))
+      expect(renderedIds).toEqual([13, 14])
+    })
+
     it('points the link at the new replies when there are some', () => {
       // The link declares the intent in the URL, so the thread page knows
       // where to land without inferring it, and the link survives a reload.


### PR DESCRIPTION
## The bug

On a busy ChitChat card the newest reply could be missing altogether, with nothing to say it existed.

Live example (thread 615449): janpryor34 replied at 17:11, I replied to them at 17:48 — and the card showed janpryor34 plus Pete Barker from **two days earlier**, ending on janpryor34 as if that were the last word.

The tail was taken from the **top-level** rows (`combinedReplies.slice(-2)`). ChitChat nests — 40% of replies are replies-to-replies — so the newest thing anyone said is routinely a reply to a reply, and such a reply could never reach the tail however recent it was. `becc020df` then dropped the nested stand-in link that had at least admitted a nested conversation was there, because the card's own view-all link already counts and names the whole tree. It does count it — but a count is not the same as showing the newest reply, so between the two the card could present an older reply as the latest word in silence.

## The fix

Take the tail from the thread flattened into the order things were said, so "the two most recent replies" means what it says. The rows shown still suppress their inline nested lists — that is now what stops a nested reply appearing twice (as a row of its own and again under its parent) — and older nested replies stay behind the view-all link as before.

Two changes fall out of one list serving both shapes:

- The author-run combiner is now a function over any list, with a **same-parent guard**. On the top-level list every row answers the thread head, so the guard never bites; on a time-ordered tail the neighbour can be an answer to somebody else, and two answers to different people are not one utterance however close together they land.
- The unread divider anchors on the first row **the card shows** that carries new activity. Anchoring on a top-level row the card leaves out took the line with it, so a card offering new replies could carry no sign of where they start. The thread page is unchanged — it renders every top-level row — and the "nothing older above it" rule still suppresses the line when the conversation opens with new activity.

Also makes the duplicate-message filter copy its input rather than splicing an array a computed handed it.

A nested reply rendered in the tail reads as a reply because the text carries the `@name` mention the reply box puts there, and its avatar stays the smaller nested size. No "replying to X" furniture was added.

## Verification

- **Failing test first**: the new spec reproduced the bug as `expected [ 13, 14 ] to deeply equal [ 14, 200 ]` against master's component, with the other 15,311 tests passing.
- **Green after**: 727 files / 15,313 tests pass, run through the worktree status API on the committed tree.
- **Browser, live data**: same container and card, master's code vs this branch — before, Pete Barker (2 days) + janpryor34; after, janpryor34 + the reply to them. Screenshots in the thread this came from.
- Docs freshness check passes; no page covers these components.

Four unit tests cover it: newest-reply-is-nested, rendered once with children suppressed, tail stays in time order (an old nested reply must not displace recent top-level ones), and the divider marking where the new replies start among the rows shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Nx5Kki5p3SP7jvuCHn5v1
