### PR TITLE
fix(isochrone): re-tag copied location geometry with SRID 3857 in provider-down fallback

### DIFF
--- a/iznik-server-go/isochrone/isochrone.go
+++ b/iznik-server-go/isochrone/isochrone.go
@@ -208,10 +208,14 @@ func EnsureIsochroneExists(locationid uint64, transport string, minutes int) uin
 		// original ExecInsertGetID's res.LastInsertId() exactly, including staying 0 when INSERT
 		// IGNORE skips a pre-existing row - the isoID == 0 fallback below still depends on that.
 		res := gorm.WithResult()
+		// ST_SRID(geometry, SRID) re-tags the copied location geometry: locations rows have
+		// carried SRID 0 in the past (Mar-Apr 2026 rows did), and a raw copy then poisons
+		// every later ST_Contains against this isochrone with error 3033. Re-tagging is a
+		// no-op for correctly-tagged rows and NULL-safe, so COALESCE still falls through.
 		tx := database.InsertSelect(db.Clauses(res, clause.Insert{Modifier: "IGNORE"}), "isochrones",
 			"(locationid, transport, minutes, polygon) "+
-				"SELECT ?, ?, ?, COALESCE(geometry, ST_GeomFromText(CONCAT('POINT(', lng, ' ', lat, ')'), ?)) FROM locations WHERE id = ?",
-			locationid, transport, minutes, utils.SRID, locationid)
+				"SELECT ?, ?, ?, COALESCE(ST_SRID(geometry, ?), ST_GeomFromText(CONCAT('POINT(', lng, ' ', lat, ')'), ?)) FROM locations WHERE id = ?",
+			locationid, transport, minutes, utils.SRID, utils.SRID, locationid)
 		if tx.Error != nil {
 			log.Printf("Failed to create fallback isochrone for location %d: %v", locationid, tx.Error)
 			return 0


### PR DESCRIPTION
## What

The isochrone provider-down fallback (`EnsureIsochroneExists`) copies `locations.geometry` verbatim into `isochrones.polygon`. Location geometries have carried SRID 0 in the past: 49 isochrones written 2026-03-09..2026-04-13 still hold SRID-0 POINT placeholders, all 49 referenced from `isochrones_users`. Every badge-count `ST_Contains` against one of them fails with MySQL error 3033 (mixed SRIDs 0/3857) instead of counting — observed ~3/day in the db3 apiv2 log since May.

`ST_SRID(geometry, 3857)` re-tags the copy. It is a no-op for correctly-tagged rows and NULL-safe, so the COALESCE fallthrough to the constructed lat/lng POINT is unchanged.

## Data repair

The 49 damaged prod rows are being repaired separately (one-row-at-a-time `ST_SRID(polygon, 3857)` updates); this change stops the fallback from ever writing SRID-0 again if location geometries regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)