### PR TITLE
feat(rippling): per-community opt-out so phantom and training posts never travel

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-11
+last_reviewed: 2026-08-12
 covers:
   - iznik-batch/app/Services/Ripple/**
   - iznik-batch/app/Console/Commands/Ripple/**
@@ -287,6 +287,44 @@ so the animation you watch is the targeting decision at each step, not a geometr
 approximation of it. On by default; `RIPPLE_REACHABLE_GATE=false` is the killswitch, reverting
 targeting and retraction to the polygon-overlap test.
 
+### 4a. Communities that never ripple: phantom and training
+
+Some communities exist to hold moderator practice posts rather than real items, and their
+posts must not travel. That is a per-community switch in `groups.settings`, resolved by
+[`GroupRippleOptOut`](../../../iznik-batch/app/Services/Ripple/GroupRippleOptOut.php) and
+enforced by `ExpandService`:
+
+```json
+{ "rippling": { "out": 0, "in": 0 } }
+```
+
+- **`out` off** - a post made on the community never gets a `rippling_reach` row, so it is
+  never crossposted and never surfaces in anyone's nearby feed (both read paths hang off that
+  table). Enforced in `initialiseNew`, and unlike the arrival cutoff and the saturation stop it
+  applies to `--msgid` and area-scoped runs too: this is community policy, not a rollout guard.
+- **`in` off** - the community is never a crosspost target. Enforced in `rippleIntoNewGroups`.
+
+**Absent means on**, so every community ripples both ways unless it has been switched off, and
+anything unexpected in the value is read as on. That fail-safe direction is deliberate: wrongly
+on ripples a phantom post, which is visible and a moderator can reject the copy, whereas
+wrongly off would silently stop a real community rippling and nobody would notice for weeks.
+
+**Deliberately not a moderator setting.** Which communities are phantom is a central decision,
+so the only way to change it is `php artisan ripple:opt-out` (`--direction=out|in|both`,
+`--on` to switch back on, `--list`, `--dry-run`). Switching a direction back on removes the key
+rather than storing a truthy value.
+
+Switching `out` off also stops what is already in flight: `retractOptedOutCommunities` drops the
+reach row and pulls the copies already delivered, on the same footing as a post that has left
+the browsable set (§6). Without it, the deploy that first opts a training community out would
+leave every live practice post there expanding for the rest of its life.
+
+The older `nameshort NOT LIKE '%playground%'` test in the target query predates this and stays
+as belt-and-braces for a playground community created before anyone gives it the setting. It
+only ever covered ripple-in, and only communities named that way - `FreeglePlayground` places
+its practice posts at a real Edinburgh postcode, so before this change a practice post there
+crossposted into the live Lothians communities.
+
 ### Rejected targeting approaches
 
 - **Polygon overlap** (`ST_Intersects(group polygon, reach polygon)`). Inherits every raster
@@ -339,6 +377,8 @@ soft-deletes rippled-in copies no longer in reach, and removes the ripple-join m
 when the poster has no other live post there. A **held** reach (from a report or
 Back-to-Pending) is frozen: its copies persist for per-group moderation and are never
 retracted, so re-approval restores the copy without re-rippling.
+
+A community switching ripple-out off retracts the same way - see §4a.
 
 ## 7. Consumers of the reach
 
@@ -563,6 +603,9 @@ Design spec: `docs/superpowers/specs/2026-06-22-digest-rippling-score-ordering-d
   `max_minutes`) - how long an out-of-reach reply waits (§7a). Off reverts to release on
   coverage or backstop alone.
 - `reply_saturation_stop` (5), `hazard_hours`, `rippled_in_pending_hours` (0).
+
+Per-community rather than config: `groups.settings.rippling.{out,in}` switches rippling off for
+one community in either direction (§4a), set only via `php artisan ripple:opt-out`.
 
 ## 9. Data model
 

--- a/iznik-batch/app/Console/Commands/Ripple/OptOutCommand.php
+++ b/iznik-batch/app/Console/Commands/Ripple/OptOutCommand.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Console\Commands\Ripple;
+
+use App\Services\Ripple\GroupRippleOptOut;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * ripple:opt-out — switch rippling off (or back on) for a community, in either direction.
+ *
+ * Deliberately NOT a moderator setting. This is a central decision about phantom and
+ * moderator-training communities, not something a community configures for itself, so the
+ * only way to set it is this command. It writes groups.settings.rippling, which
+ * App\Services\Ripple\GroupRippleOptOut reads and ExpandService enforces:
+ *
+ *   out = 0  posts made on the community never start rippling. Anything already rippling
+ *            there is retracted on the next ripple:expand run (its reach row is dropped and
+ *            the copies already delivered are pulled).
+ *   in  = 0  the community is never a crosspost target for anyone else's posts.
+ *
+ * Absent means on, so switching a direction back on REMOVES the key rather than writing a 1.
+ *
+ *   php artisan ripple:opt-out FreeglePlayground             # both directions off
+ *   php artisan ripple:opt-out OuterHebridesFreegle --direction=out
+ *   php artisan ripple:opt-out FreegleFreshers2 --on         # undo, both directions
+ *   php artisan ripple:opt-out --list
+ *
+ * Read-modify-writes the whole settings blob in PHP rather than using MySQL JSON_SET, because
+ * JSON_SET will not create `$.rippling.out` when `$.rippling` is missing (or is a scalar), so
+ * the SQL form silently does nothing on exactly the communities that have never had it set.
+ */
+class OptOutCommand extends Command
+{
+    protected $signature = 'ripple:opt-out
+                            {group?* : Community nameshort or id (repeatable)}
+                            {--direction=both : Which direction to change - out, in or both}
+                            {--on : Switch rippling back ON for these communities instead of off}
+                            {--list : List the communities that currently have rippling switched off, then exit}
+                            {--dry-run : Report what would change without writing}';
+
+    protected $description = 'Switch rippling off (or back on) for a community - phantom and training communities only';
+
+    public function handle(GroupRippleOptOut $optOut): int
+    {
+        if ($this->option('list')) {
+            return $this->listOptOuts($optOut);
+        }
+
+        $directions = $this->directions();
+        if ($directions === null) {
+            $this->error('--direction must be one of: out, in, both');
+
+            return Command::INVALID;
+        }
+
+        $names = (array) $this->argument('group');
+        if (empty($names)) {
+            $this->error('Name at least one community, or pass --list. See --help for examples.');
+
+            return Command::INVALID;
+        }
+
+        $groups = [];
+        foreach ($names as $name) {
+            $group = $this->resolveGroup((string) $name);
+            if ($group === null) {
+                $this->error("No community matches '$name' - give its exact nameshort or its id.");
+
+                return Command::FAILURE;
+            }
+            $groups[] = $group;
+        }
+
+        $switchOn = (bool) $this->option('on');
+        $dryRun = (bool) $this->option('dry-run');
+
+        foreach ($groups as $group) {
+            $settings = json_decode((string) $group->settings, true);
+            if (!is_array($settings)) {
+                // Empty, null or unparseable - start a fresh object rather than lose the write.
+                $settings = [];
+            }
+            $rippling = (isset($settings['rippling']) && is_array($settings['rippling']))
+                ? $settings['rippling']
+                : [];
+
+            foreach ($directions as $direction) {
+                if ($switchOn) {
+                    // Absent means on, so remove the key rather than storing a 1. That also lets
+                    // the community drop out of GroupRippleOptOut's `settings LIKE '%rippling%'`
+                    // prefilter once both directions are back on.
+                    unset($rippling[$direction]);
+                } else {
+                    $rippling[$direction] = 0;
+                }
+            }
+
+            if (empty($rippling)) {
+                unset($settings['rippling']);
+            } else {
+                $settings['rippling'] = $rippling;
+            }
+
+            $encoded = json_encode($settings);
+            $verb = $switchOn ? 'ON' : 'OFF';
+            $what = implode(' and ', $directions);
+
+            if ($dryRun) {
+                $this->line("Would switch rippling $verb ($what) for {$group->nameshort} (#{$group->id}): $encoded");
+                continue;
+            }
+
+            DB::table('groups')->where('id', $group->id)->update(['settings' => $encoded]);
+            $this->info("Rippling $verb ($what) for {$group->nameshort} (#{$group->id}).");
+            Log::info("ripple: rippling switched $verb ($what) for group {$group->id} ({$group->nameshort}) by ripple:opt-out");
+        }
+
+        if (!$dryRun && !$switchOn) {
+            $this->newLine();
+            $this->line('Posts already rippling from these communities are retracted on the next');
+            $this->line('ripple:expand run - their reach rows are dropped and delivered copies pulled.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * The directions this invocation changes.
+     *
+     * @return list<string>|null null when --direction is not a recognised value
+     */
+    private function directions(): ?array
+    {
+        return match ((string) $this->option('direction')) {
+            'both' => [GroupRippleOptOut::DIRECTION_OUT, GroupRippleOptOut::DIRECTION_IN],
+            'out' => [GroupRippleOptOut::DIRECTION_OUT],
+            'in' => [GroupRippleOptOut::DIRECTION_IN],
+            default => null,
+        };
+    }
+
+    /** Exact nameshort (the identifier moderators use) or a numeric id. */
+    private function resolveGroup(string $name): ?object
+    {
+        $q = DB::table('groups')->select('id', 'nameshort', 'settings');
+
+        return ctype_digit($name)
+            ? $q->where('id', (int) $name)->first()
+            : $q->where('nameshort', $name)->first();
+    }
+
+    private function listOptOuts(GroupRippleOptOut $optOut): int
+    {
+        $out = $optOut->excludedGroupIds(GroupRippleOptOut::DIRECTION_OUT);
+        $in = $optOut->excludedGroupIds(GroupRippleOptOut::DIRECTION_IN);
+        $ids = array_unique(array_merge($out, $in));
+
+        if (empty($ids)) {
+            $this->info('Every community ripples in both directions - nothing has opted out.');
+
+            return Command::SUCCESS;
+        }
+
+        $names = DB::table('groups')->whereIn('id', $ids)->orderBy('nameshort')->pluck('nameshort', 'id');
+
+        $rows = [];
+        foreach ($names as $id => $nameshort) {
+            $rows[] = [
+                $id,
+                $nameshort,
+                in_array((int) $id, $out, true) ? 'OFF' : 'on',
+                in_array((int) $id, $in, true) ? 'OFF' : 'on',
+            ];
+        }
+
+        $this->table(['id', 'nameshort', 'ripple out', 'ripple in'], $rows);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -34,16 +34,41 @@ class ExpandService
     /** Chooses each post's reach budget from how thinly freeglers are spread around it. */
     private DensityService $density;
 
+    /** Which communities have switched rippling off, per direction (groups.settings.rippling). */
+    private GroupRippleOptOut $optOut;
+
+    /** Releases held replies when a post's reach is dropped by an opt-out. */
+    private RippleReplyService $replies;
+
     /** Memoized rippling_reach density-column check, so a pre-migration deploy is a no-op. */
     private static ?bool $densityColumns = null;
 
     public function __construct(
         private ReachService $reach,
         ?ReachBoundsService $bounds = null,
-        ?DensityService $density = null
+        ?DensityService $density = null,
+        ?GroupRippleOptOut $optOut = null,
+        ?RippleReplyService $replies = null
     ) {
         $this->bounds = $bounds ?? new ReachBoundsService();
         $this->density = $density ?? new DensityService();
+        $this->optOut = $optOut ?? new GroupRippleOptOut();
+        $this->replies = $replies ?? new RippleReplyService(new ReachQueryService());
+    }
+
+    /**
+     * SQL fragment (leading " AND ...") excluding the communities that have opted out of
+     * the given rippling direction, or '' when none have. Every id is a DB int, so the
+     * inline list cannot inject — same shape as the reachable-gate clause below.
+     */
+    private function optOutClause(string $column, string $direction): string
+    {
+        $ids = $this->optOut->excludedGroupIds($direction);
+        if (empty($ids)) {
+            return '';
+        }
+
+        return ' AND ' . $column . ' NOT IN (' . implode(',', $ids) . ')';
     }
 
     /** Has the density-sizing migration run? Without it the cap still applies, unrecorded. */
@@ -160,6 +185,11 @@ class ExpandService
         // 1b. Pull rippled-in posts from any group whose poster has actively left it, so a
         //     leave removes the poster's post from that group (not just their membership).
         $this->pullRippledPostsFromLeftGroups($dryRun, $stats, $onlyMsgid);
+        // 1c. Stop-and-retract for posts on a community that has since switched ripple-OUT off
+        //     (groups.settings.rippling.out). initialiseNew's gate only stops NEW posts, so
+        //     without this a community that opts out keeps expanding everything it had already
+        //     started - including on the deploy that first gives it the setting.
+        $this->retractOptedOutCommunities($dryRun, $stats, $onlyMsgid);
 
         // 2. Initialise reach for posts new to messages_spatial.
         $this->initialiseNew($dryRun, $limit, $stats, $onlyMsgid, $withinPolyWkt);
@@ -321,6 +351,7 @@ class ExpandService
         if ($wkt === '') {
             return 0;
         }
+        // keep-raw: ST_Intersects/ST_GeometryType against a WKT literal - spatial predicates the builder cannot render
         $row = DB::selectOne(
             "SELECT COUNT(*) AS c
              FROM `groups` g
@@ -330,7 +361,8 @@ class ExpandService
                AND g.nameshort NOT LIKE '%playground%'
                AND g.polyindex IS NOT NULL
                AND ST_GeometryType(g.polyindex) <> 'POINT'
-               AND ST_Intersects(g.polyindex, ST_GeomFromText(?, " . self::SRID . "))",
+               AND ST_Intersects(g.polyindex, ST_GeomFromText(?, " . self::SRID . "))"
+            . $this->optOutClause('g.id', GroupRippleOptOut::DIRECTION_IN),
             [$wkt]
         );
         return (int) ($row->c ?? 0);
@@ -389,6 +421,80 @@ class ExpandService
         } catch (\Throwable $e) {
             $stats['errors']++;
             Log::warning("ripple: remove-stale-and-retract failed: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * Stop-and-retract every post whose community has switched ripple-OUT off
+     * (groups.settings.rippling.out) since the post started rippling.
+     *
+     * initialiseNew's opt-out gate only keeps NEW posts from starting, so on its own it would
+     * leave a phantom or training community's in-flight ripples expanding for the rest of their
+     * life - and on the deploy that first writes the setting, EVERY live practice post there
+     * would keep going. This closes that: drop the reach row (which stops expansion and takes the
+     * post out of every reach-driven read path), pull the copies already delivered - exactly as
+     * removeStaleAndRetract does for a post that has left the browsable set - and release any
+     * replies still held against the reach we are dropping.
+     *
+     * Skips 'held' rows for the same reason the other retraction paths do: their copies are
+     * deliberately Pending for per-group moderation. A held post that is later re-approved
+     * flips back out of 'held' and is caught by the next run of this pass.
+     *
+     * Scope: only --msgid restricts it, matching removeStaleAndRetract - retracting a committed
+     * copy must complete regardless of the current area scope.
+     */
+    private function retractOptedOutCommunities(bool $dryRun, array &$stats, ?int $onlyMsgid = null): void
+    {
+        try {
+            $excluded = $this->optOut->excludedGroupIds(GroupRippleOptOut::DIRECTION_OUT);
+            if (empty($excluded)) {
+                return;
+            }
+
+            // ms.groupid is the post's own community (messages_spatial.msgid is UNIQUE). A post
+            // whose community opted out is matched here however far it had already spread.
+            $q = DB::table('rippling_reach as mr')
+                ->join('messages_spatial as ms', 'ms.msgid', '=', 'mr.msgid')
+                ->where('mr.status', '<>', 'held')
+                ->whereIn('ms.groupid', $excluded);
+            if ($onlyMsgid !== null) {
+                $q->where('mr.msgid', $onlyMsgid);
+            }
+            $msgids = $q->pluck('mr.msgid')->map(static fn ($id) => (int) $id)->all();
+            if (empty($msgids)) {
+                return;
+            }
+
+            if ($dryRun) {
+                $stats['removed'] += count($msgids);
+                $stats['pulled_on_removal'] += (int) DB::table('messages_groups')
+                    ->whereIn('msgid', $msgids)
+                    ->where('rippled_in', 1)
+                    ->where('deleted', 0)
+                    ->count();
+
+                return;
+            }
+
+            foreach ($msgids as $msgid) {
+                $this->retractRippledCopiesForRemovedPost($msgid, $stats);
+                // Release any still-held replies BEFORE dropping the reach row. The post is live
+                // (it is still in messages_spatial), so these replies are real people waiting on
+                // a ripple that is never coming: with no reach row, ripple:release-replies takes
+                // the "transiently absent, wait for re-initialisation" branch and would hold them
+                // for ever, and initialiseNew will never re-create the row. Releasing hands them
+                // to the offerer, which is what would have happened when the reach reached them.
+                // (Replies made from here on are not held at all - the Go gate only holds when a
+                // reach row exists, so it fails open.)
+                $stats['released_on_opt_out'] = ($stats['released_on_opt_out'] ?? 0)
+                    + $this->replies->releaseAll($msgid, 'community-opted-out');
+                DB::table('rippling_reach')->where('msgid', $msgid)->delete();
+                $stats['removed']++;
+                Log::info("ripple: retracted $msgid - its community has rippling switched off");
+            }
+        } catch (\Throwable $e) {
+            $stats['errors']++;
+            Log::warning("ripple: retract-opted-out-communities failed: {$e->getMessage()}");
         }
     }
 
@@ -744,7 +850,24 @@ class ExpandService
         }
         $params[] = $limit;
 
+        // Ripple-OUT opt-out (groups.settings.rippling.out): a post on a community that has
+        // switched rippling off never gets a reach row, so it is never crossposted and never
+        // appears in another member's nearby feed (both read paths hang off rippling_reach).
+        // This is a community-level policy rather than a rollout guard, so unlike the arrival
+        // cutoff and the saturation stop it applies to --msgid and area runs too.
+        //
+        // messages_spatial.msgid is UNIQUE, so ms.groupid is the post's single recorded
+        // community. A candidate here has no reach row, hence has never rippled, so that
+        // recorded community is one it was posted to directly rather than rippled into. The
+        // NULL arm matters: groupid is nullable and `NULL NOT IN (...)` is NULL, which would
+        // silently drop every group-less row from the candidate set.
+        $outOptOut = $this->optOut->excludedGroupIds(GroupRippleOptOut::DIRECTION_OUT);
+        $optOutSql = empty($outOptOut)
+            ? ''
+            : ' AND (ms.groupid IS NULL OR ms.groupid NOT IN (' . implode(',', $outOptOut) . '))';
+
         // Candidate source: live posts with NO reach row yet (anti-join).
+        // keep-raw: ANY_VALUE + the ST_X/ST_Y spatial accessors on a GROUP BY the builder cannot render
         $rows = DB::select(
             'SELECT ms.msgid AS msgid,
                     ANY_VALUE(ST_Y(ms.point)) AS lat,
@@ -752,7 +875,7 @@ class ExpandService
                     MIN(ms.arrival) AS arrival
              FROM messages_spatial ms
              LEFT JOIN rippling_reach mr ON mr.msgid = ms.msgid
-             WHERE mr.msgid IS NULL' . $scopeSql . $cutoffSql . $satSql . '
+             WHERE mr.msgid IS NULL' . $scopeSql . $cutoffSql . $satSql . $optOutSql . '
              GROUP BY ms.msgid
              LIMIT ?',
             $params
@@ -1295,13 +1418,21 @@ class ExpandService
                 ? ' AND g.id IN (' . implode(',', array_map('intval', $reachableGroupIds)) . ')'
                 : '';
 
+            // Ripple-IN opt-out (groups.settings.rippling.in): never crosspost into a community
+            // that has switched rippling off. The `%playground%` name test below predates this
+            // and stays as belt-and-braces for a playground community created before anyone gives
+            // it the setting; the setting is the deliberate, per-community mechanism (set by
+            // ripple:opt-out), and the only one that also covers ripple-OUT (see initialiseNew).
+            $inOptOut = $this->optOutClause('g.id', GroupRippleOptOut::DIRECTION_IN);
+
+            // keep-raw: ST_Intersects/ST_GeometryType plus the correlated logs/ban NOT EXISTS arms the builder cannot render
             $targetGroups = DB::select(
                 "SELECT g.id
                  FROM `groups` g
                  WHERE g.publish = 1
                    AND g.type = 'Freegle'
                    AND g.onhere = 1
-                   AND g.nameshort NOT LIKE '%playground%'
+                   AND g.nameshort NOT LIKE '%playground%'" . $inOptOut . "
                    AND g.polyindex IS NOT NULL
                    AND ST_GeometryType(g.polyindex) <> 'POINT'
                    AND ST_Intersects(g.polyindex, ST_GeomFromText(?, " . self::SRID . "))" . $reachableGate . "

--- a/iznik-batch/app/Services/Ripple/GroupRippleOptOut.php
+++ b/iznik-batch/app/Services/Ripple/GroupRippleOptOut.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services\Ripple;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Per-community rippling opt-out, stored in `groups.settings`:
+ *
+ *     { "rippling": { "out": 0, "in": 0 } }
+ *
+ *   out = off  -> posts made ON this community never start rippling, so nothing
+ *                 posted here is ever crossposted elsewhere or surfaced in another
+ *                 member's nearby feed (ExpandService::initialiseNew skips them, and
+ *                 any reach they already had is retracted).
+ *   in  = off  -> other communities' posts are never rippled INTO this one
+ *                 (ExpandService::rippleIntoNewGroups skips it as a target).
+ *
+ * The two directions are separate because they are separate decisions: a community
+ * that doesn't want the extra moderation load of rippled-in posts may still be happy
+ * for its own posts to travel, and vice versa.
+ *
+ * ABSENT MEANS ON. Every community ripples in both directions unless it has explicitly
+ * said otherwise, so deploying this changes nothing until a setting is written.
+ *
+ * Set ONLY by `php artisan ripple:opt-out` (App\Console\Commands\Ripple\OptOutCommand).
+ * Deliberately not exposed to moderators: which communities are phantom is a central
+ * decision, not something a community configures for itself.
+ *
+ * Why the phantom/training communities need it: FreeglePlayground places its practice
+ * posts at a real Edinburgh postcode, and before this the only exclusion rippling knew
+ * about was `nameshort NOT LIKE '%playground%'` on the ripple-IN target list. Nothing
+ * gated ripple-OUT at all, so a practice post would crosspost into the real Lothians
+ * communities and show up in real members' nearby feeds.
+ *
+ * Resolution happens in PHP, not in MySQL JSON SQL, deliberately: a JSON null CASTs to
+ * 0, so an SQL truth test would read a malformed value as "opted out" and silently stop
+ * a real community rippling. See isOff() for the fail-safe direction.
+ */
+class GroupRippleOptOut
+{
+    /** Posts made on the community spreading outwards. */
+    public const DIRECTION_OUT = 'out';
+
+    /** Other communities' posts being rippled in. */
+    public const DIRECTION_IN = 'in';
+
+    /** @var array<string, list<int>>|null Memoized for the life of the instance (one batch run). */
+    private ?array $excluded = null;
+
+    /**
+     * Group ids that have opted OUT of the given direction.
+     *
+     * Returned as a plain int list so callers can splice it straight into SQL — every
+     * element comes from the DB as an int, so there is nothing to inject.
+     *
+     * @return list<int>
+     */
+    public function excludedGroupIds(string $direction): array
+    {
+        if ($this->excluded === null) {
+            $this->excluded = $this->load();
+        }
+
+        return $this->excluded[$direction] ?? [];
+    }
+
+    /** True when the community still permits rippling in the given direction. */
+    public function permits(int $groupid, string $direction): bool
+    {
+        return !in_array($groupid, $this->excludedGroupIds($direction), true);
+    }
+
+    /** Test-only: forget the memoized set after changing a group's settings mid-test. */
+    public function forget(): void
+    {
+        $this->excluded = null;
+    }
+
+    /**
+     * Read every community that has a `rippling` entry in its settings and sort the
+     * opt-outs by direction.
+     *
+     * The LIKE is a cheap prefilter on a ~2k-row table (settings is a small blob and
+     * almost no community sets this), so the common case decodes a handful of rows.
+     *
+     * @return array<string, list<int>>
+     */
+    private function load(): array
+    {
+        $excluded = [self::DIRECTION_OUT => [], self::DIRECTION_IN => []];
+
+        $rows = DB::table('groups')
+            ->where('settings', 'like', '%rippling%')
+            ->get(['id', 'settings']);
+
+        foreach ($rows as $row) {
+            $settings = json_decode((string) $row->settings, true);
+            if (!is_array($settings) || !isset($settings['rippling']) || !is_array($settings['rippling'])) {
+                continue;
+            }
+
+            foreach ([self::DIRECTION_OUT, self::DIRECTION_IN] as $direction) {
+                if (!array_key_exists($direction, $settings['rippling'])) {
+                    continue;
+                }
+                if (self::isOff($settings['rippling'][$direction])) {
+                    $excluded[$direction][] = (int) $row->id;
+                }
+            }
+        }
+
+        return $excluded;
+    }
+
+    /**
+     * Is this stored value an explicit "off"?
+     *
+     * ripple:opt-out and the seeding migration both write integer 0, but a hand-edited blob
+     * may hold a real JSON boolean or a string, so all the plausible spellings of false count.
+     *
+     * Everything else, INCLUDING a malformed or unexpected value, leaves rippling ON. The
+     * fail-safe direction matters: wrongly-on ripples a phantom post (visible, and a mod
+     * can reject the copy), wrongly-off silently stops a real community rippling and
+     * nobody would notice for weeks.
+     */
+    private static function isOff(mixed $value): bool
+    {
+        return $value === false || $value === 0 || $value === '0' || $value === 'false';
+    }
+}

--- a/iznik-batch/database/migrations/2026_08_12_000001_opt_phantom_communities_out_of_rippling.php
+++ b/iznik-batch/database/migrations/2026_08_12_000001_opt_phantom_communities_out_of_rippling.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Switches rippling off, both directions, for the phantom and moderator-training
+ * communities: `{"rippling": {"out": 0, "in": 0}}` in groups.settings.
+ *
+ * These communities carry practice posts, not real ones. Before this the only exclusion
+ * rippling knew about was `nameshort NOT LIKE '%playground%'` on the ripple-IN target
+ * list, and nothing gated ripple-OUT at all - so a FreeglePlayground practice post, which
+ * is placed at a real Edinburgh postcode, would crosspost into the live Lothians
+ * communities and surface in real members' nearby feeds. See
+ * App\Services\Ripple\GroupRippleOptOut.
+ *
+ * Matched by name so it is portable across prod, dev and the test databases (group ids
+ * differ), plus Outer Hebrides Freegle by nameshort - it is a phantom community whose area
+ * is the real Outer Hebrides, so it does not follow the naming convention.
+ *
+ * Data-only and idempotent: re-running writes the same value. JSON_SET merges into whatever
+ * else is in settings rather than replacing the blob, and the CASE guards the handful of
+ * rows whose settings is empty or not valid JSON (JSON_SET would error on those).
+ */
+return new class extends Migration
+{
+    /** Communities that must never ripple, matched by name rather than id. */
+    private const WHERE = "(nameshort LIKE '%playground%'
+                            OR nameshort LIKE '%fresher%'
+                            OR nameshort = 'OuterHebridesFreegle')";
+
+    public function up(): void
+    {
+        if (!Schema::hasTable('groups') || !Schema::hasColumn('groups', 'settings')) {
+            return;
+        }
+
+        DB::statement(
+            "UPDATE `groups`
+                SET settings = JSON_SET(
+                        CASE WHEN settings IS NOT NULL AND JSON_VALID(settings)
+                             THEN settings ELSE '{}' END,
+                        '$.rippling', CAST('{\"out\": 0, \"in\": 0}' AS JSON))
+              WHERE " . self::WHERE
+        );
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('groups') || !Schema::hasColumn('groups', 'settings')) {
+            return;
+        }
+
+        DB::statement(
+            "UPDATE `groups`
+                SET settings = JSON_REMOVE(settings, '$.rippling')
+              WHERE settings IS NOT NULL AND JSON_VALID(settings)
+                AND JSON_EXTRACT(settings, '$.rippling') IS NOT NULL
+                AND " . self::WHERE
+        );
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_12_000001_opt_phantom_communities_out_of_rippling_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_12_000001_opt_phantom_communities_out_of_rippling_migration.sql
@@ -1,0 +1,31 @@
+-- Production idempotent SQL: switch rippling off for the phantom / moderator-training
+-- communities.
+--
+-- Data-only (no DDL), so it is safe to run on a live node at any time and safe to re-run:
+-- JSON_SET writes the same value each time and merges into the rest of settings rather
+-- than replacing the blob. The CASE guards rows whose settings is empty or not valid
+-- JSON, which JSON_SET would otherwise error on.
+--
+-- These communities carry moderator practice posts. FreeglePlayground places its at a real
+-- Edinburgh postcode, and before the paired code change nothing gated ripple-OUT at all, so
+-- those practice posts would crosspost into the live Lothians communities and show up in
+-- real members' nearby feeds. Outer Hebrides Freegle is listed by name because it is a
+-- phantom community whose area is the real Outer Hebrides, so it does not follow the
+-- '%fresher%'/'%playground%' naming convention.
+--
+-- Matched by name, not id, so the same statement is correct on prod, dev and test.
+UPDATE `groups`
+   SET settings = JSON_SET(
+           CASE WHEN settings IS NOT NULL AND JSON_VALID(settings)
+                THEN settings ELSE '{}' END,
+           '$.rippling', CAST('{"out": 0, "in": 0}' AS JSON))
+ WHERE (nameshort LIKE '%playground%'
+        OR nameshort LIKE '%fresher%'
+        OR nameshort = 'OuterHebridesFreegle');
+
+-- Verify: every matched community should read {"out": 0, "in": 0}.
+SELECT id, nameshort, JSON_EXTRACT(settings, '$.rippling') AS rippling
+  FROM `groups`
+ WHERE (nameshort LIKE '%playground%'
+        OR nameshort LIKE '%fresher%'
+        OR nameshort = 'OuterHebridesFreegle');

--- a/iznik-batch/tests/Unit/Commands/Ripple/OptOutCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Ripple/OptOutCommandTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Unit\Commands\Ripple;
+
+use App\Services\Ripple\GroupRippleOptOut;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class OptOutCommandTest extends TestCase
+{
+    /**
+     * The stored rippling object for a group, decoded and key-sorted.
+     *
+     * Sorted because groups.settings is longtext: a PHP write keeps its key order verbatim,
+     * but anything that goes through a MySQL JSON function (as the seeding migration does)
+     * comes back with the keys normalised. Assertions here should not care which wrote it.
+     */
+    private function rippling(int $groupid): ?array
+    {
+        $settings = json_decode((string) DB::table('groups')->where('id', $groupid)->value('settings'), true);
+        if (!is_array($settings) || !isset($settings['rippling']) || !is_array($settings['rippling'])) {
+            return null;
+        }
+        $rippling = $settings['rippling'];
+        ksort($rippling);
+
+        return $rippling;
+    }
+
+    public function test_switches_both_directions_off_by_name(): void
+    {
+        $group = $this->createTestGroup();
+
+        $this->artisan('ripple:opt-out', ['group' => [$group->nameshort]])
+            ->expectsOutputToContain('Rippling OFF')
+            ->assertExitCode(0);
+
+        $this->assertSame(['in' => 0, 'out' => 0], $this->rippling((int) $group->id));
+        $optOut = new GroupRippleOptOut();
+        $this->assertFalse($optOut->permits((int) $group->id, GroupRippleOptOut::DIRECTION_OUT));
+        $this->assertFalse($optOut->permits((int) $group->id, GroupRippleOptOut::DIRECTION_IN));
+    }
+
+    public function test_accepts_a_group_id_as_well_as_a_nameshort(): void
+    {
+        $group = $this->createTestGroup();
+
+        $this->artisan('ripple:opt-out', ['group' => [(string) $group->id]])->assertExitCode(0);
+
+        $this->assertSame(['in' => 0, 'out' => 0], $this->rippling((int) $group->id));
+    }
+
+    /** One direction at a time, so a community can stop its own posts travelling but still receive. */
+    public function test_direction_option_changes_only_that_direction(): void
+    {
+        $group = $this->createTestGroup();
+
+        $this->artisan('ripple:opt-out', ['group' => [$group->nameshort], '--direction' => 'out'])
+            ->assertExitCode(0);
+
+        $this->assertSame(['out' => 0], $this->rippling((int) $group->id));
+    }
+
+    /**
+     * Absent means on, so switching back on REMOVES the key rather than storing a 1 - and when
+     * both directions are back on the rippling object goes entirely, which drops the community
+     * out of the resolver's prefilter.
+     */
+    public function test_on_removes_the_setting_rather_than_storing_a_truthy_value(): void
+    {
+        $group = $this->createTestGroup();
+        DB::table('groups')->where('id', $group->id)->update(['settings' => '{"rippling": {"out": 0, "in": 0}}']);
+
+        $this->artisan('ripple:opt-out', ['group' => [$group->nameshort], '--direction' => 'in', '--on' => true])
+            ->expectsOutputToContain('Rippling ON')
+            ->assertExitCode(0);
+        $this->assertSame(['out' => 0], $this->rippling((int) $group->id), 'only the in key is removed');
+
+        $this->artisan('ripple:opt-out', ['group' => [$group->nameshort], '--on' => true])->assertExitCode(0);
+        $this->assertNull($this->rippling((int) $group->id), 'the whole rippling object goes when nothing is off');
+    }
+
+    /** Other settings must survive: the command merges rather than replacing the blob. */
+    public function test_preserves_other_settings(): void
+    {
+        $group = $this->createTestGroup();
+        DB::table('groups')->where('id', $group->id)->update(['settings' => '{"showjoin": 5, "closed": true}']);
+
+        $this->artisan('ripple:opt-out', ['group' => [$group->nameshort]])->assertExitCode(0);
+
+        $settings = json_decode((string) DB::table('groups')->where('id', $group->id)->value('settings'), true);
+        $this->assertSame(5, $settings['showjoin']);
+        $this->assertTrue($settings['closed']);
+        $this->assertSame(['in' => 0, 'out' => 0], $this->rippling((int) $group->id));
+    }
+
+    /**
+     * MySQL's JSON_SET cannot create `$.rippling.out` when `$.rippling` is missing, which is
+     * exactly the state of every community that has never had this set - so the command does the
+     * JSON in PHP. This is the regression guard for that.
+     */
+    public function test_writes_the_setting_when_settings_is_empty_or_unparseable(): void
+    {
+        foreach ([null, '', '{}', 'not json at all'] as $starting) {
+            $group = $this->createTestGroup();
+            DB::table('groups')->where('id', $group->id)->update(['settings' => $starting]);
+
+            $this->artisan('ripple:opt-out', ['group' => [$group->nameshort], '--direction' => 'out'])
+                ->assertExitCode(0);
+
+            $this->assertSame(
+                ['out' => 0],
+                $this->rippling((int) $group->id),
+                'the setting lands whatever settings started as: ' . var_export($starting, true)
+            );
+        }
+    }
+
+    public function test_dry_run_writes_nothing(): void
+    {
+        $group = $this->createTestGroup();
+
+        $this->artisan('ripple:opt-out', ['group' => [$group->nameshort], '--dry-run' => true])
+            ->expectsOutputToContain('Would switch rippling OFF')
+            ->assertExitCode(0);
+
+        $this->assertNull($this->rippling((int) $group->id));
+    }
+
+    public function test_rejects_an_unknown_community(): void
+    {
+        $this->artisan('ripple:opt-out', ['group' => ['NoSuchCommunity_zzz']])
+            ->expectsOutputToContain('No community matches')
+            ->assertExitCode(1);
+    }
+
+    public function test_rejects_a_bad_direction(): void
+    {
+        $group = $this->createTestGroup();
+
+        $this->artisan('ripple:opt-out', ['group' => [$group->nameshort], '--direction' => 'sideways'])
+            ->expectsOutputToContain('--direction must be one of')
+            ->assertExitCode(2);
+
+        $this->assertNull($this->rippling((int) $group->id), 'a bad direction writes nothing');
+    }
+
+    public function test_requires_a_community_or_list(): void
+    {
+        $this->artisan('ripple:opt-out')
+            ->expectsOutputToContain('Name at least one community')
+            ->assertExitCode(2);
+    }
+
+    public function test_list_reports_the_current_opt_outs(): void
+    {
+        $group = $this->createTestGroup();
+        DB::table('groups')->where('id', $group->id)->update(['settings' => '{"rippling": {"out": 0}}']);
+
+        $this->artisan('ripple:opt-out', ['--list' => true])
+            ->expectsOutputToContain($group->nameshort)
+            ->assertExitCode(0);
+    }
+
+    /** Several communities in one go, since they are set as a group. */
+    public function test_handles_several_communities_at_once(): void
+    {
+        $a = $this->createTestGroup();
+        $b = $this->createTestGroup();
+
+        $this->artisan('ripple:opt-out', ['group' => [$a->nameshort, $b->nameshort]])->assertExitCode(0);
+
+        $this->assertSame(['in' => 0, 'out' => 0], $this->rippling((int) $a->id));
+        $this->assertSame(['in' => 0, 'out' => 0], $this->rippling((int) $b->id));
+    }
+
+    /** An unknown name in the list stops the whole run, so a typo cannot half-apply. */
+    public function test_an_unknown_name_aborts_before_writing_anything(): void
+    {
+        $good = $this->createTestGroup();
+
+        $this->artisan('ripple:opt-out', ['group' => [$good->nameshort, 'NoSuchCommunity_zzz']])
+            ->assertExitCode(1);
+
+        $this->assertNull($this->rippling((int) $good->id), 'nothing is written when any name is unknown');
+    }
+}

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -9,6 +9,7 @@ use App\Models\MessageGroup;
 use App\Models\User;
 use App\Services\Ripple\ExpandService;
 use App\Services\Ripple\ReachService;
+use App\Services\Ripple\RippleReplyService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
@@ -32,6 +33,7 @@ class ExpandServiceTest extends TestCase
         config(['freegle.ripple.active_end_hour' => 24]);
         // Disable the go-live arrival cutoff so fixtures with back-dated arrivals still ripple.
         config(['freegle.ripple.enabled_at' => '']);
+        DB::statement('DELETE FROM rippling_held_replies');
         DB::statement('DELETE FROM rippling_reach');
         DB::statement('DELETE FROM messages_spatial');
     }
@@ -1344,6 +1346,219 @@ class ExpandServiceTest extends TestCase
         $this->assertNull(
             DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $playgroundGroup->id)->first(),
             'playground group is never rippled into even when the reach covers it'
+        );
+    }
+
+    /**
+     * A community with settings.rippling.in = 0 is never a crosspost target, even when the
+     * reach fully covers its area. This is the mechanism the phantom and training communities
+     * use - the older `%playground%` name test only ever covered communities named that way.
+     */
+    public function test_community_that_has_switched_ripple_in_off_is_not_rippled_into(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+
+        $area = 'POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))';
+
+        // Opted out of ripple-IN, area fully inside the reach.
+        $optedOut = $this->createTestGroup();
+        DB::statement(
+            'UPDATE `groups` SET publish = 1, settings = ?, polyindex = ST_GeomFromText(?, 3857) WHERE id = ?',
+            ['{"rippling": {"in": 0}}', $area, $optedOut->id]
+        );
+
+        // Control: same area, no setting — proves the reach really does cover it.
+        $normalGroup = $this->createTestGroup();
+        DB::statement(
+            'UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, 3857) WHERE id = ?',
+            [$area, $normalGroup->id]
+        );
+
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertNotNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $normalGroup->id)->first(),
+            'a community with no setting within reach is still rippled into'
+        );
+        $this->assertGreaterThanOrEqual(1, $stats['rippled_in']);
+
+        $this->assertNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $optedOut->id)->first(),
+            'a community with rippling.in = 0 is never rippled into, however well the reach covers it'
+        );
+    }
+
+    /**
+     * A post on a community with settings.rippling.out = 0 never gets a reach row, so it is
+     * never crossposted AND never surfaces in another member's nearby feed (both read paths
+     * hang off rippling_reach). This is the half that had no gate at all before: a
+     * FreeglePlayground practice post is placed at a real Edinburgh postcode, so without it a
+     * practice post crossposts into the live Lothians communities.
+     */
+    public function test_post_on_a_community_that_has_switched_ripple_out_off_never_starts_rippling(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+
+        // Switch ripple-out off on the post's own community, after the post was seeded.
+        $originGid = (int) DB::table('messages_spatial')->where('msgid', $msgid)->value('groupid');
+        DB::table('groups')->where('id', $originGid)->update(['settings' => '{"rippling": {"out": 0}}']);
+
+        // A neighbouring community whose area the reach would otherwise cover.
+        $neighbour = $this->createTestGroup();
+        DB::statement(
+            'UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, 3857) WHERE id = ?',
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', $neighbour->id]
+        );
+
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertSame(0, $stats['initialized'], 'no reach is computed for a post that must not ripple out');
+        $this->assertNull(
+            DB::table('rippling_reach')->where('msgid', $msgid)->first(),
+            'no reach row, so no reach-driven read path can surface the post'
+        );
+        $this->assertNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $neighbour->id)->first(),
+            'the post is not crossposted anywhere'
+        );
+    }
+
+    /**
+     * An explicit single-post run (--msgid) bypasses the arrival cutoff and the saturation stop,
+     * because those are rollout guards. The opt-out is a community-level policy, not a rollout
+     * guard, so it still applies - otherwise a practice post could be rippled by hand.
+     */
+    public function test_ripple_out_opt_out_also_applies_to_a_single_post_run(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $originGid = (int) DB::table('messages_spatial')->where('msgid', $msgid)->value('groupid');
+        DB::table('groups')->where('id', $originGid)->update(['settings' => '{"rippling": {"out": 0}}']);
+
+        $stats = $this->service()->process(false, 500, $msgid);
+
+        $this->assertSame(0, $stats['initialized']);
+        $this->assertNull(DB::table('rippling_reach')->where('msgid', $msgid)->first());
+    }
+
+    /**
+     * A post whose community has no setting still ripples: the regression guard for the whole
+     * feature, since an absent setting must mean "on" for every community on the network.
+     */
+    public function test_post_on_a_community_with_no_setting_still_ripples_out(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertSame(1, $stats['initialized'], 'the default is unchanged: communities ripple');
+        $this->assertNotNull(DB::table('rippling_reach')->where('msgid', $msgid)->first());
+    }
+
+    /**
+     * Switching ripple-out off must also stop what is ALREADY rippling: the reach row is dropped
+     * and the copies already delivered are pulled. Without this the deploy that first opts a
+     * training community out would leave every live practice post there expanding for the rest
+     * of its life, and the copies already crossposted would stay on the real communities.
+     */
+    public function test_switching_ripple_out_off_retracts_a_post_already_rippling(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+
+        $neighbour = $this->createTestGroup();
+        DB::statement(
+            'UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, 3857) WHERE id = ?',
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', $neighbour->id]
+        );
+
+        // First run: the post ripples normally and lands on the neighbour.
+        $this->service()->process(false, 500);
+        $this->assertNotNull(DB::table('rippling_reach')->where('msgid', $msgid)->first());
+        $copy = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $neighbour->id)->first();
+        $this->assertNotNull($copy, 'precondition: the post rippled into the neighbour');
+        $this->assertSame(0, (int) $copy->deleted);
+
+        // Now the community switches ripple-out off, as ripple:opt-out would.
+        $originGid = (int) DB::table('messages_spatial')->where('msgid', $msgid)->value('groupid');
+        DB::table('groups')->where('id', $originGid)->update(['settings' => '{"rippling": {"out": 0}}']);
+
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertNull(
+            DB::table('rippling_reach')->where('msgid', $msgid)->first(),
+            'the reach row is dropped, so the post stops expanding and leaves every reach-driven feed'
+        );
+        $this->assertSame(
+            1,
+            (int) DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $neighbour->id)->value('deleted'),
+            'the copy already delivered to the neighbour is pulled'
+        );
+        $this->assertGreaterThanOrEqual(1, $stats['removed']);
+    }
+
+    /**
+     * Dropping the reach row must not strand the people already waiting on it. A held reply is
+     * a real reply the offerer has not been shown yet; with no reach row, ripple:release-replies
+     * takes its "transiently absent, wait for re-initialisation" branch, and initialiseNew will
+     * never re-create the row for an opted-out community - so the reply would be held for ever.
+     */
+    public function test_switching_ripple_out_off_releases_replies_still_held_on_that_post(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+
+        // The post ripples first, so there is a reach row for a reply to be held against.
+        $this->service()->process(false, 500);
+        $this->assertNotNull(DB::table('rippling_reach')->where('msgid', $msgid)->first());
+
+        // A reply from well outside the reach, held pending the ripple reaching them.
+        $replier = $this->createTestUser();
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom($replier, $other);
+        $chatmsg = $this->createTestChatMessage($room, $replier);
+        $heldId = app(RippleReplyService::class)
+            ->hold($room->id, $chatmsg->id, $msgid, $replier->id, 53.4, -2.2);
+        $this->assertSame('held', DB::table('rippling_held_replies')->where('id', $heldId)->value('status'));
+
+        // The community switches ripple-out off.
+        $originGid = (int) DB::table('messages_spatial')->where('msgid', $msgid)->value('groupid');
+        DB::table('groups')->where('id', $originGid)->update(['settings' => '{"rippling": {"out": 0}}']);
+
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertSame(
+            'released',
+            DB::table('rippling_held_replies')->where('id', $heldId)->value('status'),
+            'a reply held against the dropped reach is released to the offerer, not stranded'
+        );
+        $this->assertSame(1, $stats['released_on_opt_out'] ?? 0);
+    }
+
+    /**
+     * The retraction is scoped to the opted-out community: a post on a community that still
+     * ripples keeps its reach and its copies when some OTHER community opts out.
+     */
+    public function test_retraction_leaves_posts_on_other_communities_alone(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+
+        $this->service()->process(false, 500);
+        $this->assertNotNull(DB::table('rippling_reach')->where('msgid', $msgid)->first());
+
+        // An unrelated community opts out.
+        $other = $this->createTestGroup();
+        DB::table('groups')->where('id', $other->id)->update(['settings' => '{"rippling": {"out": 0}}']);
+
+        $this->service()->process(false, 500);
+
+        $this->assertNotNull(
+            DB::table('rippling_reach')->where('msgid', $msgid)->first(),
+            'a post on a community that still ripples is untouched by another community opting out'
         );
     }
 

