### PR TITLE
ci(android): cache the Gradle distribution so a release does not hinge on one download

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -42,7 +42,14 @@ orbs:
   # download. Pipeline #10729 on production 4140acbb3 lost it to
   # "java.net.SocketException: Connection reset", which failed bundleRelease and
   # left that commit with an iOS build but no Play beta artifact.
-  freegle: freegle/tests@1.1.374
+  #
+  # 1.1.375 makes that cache warm on the FIRST release rather than the second.
+  # build-android runs only on production and is the only writer of the
+  # gradle-dist key, so a restore keyed on it alone misses on the next release
+  # and downloads anyway; it now also falls back to the gradle-deps cache that
+  # build-android-debug/-dev keep warm from master, which already contains the
+  # unpacked distribution.
+  freegle: freegle/tests@1.1.375
 
 jobs:
   mark-ci-passed:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -35,7 +35,14 @@ orbs:
   # would not have broken anything (that step self-guarded on ci-ratchet.sh
   # existing, so it would exit 0 once this merges) - it would just have kept
   # provisioning a toolchain for a gate that no longer runs.
-  freegle: freegle/tests@1.1.373
+  #
+  # 1.1.374 caches the Gradle distribution in build-android. Every Android build
+  # was fetching gradle-8.11.1-all.zip (~200MB) from services.gradle.org, so a
+  # release only shipped if that host held the connection for the whole
+  # download. Pipeline #10729 on production 4140acbb3 lost it to
+  # "java.net.SocketException: Connection reset", which failed bundleRelease and
+  # left that commit with an iOS build but no Play beta artifact.
+  freegle: freegle/tests@1.1.374
 
 jobs:
   mark-ci-passed:

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -4226,11 +4226,26 @@ jobs:
       # got no Play beta artifact at all while its iOS half built fine.
       #
       # A distribution is immutable for a given version, so key on the wrapper
