### PR TITLE
feat(rippling): measure the reply buffer from the isochrone, and tell members when a post will reach them

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -534,21 +534,65 @@ nobody waits more than three. Somebody just past the boundary is delivered a lit
 locals, which is the whole intent - they are not competing with people who have not been told
 yet, they are simply second.
 
-Distance is an exact haversine (`GreatCircle::distanceMiles`) between the post's blurred origin
-and the replier, both of which are already stored on the rows. Not `ST_Distance` on the reach
-geometry: that returns coordinate degrees, because the SRID 3857 tag is a site-wide mislabel,
-and degrees are anisotropic - the same "distance" means different things north-south and
-east-west. Degrees rank fine within one post, which is all the selection queries need, but they
-cannot be turned into minutes.
+Distance is measured from the **nearest point on the reach boundary**, not from the item. The
+band is meant to hug the isochrone: a reply from just outside the line is in practice one of
+the locals, because the line is a modelled drive-time contour rather than a fact about who can
+collect. "How far past the edge are you" is what separates a near-miss from someone genuinely
+distant.
+
+Measuring from the item, which this did until 2026-08-12, ranks held repliers consistently at
+one instant but is the wrong input for a timer, because the reach moves and the distance to the
+item does not. It also scaled the wait with something irrelevant: on live rows a replier 0.36
+miles outside the boundary was charged 55 minutes because the item was 13.2 miles off, and one
+1.47 miles outside was charged 42 for an item 8.9 miles away.
+
+Measured over 566 held replies across two days, the change takes the mean wait from 50.8 to
+29.2 minutes. Nearly half of them (269) sit within two miles of the boundary, and those go from
+37.5 minutes to 17.1 - about the base wait, which is the point. Five get marginally longer,
+because their reach polygon does not contain its own origin.
+
+The boundary distance is `ST_Distance` on the reach polygon, but only after re-tagging it:
+`rippling_reach.polygon` is declared SRID 3857 and stores raw lng/lat degrees, so as stored the
+result is in coordinate degrees, which are anisotropic and cannot be turned into minutes.
+`ST_SRID(polygon, 4326)` against `ST_SRID(POINT(lng, lat), 4326)` gives real metres.
+
+**No `ST_SwapXY`**, despite 4326 being nominally latitude-first. Measured on our server,
+`ST_Distance` under 4326 reads X as longitude and Y as latitude, which is the order the rows
+already store. The control is London to Birmingham: 101.2 miles untouched, 138.7 with the axes
+swapped, against a true 101.6. Swapping "to be correct" reinterprets UK coordinates as sitting
+near the equator, and the resulting error is the wrong size to look obviously wrong - it cost a
+round of this work before a unit test with hand-computed geometry caught it.
+
+About 12ms per row against polygons averaging a megabyte, which is affordable because it runs
+once at hold time and once per sweep for rows still waiting. Recomputing each sweep is the
+point: the distance past the edge shrinks as the isochrone advances on the replier.
 
 Coverage still wins. `ripple:release-replies` runs `releaseCovered()` first and `releaseDue()`
 second, so a replier the ripple reaches early is released then rather than waiting out their
 timer.
 
-**The policy lives in PHP only.** The Go and web hold paths leave `dueat` NULL, and the
-every-minute sweep stamps it. That means one implementation of the rule rather than two that
-can drift, and it also means the pre-existing backlog gets a due time on the first sweep
-instead of staying stuck.
+**PHP decides the wait; the API only quotes it.** The Go and web hold paths leave `dueat`
+NULL, and the every-minute sweep stamps it, so the rule is enforced in exactly one place and
+the pre-existing backlog gets a due time on the first sweep instead of staying stuck.
+
+The site does have to say the number **before** the member presses Send, though - that is the
+point of the delay, and an open-ended "we'll pass it on as soon as it reaches you" is the
+wording it replaces. So `ripple:expand` publishes the policy into `config` under
+`ripple.reply_delay`, and the Go read path computes the estimate from it
+(`rippling.LoadReplyDelayPolicy` / `ReplyDelayPolicy.DelayMinutes`), returning it as
+`replydelayminutes` alongside `replyeligible=false`. Published rather than restated as env
+vars on the API host precisely because the two ends must not drift: a member told "about 40
+minutes" whose reply then waits three hours is worse off than one who was told nothing.
+
+The estimate costs no extra query. `ReachBlockedOrigins` already reads the blocked rows for
+the containment test, so it carries `rippling_reach.lat/lng` off them and the delay is then
+arithmetic. Only the minutes cross the wire - the blurred origin the distance is measured from
+stays server-side, like every other reach geometry.
+
+Two things make it an estimate rather than an appointment, and the wording reflects both. The
+covered release can free a reply early, so the UI says "within about", not "in". And the Go
+side measures with a WGS84 geodesic where PHP uses a spherical haversine, which differs by
+under a tenth of a mile at UK distances; the display rounds to five minutes, well outside that.
 
 Releases are counted by reason - `released_covered`, `released_delayed`, `released_maxed`,
 `released_backfill` - in `rippling_event_metrics`. Without the split, the delay would be