--- a/iznik-batch/tests/Unit/Services/Ripple/GroupRippleOptOutTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/GroupRippleOptOutTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Unit\Services\Ripple;
+
+use App\Services\Ripple\GroupRippleOptOut;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class GroupRippleOptOutTest extends TestCase
+{
+    private function optOut(): GroupRippleOptOut
+    {
+        return new GroupRippleOptOut();
+    }
+
+    /** Give a group a settings blob and return its id. */
+    private function groupWithSettings(?string $settings): int
+    {
+        $group = $this->createTestGroup();
+        DB::table('groups')->where('id', $group->id)->update(['settings' => $settings]);
+
+        return (int) $group->id;
+    }
+
+    /**
+     * The whole point of the default: a community that has never been given the setting
+     * ripples in both directions, so deploying this changes nothing on its own.
+     */
+    public function test_group_with_no_rippling_setting_is_not_excluded(): void
+    {
+        $plain = $this->groupWithSettings(null);
+        $other = $this->groupWithSettings('{"showjoin": 5}');
+
+        $optOut = $this->optOut();
+
+        foreach ([GroupRippleOptOut::DIRECTION_OUT, GroupRippleOptOut::DIRECTION_IN] as $direction) {
+            $this->assertTrue($optOut->permits($plain, $direction), "settings NULL still ripples $direction");
+            $this->assertTrue($optOut->permits($other, $direction), "unrelated settings still ripple $direction");
+        }
+    }
+
+    /**
+     * The two directions are independent - switching ripple-out off must not stop the
+     * community being a crosspost target, and vice versa.
+     */
+    public function test_directions_are_independent(): void
+    {
+        $outOff = $this->groupWithSettings('{"rippling": {"out": 0}}');
+        $inOff = $this->groupWithSettings('{"rippling": {"in": 0}}');
+
+        $optOut = $this->optOut();
+
+        $this->assertFalse($optOut->permits($outOff, GroupRippleOptOut::DIRECTION_OUT));
+        $this->assertTrue($optOut->permits($outOff, GroupRippleOptOut::DIRECTION_IN), 'out=0 leaves ripple-in alone');
+
+        $this->assertFalse($optOut->permits($inOff, GroupRippleOptOut::DIRECTION_IN));
+        $this->assertTrue($optOut->permits($inOff, GroupRippleOptOut::DIRECTION_OUT), 'in=0 leaves ripple-out alone');
+    }
+
+    /**
+     * ModTools-style integer 0, a real JSON boolean and the string spellings all mean off.
+     * The command writes 0; a hand-edited blob or another writer may use any of these.
+     */
+    public function test_every_false_spelling_counts_as_off(): void
+    {
+        foreach (['0', 'false', '"0"', '"false"'] as $spelling) {
+            $id = $this->groupWithSettings('{"rippling": {"out": ' . $spelling . '}}');
+            $this->assertFalse(
+                $this->optOut()->permits($id, GroupRippleOptOut::DIRECTION_OUT),
+                "out: $spelling is an opt-out"
+            );
+        }
+    }
+
+    /**
+     * Anything that is not an explicit false leaves rippling ON, including a malformed value.
+     * The fail-safe direction matters: wrongly-off silently stops a real community rippling
+     * and nobody would notice, whereas wrongly-on is visible and a mod can reject the copy.
+     */
+    public function test_unrecognised_and_malformed_values_leave_rippling_on(): void
+    {
+        $cases = [
+            'explicit 1' => '{"rippling": {"out": 1}}',
+            'explicit true' => '{"rippling": {"out": true}}',
+            'json null' => '{"rippling": {"out": null}}',
+            'empty string' => '{"rippling": {"out": ""}}',
+            'typo value' => '{"rippling": {"out": "nope"}}',
+            'rippling not an object' => '{"rippling": 0}',
+            'rippling a string' => '{"rippling": "off"}',
+            'unparseable settings' => '{rippling not json',
+            'wrong direction key' => '{"rippling": {"outward": 0}}',
+        ];
+
+        foreach ($cases as $label => $settings) {
+            $id = $this->groupWithSettings($settings);
+            $this->assertTrue(
+                $this->optOut()->permits($id, GroupRippleOptOut::DIRECTION_OUT),
+                "$label must leave rippling on"
+            );
+        }
+    }
+
+    /** The id list is what gets spliced into SQL, so it must be plain ints. */
+    public function test_excluded_ids_are_ints(): void
+    {
+        $id = $this->groupWithSettings('{"rippling": {"out": 0, "in": 0}}');
+
+        $optOut = $this->optOut();
+        foreach ([GroupRippleOptOut::DIRECTION_OUT, GroupRippleOptOut::DIRECTION_IN] as $direction) {
+            $ids = $optOut->excludedGroupIds($direction);
+            $this->assertContains($id, $ids, "the group appears in the $direction exclusion list");
+            foreach ($ids as $one) {
+                $this->assertIsInt($one, 'exclusion ids are ints, so they cannot inject');
+            }
+        }
+    }
+
+    /** Memoized for the run, so a batch pass reads the groups table once. */
+    public function test_result_is_memoized_until_forgotten(): void
+    {
+        $id = $this->groupWithSettings(null);
+        $optOut = $this->optOut();
+        $this->assertTrue($optOut->permits($id, GroupRippleOptOut::DIRECTION_OUT));
+
+        DB::table('groups')->where('id', $id)->update(['settings' => '{"rippling": {"out": 0}}']);
+        $this->assertTrue($optOut->permits($id, GroupRippleOptOut::DIRECTION_OUT), 'memoized within the run');
+
+        $optOut->forget();
+        $this->assertFalse($optOut->permits($id, GroupRippleOptOut::DIRECTION_OUT), 'forget() re-reads');
+    }
+}


