### PR TITLE
fix(moderation): show matched text, not raw regex pattern, for concern keyword flags

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -836,6 +836,24 @@ class ContentCheckService
         return $result === 1;
     }
 
+    // Like safePreg, but returns the substring the pattern actually matched
+    // rather than a bool. Regex-mode concern keywords store a PATTERN (e.g.
+    // 'crack\s+cocaine'), not a literal word, so the mod-facing reason needs
+    // what the pattern matched in the post text, not the pattern itself -
+    // otherwise the flag notice reads as regex soup (Discourse #10024).
+    private function safePregCapture(string $pattern, string $subject): ?string
+    {
+        $result = @preg_match($pattern, $subject, $matches);
+        if (preg_last_error() !== PREG_NO_ERROR) {
+            Log::warning('ContentCheck: invalid regex pattern', [
+                'pattern' => $pattern,
+                'error'   => preg_last_error_msg(),
+            ]);
+            return null;
+        }
+        return $result === 1 ? $matches[0] : null;
+    }
+
     // -------------------------------------------------------------------------
     // Concern keywords — unified table replacing worrywords + spam_keywords.
     // Supports match_mode (fuzzy/literal/regex), global + per-group scope,
@@ -871,8 +889,13 @@ class ContentCheckService
                 continue;
             }
 
+            // For regex mode, $word is a PATTERN rather than the literal text
+            // to display - capture what it actually matched so the mod-facing
+            // reason names real text from the post, not the pattern.
+            $matchedText = null;
+
             $matched = match ($kw->match_mode) {
-                'regex'   => $this->safePreg('/' . $word . '/i', $original),
+                'regex'   => ($matchedText = $this->safePregCapture('/' . $word . '/i', $original)) !== null,
                 'literal' => preg_match('/\b' . preg_quote(strtolower($word), '/') . '\b/', $haystack) === 1,
                 default   => $this->matchesFuzzy($haystack, $word),
             };
@@ -892,12 +915,14 @@ class ContentCheckService
                 continue;
             }
 
+            $displayWord = $matchedText ?? $word;
+
             return [
                 'check'    => self::CHECK_CONCERN_KEYWORD,
                 'category' => $kw->category,
                 'action'   => $kw->action ?? 'flag',
-                'keyword'  => $word,
-                'detail'   => "Matched concern keyword '{$word}'",
+                'keyword'  => $displayWord,
+                'detail'   => "Matched concern keyword '{$displayWord}'",
             ];
         }
 

--- a/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
@@ -850,6 +850,28 @@ class ContentCheckServiceTest extends TestCase
         $this->assertSame(ContentCheckService::CHECK_CONCERN_KEYWORD, $result['check']);
     }
 
+    // Regression test for Discourse #10024: a regex-mode concern keyword must
+    // report the text it actually matched in the post, not the raw pattern -
+    // a moderator reading "Matched concern keyword 'crack\s+cocaine'" has no
+    // idea what in the post triggered it.
+    public function test_check_concern_keywords_regex_match_reports_matched_text_not_pattern(): void
+    {
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'crack\s+cocaine',
+            'category'   => 'substance_regulated',
+            'match_mode' => 'regex',
+            'scope'      => 'global',
+            'group_id'   => 0,
+            'action'     => 'block',
+        ]);
+
+        $result = $this->service->checkConcernKeywords('', 'selling crack cocaine cheap', 1);
+        $this->assertNotNull($result);
+        $this->assertSame('crack cocaine', $result['keyword'], 'keyword should be the matched text, not the regex pattern');
+        $this->assertSame("Matched concern keyword 'crack cocaine'", $result['detail']);
+        $this->assertStringNotContainsString('\s+', $result['detail'], 'detail must not leak the raw regex pattern');
+    }
+
     public function test_check_concern_keywords_exclude_pattern_skips(): void
     {
         DB::table('concern_keywords')->insert([


### PR DESCRIPTION
## Root Cause
`ContentCheckService::checkConcernKeywords()` in iznik-batch used the regex-mode concern keyword's **pattern** (e.g. `crack\s+cocaine`) directly as the display `keyword` and in the `detail` string ("Matched concern keyword '...'"). ModTools' `ModMessageWorry.vue` renders that same `keyword`/`detail` pair for both the "Matched concern keyword" text and the "Triggered by the word" line, so any regex-mode keyword flag showed the raw pattern to moderators instead of the text that actually matched in the post.

Literal and fuzzy match modes were unaffected, since for those modes the stored `keyword` already is the literal word.

## Evidence
Added a regression test that fails on the old code:
```
1) Tests\Unit\Services\ContentCheckServiceTest::test_check_concern_keywords_regex_match_reports_matched_text_not_pattern
keyword should be the matched text, not the regex pattern
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'crack cocaine'
+'crack\s+cocaine'
```

## Fix
Added `safePregCapture()` (a variant of the existing `safePreg()` helper) that returns the matched substring instead of a bool. For `match_mode === 'regex'`, the matched substring is now used as the `keyword`/`detail` display text instead of the raw pattern. Literal/fuzzy modes are untouched — both `keyword` and `detail` are derived from the same `$displayWord`, so both the "Matched concern keyword" and "Triggered by the word" notices are fixed by the single change.

## Other Call Sites
Grepped for other places that build a keyword-flag message. `iznik-server-go/chat/chatmessage.go`'s `enrichReviewReason()` also checks regex-mode concern keywords (for chat spam review), but it never displays the keyword or pattern — it only returns a fixed string `"Known spam keyword"` — so it is not affected by this bug and needs no change. The Go real-time worry-word check (`message.go: checkWorryWords`) only loads `match_mode = 'fuzzy'` keywords, so it never sees regex-mode entries either.

## Test
- File: `iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php`
- Command: `POST http://localhost:8081/api/tests/laravel {"filter":"test_check_concern_keywords_regex_match"}`
- Proves fail-before (raw pattern `crack\s+cocaine` returned) / pass-after (matched text `crack cocaine` returned) for both the new test and the existing `test_check_concern_keywords_regex_match` test.

## Discourse
https://discourse.ilovefreegle.org/t/10024/1