### PR TITLE
feat(discourse): artisan command to set up, announce and close the annual AGM category

### DIFF
--- a/docs/ops/runbooks/README.md
+++ b/docs/ops/runbooks/README.md
@@ -48,6 +48,16 @@ host after any change).
 - Full steps: **[deployment-spend-optimisation.md](deployment-spend-optimisation.md)**.
 - Run roughly monthly, or when a host crosses ~75% disk use.
 
+## Annual AGM category on Discourse
+
+Once a year the AGM gets its own Discourse category, which every user is put on
+"Watching" so the announcements reach them. Set up, announced and closed with the
+`discourse:agm` artisan command, run by hand in three separate steps.
+
+- Full steps: **[agm-category.md](agm-category.md)**.
+- The steps are separate on purpose: switching Watching on before the information
+  posts exist means every draft notifies the whole forum.
+
 ## Adding a runbook
 
 Keep summaries here **non-confidential**: describe impact, what pauses, what stays up, and

--- a/docs/ops/runbooks/agm-category.md
+++ b/docs/ops/runbooks/agm-category.md
@@ -1,0 +1,101 @@
+---
+last_reviewed: 2026-08-12
+owner: Freegle dev team
+covers:
+  - iznik-batch/app/Console/Commands/Discourse/AgmCommand.php
+  - iznik-batch/app/Services/AgmCategoryService.php
+---
+
+# Annual AGM category on Discourse
+
+Each year the AGM gets its own Discourse category. Everyone can read it and reply,
+only staff and the Announcers group can start topics, and every Discourse user is
+put on "Watching" so the announcements reach them.
+
+This is done with `discourse:agm`, run by hand. It is deliberately not scheduled:
+each step is a decision about when to notify every user on the forum.
+
+## The three steps, in order
+
+```bash
+docker exec freegle-batch php artisan discourse:agm setup
+# ... write the information posts in Discourse ...
+docker exec freegle-batch php artisan discourse:agm announce
+# ... the AGM happens ...
+docker exec freegle-batch php artisan discourse:agm close --year=2026
+```
+
+`--year` defaults to the current year. Every action takes `--dry-run`, which
+reports what would change and writes nothing.
+
+### setup
+
+Creates "AGM &lt;year&gt;" (slug `agm-<year>`) with these permissions:
+
+| Group | Permission |
+|-------|-----------|
+| everyone | reply / see |
+| staff | create / reply / see |
+| Announcers | create / reply / see |
+
+No custom incoming email address is set. The category description is seeded from
+`freegle.discourse.agm.description`, which Discourse turns into the body of the
+"About the AGM &lt;year&gt; category" topic.
+
+Re-running `setup` on a category that already exists re-applies the permissions
+rather than creating a duplicate. It leaves the description alone, because for an
+existing category Discourse takes the description from the About topic's first
+post, so changing it means editing that post in the UI.
+
+**`setup` does not switch Watching on.** That is the whole reason it is a separate
+step: write the information posts first, otherwise every draft and correction
+notifies the entire forum.
+
+### announce
+
+Adds the category to the `default_categories_watching` site setting and applies it
+to existing users, so everyone is set to Watching. From this point on, new posts in
+the category notify every user.
+
+Two things about how Discourse implements this are worth knowing, because both
+produce a silent no-op that looks like success:
+
+- The backfill flag is `update_existing_user`, **singular**. The plural spelling is
+  accepted and then ignored, which saves the setting while leaving every existing
+  user untouched.
+- Discourse backfills by diffing the previous value of the setting against the new
+  one. Re-sending a value that is already set changes nothing, whatever the flag
+  says.
+
+So if the category is already in the setting, `announce` reports that and stops
+rather than pretending it did something. Use `--force` to remove and re-add it,
+which makes the diff real and does backfill existing users.
+
+### close
+
+Removes the category from `default_categories_watching` with the backfill applied,
+which deletes the Watching rows that `announce` created and resets auto-watched
+topics to Regular. It then drops `everyone` and `Announcers` to see-only, so the
+category stays readable but inert. Staff keep full rights so they can still
+moderate.
+
+Topics are kept. Nothing is deleted or archived.
+
+## Who can post
+
+Membership of the Announcers group is managed in the Discourse UI at
+`/g`. Anyone in it, plus staff, can start topics in the AGM category.
+
+## Configuration
+
+Under `freegle.discourse.agm` in `iznik-batch/config/freegle.php`:
+
+| Key | Env var | Purpose |
+|-----|---------|---------|
+| `announcers_group` | `DISCOURSE_AGM_ANNOUNCERS_GROUP` | Group allowed to start topics |
+| `colour` / `text_colour` | `DISCOURSE_AGM_COLOUR` / `..._TEXT_COLOUR` | Category badge colours |
+| `description` | `DISCOURSE_AGM_DESCRIPTION` | Seeds the About topic. `:name` is replaced with the category name |
+
+The command needs `DISCOURSE_APIKEY` set to an admin key; the site settings
+endpoints are admin-only and a moderator key gets 404s. With no key set, the
+command warns and exits without doing anything.