### PR DESCRIPTION
Answers "do we have a way of excluding groups from rippling out/in?" - we didn't, properly.

## What was there before

**Ripple IN** (`ExpandService::rippleIntoNewGroups`, mirrored in `countCrosspostGroups`) filtered on `publish=1 AND type='Freegle' AND onhere=1 AND nameshort NOT LIKE '%playground%'` plus a non-POINT `polyindex`. That name test was the only deliberate exclusion.

**Ripple OUT: nothing at all.** `initialiseNew` takes every `messages_spatial` row with no reach row, gated only on the arrival cutoff and reply saturation. `MessageSpatialService` has no group filter either. So a post on *any* community rippled out from wherever its lat/lng was.

The only other lever was reactive and per-post: `rippling_reach.rejected_groups` + Go `ClipReachForRejectedGroup`, applied after a moderator rejects a rippled-in copy.

## Why it mattered

All six phantom/training communities pass every existing filter (`publish=1`, `onhere=1`, `type=Freegle`, real polygons):

| Community | id | Rippled into? | Practice posts placed at |
|---|---|---|---|
| FreegleFreshers | 21415 | yes | HS8 South Uist |
| FreegleFreshers2 | 522808 | yes | HS8 South Uist |
| FreegleFreshers3 | 522811 | yes | HS8 South Uist |
| Freegle Freshers 4 | 522813 | yes | HS8 South Uist |
| Outer Hebrides Freegle | 126728 | yes | HS8 South Uist, one at IV22 Wester Ross |
| FreeglePlayground | 21419 | no (name test) | **central Edinburgh** |

