### PR TITLE
fix(notifications): red Mark all read, and one shared treatment for every mark-read control

### DIFF
--- a/iznik-nuxt3/assets/css/buttons.scss
+++ b/iznik-nuxt3/assets/css/buttons.scss
@@ -100,6 +100,22 @@ button {
   -webkit-font-smoothing: antialiased !important;
 }
 
+/* "Mark read" / "Mark all read". Red outline so the affordance is recognisable
+ * wherever it appears - chat list, conversation header, notification dropdown,
+ * ModTools. Defined after .btn-white so it wins when combined with it. */
+.btn-mark-read {
+  background-color: $color-white !important;
+  border: 1px solid $color-red !important;
+  color: $color-red !important;
+
+  &:hover,
+  &:focus {
+    background-color: $color-red !important;
+    border-color: $color-red !important;
+    color: $color-white !important;
+  }
+}
+
 .btn-light {
   color: $color-gray--normal !important;
   background-color: inherit !important;

--- a/iznik-nuxt3/components/ChatPane.vue
+++ b/iznik-nuxt3/components/ChatPane.vue
@@ -55,7 +55,7 @@
               <b-button
                 v-if="unseen"
                 variant="white"
-                class="action-btn action-btn--mark-read"
+                class="action-btn btn-mark-read"
                 @click="markRead"
               >
                 Mark read
@@ -126,7 +126,7 @@
               <b-button
                 v-if="unseen"
                 variant="white"
-                class="action-btn action-btn--mark-read"
+                class="action-btn btn-mark-read"
                 @click="markRead"
               >
                 Mark read
@@ -278,14 +278,14 @@ import { useRouter } from '#imports'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
 
-const ChatBlockModal = defineAsyncComponent(
-  () => import('~/components/ChatBlockModal'),
+const ChatBlockModal = defineAsyncComponent(() =>
+  import('~/components/ChatBlockModal')
 )
-const ChatHideModal = defineAsyncComponent(
-  () => import('~/components/ChatHideModal'),
+const ChatHideModal = defineAsyncComponent(() =>
+  import('~/components/ChatHideModal')
 )
-const ChatReportModal = defineAsyncComponent(
-  () => import('~/components/ChatReportModal'),
+const ChatReportModal = defineAsyncComponent(() =>
+  import('~/components/ChatReportModal')
 )
 
 const chatStore = useChatStore()
@@ -306,8 +306,8 @@ function resize() {
 // Pre-reserve sticky-ad height for non-donors so chatHolder doesn't shrink when the ad renders.
 const allowAd = computed(() => !recentDonor.value)
 
-const ChatNotVisible = defineAsyncComponent(
-  () => import('~/components/ChatNotVisible.vue'),
+const ChatNotVisible = defineAsyncComponent(() =>
+  import('~/components/ChatNotVisible.vue')
 )
 
 const { chat, otheruser, milesaway, unseen } = await setupChat(props.id)
@@ -493,7 +493,7 @@ function checkScroll() {
     // messagesToShow in the v-for loop we only trigger a render of the new items.
     messagesToShow.value = Math.min(
       chatmessages?.value?.length,
-      messagesToShow?.value + 10,
+      messagesToShow?.value + 10
     )
 
     scrollTimer.value = setTimeout(checkScroll, scrollInterval.value)
@@ -804,10 +804,5 @@ function typing() {
 .action-btn {
   font-size: 0.7rem;
   padding: 2px 8px;
-}
-
-.action-btn--mark-read {
-  border: 1px solid $color-red !important;
-  color: $color-red !important;
 }
 </style>

--- a/iznik-nuxt3/components/NotificationOptions.vue
+++ b/iznik-nuxt3/components/NotificationOptions.vue
@@ -37,7 +37,7 @@
         <b-button
           variant="white"
           size="sm"
-          class="notification-list__mark-read"
+          class="btn-mark-read"
           @click="markAllRead"
         >
           Mark all read
@@ -156,13 +156,6 @@ const showAboutMe = () => {
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins/_breakpoints';
-@import 'assets/css/_color-vars.scss';
-
-/* Match the red "Mark read" treatment used in chat (see ChatPane). */
-.notification-list__mark-read {
-  border: 1px solid $color-red !important;
-  color: $color-red !important;
-}
 
 .notification-badge {
   position: absolute;

--- a/iznik-nuxt3/components/NotificationOptions.vue
+++ b/iznik-nuxt3/components/NotificationOptions.vue
@@ -34,8 +34,16 @@
       link-class="notification-list__item"
     >
       <div class="d-flex justify-content-end">
-        <b-button variant="secondary" size="sm" @click="markAllRead">
+        <b-button
+          variant="white"
+          size="sm"
+          class="notification-list__mark-read"
+          @click="markAllRead"
+        >
           Mark all read
+          <b-badge v-if="unreadNotificationCount" variant="danger" class="ms-1">
+            {{ unreadNotificationCount }}
+          </b-badge>
         </b-button>
       </div>
     </b-dropdown-item>
@@ -148,6 +156,13 @@ const showAboutMe = () => {
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins/_breakpoints';
+@import 'assets/css/_color-vars.scss';
+
+/* Match the red "Mark read" treatment used in chat (see ChatPane). */
+.notification-list__mark-read {
+  border: 1px solid $color-red !important;
+  color: $color-red !important;
+}
 
 .notification-badge {
   position: absolute;

--- a/iznik-nuxt3/modtools/components/ModChatHeader.vue
+++ b/iznik-nuxt3/modtools/components/ModChatHeader.vue
@@ -104,7 +104,7 @@
       <b-button
         v-if="unseen"
         variant="white"
-        class="ms-1 d-block d-md-none"
+        class="ms-1 d-block d-md-none btn-mark-read"
         @click="markRead"
       >
         Mark read
@@ -120,7 +120,7 @@
           <b-button
             v-if="unseen"
             variant="white"
-            class="d-none d-md-block me-2"
+            class="d-none d-md-block me-2 btn-mark-read"
             @click="markRead"
           >
             Mark read

--- a/iznik-nuxt3/modtools/pages/chats/[[id]].vue
+++ b/iznik-nuxt3/modtools/pages/chats/[[id]].vue
@@ -20,7 +20,11 @@
                 placeholder="Search chats (e.g. 'Joe' or 'mods')"
                 class="flex-shrink-1"
               />
-              <b-button class="mt-1" variant="white" @click="markAllRead">
+              <b-button
+                class="mt-1 btn-mark-read"
+                variant="white"
+                @click="markAllRead"
+              >
                 <v-icon icon="check" /> Mark all read
               </b-button>
             </div>

--- a/iznik-nuxt3/tests/unit/components/NotificationOptions.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NotificationOptions.spec.js
@@ -152,14 +152,14 @@ describe('NotificationOptions', () => {
 
     it('styles Mark all read like the chat Mark read button', () => {
       const wrapper = createWrapper()
-      const markAllBtn = wrapper.find('.notification-list__mark-read')
+      const markAllBtn = wrapper.find('.btn-mark-read')
       expect(markAllBtn.exists()).toBe(true)
       expect(markAllBtn.classes()).toContain('white')
     })
 
     it('shows the unread count as a danger badge on Mark all read', () => {
       const wrapper = createWrapper()
-      const badge = wrapper.find('.notification-list__mark-read .b-badge')
+      const badge = wrapper.find('.btn-mark-read .b-badge')
       expect(badge.exists()).toBe(true)
       expect(badge.classes()).toContain('danger')
       expect(badge.text()).toBe('2')
@@ -168,10 +168,8 @@ describe('NotificationOptions', () => {
     it('omits the Mark all read badge when nothing is unread', () => {
       mockNotificationStore.count.value = 0
       const wrapper = createWrapper()
-      expect(wrapper.find('.notification-list__mark-read').exists()).toBe(true)
-      expect(
-        wrapper.find('.notification-list__mark-read .b-badge').exists()
-      ).toBe(false)
+      expect(wrapper.find('.btn-mark-read').exists()).toBe(true)
+      expect(wrapper.find('.btn-mark-read .b-badge').exists()).toBe(false)
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/NotificationOptions.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NotificationOptions.spec.js
@@ -149,6 +149,30 @@ describe('NotificationOptions', () => {
       const wrapper = createWrapper()
       expect(wrapper.text()).toContain('Mark all read')
     })
+
+    it('styles Mark all read like the chat Mark read button', () => {
+      const wrapper = createWrapper()
+      const markAllBtn = wrapper.find('.notification-list__mark-read')
+      expect(markAllBtn.exists()).toBe(true)
+      expect(markAllBtn.classes()).toContain('white')
+    })
+
+    it('shows the unread count as a danger badge on Mark all read', () => {
+      const wrapper = createWrapper()
+      const badge = wrapper.find('.notification-list__mark-read .b-badge')
+      expect(badge.exists()).toBe(true)
+      expect(badge.classes()).toContain('danger')
+      expect(badge.text()).toBe('2')
+    })
+
+    it('omits the Mark all read badge when nothing is unread', () => {
+      mockNotificationStore.count.value = 0
+      const wrapper = createWrapper()
+      expect(wrapper.find('.notification-list__mark-read').exists()).toBe(true)
+      expect(
+        wrapper.find('.notification-list__mark-read .b-badge').exists()
+      ).toBe(false)
+    })
   })
 
   describe('mark all read', () => {

--- a/iznik-nuxt3/tests/unit/components/markReadStyling.spec.js
+++ b/iznik-nuxt3/tests/unit/components/markReadStyling.spec.js
@@ -1,0 +1,88 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, it, expect } from 'vitest'
+
+/*
+ * "Mark read" / "Mark all read" appears in several places - the chat list, a
+ * conversation header, the mobile chat navbar, the notification dropdown, and
+ * the ModTools equivalents. It is one affordance, so it should look like one
+ * affordance: a red outline with the count in a danger badge. Each component
+ * used to style it privately, which is how the notification dropdown ended up
+ * grey while everything around it was red.
+ *
+ * These tests pin the shared class and check every place that offers the
+ * action carries a red treatment.
+ */
+
+const read = (p) => readFileSync(resolve(__dirname, '../../..', p), 'utf-8')
+
+describe('shared mark-read class', () => {
+  const buttons = read('assets/css/buttons.scss')
+  const rule = buttons.match(/\.btn-mark-read\s*\{[\s\S]*?\n\}/)
+
+  it('is defined in the globally loaded stylesheet', () => {
+    /* buttons.scss is imported by global.scss, which both nuxt.config.ts and
+     * modtools/nuxt.config.ts list in `css`, so the class reaches both apps. */
+    expect(
+      rule,
+      '.btn-mark-read must exist in assets/css/buttons.scss'
+    ).not.toBeNull()
+    expect(read('assets/css/global.scss')).toContain("@import 'buttons'")
+  })
+
+  it('is a red outline that inverts on hover', () => {
+    expect(rule[0]).toMatch(/border:\s*1px solid \$color-red/)
+    expect(rule[0]).toMatch(/color:\s*\$color-red/)
+    expect(rule[0]).toMatch(/&:hover/)
+    expect(rule[0]).toMatch(/background-color:\s*\$color-red/)
+  })
+
+  it('is declared after .btn-white so it wins when combined with it', () => {
+    /* Both are single-class !important rules, so source order decides. */
+    expect(buttons.indexOf('.btn-mark-read')).toBeGreaterThan(
+      buttons.indexOf('.btn-white:hover')
+    )
+  })
+})
+
+describe('every mark-read control uses a red treatment', () => {
+  it.each([
+    ['components/NotificationOptions.vue', 'Mark all read', 'btn-mark-read'],
+    ['components/ChatPane.vue', 'Mark read', 'btn-mark-read'],
+    ['modtools/components/ModChatHeader.vue', 'Mark read', 'btn-mark-read'],
+    ['modtools/pages/chats/[[id]].vue', 'Mark all read', 'btn-mark-read'],
+    /* These two predate the shared class and keep bespoke shapes - a pill in
+     * the chat list search row, a circle in the mobile navbar - but the same
+     * red language. Named here so the sweep stays complete. */
+    ['pages/chats/[[id]].vue', 'Mark all read', 'mark-read-btn'],
+    ['components/ChatMobileNavbar.vue', 'Mark read', 'action-btn--mark-read'],
+  ])('%s styles its "%s" with %s', (file, label, cls) => {
+    const src = read(file)
+    expect(src).toContain(label)
+    expect(src).toContain(cls)
+  })
+
+  it('gives each control the unread count in a danger badge', () => {
+    for (const file of [
+      'components/NotificationOptions.vue',
+      'components/ChatPane.vue',
+      'components/ChatMobileNavbar.vue',
+      'modtools/components/ModChatHeader.vue',
+      'pages/chats/[[id]].vue',
+    ]) {
+      expect(read(file), file).toMatch(/variant="danger"/)
+    }
+  })
+
+  it('leaves no component declaring its own red mark-read rule', () => {
+    /* ChatMobileNavbar keeps a rule for its circle/tint, but the plain
+     * outline-and-text case belongs to the shared class now. */
+    for (const file of [
+      'components/ChatPane.vue',
+      'components/NotificationOptions.vue',
+      'modtools/components/ModChatHeader.vue',
+    ]) {
+      expect(read(file), file).not.toMatch(/mark-read\s*\{/)
+    }
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatHeader.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatHeader.spec.js
@@ -493,6 +493,20 @@ describe('ModChatHeader', () => {
       wrapper = await mountComponent()
       expect(wrapper.text()).not.toContain('Mark read')
     })
+
+    it('gives Mark read the shared red treatment', async () => {
+      /* .btn-mark-read lives in assets/css/buttons.scss so the affordance
+       * looks the same here as in the member site and the chat list. */
+      mockUnseen.value = 5
+      const wrapper = await mountComponent()
+      const markReadBtns = wrapper
+        .findAll('button')
+        .filter((b) => b.text().includes('Mark read'))
+      expect(markReadBtns.length).toBeGreaterThan(0)
+      for (const btn of markReadBtns) {
+        expect(btn.classes()).toContain('btn-mark-read')
+      }
+    })
   })
 
   describe('chat status buttons', () => {


### PR DESCRIPTION
The notification dropdown's **Mark all read** was a grey `secondary` button with no count, while every other mark-read control on the site is a red outline with the count in a `danger` badge.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/mark-read-red/notif-before.png) | ![after](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/mark-read-red/notif-after.png) |

The control it now matches, in the chat list:

![chat list](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/mark-read-red/chat-reference.png)

## Why it drifted

Six places offer this action and each styled itself privately, so the dropdown could go grey without anything noticing. The outline now lives once in `.btn-mark-read` in `assets/css/buttons.scss`, which `global.scss` pulls into both the member site and ModTools.

| Where | Was | Now |
| --- | --- | --- |
| `NotificationOptions` dropdown | grey, no count | shared class + danger badge |
| `ChatPane` (both headers) | red, declared locally | shared class |
| `ModChatHeader` (both headers) | badge but no red | shared class |
| ModTools chat list | neither | shared class |
| `pages/chats` list | red pill | unchanged |
| `ChatMobileNavbar` | red circle / red tint | unchanged |

The last two keep their bespoke shapes - a pill in the search row, a circle in the mobile navbar - since they already speak the same red language.

Deliberately left alone: `components/ChatHeader.vue` has two unstyled Mark read buttons but is not mounted anywhere (the member-facing header is inline in `ChatPane`), and `ChatMessage`'s **Mark unread** is the inverse action and stays a plain link.

## Verification

Browser-checked on `freegle-dev-local` logged in with unread notifications. The screenshots above are a true A/B - master's version of the component swapped into the running container for the "before", then swapped back. Computed style on the button is `color`/`border-color: rgb(255, 0, 0)` on white, badge `rgb(220, 53, 69)`, and the shared class beats `.btn-white` when combined with it.

Checks: the full vitest suite was exercised against this working tree via the status API - 727 files, 15338 tests, all green. That includes `markReadStyling.spec.js`, which pins the shared class and sweeps every control listed above so the treatment cannot drift apart per component again.

The `pr-assets/mark-read-red` branch holds only the screenshots and can be deleted after merge.
