### PR TITLE
fix(api): stop discarding a reply we already hold, and stop leaving a photo marked uploading

### DIFF
--- a/iznik-nuxt3/api/BaseAPI.js
+++ b/iznik-nuxt3/api/BaseAPI.js
@@ -10,6 +10,7 @@ import { useAuthStore } from '~/stores/auth'
 import { useMiscStore } from '~/stores/misc'
 import { useLoggingContextStore } from '~/stores/loggingContext'
 import { getTraceHeaders } from '~/composables/useTrace'
+import { warn } from '~/composables/useClientLog'
 
 export { APIError, MaintenanceError, LoginError, SignUpError }
 
@@ -224,6 +225,15 @@ export default class BaseAPI {
         // This can happen if a login token is invalid, and we don't want to show errors to the user.
         if (path.startsWith('/chat?includeClosed=true')) {
           console.log('Silently handling 401 for includeClosed chat request')
+          // Deliberately never settles, to keep this out of Sentry.  That is
+          // only safe because nothing downstream is gated on the result; if
+          // that ever stops being true it becomes the same class of bug as the
+          // stranded give-flow photo, so make it visible rather than silent.
+          warn('API request abandoned without settling', {
+            event_type: 'api_abandoned',
+            reason: 'chat_401',
+            api_path: path,
+          })
           return new Promise(function (resolve) {})
         }
       }
@@ -242,6 +252,20 @@ export default class BaseAPI {
         // when you're leaving a page.  No point in rippling those errors up to result in Sentry errors.
         // Swallow these by returning a problem that never resolves.  Possible memory leak but it's a rare case.
         console.log('Aborted - ignore')
+        // An abort during logout or unload is expected and the page is going
+        // away, so nothing is left waiting.  An abort at any other time leaves
+        // the caller's await hanging for the life of the page with no error to
+        // catch, which is how a give-flow photo got stranded at uploading:true.
+        // We cannot tell the two apart here, so record it: one of these in Loki
+        // beside a stuck UI is the answer straight away, rather than a day of
+        // working backwards from what is missing.
+        warn('API request abandoned without settling', {
+          event_type: 'api_abandoned',
+          reason: 'aborted',
+          api_path: path,
+          api_method: method,
+          detail: e?.message,
+        })
         return new Promise(function (resolve) {})
       }
 

--- a/iznik-nuxt3/components/PhotoUploader.vue
+++ b/iznik-nuxt3/components/PhotoUploader.vue
@@ -223,7 +223,8 @@ import {
   createHeicPreProcessor,
   createHeicSafeCompressor,
 } from '~/composables/useUppyHeic'
-import { action } from '~/composables/useClientLog'
+import { action, error as logError } from '~/composables/useClientLog'
+import { withTimeout } from '~/composables/usePromiseTimeout'
 import { describeUploadError } from '~/composables/useUploadErrorDetail'
 import { reportCameraError } from '~/composables/useCameraErrorMessage'
 import { useRuntimeConfig } from '#app'
@@ -233,6 +234,11 @@ import {
   analyzePhotoQuality,
   getQualityMessage,
 } from '~/composables/usePhotoQuality'