FreeglePlayground is the sharp case: the name test stopped posts rippling *into* it, but nothing stopped its practice posts rippling *out* into the live Lothians communities and appearing in real members' nearby feeds. Rippling is fully live (51,743 reach rows, 86,468 ripple-ins in the last 7 days), so this was a live exposure rather than a theoretical one. The Freshers communities were only accidentally safe - practice posts sit in South Uist with no road-connected neighbour, and 522811/522813 have `polyindex` at negative latitude (Falklands) while `groups.lat/lng` reads the positive equivalent, a sign-flip that currently doubles as protection.

## The change

`groups.settings.rippling.{out,in}`, resolved by `GroupRippleOptOut` and enforced in `ExpandService`:

- **`out` off** - the post never gets a `rippling_reach` row (`initialiseNew`), so it is neither crossposted nor surfaced in anyone's nearby feed: both read paths hang off that table. Applies to `--msgid` and area-scoped runs too, unlike the arrival cutoff and saturation stop, because this is community policy rather than a rollout guard.
- **`in` off** - never a crosspost target (`rippleIntoNewGroups`, and `countCrosspostGroups` so the breadth stat matches reality).
- **Already in flight** - `retractOptedOutCommunities` drops the reach row, pulls the copies already delivered, and releases replies still held against that reach. Without the last part they would be held for ever: the Go hold gate fails open with no reach row, but `ReleaseRepliesCommand` reads a missing reach row on a live post as "transiently absent, wait for re-initialisation", and `initialiseNew` will never re-create it.