--- a/iznik-batch/app/Console/Commands/Discourse/AgmCommand.php
+++ b/iznik-batch/app/Console/Commands/Discourse/AgmCommand.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Console\Commands\Discourse;
+
+use App\Services\AgmCategoryService;
+use Illuminate\Console\Command;
+
+/**
+ * Yearly maintenance of the AGM category on Discourse. Run by hand, not
+ * scheduled: each step is a deliberate decision about when to notify everyone.
+ *
+ *   php artisan discourse:agm setup                # create AGM <this year>
+ *   ... write the information posts in Discourse ...
+ *   php artisan discourse:agm announce             # put every user on Watching
+ *   php artisan discourse:agm close --year=2026    # after the AGM
+ */
+class AgmCommand extends Command
+{
+    protected $signature = 'discourse:agm
+        {action : setup, announce or close}
+        {--year= : Defaults to the current year}
+        {--force : announce only - re-apply even if already watching, so the backfill runs}
+        {--dry-run : Report what would change without writing anything}';
+
+    protected $description = 'Set up, announce or close the annual AGM category on Discourse';
+
+    public function handle(AgmCategoryService $service): int
+    {
+        $action = strtolower(trim((string) $this->argument('action')));
+        $year = (int) ($this->option('year') ?: now()->year);
+        $dryRun = (bool) $this->option('dry-run');
+
+        if (!in_array($action, ['setup', 'announce', 'close'], true)) {
+            $this->error("Unknown action '{$action}'. Expected setup, announce or close.");
+
+            return self::FAILURE;
+        }
+
+        try {
+            $result = match ($action) {
+                'setup' => $service->setup($year, $dryRun),
+                'announce' => $service->announce($year, (bool) $this->option('force'), $dryRun),
+                'close' => $service->close($year, $dryRun),
+            };
+        } catch (\RuntimeException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($result['skipped'] ?? false) {
+            $this->warn('Discourse API key not configured - skipped.');
+
+            return self::SUCCESS;
+        }
+
+        if ($dryRun) {
+            $this->warn('Dry run - nothing was written.');
+        }
+
+        match ($action) {
+            'setup' => $this->reportSetup($result, $year),
+            'announce' => $this->reportAnnounce($result),
+            'close' => $this->reportClose($result, $year),
+        };
+
+        return self::SUCCESS;
+    }
+
+    /** @param  array<string, mixed>  $result */
+    private function reportSetup(array $result, int $year): void
+    {
+        $this->info(sprintf(
+            '%s category "%s"%s.',
+            $result['created'] ? 'Created' : 'Re-applied settings to existing',
+            $result['name'],
+            $result['categoryId'] ? ' (id '.$result['categoryId'].')' : ''
+        ));
+
+        foreach ($result['permissions'] as $group => $permission) {
+            $this->line(sprintf('  %-14s %s', $group, $this->permissionLabel((int) $permission)));
+        }
+
+        if (!$result['created']) {
+            $this->line('  Description left as-is - edit the "About the ..." topic to change it.');
+        }
+
+        $this->line('');
+        $this->line('Next: add the information posts, then run:');
+        $this->line("  php artisan discourse:agm announce --year={$year}");
+    }
+
+    /** @param  array<string, mixed>  $result */
+    private function reportAnnounce(array $result): void
+    {
+        if ($result['alreadyWatching'] && !$result['backfilled']) {
+            $this->warn(sprintf(
+                'Category %d is already in %s ("%s").',
+                $result['categoryId'],
+                AgmCategoryService::WATCHING_SETTING,
+                $result['previous']
+            ));
+            $this->line('Discourse only backfills users when the setting actually changes, so nothing happened.');
+            $this->line("Re-run with --force to remove and re-add it, which does backfill existing users.");
+
+            return;
+        }
+
+        $this->info(sprintf(
+            '%s = "%s" (was "%s").',
+            AgmCategoryService::WATCHING_SETTING,
+            $result['value'],
+            $result['previous']
+        ));
+
+        if ($result['backfilled']) {
+            $this->line('Existing users backfilled to Watching. New posts in the AGM category now notify everyone.');
+        }
+    }
+
+    /** @param  array<string, mixed>  $result */
+    private function reportClose(array $result, int $year): void
+    {
+        $this->info(sprintf('Closed the AGM %d category (id %d).', $year, $result['categoryId']));
+
+        if ($result['wasWatching']) {
+            $this->line(sprintf(
+                '  %s = "%s" - Watching rows for this category removed.',
+                AgmCategoryService::WATCHING_SETTING,
+                $result['value']
+            ));
+        } else {
+            $this->line('  It was not in the watching setting, so nothing to unwatch.');
+        }
+
+        foreach ($result['permissions'] as $group => $permission) {
+            $this->line(sprintf('  %-14s %s', $group, $this->permissionLabel((int) $permission)));
+        }
+
+        $this->line('  Topics are kept and stay readable.');
+    }
+
+    private function permissionLabel(int $permission): string
+    {
+        return match ($permission) {
+            1 => 'create / reply / see',
+            2 => 'reply / see',
+            3 => 'see only',
+            default => 'unknown ('.$permission.')',
+        };
+    }
+}

--- a/iznik-batch/app/Services/AgmCategoryService.php
+++ b/iznik-batch/app/Services/AgmCategoryService.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Sets up, announces and closes the annual AGM category on Discourse.
+ *
+ * The AGM runs once a year in its own category: anyone may read and reply, but
+ * only staff and the Announcers group may start topics, and every Discourse
+ * user is put on "Watching" so they see the announcements. This service does
+ * that in three deliberately separate steps.
+ *
+ * The separation matters. Watching is switched on by adding the category to the
+ * `default_categories_watching` site setting, and from that moment every new
+ * post notifies every user - so the category has to be created and filled with
+ * the information posts *before* the announcement is made, not at the same time.
+ */
+class AgmCategoryService
+{
+    /**
+     * Discourse category permission types, from
+     * CategoryGroup.permission_types: 1 full (create/reply/see),
+     * 2 create_post (reply/see), 3 readonly (see).
+     */
+    private const PERMISSION_CREATE = 1;
+
+    private const PERMISSION_REPLY = 2;
+
+    private const PERMISSION_SEE = 3;
+
+    public const WATCHING_SETTING = 'default_categories_watching';
+
+    public function __construct(private DiscourseClient $client) {}
+
+    public function categoryName(int $year): string
+    {
+        return "AGM {$year}";
+    }
+
+    public function categorySlug(int $year): string
+    {
+        return "agm-{$year}";
+    }
+
+    /**
+     * Create (or re-apply settings to) this year's AGM category.
+     *
+     * Deliberately does not switch Watching on - see the class docblock, and run
+     * announce() once the information posts are in place.
+     *
+     * @return array<string, mixed>
+     */
+    public function setup(int $year, bool $dryRun = false): array
+    {
+        if (!$this->client->isConfigured()) {
+            return ['skipped' => true];
+        }
+
+        $name = $this->categoryName($year);
+        $slug = $this->categorySlug($year);
+        $existing = $this->client->findCategoryBySlug($slug);
+        $permissions = $this->permissions(open: true);
+
+        $result = [
+            'skipped' => false,
+            'dryRun' => $dryRun,
+            'name' => $name,
+            'slug' => $slug,
+            'created' => $existing === null,
+            'permissions' => $permissions,
+            'categoryId' => $existing === null ? null : (int) $existing['id'],
+        ];
+
+        if ($dryRun) {
+            return $result;
+        }
+
+        if ($existing === null) {
+            // Discourse seeds the "About the ... category" topic from the
+            // description passed at creation time (Category#create_category_definition
+            // builds the first post with `raw: description || post_template`).
+            $category = $this->client->createCategory([
+                'name' => $name,
+                'slug' => $slug,
+                'color' => (string) config('freegle.discourse.agm.colour'),
+                'text_color' => (string) config('freegle.discourse.agm.text_colour'),
+                'description' => $this->description($name),
+                'permissions' => $permissions,
+            ]);
+
+            $result['categoryId'] = (int) ($category['id'] ?? 0);
+
+            return $result;
+        }
+
+        // Re-applying to an existing category fixes its permissions but leaves
+        // the description alone: on update Discourse takes the description from
+        // the About topic's first post, so changing it means editing that post.
+        $this->client->updateCategory((int) $existing['id'], [
+            'name' => $name,
+            'slug' => $slug,
+            'color' => (string) ($existing['color'] ?? config('freegle.discourse.agm.colour')),
+            'text_color' => (string) ($existing['text_color'] ?? config('freegle.discourse.agm.text_colour')),
+            'permissions' => $permissions,
+        ]);
+
+        return $result;
+    }
+
+    /**
+     * Put every Discourse user on Watching for this year's AGM category.
+     *
+     * @return array<string, mixed>
+     */
+    public function announce(int $year, bool $force = false, bool $dryRun = false): array
+    {
+        if (!$this->client->isConfigured()) {
+            return ['skipped' => true];
+        }
+
+        $id = (string) $this->requireCategory($year, 'Run discourse:agm setup first.')['id'];
+        $current = $this->client->getSiteSetting(self::WATCHING_SETTING);
+        $ids = $this->splitIds($current);
+        $already = in_array($id, $ids, true);
+
+        $without = array_values(array_diff($ids, [$id]));
+        $with = array_merge($without, [$id]);
+
+        $result = [
+            'skipped' => false,
+            'dryRun' => $dryRun,
+            'categoryId' => (int) $id,
+            'alreadyWatching' => $already,
+            'previous' => $current,
+            'value' => $this->joinIds($with),
+            'backfilled' => false,
+        ];
+
+        // Discourse backfills existing users by diffing the previous value
+        // against the new one, so re-sending a value that is already set never
+        // touches a user however the backfill flag is set. Without --force,
+        // say so rather than pretending a no-op did something.
+        if ($already && !$force) {
+            return $result;
+        }
+
+        if ($dryRun) {
+            return $result;
+        }
+
+        if ($already) {
+            // Drop it first so the re-add is a real change and the backfill runs.
+            $this->client->updateSiteSetting(self::WATCHING_SETTING, $this->joinIds($without), false);
+        }
+
+        $this->client->updateSiteSetting(self::WATCHING_SETTING, $this->joinIds($with), true);
+        $result['backfilled'] = true;
+
+        return $result;
+    }
+
+    /**
+     * Close a finished AGM: stop notifying everyone and make it read-only.
+     *
+     * Removing the category from the watching setting with the backfill flag
+     * deletes the Watching rows it created and resets auto-watched topics to
+     * Regular, so this genuinely undoes announce() rather than leaving stale
+     * rows behind. The category and its topics are kept, readable.
+     *
+     * @return array<string, mixed>
+     */
+    public function close(int $year, bool $dryRun = false): array
+    {
+        if (!$this->client->isConfigured()) {
+            return ['skipped' => true];
+        }
+
+        $category = $this->requireCategory($year, 'There is nothing to close.');
+        $id = (string) $category['id'];
+        $current = $this->client->getSiteSetting(self::WATCHING_SETTING);
+        $ids = $this->splitIds($current);
+        $without = array_values(array_diff($ids, [$id]));
+        $wasWatching = count($without) !== count($ids);
+        $permissions = $this->permissions(open: false);
+
+        $result = [
+            'skipped' => false,
+            'dryRun' => $dryRun,
+            'categoryId' => (int) $id,
+            'wasWatching' => $wasWatching,
+            'value' => $this->joinIds($without),
+            'permissions' => $permissions,
+        ];
+
+        if ($dryRun) {
+            return $result;
+        }
+
+        if ($wasWatching) {
+            $this->client->updateSiteSetting(self::WATCHING_SETTING, $this->joinIds($without), true);
+        }
+
+        $this->client->updateCategory((int) $id, [
+            'name' => (string) ($category['name'] ?? $this->categoryName($year)),
+            'slug' => $this->categorySlug($year),
+            'color' => (string) ($category['color'] ?? config('freegle.discourse.agm.colour')),
+            'text_color' => (string) ($category['text_color'] ?? config('freegle.discourse.agm.text_colour')),
+            'permissions' => $permissions,
+        ]);
+
+        return $result;
+    }
+
+    /** @return array<string, mixed> */
+    private function requireCategory(int $year, string $hint): array
+    {
+        $slug = $this->categorySlug($year);
+        $category = $this->client->findCategoryBySlug($slug);
+
+        if ($category === null) {
+            throw new \RuntimeException("Discourse category '{$slug}' does not exist. {$hint}");
+        }
+
+        return $category;
+    }
+
+    /**
+     * Everyone may reply while the AGM is open and only see it once closed;
+     * staff keep full rights throughout so they can still moderate.
+     *
+     * @return array<string, int>
+     */
+    private function permissions(bool $open): array
+    {
+        $announcers = (string) config('freegle.discourse.agm.announcers_group', 'Announcers');
+
+        return [
+            'everyone' => $open ? self::PERMISSION_REPLY : self::PERMISSION_SEE,
+            'staff' => self::PERMISSION_CREATE,
+            $announcers => $open ? self::PERMISSION_CREATE : self::PERMISSION_SEE,
+        ];
+    }
+
+    private function description(string $name): string
+    {
+        return str_replace(':name', $name, (string) config('freegle.discourse.agm.description'));
+    }
+
+    /** @return array<int, string> */
+    private function splitIds(string $value): array
+    {
+        return array_values(array_filter(explode('|', $value), static fn ($id) => $id !== ''));
+    }
+
+    /** @param  array<int, string>  $ids */
+    private function joinIds(array $ids): string
+    {
+        return implode('|', $ids);
+    }
+}

--- a/iznik-batch/app/Services/DiscourseClient.php
+++ b/iznik-batch/app/Services/DiscourseClient.php
@@ -60,11 +60,31 @@ class DiscourseClient
      */
     private function getJson(string $url, array $query = []): array
     {
+        return $this->send('GET', $url, $query) ?? [];
+    }
+
+    /**
+     * Issue a request, retrying while Discourse rate-limits us.
+     *
+     * Writes go out form-encoded rather than as JSON because that is the shape
+     * the admin endpoints were verified against by hand: nested keys such as
+     * `permissions[everyone]=2` are what Discourse's own admin UI sends.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>|null  null only when $notFoundIsNull and Discourse replied 404
+     */
+    private function send(string $method, string $url, array $payload = [], bool $notFoundIsNull = false): ?array
+    {
         $maxRetries = max(1, (int) config('freegle.discourse.max_retries', 60));
         $retryDelay = max(0, (int) config('freegle.discourse.retry_delay_s', 1));
 
         for ($attempt = 1; ; $attempt++) {
-            $resp = $this->request()->get($url, $query);
+            $resp = match ($method) {
+                'GET' => $this->request()->get($url, $payload),
+                'POST' => $this->request()->asForm()->post($url, $payload),
+                'PUT' => $this->request()->asForm()->put($url, $payload),
+                default => throw new \InvalidArgumentException("Discourse: unsupported method {$method}"),
+            };
             $data = $resp->json();
             $errors = is_array($data) && isset($data['errors']) ? (array) $data['errors'] : [];
 
@@ -83,6 +103,19 @@ class DiscourseClient
                     sleep($retryDelay);
                 }
                 continue;
+            }
+
+            if ($notFoundIsNull && $resp->status() === 404) {
+                return null;
+            }
+
+            // The site-settings endpoint answers 204 with an empty body. That is
+            // a success; treating a non-JSON body as malformed would make every
+            // successful write throw. Writes only: a GET that comes back empty
+            // is still the malformed response the existing callers throw on,
+            // rather than something to be quietly read as "no data".
+            if ($method !== 'GET' && $resp->successful() && trim((string) $resp->body()) === '') {
+                return [];
             }
 
             if (!is_array($data)) {
@@ -133,5 +166,75 @@ class DiscourseClient
         $data = $this->getJson($this->baseUrl."/users/{$username}/emails.json");
 
         return (string) ($data['email'] ?? '');
+    }
+
+    /**
+     * Look a category up by slug, or null when it does not exist yet.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function findCategoryBySlug(string $slug): ?array
+    {
+        $data = $this->send('GET', $this->baseUrl."/c/{$slug}/find_by_slug.json", [], notFoundIsNull: true);
+
+        return $data === null ? null : ($data['category'] ?? null);
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
+     */
+    public function createCategory(array $params): array
+    {
+        $data = $this->send('POST', $this->baseUrl.'/categories.json', $params) ?? [];
+
+        return $data['category'] ?? $data;
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
+     */
+    public function updateCategory(int $id, array $params): array
+    {
+        $data = $this->send('PUT', $this->baseUrl."/categories/{$id}.json", $params) ?? [];
+
+        return $data['category'] ?? $data;
+    }
+
+    /** Current value of a site setting. */
+    public function getSiteSetting(string $name): string
+    {
+        $data = $this->getJson($this->baseUrl.'/admin/site_settings.json', ['names' => $name]);
+
+        foreach (($data['site_settings'] ?? []) as $setting) {
+            if (($setting['setting'] ?? null) === $name) {
+                return (string) ($setting['value'] ?? '');
+            }
+        }
+
+        throw new \RuntimeException("Discourse: site setting not found: {$name}");
+    }
+
+    /**
+     * Change a site setting, optionally applying it to existing users.
+     *
+     * The backfill flag is `update_existing_user` - singular. The plural
+     * spelling is accepted by the request and then silently ignored, so the
+     * setting saves while every existing user is left untouched. Discourse also
+     * backfills by diffing the previous value against the new one, so re-sending
+     * a value that is already set is a no-op no matter what this flag says.
+     *
+     * @return array<string, mixed>
+     */
+    public function updateSiteSetting(string $name, string $value, bool $backfillExistingUsers = false): array
+    {
+        $payload = [$name => $value];
+
+        if ($backfillExistingUsers) {
+            $payload['update_existing_user'] = 'true';
+        }
+
+        return $this->send('PUT', $this->baseUrl.'/admin/site_settings/'.$name, $payload) ?? [];
     }
 }

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -201,6 +201,21 @@ return [
         // Rate-limit retry policy (V1 Utils::curlWithRetry: 60 retries, 1s delay).
         'max_retries' => (int) env('DISCOURSE_MAX_RETRIES', 60),
         'retry_delay_s' => (int) env('DISCOURSE_RETRY_DELAY_S', 1),
+
+        // The annual AGM category (discourse:agm). Only staff and this group
+        // may start topics in it; everyone else may read and reply.
+        'agm' => [
+            'announcers_group' => env('DISCOURSE_AGM_ANNOUNCERS_GROUP', 'Announcers'),
+            'colour' => env('DISCOURSE_AGM_COLOUR', '0088CC'),
+            'text_colour' => env('DISCOURSE_AGM_TEXT_COLOUR', 'FFFFFF'),
+            // Seeds the "About the ... category" topic. :name is the category name.
+            'description' => env(
+                'DISCOURSE_AGM_DESCRIPTION',
+                'All users of Discourse have been put on settings so that they are watching this group. '
+                .'You can switch this off, if you wish, by clicking on the user-cog icon at the top of the page '
+                .'and then select "+ Tracking" then remove ":name" from your Watched list.'
+            ),
+        ],
     ],
 
     // PayPal NVP/SOAP API (V1 paypal_download.php fallback transaction downloader).

--- a/iznik-batch/tests/Feature/Discourse/AgmCommandTest.php
+++ b/iznik-batch/tests/Feature/Discourse/AgmCommandTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature\Discourse;
+
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Tests for discourse:agm, which sets up, announces and closes the annual AGM
+ * category. Driven end to end through the real AgmCategoryService with the
+ * Discourse HTTP calls faked, so the command's reporting and exit codes are
+ * asserted against the same behaviour the service actually produces.
+ *
+ * The reporting matters as much as the writes here: announce is expected to say
+ * plainly when it did nothing, because Discourse only backfills existing users
+ * when the setting's value actually changes.
+ */
+class AgmCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'freegle.discourse.url' => 'https://discourse.test',
+            'freegle.discourse.api_key' => 'test-key',
+            'freegle.discourse.api_username' => 'system',
+            'freegle.discourse.max_retries' => 3,
+            'freegle.discourse.retry_delay_s' => 0,
+            'freegle.discourse.agm.announcers_group' => 'Announcers',
+            'freegle.discourse.agm.colour' => '0088CC',
+            'freegle.discourse.agm.text_colour' => 'FFFFFF',
+            'freegle.discourse.agm.description' => 'Watching :name is on by default.',
+        ]);
+    }
+
+    private function fakeMissing(): void
+    {
+        Http::fake([
+            'discourse.test/c/*/find_by_slug.json*' => Http::response(['errors' => ['Not found']], 404),
+            'discourse.test/categories.json' => Http::response(['category' => ['id' => 42]], 200),
+        ]);
+    }
+
+    private function fakeExisting(string $watching = '7'): void
+    {
+        Http::fake([
+            'discourse.test/c/*/find_by_slug.json*' => Http::response([
+                'category' => ['id' => 18, 'name' => 'AGM 2026', 'color' => '0088CC', 'text_color' => 'FFFFFF'],
+            ], 200),
+            'discourse.test/admin/site_settings.json*' => Http::response([
+                'site_settings' => [['setting' => 'default_categories_watching', 'value' => $watching]],
+            ], 200),
+            'discourse.test/admin/site_settings/*' => Http::response('', 204),
+            'discourse.test/categories/*' => Http::response(['category' => ['id' => 18]], 200),
+        ]);
+    }
+
+    public function test_setup_reports_the_new_category_and_the_next_step(): void
+    {
+        $this->fakeMissing();
+
+        $this->artisan('discourse:agm', ['action' => 'setup', '--year' => 2027])
+            ->expectsOutputToContain('Created category "AGM 2027"')
+            ->expectsOutputToContain('reply / see')
+            ->expectsOutputToContain('discourse:agm announce --year=2027')
+            ->assertExitCode(0);
+    }
+
+    public function test_setup_on_an_existing_category_says_the_description_is_left_alone(): void
+    {
+        $this->fakeExisting();
+
+        $this->artisan('discourse:agm', ['action' => 'setup', '--year' => 2026])
+            ->expectsOutputToContain('Re-applied settings to existing')
+            ->expectsOutputToContain('Description left as-is')
+            ->assertExitCode(0);
+    }
+
+    public function test_announce_reports_the_new_setting_value_and_the_backfill(): void
+    {
+        $this->fakeExisting(watching: '7');
+
+        $this->artisan('discourse:agm', ['action' => 'announce', '--year' => 2026])
+            ->expectsOutputToContain('default_categories_watching = "7|18"')
+            ->expectsOutputToContain('Existing users backfilled')
+            ->assertExitCode(0);
+    }
+
+    public function test_announce_says_plainly_when_it_did_nothing(): void
+    {
+        // Re-sending an unchanged value backfills nobody, so the command must
+        // not imply it worked. It points at --force instead.
+        $this->fakeExisting(watching: '7|18');
+
+        $this->artisan('discourse:agm', ['action' => 'announce', '--year' => 2026])
+            ->expectsOutputToContain('is already in')
+            ->expectsOutputToContain('nothing happened')
+            ->expectsOutputToContain('--force')
+            ->assertExitCode(0);
+    }
+
+    public function test_close_reports_the_unwatch_and_the_locked_down_permissions(): void
+    {
+        $this->fakeExisting(watching: '7|18');
+
+        $this->artisan('discourse:agm', ['action' => 'close', '--year' => 2026])
+            ->expectsOutputToContain('Closed the AGM 2026 category')
+            ->expectsOutputToContain('Watching rows for this category removed')
+            ->expectsOutputToContain('see only')
+            ->expectsOutputToContain('Topics are kept')
+            ->assertExitCode(0);
+    }
+
+    public function test_close_reports_when_there_was_nothing_to_unwatch(): void
+    {
+        $this->fakeExisting(watching: '7');
+
+        $this->artisan('discourse:agm', ['action' => 'close', '--year' => 2026])
+            ->expectsOutputToContain('nothing to unwatch')
+            ->assertExitCode(0);
+    }
+
+    public function test_dry_run_says_nothing_was_written_and_writes_nothing(): void
+    {
+        $this->fakeExisting(watching: '7');
+
+        $this->artisan('discourse:agm', ['action' => 'announce', '--year' => 2026, '--dry-run' => true])
+            ->expectsOutputToContain('Dry run')
+            ->assertExitCode(0);
+
+        Http::assertNotSent(fn ($r) => in_array($r->method(), ['POST', 'PUT'], true));
+    }
+
+    public function test_an_unknown_action_fails_without_calling_discourse(): void
+    {
+        Http::fake();
+
+        $this->artisan('discourse:agm', ['action' => 'wibble'])
+            ->expectsOutputToContain('Unknown action')
+            ->assertExitCode(1);
+
+        Http::assertNothingSent();
+    }
+
+    public function test_a_missing_category_fails_with_a_usable_message(): void
+    {
+        $this->fakeMissing();
+
+        $this->artisan('discourse:agm', ['action' => 'announce', '--year' => 2099])
+            ->expectsOutputToContain('does not exist')
+            ->assertExitCode(1);
+    }
+
+    public function test_it_skips_when_no_api_key_is_configured(): void
+    {
+        config(['freegle.discourse.api_key' => '']);
+        Http::fake();
+
+        $this->artisan('discourse:agm', ['action' => 'setup'])
+            ->expectsOutputToContain('not configured')
+            ->assertExitCode(0);
+
+        Http::assertNothingSent();
+    }
+}