+
+// The bytes are already uploaded by the time we register the photo, so this
+// call is small.  Generous ceiling: we only want to catch a hang, never a slow
+// connection.
+const FINALISE_TIMEOUT_MS = 60000
 
 const draggable = defineAsyncComponent(() => import('vuedraggable'))
 const MessagePhotosModal = defineAsyncComponent(() =>
@@ -505,8 +511,27 @@ async function uploadPhoto(photo, webPath) {
             recognise: props.recognise && photos.value.indexOf(photo) === 0,
           }
 
+          action('photo bytes uploaded', {
+            event_type: 'photo_upload',
+            photo_stage: 'tus_complete',
+            imgtype: props.type,
+          })
+
           try {
-            const ret = await imageStore.post(att)
+            // The bytes are already up at this point; this call only registers
+            // them, so it is quick under any normal conditions.  Bound it
+            // anyway.  This is the step that has to complete for the photo to
+            // stop being "uploading", and the give flow has no way out while
+            // it is: Next is gated on anyUploading and Skip only renders in
+            // the empty state.  So an await here that never settles does not
+            // lose a photo, it locks the member out of posting entirely, and
+            // compose persists that state to the next visit.  Better a photo
+            // that failed and offers Retry than a flow with no exits.
+            const ret = await withTimeout(
+              imageStore.post(att),
+              FINALISE_TIMEOUT_MS,
+              'Timed out registering the uploaded photo'
+            )
 
             // Update photo with server data
             photo.id = ret.id
@@ -520,12 +545,23 @@ async function uploadPhoto(photo, webPath) {
             // Remove any AI-generated images now that a real photo has been added
             photos.value = photos.value.filter((p) => !p.externalmods?.ai)
 
+            action('photo registered', {
+              event_type: 'photo_upload',
+              photo_stage: 'registered',
+              attachment_id: ret.id,
+            })
+
             emit('photoProcessed', ret.id)
             resolve()
           } catch (e) {
             console.error('Image post failed:', e)
             photo.error = true
             photo.uploading = false
+            logError('Photo upload could not be completed', {
+              event_type: 'photo_upload',
+              photo_stage: 'finalise_failed',
+              reason: e?.message,
+            })
             reject(e)
           }
         },
@@ -901,6 +937,37 @@ onBeforeUnmount(() => {
     pendingPhoto.value.error = true
   }
   pendingPhoto.value = null
+
+  // Same trap as the held photo above, one step later: a photo whose upload is
+  // still outstanding when we go away.  The tray reaches the persisted compose
+  // store through a watcher that Vue stops with this component, so the last
+  // thing written out says uploading:true, and when the upload finally settles
+  // it mutates an object nothing is listening to any more.  Next is gated on
+  // anyUploading and the state is restored on the next visit, so that is a
+  // permanent posting lockout rather than a lost photo.
+  //
+  // Mark them failed and push that out by hand - the watcher will not fire for
+  // us again, and the parent's setter writes to a store that outlives us both.
+  const stranded = photos.value.filter((p) => p?.uploading)
+
+  if (stranded.length) {
+    stranded.forEach((photo) => {
+      photo.uploading = false
+      photo.error = true
+    })
+
+    emit(
+      'update:modelValue',
+      photos.value.map((p) => ({ ...p }))
+    )
+
+    logError('Left the photo tray with an upload still in flight', {
+      event_type: 'photo_upload',
+      photo_stage: 'stranded_on_unmount',
+      stranded: stranded.length,
+      max_progress: Math.max(...stranded.map((p) => p.progress ?? 0)),
+    })
+  }
 
   compressTimers.clear()
   uploadRetries.clear()

--- a/iznik-nuxt3/composables/useFetchRetry.js
+++ b/iznik-nuxt3/composables/useFetchRetry.js
@@ -33,9 +33,30 @@ export function fetchRetry(fetch) {
   }
 
   const retryOn = async function (attempt, error, response) {
-    // No point retrying until we know we are back online.
     const miscStore = useMiscStore()
-    await miscStore.waitForOnline()
+
+    // There is no point making another attempt until we believe we are back
+    // online - but that is the only thing the connection check is for.  It
+    // used to run here, as the very first act of every retry decision, before
+    // we had even looked at what came back.  So a member whose connection
+    // dropped in the moment between sending a request and its reply arriving
+    // had a perfectly good response thrown away: the online check did not
+    // resolve, the success branch below was never reached, and the caller was
+    // left awaiting a promise that could never settle.
+    //
+    // That is what stranded a give-flow photo for user 3512849 on 2026-08-10:
+    // POST /apiv2/image returned 200 with image id 45508630, the app flipped
+    // offline, and PhotoUploader's `await imageStore.post()` never returned.
+    // The photo stayed uploading:true at 100%, compose persisted it, and
+    // because the flow gates Next on anyUploading she could not post at all.
+    //
+    // So wait only on the paths that are about to try again, never before
+    // reading a reply we already hold.
+    const waitThenRetry = async function (why) {
+      console.log(why)
+      await miscStore.waitForOnline()
+      return [true, false]
+    }
 
     if (attempt >= 10) {
       return [false, false, null, new Error('Too many retries, give up')]
@@ -62,8 +83,7 @@ export function fetchRetry(fetch) {
       blandErrors.includes(response?.statusText?.toLowerCase()) ||
       blandErrors.includes(error?.message?.toLowerCase())
     ) {
-      console.log('Load failed - retry')
-      return [true, false]
+      return await waitThenRetry('Load failed - retry')
     }
 
     // A 504 means the gateway gave up on a request the server was probably still executing -
@@ -89,15 +109,15 @@ export function fetchRetry(fetch) {
     // resilience, but as deliberate policy.  Persistent 429s (real abuse) still fail via
     // the overall attempt cap.
     if (response?.status === 429) {
-      console.log('Rate limited - retry with backoff')
-      return [true, false]
+      return await waitThenRetry('Rate limited - retry with backoff')
     }
 
     // Retry on network errors or server errors (5xx).  Don't retry client errors (4xx) - these are legitimate
     // API responses (e.g. 400 Bad Request, 401 Unauthorized, 403 Forbidden, 404 Not Found, 409 Conflict).
     if (error !== null || response?.status >= 500) {
-      console.log('Error - retry', error, response?.status)
-      return [true, false]
+      return await waitThenRetry(
+        `Error - retry ${error?.message ?? ''} ${response?.status ?? ''}`
+      )
     }
 
     if (response?.status >= 200 && response?.status < 300) {
@@ -106,8 +126,7 @@ export function fetchRetry(fetch) {
 
         if (!data) {
           // We've seen 200 responses with no data, which is never valid for us, so retry.
-          console.log('Success but no data - retry')
-          return [true, false]
+          return await waitThenRetry('Success but no data - retry')
         } else {
           return [false, true, data]
         }
@@ -118,7 +137,7 @@ export function fetchRetry(fetch) {
         }
 
         // JSON parse failed on a response that should have had a body.  Retry.
-        return [true, false]
+        return await waitThenRetry('Bad JSON body - retry')
       }
     } else {
       // Client error (4xx) that we aren't supposed to retry.  Parse the response body if available

--- a/iznik-nuxt3/composables/usePromiseTimeout.js
+++ b/iznik-nuxt3/composables/usePromiseTimeout.js
@@ -1,0 +1,24 @@
+// Bound an await so it cannot hang for ever.
+//
+// A promise that never settles is not a slow operation, it is a dead one: the
+// awaiting code never runs its success path or its catch, so any state it was
+// going to clear stays set and any UI gated on that state stays gated. We have
+// shipped that bug more than once - see stores/misc.js waitForOnline() and
+// composables/useFetchRetry.js retryOn(), which between them stranded a
+// give-flow photo at uploading:true and locked the member out of posting.
+//
+// Use this wherever a hang would leave the user with no way forward, so the
+// worst case becomes an ordinary failure the caller already handles.
+export function withTimeout(promise, ms, message = 'Timed out') {
+  let timer = null
+
+  const timeout = new Promise((resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms)
+  })
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  })
+}

--- a/iznik-nuxt3/composables/useUppyHeic.js
+++ b/iznik-nuxt3/composables/useUppyHeic.js
@@ -24,6 +24,7 @@
 // ~3MB, so it is dynamically imported and only ever fetched by someone who
 // actually picks a HEIC file.
 import { action } from '~/composables/useClientLog'
+import { withTimeout } from '~/composables/usePromiseTimeout'
 
 const HEIC_MIME_TYPES = [
   'image/heic',
@@ -53,17 +54,6 @@ export function isHeicFile(file) {
 function toJpegName(name) {
   if (!name) return 'photo.jpg'
   return name.replace(/\.(heic|heif)$/i, '') + '.jpg'
-}
-
-function withTimeout(promise, ms) {
-  let timer = null
-  const timeout = new Promise((resolve, reject) => {
-    timer = setTimeout(() => reject(new Error('HEIC conversion timed out')), ms)
-  })
-
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timer) clearTimeout(timer)
-  })
 }
 
 // Returns an Uppy pre-processor which converts any HEIC files in the batch to
@@ -118,7 +108,8 @@ export function createHeicPreProcessor({ getUppy, uploader }) {
 
         const blob = await withTimeout(
           heicTo({ blob: file.data, type: 'image/jpeg', quality: 0.92 }),
-          CONVERT_TIMEOUT_MS
+          CONVERT_TIMEOUT_MS,
+          'HEIC conversion timed out'
         )
 
         if (!blob?.size) throw new Error('HEIC conversion produced no data')

--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { action } from '~/composables/useClientLog'
 import { useMessageStore } from '~/stores/message'
 import api from '~/api'
 import { useAuthStore } from '~/stores/auth'
@@ -411,15 +412,25 @@ export const useComposeStore = defineStore({
     // server is simply no longer uploading.
     sanitiseRestoredAttachments() {
       let changed = false
+      let dropped = 0
+      let cleared = 0
+      let maxProgress = 0
 
       for (const message of this.messages) {
         if (!message?.attachments?.length) {
           continue
         }
 
+        for (const attachment of message.attachments) {
+          if (attachment?.uploading) {
+            maxProgress = Math.max(maxProgress, attachment.progress ?? 0)
+          }
+        }
+
         const kept = message.attachments.filter((a) => !a?.uploading || a?.id)
 
         if (kept.length !== message.attachments.length) {
+          dropped += message.attachments.length - kept.length
           message.attachments = kept
           changed = true
         }
@@ -427,6 +438,7 @@ export const useComposeStore = defineStore({
         for (const attachment of kept) {
           if (attachment?.uploading) {
             attachment.uploading = false
+            cleared++
             changed = true
           }
         }
@@ -434,6 +446,20 @@ export const useComposeStore = defineStore({
 
       if (changed) {
         this.attachmentBump++
+
+        // Reaching here means a photo was left mid-upload on this device, which
+        // is the state that used to lock people out of posting.  Cleaning it up
+        // silently means we cannot tell whether that is now rare or routine, so
+        // say so: `progress` tells us where it died, which distinguishes an
+        // interrupted upload from one that finished and then hung waiting on a
+        // reply (see composables/useFetchRetry.js).
+        action('stranded photo cleaned up on restore', {
+          event_type: 'photo_upload',
+          photo_stage: 'stranded_restore_cleaned',
+          dropped,
+          cleared,
+          max_progress: maxProgress,
+        })
       }
     },
     removeAttachment(params) {

--- a/iznik-nuxt3/stores/misc.js
+++ b/iznik-nuxt3/stores/misc.js
@@ -1,5 +1,11 @@
 import { defineStore } from 'pinia'
+import { warn } from '~/composables/useClientLog'
 // import api from '~/api' // REMOVE FROM MT AS GENERATES SOME CIRCULAR REFERENCE
+
+// How long waitForOnline() will wait for the connection to come back before
+// giving up and letting the caller fail normally.  Long enough to ride out a
+// tunnel or a lift, short enough that nothing is parked indefinitely.
+const WAIT_FOR_ONLINE_TIMEOUT_MS = 30000
 
 export const useMiscStore = defineStore({
   id: 'misc',
@@ -168,19 +174,56 @@ export const useMiscStore = defineStore({
 
       this.onlineTimer = setTimeout(this.checkOnline, 1000)
     },
-    waitForOnline() {
+    // Wait until we believe we have a connection again, but never for ever.
+    //
+    // This used to recurse once a second with no timeout and no reject, so a
+    // caller that awaited it while the connection stayed down was awaiting a
+    // promise that could never settle.  Every API request awaits this before
+    // fetching, and useFetchRetry's retryOn() awaits it again around a retry
+    // decision, so one badly-timed connection drop could park a request for
+    // the lifetime of the page with no error, no Sentry event and nothing for
+    // the caller's catch block to see.  A give-flow photo stranded that way
+    // stayed at uploading:true / 100% for good, and because the flow gates
+    // Next on anyUploading the member could not post at all (Discourse, user
+    // 3512849, 2026-08-10).
+    //
+    // Give up after WAIT_FOR_ONLINE_TIMEOUT_MS and resolve rather than reject:
+    // callers then carry on and get an ordinary fetch failure, which they
+    // already handle.  Rejecting here would instead add a new unhandled path
+    // to every call site.
+    waitForOnline(timeoutMs = WAIT_FOR_ONLINE_TIMEOUT_MS) {
       if (this.online) {
         return
       }
 
+      const startedAt = Date.now()
+
       return new Promise((resolve) => {
-        setTimeout(() => {
-          if (this.online) {
-            resolve()
-          } else {
-            this.waitForOnline().then(resolve)
-          }
-        }, 1000)
+        const poll = () => {
+          setTimeout(() => {
+            if (this.online) {
+              resolve()
+              return
+            }
+
+            const waitedMs = Date.now() - startedAt
+
+            if (waitedMs >= timeoutMs) {
+              // Surfaced so we can see this in Loki next time rather than
+              // having to infer a silent hang from its absence.
+              warn('waitForOnline gave up', {
+                event_type: 'connection_wait_abandoned',
+                waited_ms: waitedMs,
+              })
+              resolve()
+              return
+            }
+
+            poll()
+          }, 1000)
+        }
+
+        poll()
       })
     },
     setMarketingConsent(value) {

--- a/iznik-nuxt3/tests/unit/api/BaseAPI.spec.js
+++ b/iznik-nuxt3/tests/unit/api/BaseAPI.spec.js
@@ -41,6 +41,11 @@ vi.mock('@sentry/vue', () => ({
   captureMessage: mockCaptureMessage,
 }))
 
+const mockWarn = vi.fn()
+vi.mock('~/composables/useClientLog', () => ({
+  warn: (...args) => mockWarn(...args),
+}))
+
 // Mock fetchRetry to return a function that uses our mock fetch
 const mockFetch = vi.fn()
 vi.mock('~/composables/useFetchRetry', () => ({
@@ -206,6 +211,71 @@ describe('BaseAPI', () => {
       }
 
       expect(mockCaptureMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  // Two paths here deliberately return a promise that never settles, to keep
+  // expected noise (logout aborts, a stale chat 401) out of Sentry.  That is
+  // fine only while nothing is waiting on the result.  When something is, the
+  // caller's await hangs for the life of the page with no success and no catch,
+  // and any state it was going to clear stays set - which is how a give-flow
+  // photo stayed at uploading:true and locked a member out of posting.  We
+  // cannot tell from here whether anyone is waiting, so log it: the point is
+  // that a silent hang leaves no trace at all to investigate.
+  describe('requests abandoned without settling', () => {
+    it('records an aborted request, and still does not settle', async () => {
+      mockFetch.mockRejectedValue(new Error('The user aborted a request.'))
+
+      const api = createApi()
+
+      let settled = false
+      api.$requestv2('POST', '/image', {}).then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+
+      await vi.waitFor(() => expect(mockWarn).toHaveBeenCalled(), {
+        timeout: 2000,
+      })
+
+      expect(mockWarn.mock.calls[0][0]).toContain('abandoned')
+      expect(mockWarn.mock.calls[0][1]).toMatchObject({
+        event_type: 'api_abandoned',
+        reason: 'aborted',
+        api_method: 'POST',
+      })
+      expect(settled).toBe(false)
+      expect(mockCaptureMessage).not.toHaveBeenCalled()
+    })
+
+    it('records a swallowed chat 401, and still does not settle', async () => {
+      mockFetch.mockResolvedValue([401, {}])
+
+      const api = createApi()
+
+      let settled = false
+      api.$requestv2('GET', '/chat?includeClosed=true', { params: {} }).then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+
+      await vi.waitFor(() => expect(mockWarn).toHaveBeenCalled(), {
+        timeout: 2000,
+      })
+
+      expect(mockWarn.mock.calls[0][1]).toMatchObject({
+        event_type: 'api_abandoned',
+        reason: 'chat_401',
+      })
+      expect(settled).toBe(false)
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
@@ -102,9 +102,14 @@ vi.mock('@uppy/compressor', () => ({
 // Spy on the Loki action() logger so we can assert the upload/compression
 // telemetry payloads. Keep the module's other exports real.
 const mockAction = vi.hoisted(() => vi.fn())
+const mockLogError = vi.fn()
 vi.mock('~/composables/useClientLog', async (importOriginal) => {
   const actual = await importOriginal()
-  return { ...actual, action: (...args) => mockAction(...args) }
+  return {
+    ...actual,
+    action: (...args) => mockAction(...args),
+    error: (...args) => mockLogError(...args),
+  }
 })
 
 // Mock image store
@@ -1843,6 +1848,110 @@ describe('PhotoUploader', () => {
       await flushPromises()
 
       expect(viewer()).toBeNull()
+    })
+  })
+
+  // The bytes go up via tus, then we register them with the API.  That second
+  // call is what has to finish for the photo to stop being "uploading", and the
+  // give flow has no exits while it is: Next is gated on anyUploading and Skip
+  // only renders in the empty state.  So if the register call never settles the
+  // member is not just missing a photo, they cannot post at all - and compose
+  // persists that to their next visit.  This happened live: the API layer
+  // awaited a connection check that polled for ever, so a 200 that had already
+  // come back was never read (see composables/useFetchRetry.js).  That is fixed
+  // at source, but the flow should not depend on the API layer never hanging.
+  describe('registering the uploaded photo hangs', () => {
+    async function startUploadThatHangs() {
+      mockImageStore.post.mockReturnValueOnce(new Promise(() => {}))
+
+      createWrapper({ modelValue: [] })
+      await flushPromises()
+
+      wrapper.vm.processPhoto('/photo.jpg')
+      await flushPromises()
+
+      mockTusUpload._options.onProgress(100, 100)
+      mockTusUpload._options.onSuccess()
+      await flushPromises()
+    }
+
+    it('leaves the photo uploading while the register call is still outstanding', async () => {
+      vi.useFakeTimers()
+      try {
+        await startUploadThatHangs()
+
+        expect(wrapper.vm.photos[0].uploading).toBe(true)
+        expect(wrapper.vm.photos[0].progress).toBe(100)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('gives the photo up as failed rather than blocking the flow for ever', async () => {
+      vi.useFakeTimers()
+      try {
+        await startUploadThatHangs()
+
+        await vi.advanceTimersByTimeAsync(61000)
+
+        expect(wrapper.vm.photos[0].uploading).toBe(false)
+        expect(wrapper.vm.photos[0].error).toBe(true)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    // The tray syncs to the persisted compose store through a watcher that Vue
+    // stops when this component unmounts.  So if we go away while an upload is
+    // outstanding, the last thing written to the store says uploading:true, and
+    // when the upload does settle it mutates an object nothing is listening to.
+    // The store keeps uploading:true for ever, the give flow gates Next on it,
+    // and it is restored in that state on the next visit.  Live, the member
+    // navigated off the photos page 22s after the reply came back, which is
+    // what made her lockout permanent rather than momentary.
+    it('does not leave the tray saying uploading when we navigate away mid-upload', async () => {
+      // Stand in for the compose store: whatever the component last pushed out
+      // is what gets persisted and restored on the next visit.
+      const pushedOut = []
+
+      mockImageStore.post.mockReturnValueOnce(new Promise(() => {}))
+      createWrapper({
+        modelValue: [],
+        'onUpdate:modelValue': (v) => pushedOut.push(v),
+      })
+      await flushPromises()
+
+      wrapper.vm.processPhoto('/photo.jpg')
+      await flushPromises()
+      mockTusUpload._options.onProgress(100, 100)
+      mockTusUpload._options.onSuccess()
+      await flushPromises()
+
+      expect(pushedOut.length).toBeGreaterThan(0)
+      expect(pushedOut.at(-1)[0].uploading).toBe(true)
+
+      wrapper.unmount()
+      await flushPromises()
+
+      const persisted = pushedOut.at(-1)[0]
+      expect(persisted.uploading).toBe(false)
+      expect(persisted.error).toBe(true)
+    })
+
+    it('offers retry and delete once it has failed, so there is a way forward', async () => {
+      vi.useFakeTimers()
+      try {
+        await startUploadThatHangs()
+        await vi.advanceTimersByTimeAsync(61000)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      await flushPromises()
+
+      const card = wrapper.find('.photo-card')
+      expect(card.attributes('data-error')).toBe('true')
+      expect(card.attributes('data-uploading')).toBe('false')
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/composables/useFetchRetry.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useFetchRetry.spec.js
@@ -452,7 +452,6 @@ describe('useFetchRetry', () => {
   describe('retry delay calculation', () => {
     it('should use exponential delay: attempt * 1000', async () => {
       const responseData = { success: true }
-      const delayCalls = []
 
       mockFetch
         .mockRejectedValueOnce(new Error('Network error'))
@@ -486,10 +485,115 @@ describe('useFetchRetry', () => {
       })
 
       const retryFetch = fetchRetry(mockFetch)
-      const init = { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+      const init = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }
       await retryFetch('http://test.com/api', init)
 
       expect(mockFetch).toHaveBeenCalledWith('http://test.com/api', init)
+    })
+  })
+
+  // retryOn() used to await waitForOnline() as its very first act, before it
+  // had even looked at what came back.  A member whose connection dropped in
+  // the moment between sending a request and its reply arriving therefore had
+  // a perfectly good response thrown away: the online check never resolved, so
+  // the success branch was never reached and the promise never settled.
+  //
+  // Live case (2026-08-10, user 3512849): POST /apiv2/image returned 200 with
+  // image id 45508630, the app flipped offline, and PhotoUploader's
+  // `await imageStore.post()` never returned.  The photo stayed uploading:true
+  // at 100%, compose persisted it, and because the give flow gates Next on
+  // anyUploading she could not post at all until the app's storage was
+  // cleared.  Waiting for the connection is only meaningful before we make
+  // another attempt, never before reading a reply we already hold.
+  describe('connection loss while a response is in flight', () => {
+    it('delivers a response that has already arrived even if the connection check never resolves', async () => {
+      miscStore.waitForOnline = vi.fn(() => new Promise(() => {}))
+
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        json: vi.fn().mockResolvedValueOnce({ id: 45508630 }),
+      })
+
+      const retryFetch = fetchRetry(mockFetch)
+
+      let settled = null
+      retryFetch('http://test.com/image').then(
+        (r) => {
+          settled = r
+        },
+        (e) => {
+          settled = e
+        }
+      )
+
+      await vi.waitFor(() => expect(settled).not.toBeNull(), { timeout: 2000 })
+
+      expect(settled).toEqual([200, { id: 45508630 }])
+    })
+
+    it('reports a client error that has already arrived even if the connection check never resolves', async () => {
+      miscStore.waitForOnline = vi.fn(() => new Promise(() => {}))
+
+      mockFetch.mockResolvedValueOnce({
+        status: 404,
+        json: vi.fn().mockResolvedValueOnce({ error: 'nope' }),
+      })
+
+      const retryFetch = fetchRetry(mockFetch)
+
+      let settled = null
+      retryFetch('http://test.com/image').then(
+        () => {
+          settled = 'resolved'
+        },
+        (e) => {
+          settled = e
+        }
+      )
+
+      await vi.waitFor(() => expect(settled).not.toBeNull(), { timeout: 2000 })
+
+      expect(settled).toBeInstanceOf(Error)
+      expect(settled).not.toBe('resolved')
+    })
+
+    it('still waits for the connection before making another attempt', async () => {
+      let releaseOnline
+      const onlineGate = new Promise((resolve) => {
+        releaseOnline = resolve
+      })
+      miscStore.waitForOnline = vi.fn(() => onlineGate)
+
+      mockFetch
+        .mockRejectedValueOnce(new Error('Failed to fetch'))
+        .mockResolvedValueOnce({
+          status: 200,
+          json: vi.fn().mockResolvedValueOnce({ ok: true }),
+        })
+
+      const retryFetch = fetchRetry(mockFetch)
+
+      let settled = null
+      retryFetch('http://test.com/image').then((r) => {
+        settled = r
+      })
+
+      // First attempt failed, so we are about to retry - and must not until we
+      // believe we have a connection again.
+      await vi.waitFor(
+        () => expect(miscStore.waitForOnline).toHaveBeenCalled(),
+        { timeout: 2000 }
+      )
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(settled).toBeNull()
+
+      releaseOnline()
+
+      await vi.waitFor(() => expect(settled).not.toBeNull(), { timeout: 5000 })
+      expect(settled).toEqual([200, { ok: true }])
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/composables/usePromiseTimeout.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/usePromiseTimeout.spec.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { withTimeout } from '~/composables/usePromiseTimeout'
+
+describe('usePromiseTimeout', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('passes through the resolved value when the promise wins', async () => {
+    await expect(withTimeout(Promise.resolve('done'), 1000)).resolves.toBe(
+      'done'
+    )
+  })
+
+  it('passes through a rejection when the promise wins', async () => {
+    await expect(
+      withTimeout(Promise.reject(new Error('nope')), 1000)
+    ).rejects.toThrow('nope')
+  })
+
+  it('rejects once the deadline passes', async () => {
+    vi.useFakeTimers()
+
+    const settled = vi.fn()
+    withTimeout(new Promise(() => {}), 5000, 'Took too long').catch(settled)
+
+    await vi.advanceTimersByTimeAsync(4999)
+    expect(settled).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(settled).toHaveBeenCalledTimes(1)
+    expect(settled.mock.calls[0][0].message).toBe('Took too long')
+  })
+
+  it('uses a default message when none is given', async () => {
+    vi.useFakeTimers()
+
+    const settled = vi.fn()
+    withTimeout(new Promise(() => {}), 10).catch(settled)
+
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(settled.mock.calls[0][0].message).toBe('Timed out')
+  })
+
+  // A stray timer would keep the event loop (and in the app, a pending task)
+  // alive after the work has already finished.
+  it('clears its timer as soon as the promise settles', async () => {
+    vi.useFakeTimers()
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+
+    await withTimeout(Promise.resolve('quick'), 60000)
+
+    expect(clearSpy).toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/misc.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/misc.spec.js
@@ -338,7 +338,7 @@ describe('misc store', () => {
   })
 
   describe('startOnlineCheck', () => {
-    it('starts online check when no timer exists', async () => {
+    it('starts online check when no timer exists', () => {
       vi.useFakeTimers()
       const store = useMiscStore()
       store.init({ public: { APIv2: 'http://test' } })
@@ -390,6 +390,36 @@ describe('misc store', () => {
       vi.advanceTimersByTime(1000)
 
       await promise
+    })
+
+    // Every API request awaits this before fetching, and useFetchRetry's
+    // retryOn() awaits it again before deciding whether to make another
+    // attempt.  It used to poll every second for ever with no timeout and no
+    // reject, so a member who went offline at the wrong moment left a caller
+    // awaiting a promise that could never settle.  That is how a give-flow
+    // photo got stranded at uploading:true / 100% for good: the server had
+    // accepted the image (200) but PhotoUploader's `await imageStore.post()`
+    // never returned, so nothing ever cleared the flag, and compose persisted
+    // it.  Give up instead - the caller then gets a normal failure it already
+    // knows how to handle.
+    it('gives up rather than polling for ever when we stay offline', async () => {
+      vi.useFakeTimers()
+      const store = useMiscStore()
+      store.online = false
+
+      let settled = false
+      Promise.resolve(store.waitForOnline()).then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000)
+
+      expect(settled).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary

Two independent defects combined to lock a member out of posting. Either one alone would have spared her, and both are fixed here.

**Defect 1: a reply already in hand was gated on connectivity.** `useFetchRetry`'s `retryOn()` awaited `waitForOnline()` before inspecting the response, and `waitForOnline()` recursed once a second with no timeout and no reject. With `online` false, the success branch was unreachable even though the response object was already available.

**Defect 2: unmounting mid-upload persisted `uploading:true`.** `PhotoUploader` reaches the persisted compose store through a watcher that Vue stops on unmount. Leaving the photos page with an upload outstanding wrote `uploading:true / progress:100` as the final value, and a later settle mutated an object with no listener. Next is `:disabled="anyUploading"`, Skip renders only in the empty state, and compose persists, so the state is restored on every subsequent visit.

**Live case.** `POST /apiv2/image` was accepted (200, image id 45508630) with the app offline; the member left the photos page 22s later; the photo remained at 100% with Next dead across two days. Her app build predates #1271, so the hydrate cleanup was not present either. 15 members show this signature over four days, one across three days.

The absence of any retry `POST` in the API logs is what establishes the reply arrived rather than being lost: a lost reply would have been re-sent once connectivity returned, and connectivity did return.

**Invariant.** The connection check gates retries only. It does not gate reading a reply already held, and no component hands the store a transient state it can no longer correct.

### Changes
- **`composables/useFetchRetry.js`** — `retryOn` evaluates the response first; the wait lives in one `waitThenRetry` helper used by every retry path. An arrived 200 or 4xx is acted on regardless of connection state. The attempt cap, the 504 give-up and the 4xx path do not wait, because none of them retries.
- **`stores/misc.js`** — `waitForOnline` gives up after 30s, resolving rather than rejecting so callers fail through the fetch error they already handle instead of gaining a new unhandled path.
- **`components/PhotoUploader.vue`** — `onBeforeUnmount` marks any photo still uploading as failed and pushes the corrected tray out explicitly, since the watcher will not fire again. This extends the existing quality-modal rescue to uploads in flight.
- **`components/PhotoUploader.vue`** — the register-the-photo call is bounded at 60s. The bytes are already up via tus by then, so the bound catches a hang, not a slow connection; on expiry the card offers Retry and Delete.
- **`composables/usePromiseTimeout.js`** — new shared `withTimeout`; the private duplicate in `useUppyHeic` now uses it.

### Instrumentation
This class of failure produces no error, no Sentry event and no client log. Added so a recurrence identifies itself in Loki:
- `stores/compose.js` logs what `sanitiseRestoredAttachments` cleaned up, including the progress the upload died at, which separates an interrupted upload from one stalled waiting on a reply and makes the rate countable fleet-wide.
- `PhotoUploader` logs the lifecycle through `tus_complete` to `registered`, `finalise_failed` or `stranded_on_unmount`.
- `waitForOnline` logs abandoned waits with the time waited.
- `BaseAPI`'s two deliberately never-settling returns log `api_abandoned` with path and reason.

## Code Quality Review

- One helper owns the retry wait, so it cannot drift back to the top of `retryOn`.
- `waitForOnline` keeps returning `undefined` synchronously when already online; the existing test covering that still passes.
- The unmount sweep runs after the existing `pendingPhoto` rescue and emits once for both, rather than duplicating the emit.
- `withTimeout` was already duplicated in the codebase. This adds one shared copy and migrates `useUppyHeic`; the differently-shaped race in `OurUploader` is untouched.
- Three pre-existing lint errors in touched files are fixed (unused variable, format nit, `async` with no `await`). CI lints changed files only, so they had not previously surfaced.

## Known Limits

- `BaseAPI` retains two returns that never settle by design. They are logged, not changed: the abort case is safe during logout and unload, and the chat 401 case exists to keep Sentry quiet. Worth revisiting separately.
- The 60s finalise bound is a backstop, not a guarantee: a hang longer than the member's patience still costs them the photo, though no longer the flow.
- The shipped Android bundle predates #1271, so members already affected need an app release. Not addressable in code.
- `Coveralls - playwright` reports -0.02%, and nothing here can or should offset it. This branch measures **21.371%**, the same figure as #1303, #1305, #1307, #1309, #1310, #1311 and #1312 — including #1309, which changed nine covered `iznik-nuxt3/` files and did not move it. The baseline is 21.395%, set by #1313 and #1315, which changed **zero** covered frontend files yet measured higher. So the flag has at least two discrete states and this branch landed on the ordinary one. The required check, `ci/circleci: build-and-test`, is green; there is no aggregate Coveralls context on this head, so that single flag is what makes the commit state red.

## Test Plan

| Test | Behaviour without the fix |
|---|---|
| `useFetchRetry` delivers an arrived 200 when the connection check never resolves | never settles |
| `useFetchRetry` reports an arrived 4xx when the connection check never resolves | never settles |
| `useFetchRetry` gates a retry on the connection check | n/a; asserts retries stay gated |
| `misc` `waitForOnline` gives up rather than polling for ever | never settles |
| `PhotoUploader` does not leave the tray saying uploading when navigating away mid-upload | `expected true to be false` |
| `PhotoUploader` gives the photo up as failed rather than blocking the flow for ever | `expected true to be false` |
| `PhotoUploader` offers Retry and Delete once it has failed | `expected 'false' to be 'true'` |
| `usePromiseTimeout` resolve/reject passthrough, deadline, default message, timer cleanup | new module |

The `PhotoUploader` assertions were each confirmed against the unfixed code before the corresponding change was made.

Verification on this branch head:
- Full vitest suite: **728 files, 15347 tests, 0 failures**
- eslint clean on all changed files
- `check-docs-freshness.mjs`: OK across 49 pages