**Absent means on**, and any unexpected value reads as on. That fail-safe direction is deliberate: wrongly-off would silently stop a real community rippling and nobody would notice for weeks, whereas wrongly-on is visible and a moderator can reject the copy.

**Deliberately not a moderator setting** - which communities are phantom is a central decision. The only writer is `php artisan ripple:opt-out` (`--direction=out|in|both`, `--on` to switch back on, `--list`, `--dry-run`). Switching a direction back on removes the key rather than storing a truthy value.

The migration seeds the six communities by name, so it is portable across prod, dev and test. The `%playground%` name test stays as belt-and-braces for a playground community created before anyone gives it the setting.

## Two traps worth knowing

- `groups.settings` is **longtext, not JSON**. A PHP write keeps its key order verbatim; `JSON_SET` output comes back normalised. Assertions must not care which wrote it.
- MySQL `JSON_SET` will **not** create `$.rippling.out` when `$.rippling` is missing or is a scalar - i.e. it silently no-ops on exactly the communities that have never had it set. The command does its JSON in PHP for that reason; the migration only sets the top-level `$.rippling` object, which does work. Resolution is in PHP too, since a JSON null CASTs to 0 and an SQL truth test would read a malformed value as "opted out".

## Testing

- 7 new `ExpandServiceTest` cases: ripple-in blocked, ripple-out blocked, opt-out applies to a single-post run, no-setting still ripples (the regression guard for the default), in-flight retraction, held replies released, and retraction scoped to the opted-out community only.
- `GroupRippleOptOutTest` (6): default-on, directions independent, every false spelling, malformed values leave rippling on, ids are ints, memoization.
- `OptOutCommandTest` (13): both directions, by id, single direction, `--on` removes the key, other settings preserved, writes over null/empty/invalid settings, dry-run, unknown community, bad direction, `--list`, several at once, abort-before-write on a typo.
- RED proof: with the gate neutered, the 4 gate tests fail 0✓ 4✗; restored, they pass.
- Full Laravel suite green on the committed tree: **5520 passed**.
- Migration verified against null / empty / `{}` / other-keys-present / invalid-JSON / `rippling`-as-scalar starting states, idempotent on re-run, resolver agrees, and `down()` removes only the rippling key.
- CLI exercised end to end against the dev DB, including the error paths and exit codes.

Discourse: no thread - raised directly by Edward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALk2T2AAsAURU9pAKwZk2S