--- a/iznik-batch/tests/Unit/Services/AgmCategoryServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AgmCategoryServiceTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\AgmCategoryService;
+use App\Services\DiscourseClient;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * The AGM category is created open (everyone may reply, only staff and
+ * Announcers may start topics), announced separately once the information posts
+ * exist, and closed to read-only afterwards.
+ *
+ * The behaviour worth guarding is the backfill: Discourse only applies
+ * `default_categories_watching` to existing users when the setting's value
+ * actually changes, so re-sending an unchanged value silently touches nobody.
+ */
+class AgmCategoryServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'freegle.discourse.url' => 'https://discourse.test',
+            'freegle.discourse.api_key' => 'test-key',
+            'freegle.discourse.api_username' => 'system',
+            'freegle.discourse.max_retries' => 3,
+            'freegle.discourse.retry_delay_s' => 0,
+            'freegle.discourse.agm.announcers_group' => 'Announcers',
+            'freegle.discourse.agm.colour' => '0088CC',
+            'freegle.discourse.agm.text_colour' => 'FFFFFF',
+            'freegle.discourse.agm.description' => 'Watching :name is on by default.',
+        ]);
+    }
+
+    private function service(): AgmCategoryService
+    {
+        return new AgmCategoryService(new DiscourseClient());
+    }
+
+    private function fakeCategoryMissing(): void
+    {
+        Http::fake([
+            'discourse.test/c/*/find_by_slug.json*' => Http::response(['errors' => ['Not found']], 404),
+            'discourse.test/categories.json' => Http::response(['category' => ['id' => 42]], 200),
+        ]);
+    }
+
+    /** @param  array<string, mixed>  $extra */
+    private function fakeCategoryExists(string $watching = '7', array $extra = []): void
+    {
+        Http::fake(array_merge([
+            'discourse.test/c/*/find_by_slug.json*' => Http::response([
+                'category' => ['id' => 18, 'name' => 'AGM 2026', 'color' => '0088CC', 'text_color' => 'FFFFFF'],
+            ], 200),
+            'discourse.test/admin/site_settings.json*' => Http::response([
+                'site_settings' => [['setting' => 'default_categories_watching', 'value' => $watching]],
+            ], 200),
+            'discourse.test/admin/site_settings/*' => Http::response('', 204),
+            'discourse.test/categories/*' => Http::response(['category' => ['id' => 18]], 200),
+        ], $extra));
+    }
+
+    public function test_setup_skips_when_api_key_absent(): void
+    {
+        config(['freegle.discourse.api_key' => '']);
+        Http::fake();
+
+        $this->assertTrue($this->service()->setup(2027)['skipped']);
+        Http::assertNothingSent();
+    }
+
+    public function test_setup_creates_category_everyone_can_reply_to_but_not_start(): void
+    {
+        $this->fakeCategoryMissing();
+
+        $result = $this->service()->setup(2027);
+
+        $this->assertTrue($result['created']);
+        $this->assertSame(42, $result['categoryId']);
+        Http::assertSent(function (Request $request) {
+            if ($request->method() !== 'POST' || !str_contains($request->url(), '/categories.json')) {
+                return false;
+            }
+
+            $body = urldecode($request->body());
+
+            return str_contains($body, 'name=AGM 2027')
+                && str_contains($body, 'slug=agm-2027')
+                && str_contains($body, 'permissions[everyone]=2')
+                && str_contains($body, 'permissions[staff]=1')
+                && str_contains($body, 'permissions[Announcers]=1')
+                && str_contains($body, 'description=Watching AGM 2027 is on by default.');
+        });
+    }
+
+    public function test_setup_does_not_switch_watching_on(): void
+    {
+        // Watching must stay off until the information posts exist, otherwise
+        // the first draft post notifies every user on the forum.
+        $this->fakeCategoryMissing();
+
+        $this->service()->setup(2027);
+
+        Http::assertNotSent(fn (Request $r) => str_contains($r->url(), 'site_settings'));
+    }
+
+    public function test_setup_reapplies_to_an_existing_category_rather_than_duplicating_it(): void
+    {
+        $this->fakeCategoryExists();
+
+        $result = $this->service()->setup(2026);
+
+        $this->assertFalse($result['created']);
+        $this->assertSame(18, $result['categoryId']);
+        Http::assertNotSent(fn (Request $r) => $r->method() === 'POST' && str_contains($r->url(), '/categories.json'));
+        Http::assertSent(fn (Request $r) => $r->method() === 'PUT'
+            && str_contains($r->url(), '/categories/18.json')
+            && str_contains(urldecode($r->body()), 'permissions[everyone]=2'));
+    }
+
+    public function test_announce_appends_the_category_and_backfills_existing_users(): void
+    {
+        $this->fakeCategoryExists(watching: '7');
+
+        $result = $this->service()->announce(2026);
+
+        $this->assertTrue($result['backfilled']);
+        $this->assertSame('7|18', $result['value']);
+        Http::assertSent(function (Request $request) {
+            return $request->method() === 'PUT'
+                && str_contains($request->url(), '/admin/site_settings/default_categories_watching')
+                && $request['default_categories_watching'] === '7|18'
+                && $request['update_existing_user'] === 'true';
+        });
+    }
+
+    public function test_announce_preserves_other_watched_categories(): void
+    {
+        $this->fakeCategoryExists(watching: '7|16');
+
+        $this->assertSame('7|16|18', $this->service()->announce(2026)['value']);
+    }
+
+    public function test_announce_does_nothing_when_already_watching(): void
+    {
+        // Re-sending an unchanged value backfills nobody, so claiming success
+        // would be a lie. Report it instead.
+        $this->fakeCategoryExists(watching: '7|18');
+
+        $result = $this->service()->announce(2026);
+
+        $this->assertTrue($result['alreadyWatching']);
+        $this->assertFalse($result['backfilled']);
+        Http::assertNotSent(fn (Request $r) => $r->method() === 'PUT' && str_contains($r->url(), 'site_settings'));
+    }
+
+    public function test_announce_force_removes_then_readds_so_the_backfill_actually_runs(): void
+    {
+        $this->fakeCategoryExists(watching: '7|18');
+
+        $result = $this->service()->announce(2026, force: true);
+
+        $this->assertTrue($result['backfilled']);
+
+        // First write drops the category (no backfill needed) so the second is a
+        // real change that Discourse will apply to existing users.
+        Http::assertSent(fn (Request $r) => $r->method() === 'PUT'
+            && str_contains($r->url(), 'site_settings')
+            && $r['default_categories_watching'] === '7'
+            && !isset($r['update_existing_user']));
+        Http::assertSent(fn (Request $r) => $r->method() === 'PUT'
+            && str_contains($r->url(), 'site_settings')
+            && $r['default_categories_watching'] === '7|18'
+            && $r['update_existing_user'] === 'true');
+    }
+
+    public function test_announce_fails_when_the_category_does_not_exist(): void
+    {
+        $this->fakeCategoryMissing();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/discourse:agm setup/');
+
+        $this->service()->announce(2099);
+    }
+
+    public function test_close_unwatches_with_backfill_and_makes_it_read_only(): void
+    {
+        $this->fakeCategoryExists(watching: '7|18');
+
+        $result = $this->service()->close(2026);
+
+        $this->assertTrue($result['wasWatching']);
+        $this->assertSame('7', $result['value']);
+
+        Http::assertSent(fn (Request $r) => $r->method() === 'PUT'
+            && str_contains($r->url(), 'site_settings')
+            && $r['default_categories_watching'] === '7'
+            && $r['update_existing_user'] === 'true');
+        Http::assertSent(fn (Request $r) => $r->method() === 'PUT'
+            && str_contains($r->url(), '/categories/18.json')
+            && str_contains(urldecode($r->body()), 'permissions[everyone]=3')
+            && str_contains(urldecode($r->body()), 'permissions[staff]=1'));
+    }
+
+    public function test_close_still_locks_down_when_it_was_never_watched(): void
+    {
+        $this->fakeCategoryExists(watching: '7');
+
+        $result = $this->service()->close(2026);
+
+        $this->assertFalse($result['wasWatching']);
+        Http::assertNotSent(fn (Request $r) => $r->method() === 'PUT' && str_contains($r->url(), 'site_settings'));
+        Http::assertSent(fn (Request $r) => str_contains($r->url(), '/categories/18.json'));
+    }
+
+    public function test_dry_run_writes_nothing(): void
+    {
+        $this->fakeCategoryExists(watching: '7');
+
+        $setup = $this->service()->setup(2026, dryRun: true);
+        $announce = $this->service()->announce(2026, dryRun: true);
+        $close = $this->service()->close(2026, dryRun: true);
+
+        $this->assertTrue($setup['dryRun']);
+        $this->assertSame('7|18', $announce['value']);
+        $this->assertSame('7', $close['value']);
+        Http::assertNotSent(fn (Request $r) => in_array($r->method(), ['POST', 'PUT'], true));
+    }
+}