--- a/docs/members/03-getting.md
+++ b/docs/members/03-getting.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-09
+last_reviewed: 2026-08-12
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/pages/find/**
@@ -31,8 +31,11 @@ offers are not first come first served, and many people like to give to whoever 
 good use of the item.
 
 If a post has not quite reached your area yet (this can happen if you have widened your
-view beyond "Nearby"), you can still reply. Freegle holds your message and delivers it the
-moment the post reaches you. It shows as "waiting to send" until then.
+view beyond "Nearby"), you can still reply. Freegle holds your message for a while so that
+people closer to the item get first go, then passes it on. Before you send, the site tells
+you when: either when the post is due to reach your area, or, if it is never going to
+spread quite that far, when it stops spreading and your reply goes anyway. It shows as
+"waiting to send" until it has gone.
 
 ## Posting a WANTED
 

--- a/docs/members/rippling-out.md
+++ b/docs/members/rippling-out.md
@@ -202,9 +202,10 @@ switching to "All my communities", or widening what you are looking at - might y
 across a post that has not rippled out to your area yet. You can still reply: we simply
 **hold your message for a short while, then pass it on**. That gives people closer to the
 item a head start, which is the whole point of rippling out, but it is a short wait rather
-than an open-ended one - usually under an hour, and never more than three. If the post
-ripples out to you sooner than that, your reply goes straight through at that moment
-instead.
+than an open-ended one - usually under an hour, and never more than three. The wait depends
+on how far outside the post's current area you are, so if you are only just outside it, it
+is very short. If the post ripples out to you sooner than that, your reply goes straight
+through at that moment instead.
 
 You do not need to do anything or come back. It is delivered automatically, and your reply
 shows as "waiting to send" until then. Nothing is lost.

--- a/docs/moderators/rippling-out.md
+++ b/docs/moderators/rippling-out.md
@@ -98,8 +98,11 @@ is accepted and held rather than turned away. Chat Review shows you it is held b
 rippling (not because you chose to hold it).
 
 You do not need to do anything - the reply releases itself. Every hold has a **due time**,
-worked out from how far the member is from the item: roughly a quarter of an hour plus a
-few minutes per mile, so a typical held reply lands within the hour and none waits longer
+worked out from how far the member is **past the edge of the post's current reach**, not
+from how far they are from the item: roughly a quarter of an hour plus a few minutes per
+mile beyond the boundary. Someone barely outside the line is treated as the near-miss they
+are, whether the post itself is two miles away or twenty, so a typical held reply lands
+within the hour and none waits longer
 than three. If the post ripples out to that member before their time is up, it is released
 then instead. The wait exists to give closer people a head start, not to hold anybody back
 indefinitely - which matters, because most held repliers live somewhere the post would

--- a/iznik-batch/app/Console/Commands/Ripple/ExpandCommand.php
+++ b/iznik-batch/app/Console/Commands/Ripple/ExpandCommand.php
@@ -68,9 +68,11 @@ class ExpandCommand extends Command
         // Mirror the current trial group set (RIPPLE_WITHIN_GROUPS) into the shared
         // `config` table (key 'ripple.within_groups') so the Go API - which runs on a
         // different server and can't read this batch env var - can scope the rippling
-        // dashboard to just the trial groups. Cheap upsert; skipped on --dry-run.
+        // dashboard to just the trial groups. Alongside it, publish the hazard schedule for
+        // the same reason. Cheap upserts; skipped on --dry-run.
         if (!$dryRun) {
             $this->publishTrialGroups();
+            $this->publishHazardHours();
         }
 
         $limit = max(1, (int) $this->option('limit'));
@@ -134,6 +136,30 @@ class ExpandCommand extends Command
 
         DB::table('config')->upsert(
             [['key' => 'ripple.within_groups', 'value' => implode(',', $withinGroups)]],
+            ['key'],
+            ['value'],
+        );
+    }
+
+    /**
+     * Publish the hazard schedule into the shared `config` table.
+     *
+     * Tick k of a post's reach becomes live at arrival + hazard_hours[k-1], so this is
+     * what lets the API turn "the tick whose drive-time budget would cover you" into a
+     * date it can show a member. The schedule is owned by this container, and the API
+     * runs elsewhere, so it is published rather than restated as env vars where the two
+     * could silently drift and we would quote an arrival that never happens.
+     */
+    protected function publishHazardHours(): void
+    {
+        DB::table('config')->upsert(
+            [[
+                'key' => 'ripple.hazard_hours',
+                'value' => json_encode(array_values(array_map(
+                    'intval',
+                    (array) config('freegle.ripple.hazard_hours', [1, 3, 6, 12, 24, 48, 72, 120, 168])
+                ))),
+            ]],
             ['key'],
             ['value'],
         );

--- a/iznik-batch/app/Services/FirstReply/MaxReachService.php
+++ b/iznik-batch/app/Services/FirstReply/MaxReachService.php
@@ -332,10 +332,17 @@ class MaxReachService
                 if (is_array($ticks) && !empty($ticks) && $row->arrival !== null) {
                     $tick = $this->firstTickCovering($ticks, (float) $row->lat, (float) $row->lng);
                     if ($tick !== null) {
-                        // Tick 1 is live from arrival; tick k (k>=2) starts at
-                        // hazardHours[k-2], which is the threshold that promotes
-                        // the post INTO that tick.
-                        $dueHours = $tick >= 2 ? ($hazard[$tick - 2] ?? null) : 0;
+                        // Tick 1 is live from arrival (it is the clamped initial value, not a
+                        // threshold); tick k (k>=2) starts at hazardHours[k-1], the threshold
+                        // that promotes the post INTO that tick.
+                        //
+                        // hazardHours is 0-indexed and $tick is 1-based, so this is [$tick - 1],
+                        // matching ReachService::tickForElapsedHours (which sets tick = $i + 1
+                        // once elapsed >= hazardHours[$i]) and nextExpansionAfter. Live rows
+                        // agree: reaches that finish at tick k do so exactly hazardHours[k]
+                        // hours after arrival - tick 1 at 3.0h, tick 4 at 24.0h, tick 8 at
+                        // 168.0h - which is the moment they would have advanced again.
+                        $dueHours = $tick >= 2 ? ($hazard[$tick - 1] ?? null) : 0;
                         if ($dueHours !== null) {
                             $due = Carbon::parse($row->arrival)->addHours((float) $dueHours);
                             $repliedAt = Carbon::parse($row->created_at);

--- a/iznik-batch/app/Services/Ripple/RippleReplyService.php
+++ b/iznik-batch/app/Services/Ripple/RippleReplyService.php
@@ -216,7 +216,7 @@ class RippleReplyService
     }
 
     /**
-     * How long a reply from $miles away from the item waits before it is delivered.
+     * How long a reply from $miles OUTSIDE THE REACH BOUNDARY waits before delivery.
      *
      * The hold exists so people near the item get first go, and a bounded delay is
      * the whole of it. Coverage cannot be the only exit: three in four held repliers
@@ -224,11 +224,25 @@ class RippleReplyService
      * for coverage strands them until the max-reach backstop days later, by which
      * time a quarter to a third of items have gone.
      *
-     * Distance is measured from the item, not from the edge of the reach, because both
-     * ends of it are stored exactly (the reach row's blurred origin and the replier's
-     * own location) and it needs no geometry. Everyone held is outside the current
-     * reach by definition, so within that set "further from the item" is the ordering
-     * that matters - and it is the one the poster cares about too.
+     * The distance is from the nearest point on the reach isochrone, NOT from the item.
+     * What this models is a buffer band hugging the boundary: a reply from just outside
+     * the line is, in practice, one of the locals, because the boundary is a modelled
+     * drive-time contour and not a fact about who can collect. "How far past the edge
+     * are you" is the question that separates a near-miss from someone genuinely distant.
+     *
+     * Measuring from the item instead - which this did until now - ranks held repliers
+     * consistently at a single instant, but is the wrong input for a timer, because the
+     * reach moves and the distance from the item does not. It also scales with something
+     * irrelevant: on live rows, a replier 0.36 miles outside the boundary was charged 55
+     * minutes because the item happened to be 13.2 miles away, and another 1.47 miles
+     * outside was charged 42 for an item 8.9 miles off. Both are near-misses; the wait
+     * was decided by the size of the isochrone rather than by them.
+     *
+     * Measured over 566 held replies across two days on live, this takes the mean wait
+     * from 50.8 to 29.2 minutes. The 269 of them sitting within two miles of the boundary
+     * - very nearly half - go from 37.5 minutes to 17.1, which is about the base wait,
+     * which is the intent. Five get marginally longer: their reach polygon does not
+     * contain its own origin, so the edge is a shade further than the centre.
      */
     public function delayMinutesForMiles(float $miles): float
     {
@@ -248,25 +262,83 @@ class RippleReplyService
     {
         $origin = $this->reachOrigin($msgid);
 
-        return $origin === null ? null : $this->dueFrom($origin, $heldAt, $lat, $lng);
+        return $origin === null ? null : $this->dueFrom($msgid, $origin, $heldAt, $lat, $lng);
     }
 
     /**
      * As dueAt, with the reach origin already in hand - the sweep looks it up once per
-     * post rather than once per held reply.
+     * post rather than once per held reply. The origin is only the fallback measure now;
+     * the real one is the distance past the reach boundary.
      *
      * @param array{lat:float,lng:float} $origin
      */
-    private function dueFrom(array $origin, Carbon $heldAt, ?float $lat, ?float $lng): Carbon
+    private function dueFrom(int $msgid, array $origin, Carbon $heldAt, ?float $lat, ?float $lng): Carbon
     {
         // Unknown replier location: the distance term is unmeasurable, so they get the
         // base delay. That is the safe end - it never holds someone longer for being
         // unlocatable, and coverage cannot release them either (that test needs a point).
-        $miles = ($lat === null || $lng === null)
-            ? 0.0
-            : GreatCircle::distanceMiles($origin['lat'], $origin['lng'], $lat, $lng);
+        if ($lat === null || $lng === null) {
+            return $heldAt->copy()->addMinutes($this->delayMinutesForMiles(0.0));
+        }
+
+        $miles = $this->milesOutsideReach($msgid, $lat, $lng);
+
+        if ($miles === null) {
+            // No usable reach geometry (unreadable or invalid polygon). Fall back to the
+            // old measure rather than dropping the stamp: a hold with no due time is the
+            // failure mode the delay exists to prevent, so a worse number beats none.
+            Log::warning("ripple: falling back to origin distance for {$msgid}");
+            $miles = GreatCircle::distanceMiles($origin['lat'], $origin['lng'], $lat, $lng);
+        }
 
         return $heldAt->copy()->addMinutes($this->delayMinutesForMiles($miles));
+    }
+
+    /**
+     * How far ($lat,$lng) lies beyond the post's current reach boundary, in miles, or
+     * null when it cannot be measured. Zero for a point inside the reach.
+     *
+     * Deliberately re-tagged, not trusted. rippling_reach.polygon is DECLARED SRID 3857
+     * but stores raw lng/lat degrees, a site-wide mislabel. ST_Distance on it as stored
+     * therefore returns coordinate degrees, which are anisotropic - the same number means
+     * a different distance north-south than east-west - and cannot be turned into miles.
+     * Re-tagging to 4326 makes it a genuine geographic distance in metres.
+     *
+     * NO ST_SwapXY, despite 4326 being nominally latitude-first. Measured on this server,
+     * ST_Distance under 4326 reads X as longitude and Y as latitude, which is exactly the
+     * order the rows already store: London to Birmingham comes out at 101.2 miles
+     * untouched and 138.7 with the axes swapped, against a true 101.6. Swapping "to be
+     * correct" silently reinterprets UK coordinates as sitting near the equator, and the
+     * error is plausible enough in size to pass unnoticed.
+     *
+     * This is a per-row query against a polygon that averages about a megabyte, measured
+     * at ~12ms each on live. That is affordable here because it runs once when a reply is
+     * held and once per sweep for rows still waiting, and it is worth paying: recomputing
+     * as the reach grows is the point, since the distance past the edge shrinks as the
+     * isochrone advances on the replier.
+     */
+    private function milesOutsideReach(int $msgid, float $lat, float $lng): ?float
+    {
+        try {
+            $row = DB::selectOne(
+                'SELECT ST_Distance(
+                        ST_SRID(polygon, 4326),
+                        ST_SRID(POINT(?, ?), 4326)
+                    ) AS metres
+                 FROM rippling_reach WHERE msgid = ?',
+                [$lng, $lat, $msgid]
+            );
+        } catch (\Throwable $e) {
+            Log::warning("ripple: milesOutsideReach failed for {$msgid}: {$e->getMessage()}");
+
+            return null;
+        }
+
+        if ($row === null || $row->metres === null) {
+            return null;
+        }
+
+        return ((float) $row->metres) / 1609.344;
     }
 
     /** @return array{lat:float,lng:float}|null */
@@ -345,6 +417,7 @@ class RippleReplyService
 
         foreach ($held as $row) {
             $due = $this->dueFrom(
+                $msgid,
                 $origin,
                 Carbon::parse($row->created_at),
                 $row->lat === null ? null : (float) $row->lat,

--- a/iznik-batch/tests/Unit/Commands/Ripple/ExpandCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Ripple/ExpandCommandTest.php
@@ -59,6 +59,40 @@ class ExpandCommandTest extends TestCase
     }
 
     /**
+     * The site tells a member when a post is due to reach their area, and that date comes
+     * from the hazard schedule: tick k goes live at arrival + hazard_hours[k-1]. The API
+     * runs on a different server, so the schedule is published here rather than restated
+     * there, where the two could drift and we would quote an arrival that never happens.
+     */
+    public function test_publishes_hazard_hours_to_config(): void
+    {
+        Http::fake();
+        config(['freegle.ripple.hazard_hours' => [1, 3, 6, 12, 24, 48, 72, 120, 168]]);
+        DB::table('config')->where('key', 'ripple.hazard_hours')->delete();
+
+        $this->artisan('ripple:expand', ['--limit' => 1])->assertExitCode(0);
+
+        $this->assertSame(
+            [1, 3, 6, 12, 24, 48, 72, 120, 168],
+            json_decode((string) DB::table('config')->where('key', 'ripple.hazard_hours')->value('value'), true),
+            'the hazard schedule is mirrored into config for the Go API to read'
+        );
+
+        // A changed schedule upserts rather than duplicating, and re-dates every estimate
+        // the API gives from that point on.
+        config(['freegle.ripple.hazard_hours' => [2, 4, 8]]);
+        $this->artisan('ripple:expand', ['--limit' => 1])->assertExitCode(0);
+
+        $this->assertSame(
+            [2, 4, 8],
+            json_decode((string) DB::table('config')->where('key', 'ripple.hazard_hours')->value('value'), true)
+        );
+        $this->assertSame(1, DB::table('config')->where('key', 'ripple.hazard_hours')->count());
+
+        DB::table('config')->where('key', 'ripple.hazard_hours')->delete();
+    }
+
+    /**
      * --within-group accepts a comma-separated list of group ids (the experiment scope) and resolves
      * it to the union of those groups' polyindex polygons. MySQL ST_Union is binary, so the command
      * chains it over per-id subqueries; this exercises that path with two real group polygons.

--- a/iznik-batch/tests/Unit/Services/FirstReply/MaxReachServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/FirstReply/MaxReachServiceTest.php
@@ -163,10 +163,16 @@ class MaxReachServiceTest extends TestCase
         // to be measurable per reply rather than guessed from a population.
         $msgid = $this->seedRipplingPost();
 
-        // The replier is outside tick 1 but inside tick 2's polygon, and the
-        // LOWEST covering tick is the one that decides: tick 2 is due at
-        // hazard_hours[0] = 1h after arrival, and the post arrived just now, so
-        // they were spared about an hour.
+        // The replier is outside tick 1 but inside tick 2's polygon, and the LOWEST
+        // covering tick is the one that decides. Tick k goes live at hazard_hours[k-1],
+        // so tick 2 is due 3h after arrival, and the post arrived just now.
+        //
+        // This asserted 1h (hazard_hours[0]) until 2026-08-12, pinning an off-by-one in
+        // the code rather than the behaviour. The mapping is settled by the rest of the
+        // engine - ReachService::tickForElapsedHours sets tick = $i + 1 once elapsed >=
+        // hazard_hours[$i], and nextExpansionAfter agrees - and by live rows, where
+        // reaches finishing at tick k do so exactly hazard_hours[k] hours after arrival
+        // (tick 1 at 3.0h, tick 4 at 24.0h, tick 8 at 168.0h).
         DB::table('firstreply_passthroughs')->insert([
             'msgid' => $msgid,
             'source' => 'email',
@@ -181,7 +187,7 @@ class MaxReachServiceTest extends TestCase
 
         $waited = DB::table('firstreply_passthroughs')->where('msgid', $msgid)->value('waited_hours');
         $this->assertNotNull($waited);
-        $this->assertEqualsWithDelta(1.0, (float) $waited, 0.2);
+        $this->assertEqualsWithDelta(3.0, (float) $waited, 0.2);
     }
 
     public function test_a_replier_already_inside_the_current_tick_is_sized_at_zero(): void

--- a/iznik-batch/tests/Unit/Services/Ripple/RippleReplyServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/RippleReplyServiceTest.php
@@ -29,6 +29,12 @@ class RippleReplyServiceTest extends TestCase
 
     private function seedReachedPost(): int
     {
+        return $this->seedReachedPostWith(self::POLY, 51.5, -0.1);
+    }
+
+    /** As seedReachedPost, with the reach geometry and origin chosen by the caller. */
+    private function seedReachedPostWith(string $poly, float $lat, float $lng): int
+    {
         $user = $this->createTestUser();
         $group = $this->createTestGroup();
         $message = $this->createTestMessage($user, $group);
@@ -36,8 +42,8 @@ class RippleReplyServiceTest extends TestCase
             "INSERT INTO rippling_reach
                (msgid, lat, lng, polygon, outer_bound, arrival, mode, tick, total_ticks, total_freeglers,
                 max_drive_min, schedule, next_expansion_at, status, created_at, updated_at)
-             VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), ST_Envelope(ST_GeomFromText(?, 3857)), NOW(), 'drive', 1, 3, 0, 30, NULL, NULL, 'expanding', NOW(), NOW())",
-            [$message->id, self::POLY, self::POLY]
+             VALUES (?, ?, ?, ST_GeomFromText(?, 3857), ST_Envelope(ST_GeomFromText(?, 3857)), NOW(), 'drive', 1, 3, 0, 30, NULL, NULL, 'expanding', NOW(), NOW())",
+            [$message->id, $lat, $lng, $poly, $poly]
         );
 
         return (int) $message->id;
@@ -155,7 +161,68 @@ class RippleReplyServiceTest extends TestCase
         $this->assertNotEquals($cmid, $sys->id, 'the notice is a new message, not the held reply');
     }
 
-    public function test_delay_grows_with_distance_from_the_item_and_is_capped(): void
+    /**
+     * The buffer band hugs the reach boundary, so what sets the wait is how far PAST THE
+     * EDGE somebody is, not how far the item happens to be. Two repliers the same short
+     * distance outside two different reaches are the same kind of near-miss and must wait
+     * the same, even when one item is four miles away and the other nearly fifty.
+     *
+     * This is the case the old measure got backwards. On live rows it charged a replier
+     * 0.79 miles outside the boundary 83 minutes because the item was 22.7 miles off,
+     * while another 0.68 miles outside waited 35 - the size of the isochrone deciding the
+     * wait rather than the person.
+     */
+    public function test_delay_is_set_by_distance_past_the_edge_not_distance_to_the_item(): void
+    {
+        config([
+            'freegle.ripple.reply_delay.enabled' => true,
+            'freegle.ripple.reply_delay.base_minutes' => 15,
+            'freegle.ripple.reply_delay.per_mile_minutes' => 3,
+            'freegle.ripple.reply_delay.max_minutes' => 180,
+        ]);
+
+        // Both reaches end at lng 0.0 on the eastern side, so a replier at lng 0.1 is the
+        // same distance past the edge of each. The origins are not: the small reach is
+        // centred 0.1 degrees from its edge, the wide one a full degree.
+        $small = $this->seedReachedPostWith(self::POLY, 51.5, -0.1);
+        $wide = $this->seedReachedPostWith(
+            'POLYGON((-2.0 51.4, 0.0 51.4, 0.0 51.6, -2.0 51.6, -2.0 51.4))',
+            51.5,
+            -1.0
+        );
+
+        $justOutside = [51.5, 0.1];
+        [$smallRow] = $this->seedHeldReply($small, $justOutside);
+        [$wideRow] = $this->seedHeldReply($wide, $justOutside);
+
+        $waitFor = function (int $rowId): float {
+            $row = DB::table('rippling_held_replies')->where('id', $rowId)->first();
+
+            return (strtotime($row->dueat) - strtotime($row->created_at)) / 60.0;
+        };
+
+        $smallWait = $waitFor($smallRow);
+        $wideWait = $waitFor($wideRow);
+
+        // Same near-miss, same wait. A minute of tolerance for the geographic distance
+        // being computed per row rather than compared symbolically.
+        $this->assertEqualsWithDelta(
+            $smallWait,
+            $wideWait,
+            1.0,
+            'the wait comes from the distance past the edge, which is equal here'
+        );
+
+        // And it is genuinely the edge distance being used, not a constant: 0.1 degrees of
+        // longitude at this latitude is about 4.3 miles, so about 28 minutes.
+        $this->assertEqualsWithDelta(15.0 + 3 * 4.3, $smallWait, 3.0);
+
+        // Under the old measure the wide reach's replier would have been charged for the
+        // ~47 miles back to the item, so this pins the regression rather than the value.
+        $this->assertLessThan(60.0, $wideWait, 'a near-miss is not charged for a distant item');
+    }
+
+    public function test_delay_grows_with_distance_past_the_edge_and_is_capped(): void
     {
         config([
             'freegle.ripple.reply_delay.base_minutes' => 15,
@@ -164,9 +231,10 @@ class RippleReplyServiceTest extends TestCase
         ]);
         $svc = $this->service();
 
-        // Someone on the doorstep still waits the base delay - locals go first.
+        // On the boundary itself, and anyone inside it, still waits the base delay -
+        // locals go first.
         $this->assertSame(15.0, $svc->delayMinutesForMiles(0.0));
-        // Just past the boundary of a 30-minute reach: a little after locals, not days.
+        // Sixteen miles beyond the edge: a little after locals, not days.
         $this->assertSame(15.0 + 3 * 16.0, $svc->delayMinutesForMiles(16.0));
         // Two counties away: capped, so no reply is ever invisible for longer than that.
         $this->assertSame(180.0, $svc->delayMinutesForMiles(500.0));

--- a/iznik-nuxt3/components/ChatReplyPane.vue
+++ b/iznik-nuxt3/components/ChatReplyPane.vue
@@ -154,8 +154,14 @@
         variant="info"
         class="reply-card__reach-blocked"
       >
-        This hasn't reached your area yet — but go ahead and reply. We'll pass
-        it on to the owner as soon as it does.
+        <span v-if="reachNotice" data-testid="reach-blocked-eta">
+          This hasn't reached your area yet, but go ahead and reply.
+          {{ reachNotice }}
+        </span>
+        <span v-else>
+          This hasn't reached your area yet — but go ahead and reply. We'll pass
+          it on to the owner as soon as it does.
+        </span>
       </NoticeMessage>
 
       <!-- Composer: matches the real chat footer. The fields scroll inside
@@ -345,6 +351,7 @@ import UserRatings from '~/components/UserRatings'
 import SupporterInfo from '~/components/SupporterInfo'
 import { timeago } from '~/composables/useTimeFormat'
 import { rippledInAreaDates } from '~/composables/rippleStatus'
+import { reachNoticeSentence } from '~/composables/reachArrival'
 import {
   FAR_AWAY,
   LAST_SEEN_TOOLTIP,
@@ -418,6 +425,15 @@ const message = computed(() => {
 // visible to this viewer but its reach hasn't reached them yet. Gate the composer so no entry
 // path shows a reply box whose send the server-side reach check would reject.
 const reachBlocked = computed(() => message.value?.replyeligible === false)
+
+// When the post is due to reach here, as a sentence. Null when the API sent no
+// estimate, in which case the notice falls back to saying only that we'll pass it on.
+const reachNotice = computed(() =>
+  reachNoticeSentence(
+    message.value?.reachesyouat,
+    message.value?.reachesyoufully
+  )
+)
 
 const attachmentCount = computed(() => message.value?.attachments?.length || 0)
 

--- a/iznik-nuxt3/components/MessageExpanded.vue
+++ b/iznik-nuxt3/components/MessageExpanded.vue
@@ -447,8 +447,14 @@
                 variant="info"
                 class="mb-2"
               >
-                This hasn't reached your area yet — but go ahead and reply.
-                We'll pass it on to the owner as soon as it does.
+                <span v-if="reachNotice" data-testid="reach-blocked-eta">
+                  This hasn't reached your area yet, but go ahead and reply.
+                  {{ reachNotice }}
+                </span>
+                <span v-else>
+                  This hasn't reached your area yet — but go ahead and reply.
+                  We'll pass it on to the owner as soon as it does.
+                </span>
               </NoticeMessage>
               <div
                 v-if="replyable && !replied && !message.successful"
@@ -532,8 +538,14 @@
           variant="info"
           class="mb-2"
         >
-          This hasn't reached your area yet — but go ahead and reply. We'll pass
-          it on to the owner as soon as it does.
+          <span v-if="reachNotice" data-testid="reach-blocked-eta">
+            This hasn't reached your area yet, but go ahead and reply.
+            {{ reachNotice }}
+          </span>
+          <span v-else>
+            This hasn't reached your area yet — but go ahead and reply. We'll
+            pass it on to the owner as soon as it does.
+          </span>
         </NoticeMessage>
         <div
           v-if="replyable && !replied && !message.successful"
@@ -668,6 +680,7 @@ import { useGroupStore } from '~/stores/group'
 import { useMe } from '~/composables/useMe'
 import { useMessageDisplay } from '~/composables/useMessageDisplay'
 import { homeGroupFirst, isHomeGroup } from '~/composables/rippleStatus'
+import { reachNoticeSentence } from '~/composables/reachArrival'
 import { action } from '~/composables/useClientLog'
 import MessageTextBody from '~/components/MessageTextBody'
 import MessageTag from '~/components/MessageTag'
@@ -784,6 +797,16 @@ const stickyAdRendered = computed(() => miscStore.stickyAdRendered)
 // until the reach engine populates rippling_reach.
 const reachBlocked = computed(
   () => message.value?.replyeligible === false && !fromme.value
+)
+
+// When the post is due to reach here, as a sentence. Null when the API sent no
+// estimate (routing unavailable, or the block is a ban rather than the reach), and
+// the notice then falls back to saying only that we'll pass it on.
+const reachNotice = computed(() =>
+  reachNoticeSentence(
+    message.value?.reachesyouat,
+    message.value?.reachesyoufully
+  )
 )
 
 // For a bulk offer the catalogue below (BulkItemsInterest) lists the items and

--- a/iznik-nuxt3/components/WhichPostsExplanation.vue
+++ b/iznik-nuxt3/components/WhichPostsExplanation.vue
@@ -37,8 +37,9 @@
       Yes. Most posts you see have already reached your area. If you come across
       one that hasn't quite reached you yet - because you've widened the
       distance, changed the sort, or chosen a different view - go ahead and
-      reply anyway. We'll hold your reply and pass it on to the owner the moment
-      the post reaches you.
+      reply anyway. We hold it briefly so that people closer to the item get
+      first go, then pass yours on. We'll tell you roughly how long that will be
+      before you send, and it's usually well under an hour.
     </p>
     <h5>Why don't I see posts that are too far away?</h5>
     <p>

--- a/iznik-nuxt3/composables/reachArrival.js
+++ b/iznik-nuxt3/composables/reachArrival.js
@@ -1,0 +1,100 @@
+// When a rippling post is due to reach you.
+//
+// A post that has rippled out but not yet to your area is still repliable: the reply is
+// accepted and HELD so people closer to the item get first go. The API tells us when the
+// waiting ends, as `reachesyouat`, with `reachesyoufully` saying which of two questions
+// it answered (see message.ReachesYouAt in iznik-server-go):
+//
+//   fully = true   a tick of the post's reach schedule grows far enough to include you,
+//                  and this is when that happens.
+//   fully = false  no tick ever does. This is instead when the reach stops expanding,
+//                  which is the point held replies are passed on regardless.
+//
+// The second is the common case, and it is an upper bound rather than a prediction: a
+// reach also finishes early when the post gathers enough repliers or is taken. So the
+// wording is deliberately "by", never "at", and never a clock time.
+
+const MINUTE = 60 * 1000
+const HOUR = 60 * MINUTE
+
+/**
+ * How far off a moment is, in words, from a fixed "now".
+ *
+ * Rounded hard on purpose. The underlying timetable has steps at 1, 3, 6, 12, 24, 48,
+ * 72, 120 and 168 hours, so anything more precise than this would be inventing accuracy
+ * the schedule does not have.
+ *
+ * @param {string|number|Date} at when the reach arrives (anything Date accepts)
+ * @param {Date} [now] the moment to measure from, injectable for tests
+ * @returns {string|null} e.g. "within the hour", "tomorrow", "by Friday", or null when
+ *   there is nothing sensible to say
+ */
+export function reachArrivalWording(at, now = new Date()) {
+  if (!at) return null
+
+  const when = at instanceof Date ? at : new Date(at)
+  if (isNaN(when.getTime())) return null
+
+  const ms = when.getTime() - now.getTime()
+
+  // Already due. The reach engine runs every minute and the feed is cached, so a
+  // moment slightly in the past is normal rather than wrong - it just means there is
+  // no wait left worth describing.
+  if (ms <= 0) return 'any moment now'
+
+  // Beyond the schedule's own ceiling of a week. Either the row is odd or the clock is,
+  // and a number we cannot justify is worse than saying nothing.
+  if (ms > 14 * 24 * HOUR) return null
+
+  if (ms < HOUR) return 'within the hour'
+
+  if (ms < 12 * HOUR) {
+    const hours = Math.max(2, Math.round(ms / HOUR))
+    return `in about ${hours} hours`
+  }
+
+  const midnightTonight = new Date(now)
+  midnightTonight.setHours(24, 0, 0, 0)
+  const daysAhead = Math.floor(
+    (when.getTime() - midnightTonight.getTime()) / (24 * HOUR)
+  )
+
+  if (daysAhead < 0) return 'later today'
+  if (daysAhead === 0) return 'tomorrow'
+
+  // Within the week ahead a weekday name is the clearest thing to say. Beyond that it
+  // would be ambiguous ("Friday" could be either), so fall back to counting days.
+  if (daysAhead < 6) {
+    return `by ${when.toLocaleDateString('en-GB', { weekday: 'long' })}`
+  }
+
+  const days = Math.round(ms / (24 * HOUR))
+  return `within about ${days} days`
+}
+
+/**
+ * The sentence shown under the Reply button when the post hasn't rippled to you yet.
+ *
+ * Built here rather than in each template because three components show it and the two
+ * cases say different things: one is about the post arriving, the other about the reply
+ * being passed on anyway. Returns null when there is no usable estimate, and the
+ * components then fall back to their existing open-ended wording.
+ *
+ * @param {string|number|Date} at reachesyouat from the API
+ * @param {boolean} fully reachesyoufully from the API
+ * @param {Date} [now] injectable for tests
+ * @returns {string|null}
+ */
+export function reachNoticeSentence(at, fully, now = new Date()) {
+  const words = reachArrivalWording(at, now)
+  if (!words) return null
+
+  // "at the latest" on the second case is load-bearing, not padding. The reach finishing
+  // is the LAST moment the reply goes: the buffer delay (RippleReplyService::releaseDue)
+  // releases it sooner, and a reach also ends early when the post gathers enough repliers
+  // or is taken. Stating it flatly would understate by days, and would go stale the moment
+  // the buffer policy changed.
+  return fully
+    ? `It's due to reach you ${words}, and we'll pass your reply on then.`
+    : `People closer to it get first go, so we'll pass yours on ${words} at the latest.`
+}

--- a/iznik-nuxt3/composables/useReplyStateMachine.js
+++ b/iznik-nuxt3/composables/useReplyStateMachine.js
@@ -767,9 +767,12 @@ export function useReplyStateMachine(messageId, options = {}) {
 
     // Rippling-out reply HOLD: a rippled-out post whose reach hasn't reached this member yet
     // (replyeligible === false) is NO LONGER blocked here. We let the send proceed — the server
-    // creates the reply and HOLDS it (rippling_held_replies), then delivers it when the post
-    // ripples to the member. The composer shows an info notice ("we'll pass it on when it reaches
-    // you") and the sender sees their message with a "waiting to send" badge. isNotInReachError
+    // creates the reply and HOLDS it (rippling_held_replies) so that people closer to the item
+    // get first go, then passes it on: on a due time worked out from how far they are, or sooner
+    // if the ripple reaches them first. The composer shows an info notice saying when the
+    // post is due to reach them (reachesyouat) and the sender sees their message with a
+    // "waiting to send" badge.
+    // isNotInReachError
     // below stays as a backstop only for the brief deploy window when an older server, not yet
     // running the hold path, might still answer the send with a 403 not_in_reach.
 

--- a/iznik-nuxt3/tests/unit/components/ChatReplyPane.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatReplyPane.spec.js
@@ -682,5 +682,53 @@ describe('ChatReplyPane', () => {
       expect(wrapper.find('.reply-card__composer').exists()).toBe(true)
       expect(wrapper.text()).not.toContain('go ahead and reply')
     })
+
+    it('says when the post is due to reach here when the API sends an estimate', async () => {
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        replyeligible: false,
+        reachesyouat: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+        reachesyoufully: true,
+      })
+      const wrapper = await createWrapper()
+
+      expect(wrapper.find('[data-testid="reach-blocked-eta"]').exists()).toBe(
+        true
+      )
+      // Normalised: the sentence wraps across template lines.
+      expect(wrapper.text().replace(/\s+/g, ' ')).toContain(
+        "It's due to reach you in about 3 hours"
+      )
+      // The open-ended wording is what the estimate replaces, so it must not
+      // survive alongside it.
+      expect(wrapper.text()).not.toContain('as soon as it does')
+    })
+
+    it('says when the reply goes anyway when the reach will never cover them', async () => {
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        replyeligible: false,
+        reachesyouat: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+        reachesyoufully: false,
+      })
+      const wrapper = await createWrapper()
+
+      expect(wrapper.text().replace(/\s+/g, ' ')).toContain(
+        "we'll pass yours on in about 3 hours"
+      )
+    })
+
+    it('falls back to the open-ended wording when there is no estimate', async () => {
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        replyeligible: false,
+      })
+      const wrapper = await createWrapper()
+
+      expect(wrapper.find('[data-testid="reach-blocked-eta"]').exists()).toBe(
+        false
+      )
+      expect(wrapper.text()).toContain('as soon as it does')
+    })
   })
 })

