### PR TITLE
feat(modtools): show when a chat reply was delayed by rippling, and for how long

### DIFF
--- a/docs/moderators/rippling-out.md
+++ b/docs/moderators/rippling-out.md
@@ -118,8 +118,8 @@ Chat Review tells you which of these happened, and how long it took:
 | What you see | What it means |
 | --- | --- |
 | **Held: rippling out** (with how long it has been waiting) | Still waiting. It will go out on its own. |
-| **Delivered late** (with how long it was held) | It did arrive, but only after that delay. This is what to look for when someone reports a reply that seemed to be ignored - the delay is on our side, not theirs. |
-| **Never reached the recipient** | The item went, or the hold was abandoned, while the reply was held. The owner never saw it. |
+| **Held as too far for:** (with how long it was held) | It did arrive, but only after that delay, because the sender was outside the post's reach when they replied. This is what to look for when someone reports a reply that seemed to be ignored - the delay is on our side, not theirs. |
+| **Never reached the recipient** | The item was taken by someone else while the reply was held, so the owner never saw it. |
 
 That last one matters for tone: neither person did anything wrong, and the replier may be
 upset with the owner for "ignoring" them. It is worth saying plainly that our system held the

--- a/docs/moderators/rippling-out.md
+++ b/docs/moderators/rippling-out.md
@@ -97,13 +97,33 @@ TrashNothing - wherever a member replies from outside the post's current reach, 
 is accepted and held rather than turned away. Chat Review shows you it is held because of
 rippling (not because you chose to hold it).
 
-You do not need to do anything - the reply releases itself. Every hold has a **due time**,
-worked out from how far the member is from the item: roughly a quarter of an hour plus a
-few minutes per mile, so a typical held reply lands within the hour and none waits longer
-than three. If the post ripples out to that member before their time is up, it is released
-then instead. The wait exists to give closer people a head start, not to hold anybody back
-indefinitely - which matters, because most held repliers live somewhere the post would
-never have reached on its own.
+You do not need to do anything - the reply releases itself, either when the post ripples out
+far enough to cover that member, or when the post's reach stops growing (at which point every
+reply still waiting is let through rather than stranded).
+
+**How long that takes varies a great deal, and can be days.** Some holds are given a **due
+time** worked out from how far the member is from the item, and those land quickly. Most are
+not, and wait for the reach instead. Measured over a fortnight in August 2026, of the holds
+that were eventually delivered: about a third landed within an hour, about half within three
+hours, and the other half took longer - with an average of just over a day and a long tail
+running into weeks. So if a member asks why their reply went unanswered for two days, "it was
+held by rippling" is a real and likely answer.
+
+A hold can also end **without** the reply ever being delivered: if the item is taken while the
+reply is held, the reply is dropped and the replier is told the item has gone. The owner never
+sees it.
+
+Chat Review tells you which of these happened, and how long it took:
+
+| What you see | What it means |
+| --- | --- |
+| **Held: rippling out** (with how long it has been waiting) | Still waiting. It will go out on its own. |
+| **Delivered late** (with how long it was held) | It did arrive, but only after that delay. This is what to look for when someone reports a reply that seemed to be ignored - the delay is on our side, not theirs. |
+| **Never reached the recipient** | The item went, or the hold was abandoned, while the reply was held. The owner never saw it. |
+
+That last one matters for tone: neither person did anything wrong, and the replier may be
+upset with the owner for "ignoring" them. It is worth saying plainly that our system held the
+message.
 
 The member who sent it sees their own message marked as "waiting to send"; the owner is not
 shown it until it is released.