--- a/iznik-batch/tests/Unit/Services/DiscourseClientTest.php
+++ b/iznik-batch/tests/Unit/Services/DiscourseClientTest.php
@@ -91,4 +91,118 @@ class DiscourseClientTest extends TestCase
 
         $this->assertSame('mod@example.com', (new DiscourseClient())->getUserEmail('alice'));
     }
+
+    public function test_find_category_by_slug_returns_category(): void
+    {
+        Http::fake(fn () => Http::response(['category' => ['id' => 18, 'name' => 'AGM 2026']], 200));
+
+        $category = (new DiscourseClient())->findCategoryBySlug('agm-2026');
+
+        $this->assertSame(18, $category['id']);
+    }
+
+    public function test_find_category_by_slug_returns_null_when_absent(): void
+    {
+        // A missing category is an expected outcome for the AGM setup command
+        // (that is how it decides to create one), not an error to throw on.
+        Http::fake(fn () => Http::response(['errors' => ['The requested URL or resource could not be found.']], 404));
+
+        $this->assertNull((new DiscourseClient())->findCategoryBySlug('agm-2099'));
+    }
+
+    public function test_update_site_setting_sends_singular_update_existing_user(): void
+    {
+        // Discourse reads the backfill flag from `update_existing_user` (singular).
+        // Sending `update_existing_users` is silently ignored: the setting saves
+        // but no existing user is touched, which is exactly the failure this
+        // assertion exists to prevent.
+        Http::fake(fn () => Http::response('', 204));
+
+        (new DiscourseClient())->updateSiteSetting('default_categories_watching', '7|18', true);
+
+        Http::assertSent(function ($request) {
+            return $request->method() === 'PUT'
+                && str_contains($request->url(), '/admin/site_settings/default_categories_watching')
+                && $request['default_categories_watching'] === '7|18'
+                && $request['update_existing_user'] === 'true';
+        });
+    }
+
+    public function test_update_site_setting_omits_backfill_flag_when_not_requested(): void
+    {
+        Http::fake(fn () => Http::response('', 204));
+
+        (new DiscourseClient())->updateSiteSetting('default_categories_watching', '7', false);
+
+        Http::assertSent(fn ($request) => !isset($request['update_existing_user']));
+    }
+
+    public function test_write_accepts_204_with_empty_body(): void
+    {
+        // The site-settings endpoint answers 204 with no body. Treating a
+        // non-JSON body as a failure would make every successful write throw.
+        Http::fake(fn () => Http::response('', 204));
+
+        $this->assertSame([], (new DiscourseClient())->updateSiteSetting('default_categories_watching', '7', false));
+    }
+
+    public function test_get_with_an_empty_body_still_throws(): void
+    {
+        // The empty-body allowance is for writes only. A GET that comes back
+        // empty is still the malformed response the existing callers abort on,
+        // rather than something to read quietly as "no data".
+        Http::fake(fn () => Http::response('', 200));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/unexpected non-JSON/');
+
+        (new DiscourseClient())->getUserEmail('alice');
+    }
+
+    public function test_write_retries_on_rate_limit(): void
+    {
+        // Admin writes are rate-limited hard; the retry must cover PUT as well as GET.
+        Http::fakeSequence()
+            ->push(['errors' => ['You’ve performed this action too many times.']], 429)
+            ->push('', 204);
+
+        (new DiscourseClient())->updateSiteSetting('default_categories_watching', '7', false);
+
+        Http::assertSentCount(2);
+    }
+
+    public function test_create_category_posts_name_and_permissions(): void
+    {
+        Http::fake(fn () => Http::response(['category' => ['id' => 42]], 200));
+
+        $category = (new DiscourseClient())->createCategory([
+            'name' => 'AGM 2027',
+            'slug' => 'agm-2027',
+            'permissions' => ['everyone' => 2, 'staff' => 1],
+        ]);
+
+        $this->assertSame(42, $category['id']);
+        Http::assertSent(function ($request) {
+            // Assert on the encoded body: nested keys go out as
+            // permissions[everyone]=2, which is the shape Discourse expects.
+            $body = urldecode($request->body());
+
+            return $request->method() === 'POST'
+                && str_contains($request->url(), '/categories.json')
+                && str_contains($body, 'name=AGM 2027')
+                && str_contains($body, 'permissions[everyone]=2')
+                && str_contains($body, 'permissions[staff]=1');
+        });
+    }
+
+    public function test_get_site_setting_reads_value_by_name(): void
+    {
+        Http::fake(fn () => Http::response([
+            'site_settings' => [
+                ['setting' => 'default_categories_watching', 'value' => '7|18'],
+            ],
+        ], 200));
+
+        $this->assertSame('7|18', (new DiscourseClient())->getSiteSetting('default_categories_watching'));
+    }
 }