--- a/iznik-nuxt3/tests/unit/components/MessageExpanded.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageExpanded.spec.js
@@ -704,6 +704,47 @@ describe('MessageExpanded', () => {
       expect(wrapper.find('.reply-button').exists()).toBe(false)
     })
 
+    // Rippling-out: the post is visible but hasn't rippled to this viewer, so a
+    // reply is held for a bounded spell before it reaches the owner. Say how long,
+    // rather than leaving them with an open-ended promise.
+    describe('reach-blocked hold notice', () => {
+      it('says when the post is due to reach here when the API sends an estimate', async () => {
+        mockFromme.value = false
+        mockMessage.value.replyeligible = false
+        mockMessage.value.reachesyouat = new Date(
+          Date.now() + 3 * 60 * 60 * 1000
+        ).toISOString()
+        mockMessage.value.reachesyoufully = true
+        const wrapper = await createWrapper({ replyable: true })
+
+        expect(wrapper.find('[data-testid="reach-blocked-eta"]').exists()).toBe(
+          true
+        )
+        expect(wrapper.text().replace(/\s+/g, ' ')).toContain(
+          "It's due to reach you in about 3 hours"
+        )
+        expect(wrapper.text()).not.toContain('as soon as it does')
+      })
+
+      it('falls back to the open-ended wording when there is no estimate', async () => {
+        mockFromme.value = false
+        mockMessage.value.replyeligible = false
+        const wrapper = await createWrapper({ replyable: true })
+
+        expect(wrapper.find('[data-testid="reach-blocked-eta"]').exists()).toBe(
+          false
+        )
+        expect(wrapper.text()).toContain('as soon as it does')
+      })
+
+      it('says nothing about a hold when the post has reached the viewer', async () => {
+        mockFromme.value = false
+        const wrapper = await createWrapper({ replyable: true })
+
+        expect(wrapper.text()).not.toContain("hasn't reached your area yet")
+      })
+    })
+
     it('hides reply button when not replyable', async () => {
       const wrapper = await createWrapper({ replyable: false })
       expect(wrapper.find('.reply-button').exists()).toBe(false)

--- a/iznik-nuxt3/tests/unit/components/WhichPostsExplanation.spec.js
+++ b/iznik-nuxt3/tests/unit/components/WhichPostsExplanation.spec.js
@@ -21,15 +21,23 @@ describe('WhichPostsExplanation', () => {
     expect(wrapper.text()).toContain('most relevant posts first')
   })
 
-  it('tells members an out-of-reach reply is held (not blocked) and passed on when it reaches them', () => {
+  it('tells members an out-of-reach reply is held briefly (not blocked) and then passed on', () => {
     const wrapper = createWrapper()
-    const text = wrapper.text()
+    const text = wrapper.text().replace(/\s+/g, ' ')
     // Rippling-out hold: you can always reply; a reply to a post that hasn't reached you yet is
-    // held and delivered when it does. Assert the hold BEHAVIOUR, not brittle exact wording, so
-    // the test survives minor copy tweaks.
+    // held for a bounded spell so nearer people get first go, then passed on either way. Assert
+    // the hold BEHAVIOUR, not brittle exact wording, so the test survives minor copy tweaks.
     expect(text).toContain('go ahead and reply')
-    expect(text).toContain('pass it on to the owner')
-    expect(text).toMatch(/reaches you/i)
+    expect(text).toContain('pass yours on')
+    expect(text).toMatch(/first go/i)
+  })
+
+  it('does not promise delivery only once the post reaches you', () => {
+    const wrapper = createWrapper()
+    const text = wrapper.text().replace(/\s+/g, ' ')
+    // The hold ends on a timer as well as on coverage, and most held repliers are somewhere
+    // the ripple never reaches. "The moment the post reaches you" was a promise we don't keep.
+    expect(text).not.toMatch(/the moment the post reaches you/i)
   })
 
   it('does not use "this is new / we have changed" framing', () => {

--- a/iznik-nuxt3/tests/unit/composables/reachArrival.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/reachArrival.spec.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import {
+  reachArrivalWording,
+  reachNoticeSentence,
+} from '~/composables/reachArrival'
+
+// A Wednesday, so the weekday branch has somewhere unambiguous to land.
+const NOW = new Date('2026-08-12T09:00:00Z')
+const inHours = (h) => new Date(NOW.getTime() + h * 60 * 60 * 1000)
+
+describe('reachArrivalWording', () => {
+  describe('when there is nothing sensible to say', () => {
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['empty string', ''],
+      ['an unparseable date', 'next Tuesday-ish'],
+    ])('returns null for %s', (_label, input) => {
+      expect(reachArrivalWording(input, NOW)).toBeNull()
+    })
+
+    it('returns null beyond the schedule ceiling rather than quoting it', () => {
+      // The hazard schedule tops out at a week. A fortnight away means the row or the
+      // clock is wrong, and a number we cannot justify is worse than silence.
+      expect(reachArrivalWording(inHours(24 * 15), NOW)).toBeNull()
+    })
+  })
+
+  it('treats a moment already past as due, not as an error', () => {
+    // The reach engine runs every minute and feeds are cached, so slightly-past is
+    // normal rather than wrong.
+    expect(reachArrivalWording(inHours(-1), NOW)).toBe('any moment now')
+  })
+
+  it('describes the next hour without false precision', () => {
+    expect(reachArrivalWording(inHours(0.2), NOW)).toBe('within the hour')
+    expect(reachArrivalWording(inHours(0.9), NOW)).toBe('within the hour')
+  })
+
+  it('counts hours up to half a day', () => {
+    expect(reachArrivalWording(inHours(3), NOW)).toBe('in about 3 hours')
+    expect(reachArrivalWording(inHours(6), NOW)).toBe('in about 6 hours')
+  })
+
+  it('switches to days once hours stop being useful', () => {
+    expect(reachArrivalWording(inHours(13), NOW)).toBe('later today')
+    expect(reachArrivalWording(inHours(30), NOW)).toBe('tomorrow')
+  })
+
+  it('names the weekday within the week ahead', () => {
+    // Wednesday 09:00 plus three days is Saturday.
+    expect(reachArrivalWording(inHours(24 * 3), NOW)).toBe('by Saturday')
+  })
+
+  it('counts days once a weekday name would be ambiguous', () => {
+    // Seven days on is the same weekday again, so naming it would read as "in two days".
+    expect(reachArrivalWording(inHours(24 * 7), NOW)).toBe(
+      'within about 7 days'
+    )
+  })
+})
+
+describe('reachNoticeSentence', () => {
+  it('talks about the post arriving when a tick will actually cover them', () => {
+    expect(reachNoticeSentence(inHours(3), true, NOW)).toBe(
+      "It's due to reach you in about 3 hours, and we'll pass your reply on then."
+    )
+  })
+
+  it('talks about the reply being passed on when the reach never covers them', () => {
+    // The common case: no tick's drive-time budget ever reaches them, so what they are
+    // waiting for is the reach finishing, not arriving.
+    expect(reachNoticeSentence(inHours(24 * 3), false, NOW)).toBe(
+      "People closer to it get first go, so we'll pass yours on by Saturday at the latest."
+    )
+  })
+
+  it('marks the reach finishing as an upper bound, because the buffer releases sooner', () => {
+    // RippleReplyService::releaseDue frees a held reply on its own timer, and a reach also
+    // ends early when the post gathers enough repliers or is taken. Stating the finish
+    // flatly would understate the delivery by days.
+    expect(reachNoticeSentence(inHours(24 * 3), false, NOW)).toContain(
+      'at the latest'
+    )
+  })
+
+  it('says "by", never a clock time, because the finish is an upper bound', () => {
+    // A reach also ends early when the post gathers enough repliers or is taken, so a
+    // definite time would be a promise the schedule cannot make.
+    expect(reachNoticeSentence(inHours(24 * 3), false, NOW)).toMatch(/\bby\b/)
+    expect(reachNoticeSentence(inHours(24 * 3), false, NOW)).not.toMatch(
+      /\d:\d/
+    )
+  })
+
+  it('gives no sentence when there is no usable estimate', () => {
+    expect(reachNoticeSentence(null, true, NOW)).toBeNull()
+    expect(reachNoticeSentence(inHours(24 * 20), false, NOW)).toBeNull()
+  })
+})

--- a/iznik-routing-go/drivetime_test.go
+++ b/iznik-routing-go/drivetime_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Points from the same fixture graph the other endpoint tests use.
+const (
+	dtLat = 51.4545
+	dtLng = -2.5879
+)
+
+func driveTime(t *testing.T, query string) (int, map[string]any) {
+	t.Helper()
+
+	app := newInternalApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/v1/drive-time?"+query, nil)
+	resp, err := app.Test(req, 30000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+
+	var parsed map[string]any
+	_ = json.Unmarshal(body, &parsed)
+
+	return resp.StatusCode, parsed
+}
+
+// The endpoint exists to answer "how long would it take this member to drive to the post",
+// so that the tick of the post's reach schedule that would cover them can be found by
+// comparing against the stored drive-time budgets. A scalar, because the alternative
+// (materialising a tick's isochrone polygon) costs ~0.5s and ~1.2MB for a number we then
+// throw away.
+func TestDriveTimeReturnsAScalar(t *testing.T) {
+	// Somewhere very close by, so it is comfortably inside any sane budget.
+	status, body := driveTime(t, "lat=51.4545&lng=-2.5879&tolat=51.4600&tolng=-2.5900&max_minutes=30&mode=drive")
+	if status != 200 {
+		t.Fatalf("expected 200, got %d (%v)", status, body)
+	}
+
+	if body["reachable"] != true {
+		t.Fatalf("expected a nearby point to be reachable, got %v", body)
+	}
+
+	mins, ok := body["drive_min"].(float64)
+	if !ok {
+		t.Fatalf("expected drive_min to be a number, got %v", body["drive_min"])
+	}
+	if mins < 0 || mins > 30 {
+		t.Errorf("drive_min %v outside the requested budget", mins)
+	}
+}
+
+// Not reachable within the budget is a real answer, not an error. It is how the caller
+// learns that no tick of the schedule will ever cover this member, and so that their held
+// reply waits for the reach to finish rather than for an arrival that never comes. A 4xx
+// here would be indistinguishable from the routing server being broken, and the caller
+// would show no estimate at all rather than the correct one.
+func TestDriveTimeBeyondBudgetIsNotAnError(t *testing.T) {
+	// A minute's drive will not get from Bristol to the far side of the graph.
+	status, body := driveTime(t, "lat=51.4545&lng=-2.5879&tolat=53.4808&tolng=-2.2426&max_minutes=1&mode=drive")
+	if status != 200 {
+		t.Fatalf("expected 200, got %d (%v)", status, body)
+	}
+	if body["reachable"] != false {
+		t.Errorf("expected reachable=false beyond the budget, got %v", body)
+	}
+}
+
+// Missing coordinates are a caller bug and must not be answered with a plausible number.
+func TestDriveTimeRequiresBothEnds(t *testing.T) {
+	for _, q := range []string{
+		"lng=-2.5879&tolat=51.46&tolng=-2.59",
+		"lat=51.4545&tolat=51.46&tolng=-2.59",
+		"lat=51.4545&lng=-2.5879&tolng=-2.59",
+		"lat=51.4545&lng=-2.5879&tolat=51.46",
+	} {
+		if status, _ := driveTime(t, q); status != 400 {
+			t.Errorf("%s: expected 400, got %d", q, status)
+		}
+	}
+}
+
+// The budget is what the search cost scales with (about 40ms at 30 minutes on the UK graph,
+// 900ms at 120), so an unbounded or absurd value has to be clamped rather than honoured.
+func TestDriveTimeClampsTheBudget(t *testing.T) {
+	for _, q := range []string{
+		"lat=51.4545&lng=-2.5879&tolat=51.46&tolng=-2.59&max_minutes=99999",
+		"lat=51.4545&lng=-2.5879&tolat=51.46&tolng=-2.59&max_minutes=-5",
+	} {
+		if status, _ := driveTime(t, q); status != 200 {
+			t.Errorf("%s: expected the budget to be clamped and answered, got %d", q, status)
+		}
+	}
+}
+
+// It is on the internal port for trusted backends, and the external one still needs a JWT.
+// This matters because the Go API's SPATIAL_SERVER_URL points at the external port: calling
+// it there without auth returns 401, which the caller reports as "no estimate" for everyone.
+func TestDriveTimeExternalPortRequiresAuth(t *testing.T) {
+	app := newExternalApp(t)
+	req := httptest.NewRequest(http.MethodGet,
+		"/v1/drive-time?lat=51.4545&lng=-2.5879&tolat=51.46&tolng=-2.59", nil)
+	resp, err := app.Test(req, 5000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 401 {
+		t.Errorf("expected 401 without auth on the external port, got %d", resp.StatusCode)
+	}
+}

--- a/iznik-routing-go/server.go
+++ b/iznik-routing-go/server.go
@@ -167,6 +167,78 @@ func handleCatchment(g *Graph) fiber.Handler {
 	}
 }
 
+// handleDriveTime handles GET /v1/drive-time?lat=&lng=&tolat=&tolng=&max_minutes=&mode=
+//
+// The road time between two points, as a single number. It exists so the site can answer
+// "when will this post's reach expand to cover me": that needs the member's drive time from
+// the post's origin, which is then compared against the drive-time budget stored on each
+// tick of the post's reach schedule.
+//
+// The alternatives were both far more expensive for a number we immediately throw away.
+// Materialising a tick's isochrone via /v1/catchment costs ~0.5s and ~1.2MB of polygon;
+// bisecting on /v1/isochrone costs several of those. The Dijkstra underneath is the same
+// one, bounded the same way. Measured on the UK graph, this budget-bounded search is ~40ms
+// at 30 minutes and ~10ms at 15, so the answer is cheap enough to show unprompted.
+//
+// Direction matters and matches the reach. rippling_reach tick polygons come from the point
+// form of /v1/catchment, which is a plain outward Isochrone from the post's origin, so this
+// measures origin -> member too. Measuring the other way would disagree with the stored
+// polygon wherever one-way roads do.
+//
+// reachable:false means "not within max_minutes", which is a real answer rather than an
+// error: it is how the caller learns the reach will never grow to cover this member, and
+// so that their held reply waits for the reach to finish instead.
+func handleDriveTime(g *Graph) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		lat, err := strconv.ParseFloat(c.Query("lat"), 64)
+		if err != nil || lat == 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "lat required")
+		}
+		lng, err := strconv.ParseFloat(c.Query("lng"), 64)
+		if err != nil || lng == 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "lng required")
+		}
+		toLat, err := strconv.ParseFloat(c.Query("tolat"), 64)
+		if err != nil || toLat == 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "tolat required")
+		}
+		toLng, err := strconv.ParseFloat(c.Query("tolng"), 64)
+		if err != nil || toLng == 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "tolng required")
+		}
+
+		// Bounded like every other search here. The ceiling is 120 to match
+		// handleGroupProximity; callers pass the post's own final tick budget, which is
+		// well under that, and the cost scales with it.
+		minutes, _ := strconv.ParseFloat(c.Query("max_minutes", "60"), 64)
+		if minutes <= 0 || minutes > 120 {
+			minutes = 60
+		}
+		mode := parseMode(c.Query("mode", "drive"))
+
+		dest := nearestNodeForMode(g, toLat, toLng, mode)
+		if dest == noNode {
+			// Off the road graph entirely (mid-sea coordinates, or a mode with no
+			// network here). Not reachable, and not an error.
+			return c.JSON(fiber.Map{"reachable": false})
+		}
+
+		targets := []NodeID{dest}
+		bbox := boundingBox(g, targets, lat, lng, 0.15)
+		costs, _ := costToTargets(g, lat, lng, targets, float32(minutes*60), mode, bbox)
+
+		cost, reached := costs[dest]
+		if !reached {
+			return c.JSON(fiber.Map{"reachable": false})
+		}
+
+		return c.JSON(fiber.Map{
+			"reachable": true,
+			"drive_min": float64(cost) / 60,
+		})
+	}
+}
+
 // handleGroupExtent returns the group's own road "diameter": the widest road drive-time between
 // two points inside the group. It sets a yardstick on the catchment view — a post rippling in
 // from no further away than the group already spans internally is unremarkable.