--- a/file-sync.sh
+++ b/file-sync.sh
@@ -94,7 +94,7 @@ _compute_container_info() {
             targets="$targets"$'\n'"${CN}-modtools-dev-live /app/${relative_path#iznik-nuxt3/} ModTools-Dev-Live"
         fi
         GCI_RESULT="$targets"
-    elif [[ "$relative_path" == iznik-nuxt3/plugins/* || "$relative_path" == iznik-nuxt3/composables/* || "$relative_path" == iznik-nuxt3/stores/* || "$relative_path" == iznik-nuxt3/utils/* || "$relative_path" == iznik-nuxt3/components/* || "$relative_path" == iznik-nuxt3/assets/* || "$relative_path" == iznik-nuxt3/pages/* || "$relative_path" == iznik-nuxt3/layouts/* || "$relative_path" == iznik-nuxt3/middleware/* ]]; then
+    elif [[ "$relative_path" == iznik-nuxt3/plugins/* || "$relative_path" == iznik-nuxt3/composables/* || "$relative_path" == iznik-nuxt3/stores/* || "$relative_path" == iznik-nuxt3/utils/* || "$relative_path" == iznik-nuxt3/components/* || "$relative_path" == iznik-nuxt3/assets/* || "$relative_path" == iznik-nuxt3/pages/* || "$relative_path" == iznik-nuxt3/layouts/* || "$relative_path" == iznik-nuxt3/middleware/* || "$relative_path" == iznik-nuxt3/api/* || "$relative_path" == iznik-nuxt3/server/* ]]; then
         # Shared code used by both Freegle and ModTools - sync to all containers.
         # assets/ is here rather than in the generic iznik-nuxt3/* branch below because that
         # branch skips modtools-dev-local, which is where vitest runs: a unit test that reads
@@ -104,6 +104,16 @@ _compute_container_info() {
         # tests/unit/pages import ~/pages/<x>.vue directly, so without this the
         # spec syncs but the page under test does not, and vitest silently
         # validates the copy baked into the image instead of the edit on disk.
+        # api/ and server/ are here for that same reason, and it had already bitten:
+        # tests/unit/api/*.spec.js import ~/api/BaseAPI.js and friends, and
+        # tests/unit/server/sitemap.spec.js imports ~/server/utils/sitemap. Because the
+        # spec synced and the source did not, the two "abandoned without settling" tests
+        # added with the never-settling-await fix (#1317) failed against a BAKED BaseAPI.js
+        # that predated the warn() calls they assert - a false RED that reads exactly like a
+        # real regression. The same gap hides false GREENs, which is worse.
+        # When adding a top-level source directory that unit specs import, add it here:
+        #   grep -rhoE "from '~/[a-zA-Z0-9_-]+/" iznik-nuxt3/tests/unit/ | sort -u
+        # must be a subset of this branch (plus modtools/, handled above).
         local targets="${CN}-dev-local /app/${relative_path#iznik-nuxt3/} Freegle-Dev-Local"
         if is_running "${CN}-dev-live"; then
             targets="$targets"$'\n'"${CN}-dev-live /app/${relative_path#iznik-nuxt3/} Freegle-Dev-Live"

--- a/iznik-nuxt3/components/ChatMessage.vue
+++ b/iznik-nuxt3/components/ChatMessage.vue
@@ -129,12 +129,16 @@
       data-testid="rippling-ended-badge"
     >
       <span v-if="chatmessage?.ripplinghold?.delivered">
-        Delivered late: held {{ ripplingHeldFor }}
+        Held as too far for: {{ ripplingHeldFor }}
       </span>
       <span v-else-if="chatmessage?.ripplinghold?.status === 'taken-gone'">
-        Never delivered: item went after {{ ripplingHeldFor }}
+        Never delivered: held as too far for {{ ripplingHeldFor }}, item went
       </span>
-      <span v-else> Never delivered: dropped after {{ ripplingHeldFor }} </span>
+      <!-- 'dropped' is not produced anywhere - see the note in ModChatReview.vue.
+           Kept as a safety net so an unexpected status is not silently invisible. -->
+      <span v-else>
+        Never delivered: held as too far for {{ ripplingHeldFor }}
+      </span>
     </b-badge>
     <chat-message-warning v-if="phoneNumber" />
     <chat-message-date-read :id="id" :chatid="chatid" :last="last" :pov="pov" />

--- a/iznik-nuxt3/components/ChatMessage.vue
+++ b/iznik-nuxt3/components/ChatMessage.vue
@@ -114,7 +114,27 @@
       class="mt-1"
       data-testid="rippling-held-badge"
     >
-      Held: rippling out
+      Held: rippling out<span v-if="ripplingHeldFor">
+        ({{ ripplingHeldFor }})</span
+      >
+    </b-badge>
+    <!-- A hold that has ENDED. ripplinghold is only ever sent to moderators, so this is
+         inherently mod-only and needs no myid guard - a member never has the field. Without
+         it a delayed or binned reply looks like an ordinary one, which is how a 47-hour
+         rippling hold got reported as a mail fault (Discourse 10025). -->
+    <b-badge
+      v-if="ripplingEnded"
+      :variant="chatmessage?.ripplinghold?.delivered ? 'warning' : 'danger'"
+      class="mt-1"
+      data-testid="rippling-ended-badge"
+    >
+      <span v-if="chatmessage?.ripplinghold?.delivered">
+        Delivered late: held {{ ripplingHeldFor }}
+      </span>
+      <span v-else-if="chatmessage?.ripplinghold?.status === 'taken-gone'">
+        Never delivered: item went after {{ ripplingHeldFor }}
+      </span>
+      <span v-else> Never delivered: dropped after {{ ripplingHeldFor }} </span>
     </b-badge>
     <chat-message-warning v-if="phoneNumber" />
     <chat-message-date-read :id="id" :chatid="chatid" :last="last" :pov="pov" />
@@ -176,6 +196,7 @@ import ChatMessageModMail from './ChatMessageModMail'
 import ChatMessageReminder from './ChatMessageReminder'
 import { setupChat } from '~/composables/useChat'
 import { useChatStore } from '~/stores/chat'
+import { durationMinutes } from '~/composables/useTimeFormat'
 import { ref, computed } from '#imports'
 import SupportLink from '~/components/SupportLink.vue'
 import ChatMessageWarning from '~/components/ChatMessageWarning'
@@ -233,6 +254,22 @@ const showConfirmModal = ref(false)
 const { chat, otheruser, chatmessage } = await setupChat(props.chatid, props.id)
 
 // Computed properties
+
+// Rippling reply-hold, mod-only (the API sends ripplinghold to moderators only). heldminutes
+// is server-computed, so a still-open hold does not depend on this device's clock.
+const ripplingHeldFor = computed(() =>
+  durationMinutes(chatmessage.value?.ripplinghold?.heldminutes)
+)
+
+// A hold that has finished, whichever way it finished. 'held' is covered by the existing
+// heldbyrippling badge, so this is only the terminal states.
+const ripplingEnded = computed(() => {
+  const status = chatmessage.value?.ripplinghold?.status
+  return (
+    status === 'released' || status === 'taken-gone' || status === 'dropped'
+  )
+})
+
 const phoneNumber = computed(() => {
   let ret = false
 

--- a/iznik-nuxt3/composables/useTimeFormat.js
+++ b/iznik-nuxt3/composables/useTimeFormat.js
@@ -130,6 +130,45 @@ export function timeagoMedium(val) {
   }
 }
 
+/**
+ * Render an ELAPSED SPAN given as a count of minutes: "35 mins", "46 hours", "2 days".
+ *
+ * Not the same job as timeagoMedium, which takes a date and measures from now. A rippling
+ * reply-hold reports heldminutes (computed server-side so a still-open hold does not depend on
+ * the client clock), and a hold that has already ended has no "now" to measure from at all.
+ *
+ * Hours run to 48h rather than 24h: for a delay, "2 days" hides whether the reply sat for one
+ * night or three, which is exactly what a moderator is trying to establish.
+ */
+export function durationMinutes(mins) {
+  if (mins === null || mins === undefined || Number.isNaN(Number(mins))) {
+    return ''
+  }
+
+  const m = Math.floor(Number(mins))
+
+  if (m < 1) {
+    // Includes negatives, which would only arise from clock skew between rows.
+    return 'less than a minute'
+  }
+  if (m < 60) {
+    return m === 1 ? '1 min' : `${m} mins`
+  }
+
+  const hours = Math.floor(m / 60)
+  if (hours < 48) {
+    return hours === 1 ? '1 hour' : `${hours} hours`
+  }
+
+  const days = Math.floor(m / (60 * 24))
+  if (days < 7) {
+    return days === 1 ? '1 day' : `${days} days`
+  }
+
+  const weeks = Math.floor(days / 7)
+  return weeks === 1 ? '1 week' : `${weeks} weeks`
+}
+
 export function timeadapt(val) {
   const t = dayjs(val)
 

--- a/iznik-nuxt3/modtools/components/ModChatReview.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReview.vue
@@ -73,16 +73,52 @@
             think it should be released.
           </span>
         </NoticeMessage>
+        <!-- Rippling reply-hold. Four outcomes a mod must be able to tell apart; before this
+             only "held now" was visible, so a hold that had already released left no trace and
+             its delay looked like a mail fault, while taken-gone/dropped wrongly read as
+             "still on its way". -->
         <NoticeMessage
-          v-if="message.heldbyrippling"
+          v-if="ripplingHoldState === 'held'"
           class="mb-2"
           variant="warning"
           data-testid="rippling-held-notice"
         >
           <v-icon icon="pause-circle" class="me-1" />
           Held: rippling out - this reply arrived before the post's reach grew
-          to cover the sender's location. It will be delivered automatically
-          once the reach expands far enough.
+          to cover the sender's location<span v-if="ripplingHeldFor"
+            >, and has been waiting {{ ripplingHeldFor }}</span
+          >. It will be delivered automatically once the reach expands far
+          enough.
+        </NoticeMessage>
+        <NoticeMessage
+          v-else-if="ripplingHoldState === 'released'"
+          class="mb-2"
+          variant="warning"
+          data-testid="rippling-delayed-notice"
+        >
+          <v-icon icon="clock" class="me-1" />
+          Delivered late: rippling out held this reply for
+          {{ ripplingHeldFor }} because the sender was outside the post's reach
+          when they replied. The recipient saw nothing for that long, and the
+          sender had no answer - so each may believe the other ignored them.
+        </NoticeMessage>
+        <NoticeMessage
+          v-else-if="ripplingHoldState === 'undelivered'"
+          class="mb-2"
+          variant="danger"
+          data-testid="rippling-undelivered-notice"
+        >
+          <v-icon icon="ban" class="me-1" />
+          <span v-if="message.ripplinghold?.status === 'taken-gone'">
+            Never reached the recipient: rippling out held this reply because
+            the sender was outside the post's reach, and after
+            {{ ripplingHeldFor }} the item was taken by someone else, so it was
+            dropped undelivered.
+          </span>
+          <span v-else>
+            Never reached the recipient: rippling out held this reply for
+            {{ ripplingHeldFor }} and then abandoned it.
+          </span>
         </NoticeMessage>
         <NoticeMessage
           v-if="message.processingfailreason"
@@ -294,6 +330,10 @@ import { useMe } from '~/composables/useMe'
 import { useModMe } from '~/modtools/composables/useModMe'
 import { useChatStore } from '~/stores/chat'
 import { useAuthStore } from '~/stores/auth'
+// Imported rather than relying on the Nuxt auto-import: the component unit tests mount without
+// the auto-import layer (they inject timeago as a mock), and a hold duration is worth asserting
+// against the real formatter rather than a stub.
+import { durationMinutes } from '~/composables/useTimeFormat'
 
 const props = defineProps({
   id: {
@@ -334,6 +374,24 @@ const chatPov = computed(() => {
   if (chat) return chat.user2 || null
   return null
 })
+
+// Which rippling reply-hold notice applies: 'held' | 'released' | 'undelivered' | null.
+// Collapses the four raw statuses into the three notices, because 'taken-gone' and 'dropped'
+// both mean "never arrived, never will" and read the same way to a mod.
+const ripplingHoldState = computed(() => {
+  const status = message.value?.ripplinghold?.status
+  if (status === 'held') return 'held'
+  if (status === 'released') return 'released'
+  if (status === 'taken-gone' || status === 'dropped') return 'undelivered'
+  // Older API build (or a cached response) sends heldbyrippling with no detail: still warn.
+  return message.value?.heldbyrippling ? 'held' : null
+})
+
+// How long the reply was undelivered. Empty string when the API sent no detail, which the
+// 'held' notice guards on so it degrades to the original wording.
+const ripplingHeldFor = computed(() =>
+  durationMinutes(message.value?.ripplinghold?.heldminutes)
+)
 
 const isActiveMod = computed(() => {
   const groupid = message.value?.group?.id

--- a/iznik-nuxt3/modtools/components/ModChatReview.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReview.vue
@@ -97,11 +97,17 @@
           data-testid="rippling-delayed-notice"
         >
           <v-icon icon="clock" class="me-1" />
-          Delivered late: rippling out held this reply for
-          {{ ripplingHeldFor }} because the sender was outside the post's reach
-          when they replied. The recipient saw nothing for that long, and the
-          sender had no answer - so each may believe the other ignored them.
+          Held as too far for: {{ ripplingHeldFor }}. The sender was outside the
+          post's reach when they replied, so rippling out held the reply for
+          that long before delivering it. The recipient saw nothing in the
+          meantime and the sender had no answer - so each may believe the other
+          ignored them.
         </NoticeMessage>
+        <!-- Terminal, never delivered. In practice this is always 'taken-gone':
+             nothing in the codebase writes 'dropped', and production has never
+             recorded one (0 rows since the table began, against ~9,800 released
+             and ~3,200 taken-gone). The generic wording is kept as a safety net
+             for a status we do not produce, rather than inventing a story for it. -->
         <NoticeMessage
           v-else-if="ripplingHoldState === 'undelivered'"
           class="mb-2"
@@ -110,14 +116,13 @@
         >
           <v-icon icon="ban" class="me-1" />
           <span v-if="message.ripplinghold?.status === 'taken-gone'">
-            Never reached the recipient: rippling out held this reply because
-            the sender was outside the post's reach, and after
-            {{ ripplingHeldFor }} the item was taken by someone else, so it was
-            dropped undelivered.
+            Never reached the recipient: held as too far for
+            {{ ripplingHeldFor }}, and in that time the item was taken by
+            someone else, so the reply was dropped undelivered.
           </span>
           <span v-else>
-            Never reached the recipient: rippling out held this reply for
-            {{ ripplingHeldFor }} and then abandoned it.
+            Never reached the recipient: held as too far for
+            {{ ripplingHeldFor }}, then ended without being delivered.
           </span>
         </NoticeMessage>
         <NoticeMessage

--- a/iznik-nuxt3/tests/unit/components/ChatMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMessage.spec.js
@@ -479,4 +479,92 @@ describe('ChatMessage', () => {
       expect(wrapper.find('.chat-message-warning').exists()).toBe(false)
     })
   })
+
+  // ripplinghold is only ever sent to moderators, so these badges are inherently mod-only.
+  // Without the ended states, a reply that was delayed for days - or binned undelivered -
+  // looks identical to an ordinary one when a mod reads the thread.
+  describe('rippling hold badges', () => {
+    async function withHold(hold, extra = {}) {
+      const { setupChat } = await import('~/composables/useChat')
+      setupChat.mockResolvedValueOnce({
+        chat: ref(mockChat),
+        otheruser: ref(mockOtherUser),
+        chatmessage: ref({ ...mockChatMessage, ...extra, ripplinghold: hold }),
+      })
+      return await createWrapper()
+    }
+
+    it('shows how long a live hold has been waiting', async () => {
+      const wrapper = await withHold(
+        { status: 'held', heldminutes: 180, delivered: false },
+        { heldbyrippling: true }
+      )
+      const badge = wrapper.find('[data-testid="rippling-held-badge"]')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toContain('Held: rippling out')
+      expect(badge.text()).toContain('3 hours')
+    })
+
+    it('still hides the live-hold badge from the sender themselves', async () => {
+      // myid is 1 in this spec, so a message from userid 1 is the viewer's own.
+      const wrapper = await withHold(
+        { status: 'held', heldminutes: 180, delivered: false },
+        { heldbyrippling: true, userid: 1 }
+      )
+      expect(wrapper.find('[data-testid="rippling-held-badge"]').exists()).toBe(
+        false
+      )
+    })
+
+    it('reports a delay that already happened', async () => {
+      const wrapper = await withHold({
+        status: 'released',
+        heldminutes: 2812,
+        delivered: true,
+      })
+      const badge = wrapper.find('[data-testid="rippling-ended-badge"]')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toContain('Delivered late')
+      expect(badge.text()).toContain('46 hours')
+      // Not still waiting.
+      expect(wrapper.find('[data-testid="rippling-held-badge"]').exists()).toBe(
+        false
+      )
+    })
+
+    it('says never delivered when the item went while held', async () => {
+      const wrapper = await withHold({
+        status: 'taken-gone',
+        heldminutes: 2812,
+        delivered: false,
+      })
+      const badge = wrapper.find('[data-testid="rippling-ended-badge"]')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toContain('Never delivered')
+      expect(badge.text()).toContain('item went')
+      expect(badge.text()).toContain('46 hours')
+    })
+
+    it('says never delivered when the hold was dropped', async () => {
+      const wrapper = await withHold({
+        status: 'dropped',
+        heldminutes: 300,
+        delivered: false,
+      })
+      const badge = wrapper.find('[data-testid="rippling-ended-badge"]')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toContain('Never delivered')
+      expect(badge.text()).toContain('5 hours')
+    })
+
+    it('shows no hold badge at all on an ordinary message', async () => {
+      const wrapper = await createWrapper()
+      expect(wrapper.find('[data-testid="rippling-held-badge"]').exists()).toBe(
+        false
+      )
+      expect(
+        wrapper.find('[data-testid="rippling-ended-badge"]').exists()
+      ).toBe(false)
+    })
+  })
 })

--- a/iznik-nuxt3/tests/unit/components/ChatMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMessage.spec.js
@@ -524,8 +524,7 @@ describe('ChatMessage', () => {
       })
       const badge = wrapper.find('[data-testid="rippling-ended-badge"]')
       expect(badge.exists()).toBe(true)
-      expect(badge.text()).toContain('Delivered late')
-      expect(badge.text()).toContain('46 hours')
+      expect(badge.text()).toContain('Held as too far for: 46 hours')
       // Not still waiting.
       expect(wrapper.find('[data-testid="rippling-held-badge"]').exists()).toBe(
         false
@@ -541,11 +540,12 @@ describe('ChatMessage', () => {
       const badge = wrapper.find('[data-testid="rippling-ended-badge"]')
       expect(badge.exists()).toBe(true)
       expect(badge.text()).toContain('Never delivered')
+      expect(badge.text()).toContain('held as too far for 46 hours')
       expect(badge.text()).toContain('item went')
-      expect(badge.text()).toContain('46 hours')
     })
 
-    it('says never delivered when the hold was dropped', async () => {
+    // Safety net only - nothing writes 'dropped'. See the note in ModChatReview.vue.
+    it('an unexpected terminal status still shows a badge, without inventing a reason', async () => {
       const wrapper = await withHold({
         status: 'dropped',
         heldminutes: 300,
@@ -554,7 +554,8 @@ describe('ChatMessage', () => {
       const badge = wrapper.find('[data-testid="rippling-ended-badge"]')
       expect(badge.exists()).toBe(true)
       expect(badge.text()).toContain('Never delivered')
-      expect(badge.text()).toContain('5 hours')
+      expect(badge.text()).toContain('held as too far for 5 hours')
+      expect(badge.text()).not.toContain('item went')
     })
 
     it('shows no hold badge at all on an ordinary message', async () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
@@ -806,8 +806,7 @@ describe('ModChatReview', () => {
       })
       const notice = wrapper.find('[data-testid="rippling-delayed-notice"]')
       expect(notice.exists()).toBe(true)
-      expect(notice.text()).toContain('46 hours')
-      expect(notice.text()).toMatch(/delayed|delivered late/i)
+      expect(notice.text()).toContain('Held as too far for: 46 hours')
       // Must NOT claim it is still waiting.
       expect(
         wrapper.find('[data-testid="rippling-held-notice"]').exists()
@@ -835,7 +834,10 @@ describe('ModChatReview', () => {
       ).toBe(false)
     })
 
-    it('dropped: says never delivered', () => {
+    // Safety net only. Nothing writes 'dropped' - production has never recorded one
+    // against ~9,800 released and ~3,200 taken-gone - so this covers the defensive
+    // branch rather than a state moderators will meet. It must not go silently blank.
+    it('an unexpected terminal status still says never delivered, without inventing a reason', () => {
       const wrapper = mountComponent({
         ripplinghold: {
           status: 'dropped',
@@ -847,6 +849,9 @@ describe('ModChatReview', () => {
       const notice = wrapper.find('[data-testid="rippling-undelivered-notice"]')
       expect(notice.exists()).toBe(true)
       expect(notice.text()).toMatch(/never (reached|delivered)/i)
+      expect(notice.text()).toContain('5 hours')
+      // No claim about an item being taken - we do not know that here.
+      expect(notice.text()).not.toContain('taken by someone else')
       expect(wrapper.text()).not.toContain('delivered automatically')
     })
 

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
@@ -771,6 +771,107 @@ describe('ModChatReview', () => {
     })
   })
 
+  // The four rippling-hold states a mod needs to tell apart. Before this, only "held now"
+  // was visible: a hold that had already released left NO trace, which is why the delay in
+  // Discourse 10025 looked like a mail-system fault, and 'taken-gone' rendered as "held ...
+  // will be delivered automatically" when in fact it never was and never will be.
+  describe('rippling hold states', () => {
+    it('held: shows how long it has been waiting so far', () => {
+      const wrapper = mountComponent({
+        heldbyrippling: true,
+        ripplinghold: {
+          status: 'held',
+          heldat: '2026-08-04T14:22:58Z',
+          heldminutes: 180,
+          delivered: false,
+        },
+      })
+      const notice = wrapper.find('[data-testid="rippling-held-notice"]')
+      expect(notice.exists()).toBe(true)
+      expect(notice.text()).toContain('Held: rippling out')
+      expect(notice.text()).toContain('3 hours')
+      // Still true for a live hold - it really will go out when the reach grows.
+      expect(notice.text()).toContain('delivered automatically')
+    })
+
+    it('released: reports the delay that already happened', () => {
+      const wrapper = mountComponent({
+        ripplinghold: {
+          status: 'released',
+          heldat: '2026-08-04T14:22:58Z',
+          releasedat: '2026-08-06T13:15:08Z',
+          heldminutes: 2812,
+          delivered: true,
+        },
+      })
+      const notice = wrapper.find('[data-testid="rippling-delayed-notice"]')
+      expect(notice.exists()).toBe(true)
+      expect(notice.text()).toContain('46 hours')
+      expect(notice.text()).toMatch(/delayed|delivered late/i)
+      // Must NOT claim it is still waiting.
+      expect(
+        wrapper.find('[data-testid="rippling-held-notice"]').exists()
+      ).toBe(false)
+    })
+
+    it('taken-gone: says never delivered, and does NOT promise delivery', () => {
+      const wrapper = mountComponent({
+        ripplinghold: {
+          status: 'taken-gone',
+          heldat: '2026-08-04T14:22:58Z',
+          releasedat: '2026-08-06T13:15:08Z',
+          heldminutes: 2812,
+          delivered: false,
+        },
+      })
+      const notice = wrapper.find('[data-testid="rippling-undelivered-notice"]')
+      expect(notice.exists()).toBe(true)
+      expect(notice.text()).toMatch(/never (reached|delivered)/i)
+      expect(notice.text()).toContain('46 hours')
+      // The bug this fixes: the old notice promised automatic delivery.
+      expect(wrapper.text()).not.toContain('delivered automatically')
+      expect(
+        wrapper.find('[data-testid="rippling-held-notice"]').exists()
+      ).toBe(false)
+    })
+
+    it('dropped: says never delivered', () => {
+      const wrapper = mountComponent({
+        ripplinghold: {
+          status: 'dropped',
+          heldat: '2026-08-04T14:22:58Z',
+          heldminutes: 300,
+          delivered: false,
+        },
+      })
+      const notice = wrapper.find('[data-testid="rippling-undelivered-notice"]')
+      expect(notice.exists()).toBe(true)
+      expect(notice.text()).toMatch(/never (reached|delivered)/i)
+      expect(wrapper.text()).not.toContain('delivered automatically')
+    })
+
+    it('falls back to the old notice when the API sends no ripplinghold detail', () => {
+      // Older API build, or a cached response: heldbyrippling alone must still warn.
+      const wrapper = mountComponent({ heldbyrippling: true })
+      const notice = wrapper.find('[data-testid="rippling-held-notice"]')
+      expect(notice.exists()).toBe(true)
+      expect(notice.text()).toContain('Held: rippling out')
+    })
+
+    it('shows nothing when there is no hold at all', () => {
+      const wrapper = mountComponent({})
+      expect(
+        wrapper.find('[data-testid="rippling-held-notice"]').exists()
+      ).toBe(false)
+      expect(
+        wrapper.find('[data-testid="rippling-delayed-notice"]').exists()
+      ).toBe(false)
+      expect(
+        wrapper.find('[data-testid="rippling-undelivered-notice"]').exists()
+      ).toBe(false)
+    })
+  })
+
   describe('edge cases', () => {
     it('handles message without group', () => {
       const wrapper = mountComponent({ group: null })

--- a/iznik-nuxt3/tests/unit/composables/useTimeFormat.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useTimeFormat.spec.js
@@ -13,6 +13,7 @@ import {
   dateonlyNoYear,
   dateshortNoYear,
   weekdayshort,
+  durationMinutes,
 } from '~/composables/useTimeFormat'
 
 // Fixed reference instant — Friday 2026-04-17 12:00:00 UTC
@@ -121,28 +122,48 @@ describe('useTimeFormat', () => {
     })
 
     it('singularises 1 min and pluralises others', () => {
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 60 * 1000))).toBe('1 min')
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 5 * 60 * 1000))).toBe('5 mins')
+      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 60 * 1000))).toBe(
+        '1 min'
+      )
+      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 5 * 60 * 1000))).toBe(
+        '5 mins'
+      )
     })
 
     it('singularises 1 hour and pluralises others', () => {
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 60 * 60 * 1000))).toBe('1 hour')
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 3 * 60 * 60 * 1000))).toBe('3 hours')
+      expect(
+        timeagoMedium(new Date(FIXED_NOW.getTime() - 60 * 60 * 1000))
+      ).toBe('1 hour')
+      expect(
+        timeagoMedium(new Date(FIXED_NOW.getTime() - 3 * 60 * 60 * 1000))
+      ).toBe('3 hours')
     })
 
     it('singularises 1 day and pluralises others', () => {
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 24 * 60 * 60 * 1000))).toBe('1 day')
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 3 * 24 * 60 * 60 * 1000))).toBe('3 days')
+      expect(
+        timeagoMedium(new Date(FIXED_NOW.getTime() - 24 * 60 * 60 * 1000))
+      ).toBe('1 day')
+      expect(
+        timeagoMedium(new Date(FIXED_NOW.getTime() - 3 * 24 * 60 * 60 * 1000))
+      ).toBe('3 days')
     })
 
     it('singularises 1 week and pluralises others', () => {
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 7 * 24 * 60 * 60 * 1000))).toBe('1 week')
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 14 * 24 * 60 * 60 * 1000))).toBe('2 weeks')
+      expect(
+        timeagoMedium(new Date(FIXED_NOW.getTime() - 7 * 24 * 60 * 60 * 1000))
+      ).toBe('1 week')
+      expect(
+        timeagoMedium(new Date(FIXED_NOW.getTime() - 14 * 24 * 60 * 60 * 1000))
+      ).toBe('2 weeks')
     })
 
     it('falls back to months past 5 weeks', () => {
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 35 * 24 * 60 * 60 * 1000))).toBe('1 month')
-      expect(timeagoMedium(new Date(FIXED_NOW.getTime() - 120 * 24 * 60 * 60 * 1000))).toBe('3 months')
+      expect(
+        timeagoMedium(new Date(FIXED_NOW.getTime() - 35 * 24 * 60 * 60 * 1000))
+      ).toBe('1 month')
+      expect(
+        timeagoMedium(new Date(FIXED_NOW.getTime() - 120 * 24 * 60 * 60 * 1000))
+      ).toBe('3 months')
     })
   })
 
