### PR TITLE
fix(browse): badge count must ignore held and deleted reaches

### DIFF
--- a/iznik-server-go/isochrone/reachspatial.go
+++ b/iznik-server-go/isochrone/reachspatial.go
@@ -42,18 +42,37 @@ func spatialReachIDs(latlng utils.LatLng) (in []int64, partial []int64, ok bool)
 	return in, partial, true
 }
 
-// reachCandidateQueryFromIDs is reachCandidateQuery with the containment
-// answered by id lists instead of geometry: same joins (minus rippling_reach
-// — its only jobs here were containment and the held filter), same unseen
-// and author-cap conjuncts, so membership is identical by construction.
-// Partial ids get the exact polygon test, by primary key, with the held
-// re-check folded in (a hold newer than the spatial delta cadence must still
-// hide the post).
+// reachCandidateQueryFromIDs is reachCandidateQuery with the CONTAINMENT
+// answered by id lists instead of geometry: same joins, same unseen and
+// author-cap conjuncts, so membership is identical by construction.
+//
+// Only containment comes from the raster. The reach row's live STATUS is still
+// read from MySQL for BOTH buckets, because the raster is rebuilt on a delta
+// cadence (iznik-spatial-go dataset_reach.go DeltaInterval, 2 minutes) and a
+// hold takes effect the instant a member reports a post or a moderator sends it
+// Back to Pending. For up to a delta cycle the index therefore still says a
+// held post covers this viewer.
+//
+// That matters because this query serves the badge COUNT while the feed is
+// always served by reachCandidateQuery, which joins rippling_reach and tests
+// rr.status != 'held' unconditionally. Any status the two disagree about is a
+// count that names a post the feed will not render - the "N new posts" sitting
+// above "you're up to date" with nothing in between. The partial bucket already
+// had this re-check folded into its exact polygon test; the in bucket had no
+// reference to rippling_reach at all, so it counted held posts. Requiring a live
+// non-held row for both closes that, and costs one primary-key lookup per id.
 func reachCandidateQueryFromIDs(db *gorm.DB, myid uint64, latlng utils.LatLng, in, partial []int64) *gorm.DB {
 	// One concatenated WHERE string in a single Where() call — same GORM
 	// extra-paren gotcha as reachCandidateQuery (see there).
+	//
+	// EXISTS rather than a join: it also means a reach row that has been deleted
+	// outright (retraction) drops the id, instead of it staying countable on the
+	// strength of a raster entry alone.
 	whereSQL := "ms.successful = 0 AND ml.msgid IS NULL " +
-		"AND (ms.msgid IN (?) OR (ms.msgid IN (?) AND EXISTS (" +
+		"AND ((ms.msgid IN (?) AND EXISTS (" +
+		"SELECT 1 FROM rippling_reach r1 WHERE r1.msgid = ms.msgid " +
+		"AND r1.status != 'held')) " +
+		"OR (ms.msgid IN (?) AND EXISTS (" +
 		"SELECT 1 FROM rippling_reach r2 WHERE r2.msgid = ms.msgid " +
 		"AND r2.status != 'held' " +
 		"AND ST_Contains(r2.polygon, ST_SRID(POINT(?, ?), ?))))) " +

--- a/iznik-server-go/test/isochrone_reach_test.go
+++ b/iznik-server-go/test/isochrone_reach_test.go
@@ -563,6 +563,28 @@ func TestNearbyCountSpatialReach(t *testing.T) {
 		"a freshly-held partial id is re-checked in SQL and excluded")
 	db.Exec("UPDATE rippling_reach SET status = 'expanding' WHERE msgid = ?", boundary)
 
+	// The same must hold for a definite `in` id. The raster is rebuilt on a 2-minute
+	// delta (iznik-spatial-go dataset_reach.go DeltaInterval), so for up to that long
+	// after a member report or a moderator's Back to Pending the index still says the
+	// post covers this viewer. The FEED excludes it immediately - reachCandidateQuery
+	// always joins rippling_reach and tests rr.status != 'held' - so without the same
+	// re-check here the badge counts a post the feed will not show, which is exactly
+	// the "N new posts" / "you're up to date" mismatch members report.
+	db.Exec("UPDATE rippling_reach SET status = 'held' WHERE msgid = ?", covered)
+	assert.Equal(t, float64(1), countOf(),
+		"a freshly-held in-list id is re-checked in SQL and excluded, like a partial one")
+	db.Exec("UPDATE rippling_reach SET status = 'expanding' WHERE msgid = ?", covered)
+
+	// And a reach row that has gone entirely (retraction) must not leave the id
+	// countable either - the in-list disjunct has to require a live reach row, not
+	// merely the absence of a held one.
+	db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", covered)
+	assert.Equal(t, float64(1), countOf(),
+		"an in-list id whose reach row has gone is not counted")
+	// Put it back: the fallback assertions below expect both posts in reach again.
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, outer_bound, status) VALUES (?, 51.5, -0.1, "+
+		coveringPoly+", ST_Envelope("+coveringPoly+"), 'expanding')", covered)
+
 	// Spatial down: transparent fallback to the SQL containment path, same answer.
 	stub.Close()
 	assert.Equal(t, float64(2), countOf(),

--- a/plans/active/2026-08-11-badge-count-via-spatial-knn.md
+++ b/plans/active/2026-08-11-badge-count-via-spatial-knn.md
@@ -149,3 +149,24 @@ db1/2/3 at :8194, co-located with apiv2) and serve point-in-reach from RAM:
   their exact-test residue is larger; option = finer grid for small
   polygons, or skip rasterising polygons under ~N cells and mark all-partial
   (they're cheap to exact-test anyway). Parity harness is the check.
+- 2026-08-11 (later still): the `in` bucket had no rippling_reach reference at
+  all, so it counted posts the FEED excludes. Only the count uses the raster; the
+  feed is always reachCandidateQuery with its unconditional `rr.status != 'held'`,
+  so any status the two disagree about shows a member "N new posts" above
+  "you're up to date" with nothing in between. Fixed: both buckets now require a
+  live, non-held reach row via EXISTS (one PK lookup per id; the `in` bucket still
+  skips the geometry, which is the whole point of the raster). Deleted rows drop out
+  too, so the SQL side no longer relies on reconcile() alone for hard deletes.
+  Tests added to TestNearbyCountSpatialReach: fresh-hold on an `in` id, and an
+  `in` id whose reach row has gone. NOTE this is now a LIVE defect, not a
+  pre-rollout one: the mode went on everywhere the same evening. The 6/6 parity
+  harness would not have caught it - it compares counts at a moment, while this
+  window only opens for the ~2 minutes after a hold, so a spot-check almost always
+  lands outside it.
+- KNOWN RESIDUAL, now live: a polygon that SHRINKS (retraction, trimming) is only
+  picked up on the next delta, so for up to ~2 minutes an `in` id can claim
+  containment the feed's ST_Contains would refuse. Not closed, deliberately: testing
+  containment for `in` ids is exactly the geometry cost the raster exists to avoid,
+  and it is what the 12-20 -> 4-8 db3 load drop bought. Status and existence are
+  cheap and are checked; containment is not. To detect it, the parity harness needs
+  to sample DURING a reach change rather than at rest.


### PR DESCRIPTION
## The problem

The unread badge on Browse can say "2 new posts" while the feed underneath says you are up to date, with nothing in between. The badge count and the feed use different queries and they disagree about held posts.

The count can be served from the spatial raster, which is enabled in production, so this affects members. The raster answers "is this viewer inside a post's reach?" from an in-memory index and splits the answer into two buckets: ids it knows are inside, and ids near the boundary that get an exact geometry test in SQL. The boundary bucket also checked that the post's reach row was not held. The inside bucket did not look at `rippling_reach` at all, so it counted held posts.

The feed is always served by `reachCandidateQuery`, which joins `rippling_reach` and requires `rr.status != 'held'`. A held post therefore stayed in the count but dropped out of the feed.

The gap is real rather than theoretical because the raster is rebuilt on a two-minute delta, while a hold takes effect the moment a member reports a post or a moderator sends it back to pending.

## What this does

Both buckets require a live, non-held reach row via `EXISTS`. The inside bucket still skips the geometry test, which is the whole point of the raster, so the extra work is one primary key lookup per id. `EXPLAIN` against production gives `type: const`, `key: PRIMARY`, `rows: 1`.

Using `EXISTS` rather than a join also drops ids whose reach row has been deleted outright, such as after a retraction, so the count does not depend on the spatial server's `reconcile()` to catch hard deletes.

## Known limit

A reach polygon that shrinks is only picked up on the next delta, so for up to two minutes an inside id can claim containment that the feed's `ST_Contains` would refuse. Closing that means running the geometry test for inside ids, which is the cost the raster exists to avoid and what took db3 query load from spikes of 12 to 20 down to a steady 4 to 8. Status and existence are cheap, and are checked. Containment is not.

Finding this class of problem needs the parity harness to sample while a reach is changing rather than comparing counts at rest, since the window only opens for the couple of minutes after a change. `plans/active/2026-08-11-badge-count-via-spatial-knn.md` records both points.

## Tests

`TestNearbyCountSpatialReach` covers a held inside id, which must be excluded in the same way a boundary one is, and an inside id whose reach row has gone, which must not be counted. The Go suite passes.