-      # properties that name it and take no fallback - a version bump must
-      # fetch fresh rather than restore the previous zip.
+      # properties that name it. Both keys pin that same checksum, so a Gradle
+      # version bump can never restore the previous version's zip - it fetches
+      # fresh, which is what we want.
+      #
+      # The second key matters because the first one is COLD on the release that
+      # follows this change: gradle-dist-v1 is written only by this job's
+      # save_cache below, and this job runs only on the production branch. So on
+      # its own it would leave the next release doing the very 200MB download
+      # this is meant to remove, and would reset the same way on every Gradle
+      # bump. build-android-debug and build-android-dev, however, already save
+      # ~/.gradle/caches + ~/.gradle/wrapper (which holds wrapper/dists) after
+      # running gradlew, on the same android-executor and working directory, on
+      # every branch bar production/modtools - so that cache is kept warm from
+      # master continuously. CircleCI caches are project-scoped and restore
+      # across branches, so falling back to it gives this job an unpacked
+      # distribution on the first release after merge rather than the second.
       - restore_cache:
           keys:
             - gradle-dist-v1-{{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}
+            - gradle-deps-v1-{{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}-
       - restore_cache:
           keys:
             - bundle-v1-{{ checksum "Gemfile.lock" }}

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -4217,6 +4217,20 @@ jobs:
       - run:
           name: Make gradlew executable
           command: chmod +x android/gradlew
+      # Without this the wrapper fetches the whole ~200MB Gradle distribution
+      # from services.gradle.org on every single Android build, so each release
+      # depends on that host holding the connection open for the length of the
+      # download.  Pipeline #10729 (production 4140acbb3) died on
+      # "java.net.SocketException: Connection reset" partway through
+      # gradle-8.11.1-all.zip: bundleRelease failed, and that production commit
+      # got no Play beta artifact at all while its iOS half built fine.
+      #
+      # A distribution is immutable for a given version, so key on the wrapper
+      # properties that name it and take no fallback - a version bump must
+      # fetch fresh rather than restore the previous zip.
+      - restore_cache:
+          keys:
+            - gradle-dist-v1-{{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}
       - restore_cache:
           keys:
             - bundle-v1-{{ checksum "Gemfile.lock" }}
@@ -4229,6 +4243,13 @@ jobs:
       - run:
           name: Build and Deploy to Google Play Beta Track
           command: bundle exec fastlane android beta
+      # After the build, so we only ever cache a distribution Gradle actually
+      # unpacked and ran.  A half-downloaded zip saved from a failed build would
+      # poison every later one.
+      - save_cache:
+          key: gradle-dist-v1-{{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}
+          paths:
+            - ~/.gradle/wrapper/dists
       - run:
           name: Update CircleCI Version Variable
           command: |


### PR DESCRIPTION
## Summary

`build-android` has no Gradle cache, so the wrapper fetches `gradle-8.11.1-all.zip` (~200MB) from `services.gradle.org` on every Android build. Each release therefore succeeds only if that host holds the connection open for the whole download.

**Observed failure**, pipeline #10729 on production `4140acbb3`:

```
Downloading https://services.gradle.org/distributions/gradle-8.11.1-all.zip
Exception in thread "main" java.net.SocketException: Connection reset
    at org.gradle.wrapper.Download.downloadInternal(Download.java:106)
```

`bundleRelease` failed on that, one second into the download. Consequences on that commit: `build-ios` succeeded but `build-android` produced no Play beta artifact, and `increment-version` had already consumed 100.0.918 / versionCode 2286. The two earlier production builds the same day ran the identical path successfully, which places the fault in the fetch rather than in the repo configuration.

### Change

- `restore_cache` before the Gradle build, with two keys, both pinning the checksum of `android/gradle/wrapper/gradle-wrapper.properties`:
  - `gradle-dist-v1-<checksum>` — this job's own cache of `~/.gradle/wrapper/dists`.
  - `gradle-deps-v1-<checksum>-` — the cache `build-android-debug` and `build-android-dev` already write, which includes `~/.gradle/wrapper` and so contains the unpacked distribution.
- `save_cache` for `~/.gradle/wrapper/dists` under `gradle-dist-v1-<checksum>` after `fastlane android beta`.
- Published as `freegle/tests@1.1.375`; the pin in `.circleci/continue-config.yml` moves to it, since CircleCI resolves the orb from the registry rather than from the copy in this repo.

### Why the second key is load-bearing

`gradle-dist-v1` is written only by this job's `save_cache`, and this job is filtered to `branches: only: production`. No other job writes that key, so a restore keyed on it alone **misses on the first release after this merges** — that release still performs the full download and keeps exactly the exposure this PR exists to remove. It would only begin helping on the second release, and would go cold again on every Gradle version bump.

`build-android-debug` (orb ~L3487) and `build-android-dev` both `save_cache` `~/.gradle/caches` + `~/.gradle/wrapper` after running `gradlew`, on the same `android-executor` and the same `~/project/iznik-nuxt3` working directory, on every branch except `production` and `modtools`. Master builds therefore keep that cache warm continuously. CircleCI caches are project-scoped and restore across branches, so falling back to it gives the release build an already-unpacked distribution on its first run.

This also makes the job consistent with its siblings rather than inventing a scheme: `build-android-debug`, `build-android-dev`, `build-android-modtools-debug` **and the ModTools release job `build-android-modtools`** all already restore `gradle-deps-v1-<checksum>-`. `build-android` was the only Android job in the orb with no Gradle cache restore of any kind, which is why the FD release downloaded on every run while the ModTools release did not.

## Code Quality Review

- **Both keys pin the same wrapper checksum**, so a Gradle version bump can still never restore the previous version's zip — it fetches fresh, which is the required behaviour. The fallback widens *which cache* is consulted, not *which Gradle version* is acceptable.
- **Save after the build, not before.** Only a distribution Gradle actually unpacked and ran gets cached; a half-downloaded zip kept from a failed build would poison every later build. A run that fails at the download caches nothing, which also means a failed release's retry re-downloads.
- **Scope note:** on a fallback hit the job also restores `~/.gradle/caches` (dependency jars from debug builds), not just the distribution. Gradle's dependency cache is content-addressed and is shared across build types on any normal developer machine, so this is safe; it is a widening of scope from the distribution alone and is called out here deliberately.
- The two existing caches in this job (`npm-deps-v1`, `bundle-v1`) keep their keys and fallbacks unchanged.

## Known Limits

- Steady state is one download per Gradle version bump. The first release after a bump downloads unless a debug/dev build on master has already run at that version and repopulated `gradle-deps-v1` — which is the normal ordering, since master builds precede a production push.
- This removes a dependency on `services.gradle.org` per build; it does not remove the other external fetches in this job (NodeSource is already worked around in-place, per the comment there).
- Nothing here recovers 100.0.918. The next push to `production` builds the next version normally.

## Test Plan

Static, since a Play upload cannot be exercised from a branch, and `build-android` does not run on PR branches (`branches: only: production`) so CI here cannot execute the changed job:

- `circleci orb validate .circleci/orb/freegle-tests.yml` → valid
- `.circleci/continue-config.yml` parses and resolves to `freegle/tests@1.1.375`
- Fallback key verified against the writers: `build-android-debug` and `build-android-dev` save `gradle-deps-v1-{{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "package-lock.json" }}` with paths `~/.gradle/caches`, `~/.gradle/wrapper`; `gradle-wrapper.properties` is committed (`distributionPath=wrapper/dists`, `distributionBase=GRADLE_USER_HOME`), so the checksum is identical across jobs on a given commit and the restored path is the one the wrapper reads.
- `build-android` step order asserted after the edit: `Make gradlew executable` → `restore_cache gradle-dist-v1` + `gradle-deps-v1` fallback → `restore_cache bundle-v1` → `setup-android-fastlane` → `save_cache bundle-v1` → `Build and Deploy to Google Play Beta Track` → `save_cache gradle-dist-v1`

The cache is exercised by the next `deploy-apps` run on `production`, which should log a restore and skip the download rather than populating from cold.