### PR DESCRIPTION
## Summary

Adds `discourse:agm setup|announce|close` so the annual AGM category on Discourse is repeatable each year instead of a hand-run sequence of admin API calls. Run by hand, deliberately **not** scheduled: each step is a decision about when to notify every user on the forum.

Context: this year's category is https://discourse.ilovefreegle.org/c/agm-2026, which was set up manually. The command reproduces that setup exactly.

- **`setup`** creates "AGM &lt;year&gt;" (slug `agm-<year>`) with `everyone` = reply/see and `staff` + `Announcers` = create/reply/see, so anyone can read and reply but only staff and Announcers can start topics. Seeds the "About the ..." topic from config. Sets no custom incoming email address. Re-running re-applies permissions rather than creating a duplicate.
- **`announce`** adds the category to `default_categories_watching` and backfills existing users onto Watching.
- **`close`** removes it from that setting with the backfill applied, then drops `everyone` and `Announcers` to see-only. Topics are kept and stay readable.

`setup` deliberately does not switch Watching on. That is the reason it is a separate step: the information posts need to exist first, otherwise every draft and correction notifies the whole forum.

All three take `--year` (defaults to the current year) and `--dry-run`.

## Discourse behaviours encoded here

Both of these are silent no-ops that return HTTP 204 and look exactly like success, so they are worth stating:

- The backfill flag is **`update_existing_user`, singular**. The plural spelling is accepted by the request and then ignored, which saves the setting while leaving every existing user untouched.
- The backfill **diffs the previous value against the new one**, so re-sending a value that is already set does nothing whatever the flag says. `announce` detects this and reports it rather than claiming success; `--force` removes and re-adds so the diff is real.

Verified against the Discourse source for the running build (2026.7.1, `cbf996f6`) and by applying it live.

## Code quality review

- `DiscourseClient` gains category and site-setting reads/writes, sharing the existing rate-limit retry rather than duplicating it. The admin API throttles these hard, so retry is not optional.
- Writes are form-encoded, matching what Discourse's own admin UI sends, including nested keys such as `permissions[everyone]=2`.
- The empty-body allowance needed for 204 responses is **scoped to writes**. An empty GET still throws as it did before, rather than being quietly read as "no data", which preserves this client's existing contract of failing loudly.
- Business logic lives in `AgmCategoryService`; the command only parses options and formats output, matching `NotSignedUpCommand` / `DiscourseNotSignedUpService`.
- Group name, colours and description text are config, not hardcoded.
- No scheduler entry, by design.

## Future improvements

- `setup` re-run against an existing category leaves the description alone, because for an existing category Discourse takes it from the About topic's first post. Changing it means editing that post. Could be automated later if it turns out to matter.
- The command does not create the information posts. That is a human writing job.

## Test plan

- 31 new tests:
  - 12 in a new `AgmCategoryServiceTest` (setup/announce/close, the already-watching no-op, the `--force` remove-then-re-add, dry-run writing nothing).
  - 9 added to `DiscourseClientTest` (6 to 15) covering the new methods, including the singular-flag assertion and an empty GET still throwing.
  - 10 in a new `AgmCommandTest`, driving the command end to end through the real service with the HTTP calls faked: all three actions, the already-watching report, dry run, unknown action and the no-API-key skip, plus both exit codes.
- Full Laravel suite green locally via the status API: **5554 passed, 15788 assertions**.
- Verified at the CLI: registers in `artisan list`, skips cleanly with no API key configured, exits 1 on an unknown action.
- Docs freshness check passes; runbook added at `docs/ops/runbooks/agm-category.md`.