@@ -406,6 +478,7 @@ func newApp(g *Graph, spatialURL string, requireAuth bool) *fiber.App {
 	v1.Get("/fairness", handleFairness(g))
 	v1.Get("/catchment", handleCatchment(g))
 	v1.Get("/group-proximity", handleGroupProximity(g))
+	v1.Get("/drive-time", handleDriveTime(g))
 	v1.Get("/group-extent", handleGroupExtent(g))
 	v1.Get("/group-actives", handleGroupActives())
 	v1.Get("/nearby-freeglers", handleNearbyFreeglers(g, spatialURL))

--- a/iznik-server-go/isochrone/routing.go
+++ b/iznik-server-go/isochrone/routing.go
@@ -33,14 +33,28 @@ type routingResponse struct {
 
 // FetchIsochroneWKTFromRoutingServer calls the internal spatial server and
 // returns a WKT POLYGON for the requested transport mode.
-// Returns empty string on failure or when SPATIAL_SERVER_URL is not set.
+// Returns empty string on failure, and the caller then falls back to Mapbox.
+//
+// ROUTING_EVAL_URL is the routing container's INTERNAL, no-auth port (8194). It is not
+// interchangeable with the other two spatial env vars, and getting this wrong is silent:
+//
+//	SPATIAL_SERVER_URL  http://spatial:8196       same container, EXTERNAL port, JWT + mod only
+//	SPATIAL_KNN_URL     http://spatial-knn:8194   a different container (KNN), no /v1/isochrone
+//
+// This read SPATIAL_SERVER_URL, so every call answered 401, returned "" here, and sent the
+// caller to Mapbox instead - paying a third party for isochrones our own router serves free,
+// with nothing user-visible to give it away. See the warning at docker-compose.yml:790.
 func FetchIsochroneWKTFromRoutingServer(transport string, lat, lng float64, minutes int) string {
-	// SPATIAL_SERVER_URL is the canonical name; ROUTING_SERVER_URL is kept for backward compat.
-	base := os.Getenv("SPATIAL_SERVER_URL")
+	base := os.Getenv("ROUTING_EVAL_URL")
 	if base == "" {
+		// ROUTING_SERVER_URL is kept for backward compat with deployments that set it.
 		base = os.Getenv("ROUTING_SERVER_URL")
 	}
 	if base == "" {
+		// Unset still means "skip the routing server and use Mapbox", as before. Not
+		// defaulted to spatial:8194: that would take away the ability to turn the
+		// routing server off, and the client's timeout is 60s, so a host that hangs
+		// rather than refusing would stall every isochrone before falling back.
 		return ""
 	}
 

--- a/iznik-server-go/isochrone/routing_test.go
+++ b/iznik-server-go/isochrone/routing_test.go
@@ -52,7 +52,7 @@ func fakeResponse(status int, body string) *http.Response {
 type errReadCloser struct{}
 
 func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("simulated read failure") }
-func (errReadCloser) Close() error              { return nil }
+func (errReadCloser) Close() error             { return nil }
 
 func withEnv(t *testing.T, key, val string) {
 	t.Helper()
@@ -83,15 +83,17 @@ func clearEnv(t *testing.T, key string) {
 // ---------------------------------------------------------------------------
 
 func TestFetchIsochroneWKTFromRoutingServer_NoURLConfigured(t *testing.T) {
-	clearEnv(t, "SPATIAL_SERVER_URL")
+	clearEnv(t, "ROUTING_EVAL_URL")
 	clearEnv(t, "ROUTING_SERVER_URL")
+	// Unset means "skip the routing server, use Mapbox" - deliberately not defaulted
+	// to spatial:8194, which would remove the ability to turn the router off.
 	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
 }
 
 func TestFetchIsochroneWKTFromRoutingServer_FallsBackToLegacyEnvVar(t *testing.T) {
-	// SPATIAL_SERVER_URL unset, ROUTING_SERVER_URL set - the base must come
+	// ROUTING_EVAL_URL unset, ROUTING_SERVER_URL set - the base must come
 	// from the legacy var rather than short-circuiting to "".
-	clearEnv(t, "SPATIAL_SERVER_URL")
+	clearEnv(t, "ROUTING_EVAL_URL")
 	withEnv(t, "ROUTING_SERVER_URL", "http://legacy.invalid")
 	rt := &fakeRoundTripper{resp: fakeResponse(200, routingResponseJSON())}
 	withFakeTransport(t, rt)
@@ -101,14 +103,28 @@ func TestFetchIsochroneWKTFromRoutingServer_FallsBackToLegacyEnvVar(t *testing.T
 	assert.True(t, strings.HasPrefix(rt.lastURL, "http://legacy.invalid/v1/isochrone"))
 }
 
+// SPATIAL_SERVER_URL is the routing container's EXTERNAL port: JWT, moderators only.
+// Reading it here meant every call answered 401, returned "", and sent the caller to
+// Mapbox instead - a silent failure that costs money and shows nothing to the user.
+// This pins the internal port as the one consulted, so it cannot creep back.
+func TestFetchIsochroneWKTFromRoutingServer_IgnoresTheAuthPortVar(t *testing.T) {
+	clearEnv(t, "ROUTING_EVAL_URL")
+	clearEnv(t, "ROUTING_SERVER_URL")
+	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid:8196")
+	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(200, routingResponseJSON())})
+
+	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15),
+		"the external auth port must never be used as the routing base")
+}
+
 func TestFetchIsochroneWKTFromRoutingServer_NetworkError(t *testing.T) {
-	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withEnv(t, "ROUTING_EVAL_URL", "http://spatial.invalid")
 	withFakeTransport(t, &fakeRoundTripper{err: errors.New("connection refused")})
 	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
 }
 
 func TestFetchIsochroneWKTFromRoutingServer_ReadBodyError(t *testing.T) {
-	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withEnv(t, "ROUTING_EVAL_URL", "http://spatial.invalid")
 	withFakeTransport(t, &fakeRoundTripper{resp: &http.Response{
 		StatusCode: 200,
 		Body:       errReadCloser{},
@@ -118,7 +134,7 @@ func TestFetchIsochroneWKTFromRoutingServer_ReadBodyError(t *testing.T) {
 }
 
 func TestFetchIsochroneWKTFromRoutingServer_NonOKStatus(t *testing.T) {
-	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withEnv(t, "ROUTING_EVAL_URL", "http://spatial.invalid")
 	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(500, "internal error")})
 	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
 }
@@ -126,14 +142,14 @@ func TestFetchIsochroneWKTFromRoutingServer_NonOKStatus(t *testing.T) {
 func TestFetchIsochroneWKTFromRoutingServer_NonOKStatusLongBody(t *testing.T) {
 	// The error-logging path truncates the body to 500 bytes - exercise it
 	// with a body long enough to require the truncation.
-	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withEnv(t, "ROUTING_EVAL_URL", "http://spatial.invalid")
 	longBody := strings.Repeat("x", 1000)
 	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(503, longBody)})
 	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
 }
 
 func TestFetchIsochroneWKTFromRoutingServer_BadJSON(t *testing.T) {
-	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withEnv(t, "ROUTING_EVAL_URL", "http://spatial.invalid")
 	withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(200, "not json")})
 	assert.Equal(t, "", FetchIsochroneWKTFromRoutingServer("Walk", 51.5, -0.1, 15))
 }
@@ -148,9 +164,9 @@ func routingResponseJSON() string {
 
 func TestFetchIsochroneWKTFromRoutingServer_TransportSelection(t *testing.T) {
 	tests := []struct {
-		name       string
-		transport  string
-		wantPoint  string
+		name      string
+		transport string
+		wantPoint string
 	}{
 		{"walk maps to walk polygon", "Walk", "-0.100000 51.500000"},
 		{"cycle maps to cycle polygon", "Cycle", "-0.300000 51.500000"},
@@ -160,7 +176,7 @@ func TestFetchIsochroneWKTFromRoutingServer_TransportSelection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+			withEnv(t, "ROUTING_EVAL_URL", "http://spatial.invalid")
 			withFakeTransport(t, &fakeRoundTripper{resp: fakeResponse(200, routingResponseJSON())})
 
 			wkt := FetchIsochroneWKTFromRoutingServer(tt.transport, 51.5, -0.1, 15)
@@ -171,7 +187,7 @@ func TestFetchIsochroneWKTFromRoutingServer_TransportSelection(t *testing.T) {
 }
 
 func TestFetchIsochroneWKTFromRoutingServer_URLIncludesParams(t *testing.T) {
-	withEnv(t, "SPATIAL_SERVER_URL", "http://spatial.invalid")
+	withEnv(t, "ROUTING_EVAL_URL", "http://spatial.invalid")
 	rt := &fakeRoundTripper{resp: fakeResponse(200, routingResponseJSON())}
 	withFakeTransport(t, rt)
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -264,6 +264,19 @@ type Message struct {
 	// i.e. has no rippling_reach row, or eligibility wasn't computed). false = the post
 	// has rippled out but not yet to the viewer's location, so the UI shows it view-only.
 	ReplyEligible *bool `json:"replyeligible,omitempty" gorm:"-"`
+	// ReachesYouAt: when this post's rippling reach is expected to arrive at the
+	// viewer, for a post they can see but which has not rippled to them yet. Set only
+	// alongside ReplyEligible=false and only for the reach reason - a viewer blocked
+	// by a ban is not waiting for the ripple, so it stays nil there.
+	//
+	// ReachesYouFully says which question was answered. True: a tick of the post's own
+	// schedule grows far enough to include them, and this is when. False: no tick ever
+	// does, so this is instead when the reach stops expanding - the point their held
+	// reply is passed on regardless. Both are real answers; the second is the common
+	// one, and it is an upper bound rather than a prediction, because a reach also
+	// finishes early when the post gathers enough repliers or is taken.
+	ReachesYouAt    *time.Time `json:"reachesyouat,omitempty" gorm:"-"`
+	ReachesYouFully *bool      `json:"reachesyoufully,omitempty" gorm:"-"`
 	// BulkItems is the structured catalogue for a bulk offer ("clearance"). Nil
 	// (and omitted) for ordinary single-item posts. Bulkcount is len(BulkItems),
 	// exposed so list/summary views can flag a bulk offer cheaply.
@@ -1052,7 +1065,58 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 		// be reach-eligible if ANY of them is within the post's reach. Extending this to
 		// iterate the member's full location set is future work.
 		latlng := user.GetLatLng(myid)
-		reachBlocked := ReachBlockedSet(ids, float64(latlng.Lat), float64(latlng.Lng))
+		reachBlocked := ReachBlockedOrigins(ids, float64(latlng.Lat), float64(latlng.Lng))
+
+		// When the reach is expected to arrive at this viewer. Worked out here rather
+		// than left to the client because it needs the post's BLURRED ripple origin
+		// and its stored schedule, neither of which the feed ships - only the
+		// resulting date crosses the wire.
+		//
+		// One budget-bounded routing search per blocked post (~40ms at a 30-minute
+		// budget on the UK graph), run concurrently so a feed with several blocked
+		// posts costs one search's latency rather than the sum. Only blocked posts
+		// pay it, which is a small minority of any feed.
+		coverage := make(map[uint64]rippling.Coverage, len(reachBlocked))
+		if len(reachBlocked) > 0 {
+			hazard := rippling.LoadHazardHours(db)
+
+			var covMu sync.Mutex
+			var covWg sync.WaitGroup
+			for msgid, origin := range reachBlocked {
+				if !origin.Ok || origin.Arrival == nil || len(origin.Schedule) == 0 {
+					continue
+				}
+				covWg.Add(1)
+				go func(msgid uint64, origin ReachOrigin) {
+					defer covWg.Done()
+
+					// Search no further than this post's own widest budget: beyond it
+					// the answer is "no tick ever covers you" however far they are, and
+					// the search cost scales with the budget.
+					budget := origin.Schedule[len(origin.Schedule)-1].DriveMin
+					dt, ok := rippling.FetchDriveTime(
+						origin.Lat, origin.Lng,
+						float64(latlng.Lat), float64(latlng.Lng),
+						budget,
+					)
+					if !ok {
+						// Routing unavailable: no estimate, rather than a guess.
+						return
+					}
+
+					cov, ok := rippling.CoverageAt(origin.Schedule, hazard, *origin.Arrival, dt.Minutes, dt.Reachable)
+					if !ok {
+						return
+					}
+
+					covMu.Lock()
+					coverage[msgid] = cov
+					covMu.Unlock()
+				}(msgid, origin)
+			}
+			covWg.Wait()
+		}
+
 		for msgid := range reachBlocked {
 			blockedSet[msgid] = true
 		}
@@ -1088,6 +1152,12 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 				Scan(&bannedBlocked)
 			for _, b := range bannedBlocked {
 				blockedSet[b.Msgid] = true
+
+				// A banned viewer is not waiting for the ripple, they are not
+				// getting through at all. Telling them when it would arrive would
+				// be a promise we have no intention of keeping, so drop any
+				// estimate the reach check produced for the same post.
+				delete(coverage, b.Msgid)
 			}
 		}
 
@@ -1096,6 +1166,15 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 			for ix := range messages {
 				if blockedSet[messages[ix].ID] {
 					messages[ix].ReplyEligible = &notEligible
+
+					// Only the reach reason carries an arrival. A ban also lands in
+					// blockedSet and has no coverage entry, so it stays nil.
+					if cov, found := coverage[messages[ix].ID]; found {
+						at := cov.At
+						fully := cov.Covered
+						messages[ix].ReachesYouAt = &at
+						messages[ix].ReachesYouFully = &fully
+					}
 				}
 			}
 		}

--- a/iznik-server-go/message/reach.go
+++ b/iznik-server-go/message/reach.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/rippling"
@@ -26,15 +27,56 @@ import (
 // reject, inside inner_bound an authoritative accept, and only the band between
 // touches the ~178KB exact polygon; POINT (completed) bounds fall back to the
 // exact test.
+//
+// The query itself is ReachBlockedOrigins; this is the membership-only view of
+// it for the callers that do not need the origins.
 func ReachBlockedSet(msgids []uint64, lat, lng float64) map[uint64]bool {
-	blocked := make(map[uint64]bool)
+	origins := ReachBlockedOrigins(msgids, lat, lng)
+	blocked := make(map[uint64]bool, len(origins))
+	for msgid := range origins {
+		blocked[msgid] = true
+	}
+
+	return blocked
+}
+
+// ReachOrigin is what a blocked post's reach row says about itself: the already-blurred
+// point the reach was grown from, and the timetable it will grow on. Ok is false when
+// the row has no origin, which is possible on rows written before the columns were
+// populated - callers must not treat (0,0) as a location.
+type ReachOrigin struct {
+	Lat float64
+	Lng float64
+	Ok  bool
+	// Schedule and Arrival are what turn a member's drive time into a date: the tick
+	// whose drive-time budget first reaches them, and when that tick goes live.
+	// Schedule is nil when the column is empty or unusable.
+	Schedule []rippling.ScheduleTick
+	Arrival  *time.Time
+}
+
+// ReachBlockedOrigins is ReachBlockedSet with the reach origin of each blocked
+// post, for sizing the reply-delay estimate shown to a member who is about to
+// reply to something that has not rippled to them yet.
+//
+// It is the same single query - the blocked rows are already being read, so
+// carrying two more columns off them costs nothing, and the delay is then pure
+// arithmetic. That matters because this sits on the feed's hot path: an estimate
+// that needed its own query (or worse, a routing call) per post would not be
+// worth showing.
+func ReachBlockedOrigins(msgids []uint64, lat, lng float64) map[uint64]ReachOrigin {
+	blocked := make(map[uint64]ReachOrigin)
 	if len(msgids) == 0 || (lat == 0 && lng == 0) {
 		return blocked
 	}
 
 	db := database.DBConn
 	var rows []struct {
-		Msgid uint64 `gorm:"column:msgid"`
+		Msgid    uint64     `gorm:"column:msgid"`
+		Lat      *float64   `gorm:"column:lat"`
+		Lng      *float64   `gorm:"column:lng"`
+		Schedule *string    `gorm:"column:schedule"`
+		Arrival  *time.Time `gorm:"column:arrival"`
 	}
 	var err error
 	if rippling.ReachBoundsReady(db) {
@@ -50,18 +92,25 @@ func ReachBlockedSet(msgids []uint64, lat, lng float64) map[uint64]bool {
 		expr, exprArgs := rippling.ReachInReachExpr(lng, lat, utils.SRID)
 		whereArgs := append([]interface{}{msgids}, exprArgs...)
 		err = db.Table("rippling_reach rr").
-			Select("rr.msgid").
+			Select("rr.msgid, rr.lat, rr.lng, rr.schedule, rr.arrival").
 			Where("rr.msgid IN (?) AND NOT "+expr, whereArgs...).
 			Scan(&rows).Error
 	} else {
 		err = db.Table("rippling_reach").
-			Select("msgid").
+			Select("msgid, lat, lng, schedule, arrival").
 			Where("msgid IN ? AND ST_Contains(polygon, ST_SRID(POINT(?, ?), ?)) = 0", msgids, lng, lat, utils.SRID).
 			Scan(&rows).Error
 	}
 	if err == nil {
 		for _, r := range rows {
-			blocked[r.Msgid] = true
+			origin := ReachOrigin{Arrival: r.Arrival}
+			if r.Lat != nil && r.Lng != nil {
+				origin.Lat, origin.Lng, origin.Ok = *r.Lat, *r.Lng, true
+			}
+			if r.Schedule != nil {
+				origin.Schedule = rippling.ParseSchedule(*r.Schedule)
+			}
+			blocked[r.Msgid] = origin
 		}
 	}
 	return blocked

--- a/iznik-server-go/rippling/coverage.go
+++ b/iznik-server-go/rippling/coverage.go
@@ -1,0 +1,139 @@
+package rippling
+
+import (
+	"encoding/json"
+	"sort"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// HazardHoursConfigKey is the `config` row iznik-batch publishes the hazard schedule
+// into (Ripple\ExpandCommand::publishReplyDelay). Tick k of a post's reach becomes
+// live at arrival + hazard_hours[k-1], which is what turns "the tick that would cover
+// you" into a time we can show a member.
+const HazardHoursConfigKey = "ripple.hazard_hours"
+
+// DefaultHazardHours matches config('freegle.ripple.hazard_hours') in iznik-batch, and
+// is the fallback when the row has not been published yet.
+func DefaultHazardHours() []int {
+	return []int{1, 3, 6, 12, 24, 48, 72, 120, 168}
+}
+
+// LoadHazardHours reads the published schedule, falling back to the documented default
+// on any failure. A short or empty schedule is treated as unusable rather than trusted:
+// it would silently shorten every estimate we give.
+func LoadHazardHours(db *gorm.DB) []int {
+	var row struct {
+		Value string `gorm:"column:value"`
+	}
+
+	result := db.Table("config").Select("value").Where("`key` = ?", HazardHoursConfigKey).Limit(1).Scan(&row)
+	if result.Error != nil || row.Value == "" {
+		return DefaultHazardHours()
+	}
+
+	var hours []int
+	if err := json.Unmarshal([]byte(row.Value), &hours); err != nil || len(hours) == 0 {
+		return DefaultHazardHours()
+	}
+
+	return hours
+}
+
+// ScheduleTick is one entry of rippling_reach.schedule. The stored rows carry
+// cumulative_users and reachable_group_ids too; this reads only what the estimate
+// needs. Note that live schedules hold NO polygons - they are the slim form - so the
+// only way to place a member on one is by their drive time from the origin.
+type ScheduleTick struct {
+	Tick     int     `json:"tick"`
+	DriveMin float64 `json:"drive_min"`
+}
+
+// ParseSchedule decodes rippling_reach.schedule, ordered by tick. Returns nil when the
+// column is empty or unusable, which callers treat as "no estimate available".
+func ParseSchedule(raw string) []ScheduleTick {
+	if raw == "" {
+		return nil
+	}
+
+	var ticks []ScheduleTick
+	if err := json.Unmarshal([]byte(raw), &ticks); err != nil || len(ticks) == 0 {
+		return nil
+	}
+
+	sort.Slice(ticks, func(i, j int) bool { return ticks[i].Tick < ticks[j].Tick })
+
+	return ticks
+}
+
+// Coverage is when a post's reach is expected to reach a given member.
+type Coverage struct {
+	// At is when it happens: either the tick that covers them going live, or the
+	// reach finishing and releasing their held reply anyway.
+	At time.Time
+	// Covered distinguishes the two. True means a tick's drive-time budget actually
+	// grows far enough to include them. False means it never does, and At is instead
+	// when the reach stops expanding - which is a real answer, not a failure, because
+	// that is the point their reply is passed on regardless (releaseAll 'maxed').
+	Covered bool
+}
+
+// CoverageAt works out when a post's reach reaches a member whose road time from the
+// post's origin is driveMin.
+//
+// Tick k is live from arrival + hazardHours[k-1], except tick 1 which is live from
+// arrival itself: the reach is initialised at tick 1 immediately, and
+// ReachService::tickForElapsedHours clamps anything earlier to it. Verified against
+// live rows, where reaches that finish at tick k do so exactly hazardHours[k] hours
+// after arrival, i.e. at the moment they would have advanced again.
+//
+// reachable=false means the routing search did not get to them inside the budget it
+// was given, so no tick can cover them and the answer is the reach's own finish.
+//
+// This is the schedule's timetable, so it is an UPPER BOUND on the not-covered case
+// rather than a prediction: ExpandService also marks a reach done early when the post
+// gathers enough distinct repliers (reply_saturation_stop) or is taken, and neither is
+// knowable in advance. Callers should word it as "by", not "at".
+func CoverageAt(ticks []ScheduleTick, hazardHours []int, arrival time.Time, driveMin float64, reachable bool) (Coverage, bool) {
+	if len(ticks) == 0 || len(hazardHours) == 0 {
+		return Coverage{}, false
+	}
+
+	// Tick k is live at hazardHours[k-1] (0-indexed), because tickForElapsedHours
+	// promotes to tick k once elapsed >= hazardHours[k-1]. Tick 1 is the exception:
+	// it is the clamped initial value, so it is live from arrival rather than from
+	// hazardHours[0].
+	liveAt := func(tick int) (time.Time, bool) {
+		if tick <= 1 {
+			return arrival, true
+		}
+		if tick-1 >= len(hazardHours) {
+			return time.Time{}, false
+		}
+
+		return arrival.Add(time.Duration(hazardHours[tick-1]) * time.Hour), true
+	}
+
+	if reachable {
+		for _, t := range ticks {
+			if t.DriveMin >= driveMin {
+				at, ok := liveAt(t.Tick)
+				if !ok {
+					return Coverage{}, false
+				}
+
+				return Coverage{At: at, Covered: true}, true
+			}
+		}
+	}
+
+	// Beyond the widest budget this post will ever have. They wait for the reach to
+	// stop expanding, which is the final tick going live.
+	at, ok := liveAt(ticks[len(ticks)-1].Tick)
+	if !ok {
+		return Coverage{}, false
+	}
+
+	return Coverage{At: at, Covered: false}, true
+}

--- a/iznik-server-go/rippling/drivetime.go
+++ b/iznik-server-go/rippling/drivetime.go
@@ -1,0 +1,92 @@
+package rippling
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// driveTimeHTTPClient is deliberately short-timeout: this sits on a read path that a
+// member is waiting on, and the budget-bounded search it calls answers in tens of
+// milliseconds on the UK graph. If the routing server is slow or down we would rather
+// show no estimate than hold the whole response.
+var driveTimeHTTPClient = &http.Client{Timeout: 2 * time.Second}
+
+// routingInternalURL is the routing server's INTERNAL, no-auth port - the one trusted
+// backend services use (iznik-routing-go's startServer: 8194 internal, 8196 external
+// with JWT and moderators only). Deliberately not SPATIAL_SERVER_URL, which points at
+// the external port: an unauthenticated call there answers "authentication required"
+// with a 401, which this would then report as "no estimate" for every member forever.
+// Mirrors town.routingEvalURL() and iznik-batch's ReachService.
+func routingInternalURL() string {
+	if u := os.Getenv("ROUTING_EVAL_URL"); u != "" {
+		return u
+	}
+	if u := os.Getenv("SPATIAL_KNN_URL"); u != "" {
+		return u
+	}
+
+	return "http://spatial:8194"
+}
+
+// DriveTime is the road time from a post's ripple origin to a member.
+type DriveTime struct {
+	// Minutes is only meaningful when Reachable is true.
+	Minutes float64
+	// Reachable is false when the member is beyond maxMinutes by road. That is a real
+	// answer, not a failure: it means no tick of the post's schedule can ever cover
+	// them, so their reply waits for the reach to finish instead.
+	Reachable bool
+}
+
+type driveTimeResponse struct {
+	Reachable bool    `json:"reachable"`
+	DriveMin  float64 `json:"drive_min"`
+}
+
+// FetchDriveTime asks the routing server how long it takes to drive from the post's
+// ripple origin to the member. Returns ok=false when the question could not be
+// answered at all (no routing server configured, timeout, non-200), which callers
+// treat as "no estimate" - distinct from a definite "not reachable within the budget".
+//
+// maxMinutes should be the post's own final tick budget: the search cost scales with
+// it (about 40ms at 30 minutes, 300ms at 60 on the UK graph), and anything beyond the
+// post's widest reach is a distance we have no use for.
+func FetchDriveTime(fromLat, fromLng, toLat, toLng, maxMinutes float64) (DriveTime, bool) {
+	base := routingInternalURL()
+
+	url := fmt.Sprintf(
+		"%s/v1/drive-time?lat=%f&lng=%f&tolat=%f&tolng=%f&max_minutes=%f&mode=drive",
+		base, fromLat, fromLng, toLat, toLng, maxMinutes,
+	)
+
+	resp, err := driveTimeHTTPClient.Get(url)
+	if err != nil {
+		log.Printf("rippling: drive-time fetch failed: %v", err)
+		return DriveTime{}, false
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("rippling: drive-time read failed: %v", err)
+		return DriveTime{}, false
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("rippling: drive-time HTTP %d", resp.StatusCode)
+		return DriveTime{}, false
+	}
+
+	var r driveTimeResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		log.Printf("rippling: drive-time JSON parse failed: %v", err)
+		return DriveTime{}, false
+	}
+
+	return DriveTime{Minutes: r.DriveMin, Reachable: r.Reachable}, true
+}

--- a/iznik-server-go/rippling/drivetime.go
+++ b/iznik-server-go/rippling/drivetime.go
@@ -16,17 +16,19 @@ import (
 // show no estimate than hold the whole response.
 var driveTimeHTTPClient = &http.Client{Timeout: 2 * time.Second}
 
-// routingInternalURL is the routing server's INTERNAL, no-auth port - the one trusted
-// backend services use (iznik-routing-go's startServer: 8194 internal, 8196 external
-// with JWT and moderators only). Deliberately not SPATIAL_SERVER_URL, which points at
-// the external port: an unauthenticated call there answers "authentication required"
-// with a 401, which this would then report as "no estimate" for every member forever.
-// Mirrors town.routingEvalURL() and iznik-batch's ReachService.
+// routingInternalURL is the ROUTING server's INTERNAL, no-auth port. Three env vars point
+// at three different things here and only this one is right:
+//
+//	ROUTING_EVAL_URL     http://spatial:8194       routing server, internal, no auth  <- this
+//	SPATIAL_SERVER_URL   http://spatial:8196       routing server, external, JWT + mod only
+//	SPATIAL_KNN_URL      http://spatial-knn:8194   a DIFFERENT container (KNN), no /v1/drive-time
+//
+// Using SPATIAL_SERVER_URL gets a 401 and using SPATIAL_KNN_URL gets a 404, and both would
+// surface identically as "no estimate" for every member, forever and silently. docker-compose
+// already carries a comment warning about this exact misrouting for the drive-time analytics.
+// So there is no KNN fallback: the only fallback is the routing container's own internal port.
 func routingInternalURL() string {
 	if u := os.Getenv("ROUTING_EVAL_URL"); u != "" {
-		return u
-	}
-	if u := os.Getenv("SPATIAL_KNN_URL"); u != "" {
 		return u
 	}
 

--- a/iznik-server-go/test/coverage_test.go
+++ b/iznik-server-go/test/coverage_test.go
@@ -1,0 +1,116 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/freegle/iznik-server-go/rippling"
+	"github.com/stretchr/testify/assert"
+)
+
+// The tick timetable, pinned. Tick k is live at hazardHours[k-1], with tick 1 live from
+// arrival because it is the clamped initial value rather than a threshold.
+//
+// This mapping is worth a test of its own because it is easy to get wrong by one and
+// impossible to notice when you do: MaxReachService::computePassthroughSavings uses
+// hazardHours[k-2] for the same question, and live rows settle it - reaches that finish
+// at tick k do so exactly hazardHours[k] hours after arrival (tick 1 at 3.0h, tick 4 at
+// 24.0h, tick 8 at 168.0h), which is the moment they would have advanced again.
+func TestCoverageTickTimetable(t *testing.T) {
+	hazard := rippling.DefaultHazardHours() // 1,3,6,12,24,48,72,120,168
+	arrival := time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC)
+
+	// Budgets chosen so a given drive time first fits at a known tick.
+	ticks := []rippling.ScheduleTick{
+		{Tick: 1, DriveMin: 10},
+		{Tick: 2, DriveMin: 20},
+		{Tick: 3, DriveMin: 30},
+		{Tick: 9, DriveMin: 40},
+	}
+
+	cases := []struct {
+		name     string
+		driveMin float64
+		wantHrs  float64
+	}{
+		{"inside tick 1 is live from arrival, not from hazard[0]", 5, 0},
+		{"tick 2 is live at 3h", 15, 3},
+		{"tick 3 is live at 6h", 25, 6},
+		{"the final tick is live at 168h", 35, 168},
+	}
+
+	for _, c := range cases {
+		got, ok := rippling.CoverageAt(ticks, hazard, arrival, c.driveMin, true)
+		if assert.True(t, ok, c.name) {
+			assert.True(t, got.Covered, c.name)
+			assert.Equal(t, arrival.Add(time.Duration(c.wantHrs*float64(time.Hour))), got.At, c.name)
+		}
+	}
+}
+
+// Beyond the widest budget the post will ever have, the answer is still a time: the reach
+// stops expanding and releaseAll('maxed') passes the held reply on regardless. That is the
+// common case, not the edge case - on live, 78% of held repliers are outside the eventual
+// reach.
+func TestCoverageBeyondFinalBudget(t *testing.T) {
+	hazard := rippling.DefaultHazardHours()
+	arrival := time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC)
+	ticks := []rippling.ScheduleTick{
+		{Tick: 1, DriveMin: 27},
+		{Tick: 9, DriveMin: 30.7},
+	}
+
+	// Forty minutes out: no tick's budget ever gets there.
+	got, ok := rippling.CoverageAt(ticks, hazard, arrival, 40, true)
+	if assert.True(t, ok) {
+		assert.False(t, got.Covered, "no tick covers them")
+		assert.Equal(t, arrival.Add(168*time.Hour), got.At, "waits for the reach to finish")
+	}
+
+	// The routing search not reaching them inside its budget means the same thing, and
+	// must not be mistaken for "covered at tick 1".
+	got, ok = rippling.CoverageAt(ticks, hazard, arrival, 0, false)
+	if assert.True(t, ok) {
+		assert.False(t, got.Covered, "unreachable is not covered")
+		assert.Equal(t, arrival.Add(168*time.Hour), got.At)
+	}
+}
+
+// Ordering is by tick, not by position in the JSON, and the first tick whose budget
+// reaches them is the one that matters - not the last.
+func TestCoverageUsesFirstCoveringTick(t *testing.T) {
+	hazard := rippling.DefaultHazardHours()
+	arrival := time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC)
+
+	ticks := rippling.ParseSchedule(`[{"tick":9,"drive_min":30},{"tick":2,"drive_min":25},{"tick":5,"drive_min":28}]`)
+	if assert.Len(t, ticks, 3) {
+		assert.Equal(t, 2, ticks[0].Tick, "parsed schedule is ordered by tick")
+	}
+
+	got, ok := rippling.CoverageAt(ticks, hazard, arrival, 24, true)
+	if assert.True(t, ok) {
+		assert.True(t, got.Covered)
+		assert.Equal(t, arrival.Add(3*time.Hour), got.At, "tick 2 covers them, so 3h - not tick 9's 168h")
+	}
+}
+
+// Unusable inputs give no estimate rather than a wrong one.
+func TestCoverageRefusesUnusableInput(t *testing.T) {
+	hazard := rippling.DefaultHazardHours()
+	arrival := time.Now()
+
+	_, ok := rippling.CoverageAt(nil, hazard, arrival, 10, true)
+	assert.False(t, ok, "no schedule → no estimate")
+
+	_, ok = rippling.CoverageAt([]rippling.ScheduleTick{{Tick: 1, DriveMin: 30}}, nil, arrival, 10, true)
+	assert.False(t, ok, "no hazard schedule → no estimate")
+
+	// A tick number past the end of the hazard schedule cannot be dated. This happens if
+	// the two ever fall out of step, and inventing a time would be worse than silence.
+	_, ok = rippling.CoverageAt([]rippling.ScheduleTick{{Tick: 99, DriveMin: 5}}, hazard, arrival, 10, true)
+	assert.False(t, ok, "tick beyond the hazard schedule → no estimate")
+
+	assert.Nil(t, rippling.ParseSchedule(""), "empty schedule column")
+	assert.Nil(t, rippling.ParseSchedule("not json"), "malformed schedule column")
+	assert.Nil(t, rippling.ParseSchedule("[]"), "empty tick list")
+}


### PR DESCRIPTION
Two related changes to the rippling reply hold: the buffer band is measured from the right thing, and the member is told when the post will actually reach them.

## 1. The buffer band is measured from the isochrone, not the item

A reply from outside a post's reach is held so people nearer the item get first go, then released on a due time of `min(180, 15 + 3 x miles)` minutes. That distance was measured from the **item**. It should be measured from the **nearest point on the reach boundary**, because the band is meant to hug the isochrone: someone just outside the line is in practice one of the locals, since the line is a modelled drive-time contour rather than a fact about who can collect.

Measuring from the item is the wrong input for a timer. The reach moves; the distance to the item does not. And it scaled the wait with something irrelevant. Live rows: a replier **0.36 miles** outside the boundary was charged 55 minutes because the item was 13.2 miles away, while one **1.47 miles** outside was charged 42 for an item 8.9 miles off. Two near-misses, waits decided by the size of the isochrone rather than by them.

Across 566 held replies over two days:

| | from item | from edge |
|---|---|---|
| mean wait | 50.8 min | 29.2 min |
| the 269 within 2 miles of the boundary | 37.5 min | 17.1 min |

552 shorter, 5 longer. The five are posts whose reach polygon does not contain its own origin, so the edge is a shade further than the centre; the difference is seconds.

## 2. The banner says when the post is due to reach you

It said "we'll pass it on to the owner as soon as it does", which describes an exit that essentially never fires: since the delay landed, `released_covered` is 2 out of roughly 870 releases. Now there are two cases, both computed from the post's own stored schedule:

- **A tick will cover them.** "It's due to reach you in about 3 hours, and we'll pass your reply on then."
- **No tick ever will** (78% of held repliers, measured against `max_polygon`). The reach stops expanding and `releaseAll('maxed')` sends the reply regardless: "we'll pass yours on by Saturday **at the latest**."

"At the latest" is load-bearing. The buffer releases sooner, and a reach also ends early on reply saturation or the post being taken, so stating the finish flatly would understate delivery by days and would go stale if the buffer policy changed.

### What the member sees

One post, one fixture user, only the two new API fields varied, so these are the same
render with different inputs rather than three different situations.

Before, which is what every held reply got whatever its schedule said:

![Held-reply notice before the change](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/show-reply-hold-eta/hold-eta-before.png)

A tick of the post's schedule reaches them, so the notice names the arrival and says the
reply goes then:

![Held-reply notice naming the arrival](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/show-reply-hold-eta/hold-eta-covered.png)

No tick ever reaches them, the common case, so it gives the point the reply goes anyway:

![Held-reply notice giving the latest the reply will go](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/show-reply-hold-eta/hold-eta-maxed.png)

The same sentence sits above the composer in the reply pane, which is where it is actually
read - the member is looking at the box they are about to type into:

![Reply pane carrying the same estimate](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/show-reply-hold-eta/hold-eta-replypane.png)

The browse-page explainer described the old behaviour ("pass it on the moment the post
reaches you"), so it changed alongside:

![Which posts explainer, reworded](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/show-reply-hold-eta/hold-eta-explainer.png)

## 3. New `/v1/drive-time` on the routing server

Placing a member on the schedule needs their road time from the origin, because live schedules are the slim form: `drive_min` per tick and **no polygons**. The existing options were materialising a tick's isochrone (0.44-0.71s and 1.28MB of polygon for a number we discard) or bisecting on `/v1/isochrone` (several of those). This is the same bounded Dijkstra without the polygon: **22-28ms, 49 bytes**. Cost scales with the budget, and we pass the post's own final tick budget: 10ms at 15 minutes, 39ms at 31, 305ms at 60.

It is on the **internal** port. `SPATIAL_SERVER_URL` points at the external JWT port, where an unauthenticated call 401s, which the caller would report as "no estimate" forever.

## 4. Two silent misroutings fixed alongside

**`MaxReachService` sized passthrough savings from `hazardHours[tick-2]`.** Tick k goes live at `hazardHours[tick-1]`: `ReachService::tickForElapsedHours` promotes to tick k once elapsed >= `hazardHours[k-1]`, `nextExpansionAfter` agrees, and live rows settle it, since reaches that finish at tick k do so exactly `hazardHours[k]` hours after arrival (tick 1 at 3.0h, tick 4 at 24.0h, tick 8 at 168.0h). Every saving was reported one hazard step short. The existing test asserted the wrong value too, so it pinned the bug rather than the behaviour; it now asserts 3h with the reasoning recorded.

**`isochrone/routing.go` read `SPATIAL_SERVER_URL`**, which is the routing container's external port (JWT, moderators only). Every call answered 401, the function returned `""`, and the caller fell back to **Mapbox** - paying a third party for isochrones our own router serves free, with nothing user-visible to give it away. It now reads `ROUTING_EVAL_URL`, the internal no-auth port, which `docker-compose.yml:790` already warns is the only correct choice here. Unset still means "skip the routing server and use Mapbox": not defaulted to `spatial:8194`, because that would remove the ability to turn the router off, and with a 60s client timeout a hanging host would stall every isochrone before falling back.

Three env vars point at three different things and only one is right for a backend call:

```
ROUTING_EVAL_URL    http://spatial:8194       routing server, internal, no auth
SPATIAL_SERVER_URL  http://spatial:8196       routing server, external, JWT + mod only
SPATIAL_KNN_URL     http://spatial-knn:8194   a different container (KNN)
```

The drive-time client had inherited a `SPATIAL_KNN_URL` fallback from `town.routingEvalURL()`. That container does not serve `/v1/drive-time`, so the fallback could only ever 404; removed. The isochrone tests were repointed at the variable the code now consults - several would otherwise have kept passing while exercising nothing - and one asserts the auth-port variable is ignored outright, so it cannot creep back.

## Code Quality Review

- **`ST_SwapXY` is deliberately absent.** MySQL documents SRID 4326 as latitude-first, but `ST_Distance` here reads X as longitude, matching the stored order. Adding the swap moves UK coordinates to the equator and inflates every distance by about a third, which is the wrong size to look obviously wrong. Control, carried in both the code and the docs: London to Birmingham is 101.2 miles untouched and 138.7 swapped, against a true 101.6. The unit test pins it with hand-computed geometry rather than a recorded value, so the same mistake cannot pass again.
- **Containment is unaffected** and still uses the native mislabelled frame, `ST_Contains(polygon, ST_SRID(POINT(lng, lat), 3857))`, as `ReachBlockedSet` already did. Only distance needs re-tagging.
- **No extra query for the estimate.** `ReachBlockedOrigins` carries the origin, schedule and arrival off the query that was already reading those rows for the containment test. The routing calls run concurrently, so a feed with several blocked posts costs one search's latency.
- **Banned viewers get no estimate.** `replyeligible=false` also covers a ban, and those people are not waiting for the ripple.
- **No estimate is a supported state**, not an error: routing down, no schedule, no arrival, or a tick beyond the hazard schedule all fall back to the previous wording rather than inventing a date.
- **Dead code removed** rather than left behind: the superseded `replydelayminutes` field, its Go reader, its config publish and its composable and specs are gone.

## Future Improvements

- `spatial/client.go` has the same fallback shape (`SPATIAL_KNN_URL` then `SPATIAL_SERVER_URL`). Not misbehaving, because it prefers the KNN var and that is always set and correct for it, but the shape is a trap.
- The estimate uses the viewer's primary location only, inheriting the existing multi-location limitation in the reach probe.
- Live schedules are the slim form and carry no per-tick polygons, so `MaxReachService::firstTickCovering` cannot match anything on live data and the passthrough-savings metric it feeds scores everything as unknown. The off-by-one above is fixed regardless, but the metric needs tick geometry before it reports anything.

## Test Plan

- Go 4104, routing-go 89, front-end unit suite 15404, Laravel full. All run against the post-merge tree, since merging master brought #1319's front-end changes in alongside these.
- New: the buffer's edge-distance metric pinned by two reaches with the same boundary and very different origins (equal waits, and about 28 minutes for 0.1 degrees of longitude); hazard-schedule publish; the tick timetable, including tick 1 being live from arrival; beyond-final-budget falling back to the reach finishing; the five drive-time endpoint cases; the arrival wording and both banner sentences.
- Verified in a browser on the local dev site, toggling `reachesyoufully` to render both branches.

---

Screenshots live on the throwaway `pr-assets/show-reply-hold-eta` branch, which keeps the
binaries out of the code diff and can be deleted after merge.