@@ -177,7 +198,9 @@ describe('useTimeFormat', () => {
 
     it('different year → D MMM YYYY HH:mm', () => {
       const t = new Date('2024-11-10T09:15:00Z')
-      expect(timeadaptChat(t)).toMatch(/^\d{1,2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}$/)
+      expect(timeadaptChat(t)).toMatch(
+        /^\d{1,2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}$/
+      )
     })
   })
 
@@ -189,7 +212,9 @@ describe('useTimeFormat', () => {
     })
 
     it('datetime — full month, year, HH:mm:ss', () => {
-      expect(datetime(d)).toMatch(/17(st|nd|rd|th) April, 2026 \d{2}:\d{2}:\d{2}/)
+      expect(datetime(d)).toMatch(
+        /17(st|nd|rd|th) April, 2026 \d{2}:\d{2}:\d{2}/
+      )
     })
 
     it('datetimeshort — short month, year, HH:mm', () => {
@@ -212,7 +237,57 @@ describe('useTimeFormat', () => {
 
     it('weekdayshort — weekday with ordinal and time', () => {
       // 2026-04-17 is a Friday
-      expect(weekdayshort(d)).toMatch(/^Friday 17(st|nd|rd|th) \d{2}:\d{2} (am|pm)$/)
+      expect(weekdayshort(d)).toMatch(
+        /^Friday 17(st|nd|rd|th) \d{2}:\d{2} (am|pm)$/
+      )
+    })
+  })
+
+  // durationMinutes renders an ELAPSED SPAN (a count of minutes), not a distance from now.
+  // timeagoMedium can't do this: it takes a date. Rippling reply-holds report heldminutes,
+  // computed server-side so it works for a still-open hold without trusting the client clock.
+  describe('durationMinutes', () => {
+    it('renders minutes below an hour, singular and plural', () => {
+      expect(durationMinutes(1)).toBe('1 min')
+      expect(durationMinutes(35)).toBe('35 mins')
+      expect(durationMinutes(59)).toBe('59 mins')
+    })
+
+    it('renders hours below a day', () => {
+      expect(durationMinutes(60)).toBe('1 hour')
+      expect(durationMinutes(150)).toBe('2 hours')
+      expect(durationMinutes(23 * 60)).toBe('23 hours')
+    })
+
+    // A delay is not a date. timeagoMedium switches to days at 24h, which is right for "when
+    // did this happen" but wrong for "how long was this stuck": "2 days" hides whether a hold
+    // straddled one night or three. So hours run to 48h before days take over.
+    it('keeps using hours past 24h, up to 48h', () => {
+      expect(durationMinutes(24 * 60)).toBe('24 hours')
+      expect(durationMinutes(2812)).toBe('46 hours')
+      expect(durationMinutes(47 * 60)).toBe('47 hours')
+    })
+
+    it('renders days from 48 hours', () => {
+      expect(durationMinutes(48 * 60)).toBe('2 days')
+      expect(durationMinutes(60 * 60)).toBe('2 days')
+      expect(durationMinutes(6 * 24 * 60)).toBe('6 days')
+    })
+
+    it('renders weeks beyond a week — 283h was the worst observed hold', () => {
+      expect(durationMinutes(7 * 24 * 60)).toBe('1 week')
+      expect(durationMinutes(283 * 60)).toBe('1 week')
+      expect(durationMinutes(21 * 24 * 60)).toBe('3 weeks')
+    })
+
+    it('handles zero, sub-minute and missing values without throwing', () => {
+      expect(durationMinutes(0)).toBe('less than a minute')
+      expect(durationMinutes(null)).toBe('')
+      expect(durationMinutes(undefined)).toBe('')
+    })
+
+    it('ignores a negative span rather than rendering nonsense', () => {
+      expect(durationMinutes(-5)).toBe('less than a minute')
     })
   })
 })

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -59,12 +59,23 @@ type ChatMessage struct {
 	// this GORM adds it to every chat_messages INSERT, which fails outright on a database
 	// that has the code but not yet the migration.
 	Processingfailreason *string `json:"processingfailreason,omitempty" gorm:"->"`
-	// HeldByRippling is true when this message is held by the rippling reply-hold engine
-	// (a non-released row exists in rippling_held_replies). Populated for moderators (any
+	// HeldByRippling is true when this message is CURRENTLY held by the rippling reply-hold
+	// engine (a rippling_held_replies row with status='held'). Populated for moderators (any
 	// message) and for a normal caller on their OWN held reply, so the sender can show a
 	// "waiting to send" indicator. It is NOT set on the poster's view (the delivery gate
 	// removes held replies from their fetch entirely).
+	//
+	// Only 'held' counts. 'taken-gone' and 'dropped' are terminal - the reply was never
+	// delivered and never will be - so treating them as "held" told a moderator (and the
+	// sender) that delivery was still coming when it was not. Use RipplingHold to tell the
+	// terminal states apart.
 	HeldByRippling bool `json:"heldbyrippling,omitempty" gorm:"-"`
+	// RipplingHold is the rippling reply-hold row in whatever state it reached, including one
+	// already released or abandoned. Moderators only. HeldByRippling covers a live hold only,
+	// so once a hold released it went false and the delay left no trace anywhere in ModTools -
+	// which is how a 47-hour rippling hold came to be reported as a mail-system fault
+	// (Discourse 10025). Absent when the message was never held.
+	RipplingHold *RipplingHold `json:"ripplinghold,omitempty" gorm:"-"`
 	// Prompt is the answerable part of a type='Prompt' message - the tappable
 	// options, and the answer once one is chosen. Nil on every other message
 	// type, which is nearly all of them, so it costs an omitted field rather
@@ -79,6 +90,26 @@ type ChatMessage struct {
 	Replysource *string `json:"replysource" gorm:"-"`
 	Archived    int     `json:"-" gorm:"-"`
 	Deleted     bool    `json:"-"`
+}
+
+// RipplingHold describes what the rippling reply-hold engine did to a chat message, so a
+// moderator investigating "they say they never got my reply" can see whether it was delayed,
+// how long for, and whether it ever arrived at all.
+type RipplingHold struct {
+	// Status is rippling_held_replies.status verbatim: held | released | dropped | taken-gone.
+	Status string `json:"status"`
+	// Heldat is when the hold was placed, i.e. when the reply was written.
+	Heldat time.Time `json:"heldat"`
+	// Releasedat is when the hold ended, whatever the ending. Nil while still held.
+	Releasedat *time.Time `json:"releasedat,omitempty"`
+	// Heldminutes is how long the reply was undelivered: Heldat to Releasedat, or Heldat to now
+	// for a live hold. Computed server-side so a still-open hold does not depend on the
+	// client's clock, and so the client need not know that a NULL releasedat means "until now".
+	Heldminutes int64 `json:"heldminutes"`
+	// Delivered is true only for 'released'. 'taken-gone' (the item went while the reply was
+	// held) and 'dropped' never reached the recipient and never will, so the UI must not offer
+	// to wait for them.
+	Delivered bool `json:"delivered"`
 }
 
 // We need a separate struct for the query so that we can return image info in a single query.  If we put the
@@ -257,20 +288,49 @@ func FetchChatMessages(chatID, userID uint64, limit int, excludeID uint64, desce
 			idxByID[m.ID] = ix
 		}
 		type ripplingHeld struct {
-			Chatmsgid uint64 `gorm:"column:chatmsgid"`
+			Chatmsgid   uint64     `gorm:"column:chatmsgid"`
+			Status      string     `gorm:"column:status"`
+			CreatedAt   time.Time  `gorm:"column:created_at"`
+			Releasedat  *time.Time `gorm:"column:releasedat"`
+			Heldminutes int64      `gorm:"column:heldminutes"`
 		}
+		// Every status, not just the live ones: a released or abandoned hold is exactly what a
+		// moderator needs to see when a member reports a reply that arrived days late or never.
+		// Heldminutes is computed in SQL against the DB clock (COALESCE(releasedat, NOW()) so a
+		// live hold measures up to now), keeping it consistent with created_at/releasedat rather
+		// than mixing in the API host's clock.
+		//
 		// msgIDs is bound directly
 		// as a []uint64 slice rather than formatted as decimal text and
 		// joined into the SQL string.
 		var held []ripplingHeld
 		db.Table("rippling_held_replies").
-			Select("chatmsgid").
-			Where("chatmsgid IN ? AND status <> 'released'", msgIDs).
+			Select("chatmsgid, status, created_at, releasedat, "+
+				"TIMESTAMPDIFF(MINUTE, created_at, COALESCE(releasedat, NOW())) AS heldminutes").
+			Where("chatmsgid IN ?", msgIDs).
 			Scan(&held)
 		for _, h := range held {
-			if ix, ok := idxByID[h.Chatmsgid]; ok {
-				if modAccess || messages[ix].Userid == userID {
-					messages[ix].HeldByRippling = true
+			ix, ok := idxByID[h.Chatmsgid]
+			if !ok {
+				continue
+			}
+			// Only a live hold is "held" - see HeldByRippling.
+			if h.Status == "held" && (modAccess || messages[ix].Userid == userID) {
+				messages[ix].HeldByRippling = true
+			}
+			// The detail is a moderation tool. Members are deliberately not told their own
+			// reply is being held (see the notice in ChatMessage.vue), so it stays mod-only.
+			if modAccess {
+				mins := h.Heldminutes
+				if mins < 0 {
+					mins = 0
+				}
+				messages[ix].RipplingHold = &RipplingHold{
+					Status:      h.Status,
+					Heldat:      h.CreatedAt,
+					Releasedat:  h.Releasedat,
+					Heldminutes: mins,
+					Delivered:   h.Status == "released",
 				}
 			}
 		}

--- a/iznik-server-go/test/chatmessage_rippling_hold_duration_test.go
+++ b/iznik-server-go/test/chatmessage_rippling_hold_duration_test.go
@@ -1,0 +1,227 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// ripplingHoldFixture builds a group/poster/replier/mod, a post, a chat and one chat message,
+// then attaches a rippling_held_replies row in the given state. Returns the chat id, the chat
+// message id and a mod JWT. Cleanup is registered on t.
+//
+// heldAgoHours/releasedAgoHours are relative to NOW so a test can assert a *duration* without
+// depending on wall-clock; releasedAgoHours < 0 means leave releasedat NULL.
+func ripplingHoldFixture(t *testing.T, tag string, status string, heldAgoHours int, releasedAgoHours int) (uint64, uint64, string) {
+	t.Helper()
+	db := database.DBConn
+	prefix := uniquePrefix(tag)
+
+	// Same CREATE TABLE IF NOT EXISTS as chatmessage_rippling_held_test.go so this file can run
+	// standalone (test order is not guaranteed).
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_held_replies (
+		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		chatid BIGINT UNSIGNED NOT NULL,
+		chatmsgid BIGINT UNSIGNED NOT NULL,
+		msgid BIGINT UNSIGNED NOT NULL,
+		replieruserid BIGINT UNSIGNED NOT NULL,
+		source ENUM('email','tn','web') NOT NULL DEFAULT 'email',
+		lat DOUBLE,
+		lng DOUBLE,
+		status ENUM('held','released','dropped','taken-gone') NOT NULL DEFAULT 'held',
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		releasedat TIMESTAMP NULL,
+		INDEX (msgid),
+		INDEX (chatid),
+		INDEX (status)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	replierID := CreateTestUser(t, prefix+"_replier", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, replierID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: "+tag, 51.5, -0.1)
+	chatID := CreateTestChatRoom(t, replierID, &posterID, nil, "User2User")
+
+	res := db.Exec(
+		"INSERT INTO chat_messages (chatid, userid, message, date, reviewrequired, processingrequired, processingsuccessful) "+
+			"VALUES (?, ?, ?, NOW(), 0, 0, 1)",
+		chatID, replierID, "I would like this please",
+	)
+	if res.Error != nil {
+		t.Fatalf("failed to insert chat message: %v", res.Error)
+	}
+	var chatMsgID uint64
+	db.Raw("SELECT id FROM chat_messages WHERE chatid = ? ORDER BY id DESC LIMIT 1", chatID).Scan(&chatMsgID)
+	if chatMsgID == 0 {
+		t.Fatal("failed to get chat message ID")
+	}
+
+	if releasedAgoHours >= 0 {
+		db.Exec(
+			"INSERT INTO rippling_held_replies (chatid, chatmsgid, msgid, replieruserid, lat, lng, status, created_at, releasedat) "+
+				"VALUES (?, ?, ?, ?, 51.5, -0.1, ?, DATE_SUB(NOW(), INTERVAL ? HOUR), DATE_SUB(NOW(), INTERVAL ? HOUR))",
+			chatID, chatMsgID, msgID, replierID, status, heldAgoHours, releasedAgoHours,
+		)
+	} else {
+		db.Exec(
+			"INSERT INTO rippling_held_replies (chatid, chatmsgid, msgid, replieruserid, lat, lng, status, created_at) "+
+				"VALUES (?, ?, ?, ?, 51.5, -0.1, ?, DATE_SUB(NOW(), INTERVAL ? HOUR))",
+			chatID, chatMsgID, msgID, replierID, status, heldAgoHours,
+		)
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM rippling_held_replies WHERE chatmsgid = ?", chatMsgID)
+		db.Exec("DELETE FROM chat_messages WHERE id = ?", chatMsgID)
+	})
+
+	_, modToken := CreateTestSession(t, modID)
+	return chatID, chatMsgID, modToken
+}
+
+// fetchChatMessage returns the JSON object for chatMsgID from GET /api/chat/:id/message.
+func fetchChatMessage(t *testing.T, chatID uint64, chatMsgID uint64, token string) map[string]interface{} {
+	t.Helper()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/chat/%d/message?jwt=%s", chatID, token), nil)
+	resp, err := getApp().Test(req, -1)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body []map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	for _, m := range body {
+		if idFloat, ok := m["id"].(float64); ok && uint64(idFloat) == chatMsgID {
+			return m
+		}
+	}
+	t.Fatalf("chat message id=%d not found in response", chatMsgID)
+	return nil
+}
+
+// TestRipplingHold_ReleasedReportsDelay is the case behind the "delayed message between TN
+// member and Freegle member" reports: the hold released long ago, so heldbyrippling is false
+// and today a mod sees NOTHING - no way to tell the reply sat undelivered for two days. The
+// ripplinghold object must survive release and carry how long the delay actually was.
+func TestRipplingHold_ReleasedReportsDelay(t *testing.T) {
+	chatID, chatMsgID, modToken := ripplingHoldFixture(t, "rhrelease", "released", 47, 0)
+
+	m := fetchChatMessage(t, chatID, chatMsgID, modToken)
+
+	// Back-compat: heldbyrippling stays false once released (the member-facing
+	// "waiting to send" indicator must not reappear).
+	held, _ := m["heldbyrippling"].(bool)
+	assert.False(t, held, "released hold must not set heldbyrippling")
+
+	hold, ok := m["ripplinghold"].(map[string]interface{})
+	assert.True(t, ok, "released hold must still expose ripplinghold so the delay is visible")
+	if !ok {
+		return
+	}
+	assert.Equal(t, "released", hold["status"])
+	delivered, _ := hold["delivered"].(bool)
+	assert.True(t, delivered, "a released hold was eventually delivered")
+
+	mins, _ := hold["heldminutes"].(float64)
+	assert.InDelta(t, 47*60, mins, 90, "heldminutes should measure created_at -> releasedat (~47h)")
+	assert.NotEmpty(t, hold["heldat"], "heldat should be present")
+	assert.NotEmpty(t, hold["releasedat"], "releasedat should be present once released")
+}
+
+// TestRipplingHold_TakenGoneIsNotHeldAndNotDelivered pins the bug: 'taken-gone' means the item
+// went while the reply was held, so it was NEVER delivered and never will be. It must not read
+// as "held" (which tells a mod, and the sender, that it is still on its way).
+func TestRipplingHold_TakenGoneIsNotHeldAndNotDelivered(t *testing.T) {
+	chatID, chatMsgID, modToken := ripplingHoldFixture(t, "rhgone", "taken-gone", 30, 2)
+
+	m := fetchChatMessage(t, chatID, chatMsgID, modToken)
+
+	held, _ := m["heldbyrippling"].(bool)
+	assert.False(t, held,
+		"taken-gone is terminal, not held: heldbyrippling must be false or the UI promises delivery that never comes")
+
+	hold, ok := m["ripplinghold"].(map[string]interface{})
+	assert.True(t, ok, "taken-gone must expose ripplinghold")
+	if !ok {
+		return
+	}
+	assert.Equal(t, "taken-gone", hold["status"])
+	delivered, _ := hold["delivered"].(bool)
+	assert.False(t, delivered, "taken-gone was never delivered")
+}
+
+// TestRipplingHold_DroppedIsNotHeld - same for 'dropped'.
+func TestRipplingHold_DroppedIsNotHeld(t *testing.T) {
+	chatID, chatMsgID, modToken := ripplingHoldFixture(t, "rhdrop", "dropped", 5, 1)
+
+	m := fetchChatMessage(t, chatID, chatMsgID, modToken)
+
+	held, _ := m["heldbyrippling"].(bool)
+	assert.False(t, held, "dropped is terminal, not held")
+
+	hold, ok := m["ripplinghold"].(map[string]interface{})
+	assert.True(t, ok, "dropped must expose ripplinghold")
+	if !ok {
+		return
+	}
+	assert.Equal(t, "dropped", hold["status"])
+	delivered, _ := hold["delivered"].(bool)
+	assert.False(t, delivered, "dropped was never delivered")
+}
+
+// TestRipplingHold_StillHeldCountsElapsed - a live hold reports how long it has been waiting
+// so far, with releasedat absent.
+func TestRipplingHold_StillHeldCountsElapsed(t *testing.T) {
+	chatID, chatMsgID, modToken := ripplingHoldFixture(t, "rhheld", "held", 3, -1)
+
+	m := fetchChatMessage(t, chatID, chatMsgID, modToken)
+
+	held, _ := m["heldbyrippling"].(bool)
+	assert.True(t, held, "a live hold still sets heldbyrippling")
+
+	hold, ok := m["ripplinghold"].(map[string]interface{})
+	assert.True(t, ok, "live hold must expose ripplinghold")
+	if !ok {
+		return
+	}
+	assert.Equal(t, "held", hold["status"])
+	delivered, _ := hold["delivered"].(bool)
+	assert.False(t, delivered, "a still-held reply has not been delivered")
+
+	mins, _ := hold["heldminutes"].(float64)
+	assert.InDelta(t, 3*60, mins, 30, "heldminutes should measure created_at -> now while still held")
+	assert.Nil(t, hold["releasedat"], "releasedat must be absent while still held")
+}
+
+// TestRipplingHold_NotExposedToNonMod - hold internals (status names, durations) are a
+// moderation tool, not member-facing. The sender keeps heldbyrippling for their own reply.
+func TestRipplingHold_NotExposedToNonMod(t *testing.T) {
+	db := database.DBConn
+	chatID, chatMsgID, _ := ripplingHoldFixture(t, "rhnonmod", "held", 3, -1)
+
+	// Fetch as the replier (the sender of the held message), who is not a mod.
+	var replierID uint64
+	db.Raw("SELECT userid FROM chat_messages WHERE id = ?", chatMsgID).Scan(&replierID)
+	_, replierToken := CreateTestSession(t, replierID)
+
+	m := fetchChatMessage(t, chatID, chatMsgID, replierToken)
+
+	held, _ := m["heldbyrippling"].(bool)
+	assert.True(t, held, "sender still sees heldbyrippling on their own held reply")
+
+	_, ok := m["ripplinghold"].(map[string]interface{})
+	assert.False(t, ok, "ripplinghold detail is mod-only")
+}


### PR DESCRIPTION
## Summary

From [Discourse 10025 - Delayed message between TN member and Freegle member](https://discourse.ilovefreegle.org/t/delayed-message-between-tn-member-and-freegle-member/10025).

A rippling reply-hold was only visible **while it was still held**. Once it released, `heldbyrippling` went false and the delay left no trace anywhere in ModTools, so a reply that sat undelivered for 47 hours looked identical to one that arrived instantly. That is why the Thurrock report was put down to a mail-system fault. It was not one: the reply reached our database in seconds (its auto-increment id sits among ids written in that same minute) and rippling held it.

What actually happened on that post, `OFFER: Girls mountain bike (Fobbing SS17)`:

| | |
| --- | --- |
| TN member replies | 04 Aug 14:22:58 - held instantly, 19.4 km / ~40 min drive against the post's 30 min cap |
| Reach marked `done` at tick 5 of 9 | 06 Aug 13:14:59 |
| `releaseAll('maxed')` | 06 Aug 13:15:08 |
| Offerer emailed | 06 Aug 13:15:10 - **47 hours late** |
| Offerer replies | 06 Aug 15:26 |
| TN member: "I have sourced another ... I had not received any response" | 06 Aug 15:28 |

Both people were telling the truth about their own timestamps, which is exactly why it turned into an argument. Meanwhile the only two replies the offerer *could* see were "Still available please" and "Can I have it please" - and she later wrote that those made her sad. Her two considered replies were the held ones.

Scale over the fortnight to 12 Aug: 2,644 TN + 742 web replies released after a mean ~30 h hold (986 over 24 h, worst 283 h), and a further ~970 ended `taken-gone`, never delivered at all.

## Screenshot

![Rippling reply-hold notices in ModTools chat review](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/mt-chat-rippling-hold-duration/hold-notices.png)

The three hold states, plus what a moderator saw before this change. Notice text, `NoticeMessage` variants and colours are as the components render them; the durations are the real output of `durationMinutes()` (2812 minutes → "46 hours"). This is a render of the notice states rather than a live ModTools page grab - the shared dev containers were checked out on another branch at the time, so a live capture would not have been of this code.

The `pr-assets/mt-chat-rippling-hold-duration` branch holds only the image and can be deleted after merge.

## Changes

- **Go API**: new mod-only `ripplinghold{status, heldat, releasedat, heldminutes, delivered}` on chat messages, covering every state including ended ones. `heldminutes` is computed in SQL against the DB clock, so a still-open hold does not depend on the client's clock.
- **`heldbyrippling` now means `status='held'` only.** It was `status <> 'released'`, which also matched the terminal `taken-gone` and `dropped`. Those replies were never delivered and never will be, but ModTools said *"it will be delivered automatically once the reach expands far enough"* and the sender's own copy showed as merely "waiting to send". This is a live mislabelling affecting roughly 970 replies a fortnight.
- **ModTools chat review**: three notices instead of one - held now (with time waited so far), "Held as too far for: <duration>" once it was delivered, and never reached the recipient (the item was taken while the reply was held). Falls back to the previous wording when the API sends no detail, so an older build or a cached response still warns.
- **Chat message badge** (what a moderator sees reading a thread) gains the same ended states. Still hidden from the sender, deliberately, as before.
- **`dropped` is not presented as a state moderators will meet.** Nothing in the codebase writes it and production has never recorded one - 0 rows since the table began on 2026-06-27, against 9,816 released and 3,219 taken-gone. So `taken-gone` is the only real undelivered case. The generic branch stays as a safety net so an unexpected status is not silently invisible, but it no longer invents a reason for it.
- **New `durationMinutes()`**. `timeagoMedium` cannot do this job: it takes a date, and an ended hold has no "now" to measure from. Hours run to 48 rather than 24, because for a delay "2 days" hides whether it was one night or three.
- **Moderator guide corrected.** It claimed held replies land "within the hour and none waits longer than three". In production `dueat` is unset on 3,578 of 4,379 holds (82%), only 48% of released holds landed within three hours, and the mean is 30.5 hours.
- **`file-sync`**: `api/` and `server/` were missing from the shared-code allowlist, so they never reached the unit-test runner. Separate commit.

## Code Quality Review

- `heldbyrippling` semantics changed, so it was checked against every existing expectation first: no test asserted it for a non-`held` status, and the member-facing indicator only ever wanted a live hold.
- Kept `heldbyrippling` rather than replacing it, so the member-facing "waiting to send" path and any cached client are unaffected.
- The hold detail is mod-gated in the API, not just hidden in the UI - members are deliberately not told their reply is held, and status names and durations are moderation internals.
- One query, unchanged shape: the existing batch lookup gained columns rather than becoming a second round trip, so there is no new N+1.
- `durationMinutes` lives beside the other time formatters and is imported explicitly in both components, because the component unit tests mount without the auto-import layer - so the tests exercise the real formatter, not a stub.
- Negative spans (possible only from clock skew between rows) are clamped in both the API and the formatter.

## A note on the `file-sync` fix

While proving the frontend tests RED first, two unrelated tests in `tests/unit/api/BaseAPI.spec.js` were failing. They were not flaky and not load-related - they failed with nothing else running. The cause was that `file-sync` never copied `api/` to the unit-test runner, so the new spec from #1317 was being run against a **baked** `api/BaseAPI.js` that predated the `warn()` calls it asserts. A false failure that reads exactly like a regression on master; the same gap hides false passes, which is worse. This is the third instance after `assets/` and `pages/`, so the comment now carries the audit command.

## Future Improvements

Not in scope here, but the investigation surfaced two things worth their own work:

1. **The hold is mostly futile.** Only 9.2% of released TN holds were ever inside the post's final reach polygon - the other ~91% were let through because the ripple *stopped*, not because it reached them. On the reported post, none of the five holds was inside any of the nine ticks, so the 47 hours bought nothing. Worth asking whether a replier beyond the post's maximum cap should be held at all, rather than either delivered or told the post is not available to them.
2. **`dueat` is unset on 82% of holds**, so the due-time mechanism the moderator guide described barely operates. The doc now describes what actually happens; the mechanism itself needs a look.

Also: `rippling_reach.polygon` and `outer_bound` are declared SRID 3857 but store raw degrees, so `ST_Area`/`ST_Distance` on them are meaningless and any containment test done in metres silently returns false for everything.

## Test Plan

- Go: 4099 pass. The 4 new tests in `chatmessage_rippling_hold_duration_test.go` were proven RED first (released / taken-gone / dropped / still-held), and nothing else moved.
- Vitest: 15381 pass. 17 new tests, all proven RED first - 7 for `durationMinutes`, 4 for the chat-review states, 6 for the message badges.
- Container copies of every file under test were md5-checked against the working tree before trusting any red or green result.
- `api/` sync verified end to end: edit a file, confirm it appears in the runner, revert.
- Docs freshness passes.