### PR TITLE
fix(ads): collapse the sticky band when there is no ad, as it did before

### DIFF
--- a/iznik-nuxt3/components/ExternalDa.vue
+++ b/iznik-nuxt3/components/ExternalDa.vue
@@ -325,14 +325,25 @@ async function checkStillVisible() {
     const myEmail = me.value?.email
 
     const runtimeConfig = useRuntimeConfig()
-    const userSite = runtimeConfig.public.USER_SITE
-    const userSite2 = userSite.replace('www.', '')
-    console.log('Consider system', myEmail, userSite, userSite2)
+    // USER_SITE is a URL - 'https://www.ilovefreegle.org' by default and in the deployed
+    // env - so the old test, `myEmail.includes(userSite)` with a `replace('www.', '')`
+    // variant, could never match: no email address contains 'https://'. Ad suppression for
+    // our own accounts was therefore dead in production. It only looked right in tests,
+    // where the fixture set USER_SITE to a bare 'ilovefreegle.org'.
+    //
+    // Compare the email's DOMAIN against the site's HOST instead, allowing subdomains so
+    // someone@mail.ilovefreegle.org still counts.
+    const host = String(runtimeConfig.public.USER_SITE ?? '')
+      .replace(/^https?:\/\//, '')
+      .replace(/^www\./, '')
+      .replace(/\/.*$/, '')
+      .toLowerCase()
+    const emailDomain = myEmail ? myEmail.split('@').pop().toLowerCase() : ''
+    const isSystemAccount = Boolean(
+      host && emailDomain && (emailDomain === host || emailDomain.endsWith('.' + host))
+    )
 
-    if (
-      myEmail &&
-      (myEmail.includes(userSite) || myEmail.includes(userSite2))
-    ) {
+    if (isSystemAccount) {
       console.log('Ads disabled as system account')
       emit('rendered', false)
     } else if (recentDonor.value) {

--- a/iznik-nuxt3/components/ExternalDa.vue
+++ b/iznik-nuxt3/components/ExternalDa.vue
@@ -17,9 +17,12 @@
         class="d-flex w-100 justify-content-md-around"
         :style="maxWidth ? `max-width: ${maxWidth}` : ''"
       >
-        <!-- Use job ads as fallback when main ads fail to load -->
+        <!-- Use job ads as fallback when main ads fail to load. jobsEmpty guards against
+             falling back into a slot that has already told us it has nothing: without it
+             the fallback re-mounts the same empty jobs list and the reserved space stays
+             blank, which is the bug this whole path exists to avoid. -->
         <JobsDaSlot
-          v-if="jobs"
+          v-if="jobs && !jobsEmpty"
           :min-width="minWidth"
           :max-width="maxWidth"
           :min-height="minHeight"
@@ -30,7 +33,7 @@
           :class="{
             'text-center': maxWidth === '100vw',
           }"
-          @rendered="rippleRendered"
+          @rendered="jobsRendered"
         />
         <!-- Final fallback: donate ad if job ads not enabled -->
         <nuxt-link v-else to="/adsoff" style="display: block; max-width: 100%">
@@ -62,7 +65,7 @@
               :class="{
                 'text-center': maxWidth === '100vw',
               }"
-              @rendered="rippleRendered"
+              @rendered="jobsRendered"
               @borednow="setBored"
             />
             <OurPlaywireDa
@@ -367,6 +370,20 @@ async function checkStillVisible() {
   } else {
     emit('rendered', false)
   }
+}
+
+// The jobs slot has nothing to show. Distinct from an ad network failing to fill: the
+// jobs list is ours, so retrying it is pointless, and re-mounting it as the "fallback"
+// just leaves the reserved space blank. Latch it and let rippleRendered fall through to
+// the donate banner, which fills the band we have already reserved.
+const jobsEmpty = ref(false)
+
+function jobsRendered(rendered) {
+  if (!rendered) {
+    jobsEmpty.value = true
+  }
+
+  rippleRendered(rendered)
 }
 
 function rippleRendered(rendered) {

--- a/iznik-nuxt3/components/ExternalDa.vue
+++ b/iznik-nuxt3/components/ExternalDa.vue
@@ -17,26 +17,12 @@
         class="d-flex w-100 justify-content-md-around"
         :style="maxWidth ? `max-width: ${maxWidth}` : ''"
       >
-        <!-- Use job ads as fallback when main ads fail to load. jobsEmpty guards against
-             falling back into a slot that has already told us it has nothing: without it
-             the fallback re-mounts the same empty jobs list and the reserved space stays
-             blank, which is the bug this whole path exists to avoid. -->
-        <JobsDaSlot
-          v-if="jobs && !jobsEmpty"
-          :min-width="minWidth"
-          :max-width="maxWidth"
-          :min-height="minHeight"
-          :max-height="maxHeight"
-          :hide-header="hideJobsHeader"
-          :list-only="listOnly"
-          :placement="placement"
-          :class="{
-            'text-center': maxWidth === '100vw',
-          }"
-          @rendered="jobsRendered"
-        />
-        <!-- Final fallback: donate ad if job ads not enabled -->
-        <nuxt-link v-else to="/adsoff" style="display: block; max-width: 100%">
+        <!-- The donate banner, and ONLY the donate banner. This block is reached from a
+             single place: the app without cookies, which cannot run a real ad at all, so a
+             banner here is genuine content rather than something filling a hole. Routing
+             failed ad loads through it instead (8b8b18176) is what reserved 123px for
+             nothing when the jobs list was also empty. -->
+        <nuxt-link to="/adsoff" style="display: block; max-width: 100%">
           <img
             src="/donate/SupportFreegle_970x250px_20May20215.png"
             alt="Please donate to help keep Freegle running"
@@ -65,7 +51,7 @@
               :class="{
                 'text-center': maxWidth === '100vw',
               }"
-              @rendered="jobsRendered"
+              @rendered="rippleRendered"
               @borednow="setBored"
             />
             <OurPlaywireDa
@@ -269,11 +255,10 @@ function visibilityChanged(visible) {
               prebidRetry++
 
               if (prebidRetry > 20) {
-                // Give up.  Probably blocked - show fallback donation ad.
-                console.log('Give up on prebid load - showing fallback')
-                fallbackAdVisible.value = true
-                adShown.value = true
-                emit('rendered', true)
+                // Give up. Probably blocked, so report no ad and let the band collapse.
+                console.log('Give up on prebid load')
+                adShown.value = false
+                emit('rendered', false)
               } else {
                 // Try again for prebid later.
                 visibleAndScriptsLoadedTimer = setTimeout(() => {
@@ -299,11 +284,10 @@ function visibilityChanged(visible) {
             tcDataRetry++
 
             if (tcDataRetry > 50) {
-              // Give up.  Probably blocked - show fallback donation ad.
-              console.log('Give up on TC data load - showing fallback')
-              fallbackAdVisible.value = true
-              adShown.value = true
-              emit('rendered', true)
+              // Give up. Probably blocked, so report no ad and let the band collapse.
+              console.log('Give up on TC data load')
+              adShown.value = false
+              emit('rendered', false)
             } else {
               visibleAndScriptsLoadedTimer = window.setTimeout(() => {
                 visibilityChanged(visible)
@@ -362,42 +346,22 @@ async function checkStillVisible() {
         showingAds
       )
       useMiscStore().adsDisabled = true
-      // Show fallback donation ad instead of empty space
-      fallbackAdVisible.value = true
-      adShown.value = true
-      emit('rendered', true)
+      adShown.value = false
+      emit('rendered', false)
+      emit('disabled')
     }
   } else {
     emit('rendered', false)
   }
 }
 
-// The jobs slot has nothing to show. Distinct from an ad network failing to fill: the
-// jobs list is ours, so retrying it is pointless, and re-mounting it as the "fallback"
-// just leaves the reserved space blank. Latch it and let rippleRendered fall through to
-// the donate banner, which fills the band we have already reserved.
-const jobsEmpty = ref(false)
-
-function jobsRendered(rendered) {
-  if (!rendered) {
-    jobsEmpty.value = true
-  }
-
-  rippleRendered(rendered)
-}
-
 function rippleRendered(rendered) {
-  if (rendered) {
-    adShown.value = true
-    emit('rendered', true)
-  } else {
-    // Ad failed to render - show fallback donation ad
-    console.log('Ad failed to render - showing fallback')
-    useMiscStore().adsDisabled = true
-    fallbackAdVisible.value = true
-    adShown.value = true
-    emit('rendered', true)
-  }
+  // Report the truth. 8b8b18176 replaced this with "show a donate banner and claim
+  // rendered:true", which is why an unfilled slot left a 123px band behind: the caller
+  // reserves space on a true, and LayoutCommon's collapse (.adNotShown, padding-bottom 0)
+  // only fires on stickyAdRendered === 0. Nothing to show means collapse, as it did before.
+  adShown.value = rendered
+  emit('rendered', rendered)
 }
 
 // When the ad (or its fallback — Jobs list, donate banner) is rendered we

--- a/iznik-nuxt3/components/JobsDaSlot.vue
+++ b/iznik-nuxt3/components/JobsDaSlot.vue
@@ -50,6 +50,7 @@
 import {
   computed,
   ref,
+  watch,
   onMounted,
   onBeforeUnmount,
   defineAsyncComponent,
@@ -111,25 +112,41 @@ const { shouldShowModal, recordShown } = useJobsFollowUpModal()
 
 const followUpModal = ref(null)
 
-const me = authStore.user
-const lat = me?.lat
-const lng = me?.lng
+// REACTIVE, deliberately. This used to be `const me = authStore.user` with `lat`/`lng`
+// as plain consts read once at setup, and a fetch that ran only if they happened to be
+// there at that instant. The sticky footer slot mounts with the layout, so whenever the
+// session had not hydrated yet - routinely in the app, which restores a token rather
+// than a cookie - lat/lng were undefined, the fetch never ran, and nothing ever
+// triggered a retry because a `computed` over a captured plain object cannot update.
+// The slot then rendered nothing while still reporting success (see below), leaving a
+// 123px grey band with no ad in it.
+const me = computed(() => authStore.user)
+const lat = computed(() => me.value?.lat)
+const lng = computed(() => me.value?.lng)
 
-const location = computed(() => me?.settings?.mylocation?.name || null)
+const location = computed(() => me.value?.settings?.mylocation?.name || null)
 
-if (location.value && lat && lng) {
-  try {
-    await jobStore.fetch(lat, lng)
-  } catch (e) {
-    console.log('Jobs fetch failed', e)
-  }
-}
+// Fetch as soon as we have somewhere to fetch for, and again if the member moves.
+// immediate covers the case where the session was already there at setup.
+watch(
+  [location, lat, lng],
+  async ([loc, la, ln]) => {
+    if (!loc || !la || !ln) return
+
+    try {
+      await jobStore.fetch(la, ln)
+    } catch (e) {
+      console.log('Jobs fetch failed', e)
+    }
+  },
+  { immediate: true }
+)
 
 let refreshTimer = null
 const AD_REFRESH_TIMEOUT = 31000
 
 onMounted(() => {
-  emit('rendered', true)
+  emit('rendered', hasContent.value)
   refreshTimer = setTimeout(() => {
     // We only show the jobs for a while.  If people don't engage with them on initial page load they're not likely
     // to, so we might as well shift to showing other ads so that we get some revenue.
@@ -164,6 +181,22 @@ const list = computed(() => {
 const displayedJobs = computed(() => {
   return props.listOnly ? list.value.slice(0, 10) : list.value.slice(0, 20)
 })
+
+// Whether this slot is actually showing anything - the same condition as the template's
+// own v-if, so the two cannot disagree. Declared after `list` because the watch below
+// reads it immediately, and `list` is a const in the same setup scope.
+const hasContent = computed(() => Boolean(location.value && list.value.length))
+
+// Report what we ACTUALLY rendered. An unconditional emit('rendered', true) in onMounted
+// is what left a 123px grey band with nothing in it at the bottom of every page whose
+// jobs list was empty: ExternalDa believed an ad had rendered, so LayoutCommon set
+// stickyAdRendered=1, reserved the height, applied the .sticky-ad-zone tint and showed
+// the "Hate ads?" CTA - while the collapse path (.adNotShown, padding-bottom 0) needs
+// stickyAdRendered === 0 and so could never fire.
+//
+// Re-emitted on change because the jobs arrive asynchronously: the first answer is
+// usually "nothing yet" and the caller has to hear the second one.
+watch(hasContent, (has) => emit('rendered', has))
 
 /* IDs of the jobs currently displayed in this slot, passed to the modal so
  * it can exclude them and show different ads. */

--- a/iznik-nuxt3/tests/unit/components/ExternalDa.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ExternalDa.spec.js
@@ -313,11 +313,18 @@ describe('ExternalDa', () => {
       expect(wrapper.emitted('rendered')).toContainEqual([true])
     })
 
-    it('shows fallback when ad fails to render', () => {
+    // Was "shows fallback when ad fails to render", pinning the behaviour 8b8b18176
+    // introduced: turn on the donate fallback and report rendered:true. That is the bug -
+    // the caller reserves 123px on a true, and when the fallback itself had nothing to draw
+    // (an empty jobs list) the band stayed blank, which is what got reported from the app.
+    // Nothing to show now means say so, and the band collapses as it did before that commit.
+    // See ExternalDaCollapse.spec.js for the full contract.
+    it('reports no ad, and shows no fallback, when the ad fails to render', () => {
       const wrapper = createWrapper()
       wrapper.vm.rippleRendered(false)
-      expect(wrapper.vm.fallbackAdVisible).toBe(true)
-      expect(mockMiscStore.adsDisabled).toBe(true)
+      expect(wrapper.emitted('rendered')).toContainEqual([false])
+      expect(wrapper.vm.fallbackAdVisible).toBe(false)
+      expect(mockMiscStore.adsDisabled).toBe(false)
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/ExternalDaCollapse.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ExternalDaCollapse.spec.js
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ExternalDa from '~/components/ExternalDa.vue'
+
+// The contract: when there is no ad to show, SAY SO, so the sticky band collapses.
+//
+// It used to. 8b8b18176 (2025-12-04, "Show fallback donation ad when ads disabled or ad
+// fails to load") replaced every `emit('rendered', false)` with "set fallbackAdVisible,
+// claim rendered:true". LayoutCommon reserves space on a true and only collapses on
+// stickyAdRendered === 0, so an unfilled slot left a 123px grey band with nothing in it -
+// measured on dev-live, with .aboveSticky padded 125px to make room for it.
+//
+// The donate banner survives in exactly one place: the app without cookies, which cannot
+// run a real ad at all, so a banner there is genuine content rather than hole-filling.
+// That is also pre-8b8b18176 behaviour, not something invented here.
+
+const { mockMe, mockRecentDonor } = vi.hoisted(() => {
+  const { ref } = require('vue')
+  return {
+    mockMe: ref({ id: 1, email: 'test@example.com' }),
+    mockRecentDonor: ref(false),
+  }
+})
+
+const mockConfigStore = { fetch: vi.fn().mockResolvedValue([{ value: '1' }]) }
+const mockMiscStore = { boredWithJobs: false, adsDisabled: false }
+const mockRuntimeConfig = {
+  public: {
+    ISAPP: false,
+    USE_COOKIES: true,
+    COOKIEYES: false,
+    USER_SITE: 'ilovefreegle.org',
+  },
+}
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({ me: mockMe, recentDonor: mockRecentDonor }),
+}))
+vi.mock('~/stores/config', () => ({ useConfigStore: () => mockConfigStore }))
+vi.mock('~/stores/misc', () => ({ useMiscStore: () => mockMiscStore }))
+vi.mock('#app', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, useRuntimeConfig: () => mockRuntimeConfig }
+})
+
+const DONATE_BANNER = 'img[src*="SupportFreegle"]'
+
+function createWrapper(props = {}) {
+  return mount(ExternalDa, {
+    props: { adUnitPath: '/12345/test-ad', divId: 'test-ad-div', ...props },
+    global: {
+      stubs: {
+        ClientOnly: { template: '<div><slot /></div>' },
+        JobsDaSlot: {
+          template: '<div class="jobs-da-slot" />',
+          emits: ['rendered', 'borednow'],
+        },
+        OurPlaywireDa: { template: '<div class="playwire-da" />', emits: ['rendered'] },
+        OurGoogleDa: { template: '<div class="google-da" />', emits: ['rendered'] },
+        OurPrebidDa: { template: '<div class="prebid-da" />', emits: ['rendered'] },
+        'nuxt-link': {
+          template: '<a class="nuxt-link" :href="to"><slot /></a>',
+          props: ['to'],
+        },
+      },
+      // Matches the sibling spec: the real directive is what drives visibilityChanged, so
+      // the stub fires it on mount rather than each test poking the method by hand.
+      directives: {
+        'observe-visibility': {
+          mounted: (el, binding) => binding.value(true),
+        },
+      },
+    },
+  })
+}
+
+/** Last `rendered` payload, or undefined if the component never reported. */
+function lastRendered(wrapper) {
+  const emitted = wrapper.emitted('rendered') ?? []
+  return emitted.length ? emitted[emitted.length - 1][0] : undefined
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+  mockMe.value = { id: 1, email: 'test@example.com' }
+  mockRecentDonor.value = false
+  mockMiscStore.boredWithJobs = false
+  mockMiscStore.adsDisabled = false
+  mockRuntimeConfig.public.ISAPP = false
+  mockRuntimeConfig.public.USE_COOKIES = true
+  mockRuntimeConfig.public.COOKIEYES = false
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('ExternalDa — an unfilled slot must collapse, not reserve space', () => {
+  it('emits rendered=false when the ad fails to render', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    wrapper.vm.rippleRendered(false)
+    await flushPromises()
+
+    expect(lastRendered(wrapper)).toBe(false)
+  })
+
+  it('shows no fallback of any kind when the ad fails to render', async () => {
+    // Asserting only on the banner would not discriminate: the old code turned
+    // fallbackAdVisible on and rendered the JOBS slot there (jobs defaults true), so the
+    // banner was absent either way while the band stayed reserved. The flag is the tell.
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    wrapper.vm.rippleRendered(false)
+    await flushPromises()
+
+    expect(wrapper.vm.fallbackAdVisible).toBe(false)
+    expect(wrapper.find(DONATE_BANNER).exists()).toBe(false)
+  })
+
+  it('does not mark ads disabled globally just because one slot went unfilled', async () => {
+    // adsDisabled is read elsewhere as "ads are off"; an unfilled auction is not that.
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    wrapper.vm.rippleRendered(false)
+    await flushPromises()
+
+    expect(mockMiscStore.adsDisabled).toBe(false)
+  })
+
+  it('still reports rendered=true when an ad really did render', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    wrapper.vm.rippleRendered(true)
+    await flushPromises()
+
+    expect(lastRendered(wrapper)).toBe(true)
+  })
+})
+
+// The app-without-cookies path itself is NOT reachable from a unit test: it lives inside
+// `if (process.client)`, which vite replaces at build time, so under vitest it compiles to
+// `if (false)`. Setting process.client makes no difference - the branch is already gone.
+// (The sibling spec's version of this test asserts `fallbackAdVisible || .pointer exists`,
+// which is why it looks like it passes.) What IS reachable is the fallback template, so pin
+// that; the runtime path is covered by the browser A/B on dev-live recorded in the PR.
+describe('ExternalDa — the fallback block holds the banner, never the jobs slot', () => {
+  it('renders the donate banner when the fallback is on', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    wrapper.vm.fallbackAdVisible = true
+    await flushPromises()
+
+    expect(wrapper.find(DONATE_BANNER).exists()).toBe(true)
+  })
+
+  it('does not render the jobs slot there, which is what left the band blank', async () => {
+    // Edward's app case: the fallback mounted JobsDaSlot, whose own list was empty, so the
+    // band was reserved and showed nothing at all. jobs defaults true, so this is the
+    // default shape, not an edge case.
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    wrapper.vm.fallbackAdVisible = true
+    await flushPromises()
+
+    expect(wrapper.find('.jobs-da-slot').exists()).toBe(false)
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ExternalDaCollapse.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ExternalDaCollapse.spec.js
@@ -2,48 +2,64 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import ExternalDa from '~/components/ExternalDa.vue'
 
-// The contract: when there is no ad to show, SAY SO, so the sticky band collapses.
+// Full decision matrix for the sticky ad slot: supporter vs not, job ads vs other ads,
+// and every fallback. What `rendered` reports here decides whether LayoutCommon reserves
+// the band or collapses it (.adNotShown, padding-bottom 0, only on stickyAdRendered === 0),
+// so each row is really "does the band take space".
 //
-// It used to. 8b8b18176 (2025-12-04, "Show fallback donation ad when ads disabled or ad
-// fails to load") replaced every `emit('rendered', false)` with "set fallbackAdVisible,
-// claim rendered:true". LayoutCommon reserves space on a true and only collapses on
-// stickyAdRendered === 0, so an unfilled slot left a 123px grey band with nothing in it -
-// measured on dev-live, with .aboveSticky padded 125px to make room for it.
+// The bug this pins: 8b8b18176 (2025-12-04, "Show fallback donation ad when ads disabled or
+// ad fails to load") replaced every `emit('rendered', false)` with "set fallbackAdVisible,
+// claim rendered:true", on the failed-render, prebid-blocked, TC-data-blocked and
+// ads-disabled-in-config paths. Nothing could collapse the band after that. Worse, the
+// fallback it switched to is the JOBS slot (jobs defaults true), so when the jobs list was
+// also empty the band was reserved and drew nothing - 123px of $gray-200 on dev-live with
+// .aboveSticky padded 125px.
 //
-// The donate banner survives in exactly one place: the app without cookies, which cannot
-// run a real ad at all, so a banner there is genuine content rather than hole-filling.
-// That is also pre-8b8b18176 behaviour, not something invented here.
+// HARNESS NOTE, learned the hard way: the component calls `useRuntimeConfig` as a Nuxt
+// auto-import, which under vitest resolves to the GLOBAL installed by tests/unit/setup.ts
+// (line ~117) - not to '#app' or '#imports'. Mocking those modules does nothing here, which
+// is why the sibling spec's app-mode test had to be written as
+// `fallbackAdVisible || find('.pointer').exists()` (always true) and never exercised the
+// branch. Override globalThis.useRuntimeConfig instead. USER_SITE must be non-empty too:
+// the system-account check is `myEmail.includes(userSite)`, and '' matches every address.
 
 const { mockMe, mockRecentDonor } = vi.hoisted(() => {
   const { ref } = require('vue')
   return {
-    mockMe: ref({ id: 1, email: 'test@example.com' }),
+    mockMe: ref({ id: 1, email: 'member@example.com' }),
     mockRecentDonor: ref(false),
   }
 })
 
 const mockConfigStore = { fetch: vi.fn().mockResolvedValue([{ value: '1' }]) }
 const mockMiscStore = { boredWithJobs: false, adsDisabled: false }
-const mockRuntimeConfig = {
-  public: {
-    ISAPP: false,
-    USE_COOKIES: true,
-    COOKIEYES: false,
-    USER_SITE: 'ilovefreegle.org',
-  },
-}
 
 vi.mock('~/composables/useMe', () => ({
   useMe: () => ({ me: mockMe, recentDonor: mockRecentDonor }),
 }))
 vi.mock('~/stores/config', () => ({ useConfigStore: () => mockConfigStore }))
 vi.mock('~/stores/misc', () => ({ useMiscStore: () => mockMiscStore }))
-vi.mock('#app', async (importOriginal) => {
-  const actual = await importOriginal()
-  return { ...actual, useRuntimeConfig: () => mockRuntimeConfig }
-})
 
 const DONATE_BANNER = 'img[src*="SupportFreegle"]'
+const JOBS = '.jobs-da-slot'
+const PLAYWIRE = '.playwire-da'
+const GOOGLE = '.google-da'
+const PREBID = '.prebid-da'
+
+let priorRuntimeConfig
+
+/** Point the component's auto-imported useRuntimeConfig at this public config. */
+function setRuntimeConfig(publicConfig) {
+  globalThis.useRuntimeConfig = () => ({
+    public: {
+      ISAPP: false,
+      USE_COOKIES: true,
+      COOKIEYES: false,
+      USER_SITE: 'https://www.ilovefreegle.org',
+      ...publicConfig,
+    },
+  })
+}
 
 function createWrapper(props = {}) {
   return mount(ExternalDa, {
@@ -63,12 +79,10 @@ function createWrapper(props = {}) {
           props: ['to'],
         },
       },
-      // Matches the sibling spec: the real directive is what drives visibilityChanged, so
-      // the stub fires it on mount rather than each test poking the method by hand.
+      // The real directive is what drives visibilityChanged, so fire it on mount rather
+      // than having each test poke the method.
       directives: {
-        'observe-visibility': {
-          mounted: (el, binding) => binding.value(true),
-        },
+        'observe-visibility': { mounted: (el, binding) => binding.value(true) },
       },
     },
   })
@@ -80,23 +94,161 @@ function lastRendered(wrapper) {
   return emitted.length ? emitted[emitted.length - 1][0] : undefined
 }
 
+/**
+ * No ad is being asked for, and no fallback is on screen.
+ *
+ * Deliberately NOT "the network component is absent": OurPlaywireDa/OurGoogleDa/OurPrebidDa
+ * are mounted whenever the slot is visible, and it is renderAd=false that stops them
+ * requesting anything. Asserting on their absence fails against correct behaviour.
+ */
+function noAdRequested(wrapper) {
+  return (
+    wrapper.vm.renderAd === false &&
+    !wrapper.find(JOBS).exists() &&
+    !wrapper.find(DONATE_BANNER).exists()
+  )
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   vi.useFakeTimers()
-  mockMe.value = { id: 1, email: 'test@example.com' }
+  priorRuntimeConfig = globalThis.useRuntimeConfig
+  process.client = true
+  setRuntimeConfig({})
+  mockMe.value = { id: 1, email: 'member@example.com' }
   mockRecentDonor.value = false
   mockMiscStore.boredWithJobs = false
   mockMiscStore.adsDisabled = false
-  mockRuntimeConfig.public.ISAPP = false
-  mockRuntimeConfig.public.USE_COOKIES = true
-  mockRuntimeConfig.public.COOKIEYES = false
+  mockConfigStore.fetch.mockResolvedValue([{ value: '1' }])
 })
 
 afterEach(() => {
   vi.useRealTimers()
+  globalThis.useRuntimeConfig = priorRuntimeConfig
+  delete process.client
 })
 
-describe('ExternalDa — an unfilled slot must collapse, not reserve space', () => {
+describe('supporter (recent donor) — no ads, and no space held for them', () => {
+  it('web: reports no ad and draws nothing', async () => {
+    mockRecentDonor.value = true
+    const wrapper = createWrapper()
+    // checkStillVisible is what consults donor status; it runs behind a 100ms timer.
+    await wrapper.vm.checkStillVisible()
+    await flushPromises()
+
+    expect(lastRendered(wrapper)).toBe(false)
+    expect(noAdRequested(wrapper)).toBe(true)
+  })
+
+  it('app without cookies: reports no ad and shows no donate banner either', async () => {
+    // The app cannot run a real ad, so it normally falls back to the banner. A supporter
+    // should not even get that - they have already paid for the ads to go away.
+    setRuntimeConfig({ ISAPP: true, USE_COOKIES: false })
+    mockRecentDonor.value = true
+
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    expect(lastRendered(wrapper)).toBe(false)
+    expect(wrapper.find(DONATE_BANNER).exists()).toBe(false)
+    expect(noAdRequested(wrapper)).toBe(true)
+  })
+
+  it('a system account too, with the deployed URL-shaped USER_SITE', async () => {
+    // The deployed value is a URL, and the old check compared the address against it
+    // verbatim, so this suppression never fired outside tests. A bare-domain fixture
+    // (as the sibling spec uses) hides that.
+    setRuntimeConfig({ USER_SITE: 'https://www.ilovefreegle.org' })
+    mockMe.value = { id: 1, email: 'geeks@ilovefreegle.org' }
+    const wrapper = createWrapper()
+    await wrapper.vm.checkStillVisible()
+    await flushPromises()
+
+    expect(lastRendered(wrapper)).toBe(false)
+    expect(noAdRequested(wrapper)).toBe(true)
+  })
+
+  it('counts a subdomain address as ours too', async () => {
+    setRuntimeConfig({ USER_SITE: 'https://www.ilovefreegle.org' })
+    mockMe.value = { id: 1, email: 'bot@mail.ilovefreegle.org' }
+    const wrapper = createWrapper()
+    await wrapper.vm.checkStillVisible()
+    await flushPromises()
+
+    expect(lastRendered(wrapper)).toBe(false)
+  })
+
+  it('leaves an ordinary member alone, even one whose domain merely ends similarly', async () => {
+    setRuntimeConfig({ USER_SITE: 'https://www.ilovefreegle.org' })
+    mockMe.value = { id: 1, email: 'someone@notilovefreegle.org' }
+    const wrapper = createWrapper()
+    await wrapper.vm.checkStillVisible()
+    await flushPromises()
+
+    // Ads are wanted here: no suppression, so the slot goes on to request one.
+    expect(wrapper.vm.renderAd).toBe(true)
+  })
+})
+
+describe('not a supporter — job ads vs other ads', () => {
+  it('shows the jobs slot when job ads are on for this placement', async () => {
+    const wrapper = createWrapper({ jobs: true })
+    wrapper.vm.isVisible = true
+    wrapper.vm.renderAd = true
+    await flushPromises()
+
+    expect(wrapper.find(JOBS).exists()).toBe(true)
+    expect(wrapper.find(PLAYWIRE).exists()).toBe(false)
+  })
+
+  it('shows the ad network instead when job ads are off for this placement', async () => {
+    const wrapper = createWrapper({ jobs: false })
+    wrapper.vm.isVisible = true
+    wrapper.vm.renderAd = true
+    await flushPromises()
+
+    expect(wrapper.find(JOBS).exists()).toBe(false)
+    expect(wrapper.find(PLAYWIRE).exists()).toBe(true)
+  })
+
+  it('switches from jobs to the ad network once the member is bored of jobs', async () => {
+    // JobsDaSlot emits borednow after ~31s so the slot earns revenue for the rest of the
+    // session instead of showing jobs nobody clicked.
+    mockMiscStore.boredWithJobs = true
+    const wrapper = createWrapper({ jobs: true })
+    wrapper.vm.isVisible = true
+    wrapper.vm.renderAd = true
+    await flushPromises()
+
+    expect(wrapper.find(JOBS).exists()).toBe(false)
+    expect(wrapper.find(PLAYWIRE).exists()).toBe(true)
+  })
+
+  it('uses Google when AdSense is the configured network', async () => {
+    const wrapper = createWrapper({ jobs: false })
+    wrapper.vm.isVisible = true
+    wrapper.vm.renderAd = true
+    wrapper.vm.playWire = false
+    wrapper.vm.adSense = true
+    await flushPromises()
+
+    expect(wrapper.find(GOOGLE).exists()).toBe(true)
+    expect(wrapper.find(PLAYWIRE).exists()).toBe(false)
+  })
+
+  it('falls to Prebid when neither Playwire nor AdSense is configured', async () => {
+    const wrapper = createWrapper({ jobs: false })
+    wrapper.vm.isVisible = true
+    wrapper.vm.renderAd = true
+    wrapper.vm.playWire = false
+    wrapper.vm.adSense = false
+    await flushPromises()
+
+    expect(wrapper.find(PREBID).exists()).toBe(true)
+  })
+})
+
+describe('an unfilled slot must collapse, not reserve space', () => {
   it('emits rendered=false when the ad fails to render', async () => {
     const wrapper = createWrapper()
     await flushPromises()
@@ -109,8 +261,8 @@ describe('ExternalDa — an unfilled slot must collapse, not reserve space', () 
 
   it('shows no fallback of any kind when the ad fails to render', async () => {
     // Asserting only on the banner would not discriminate: the old code turned
-    // fallbackAdVisible on and rendered the JOBS slot there (jobs defaults true), so the
-    // banner was absent either way while the band stayed reserved. The flag is the tell.
+    // fallbackAdVisible on and rendered the JOBS slot there, so the banner was absent
+    // either way while the band stayed reserved. The flag is the tell.
     const wrapper = createWrapper()
     await flushPromises()
 
@@ -141,35 +293,58 @@ describe('ExternalDa — an unfilled slot must collapse, not reserve space', () 
 
     expect(lastRendered(wrapper)).toBe(true)
   })
+
+  it('collapses, and says ads are disabled, when the server config switches ads off', async () => {
+    mockConfigStore.fetch.mockResolvedValue([{ value: '0' }])
+    const wrapper = createWrapper()
+    await wrapper.vm.checkStillVisible()
+    await flushPromises()
+
+    expect(lastRendered(wrapper)).toBe(false)
+    expect(wrapper.emitted('disabled')).toBeTruthy()
+    expect(mockMiscStore.adsDisabled).toBe(true)
+    expect(noAdRequested(wrapper)).toBe(true)
+  })
 })
 
-// The app-without-cookies path itself is NOT reachable from a unit test: it lives inside
-// `if (process.client)`, which vite replaces at build time, so under vitest it compiles to
-// `if (false)`. Setting process.client makes no difference - the branch is already gone.
-// (The sibling spec's version of this test asserts `fallbackAdVisible || .pointer exists`,
-// which is why it looks like it passes.) What IS reachable is the fallback template, so pin
-// that; the runtime path is covered by the browser A/B on dev-live recorded in the PR.
-describe('ExternalDa — the fallback block holds the banner, never the jobs slot', () => {
-  it('renders the donate banner when the fallback is on', async () => {
+describe('the fallback banner and its one legitimate home', () => {
+  it('app without cookies, not a supporter: shows the donate banner', async () => {
+    setRuntimeConfig({ ISAPP: true, USE_COOKIES: false })
     const wrapper = createWrapper()
     await flushPromises()
 
-    wrapper.vm.fallbackAdVisible = true
+    expect(wrapper.vm.fallbackAdVisible).toBe(true)
+    expect(wrapper.find(DONATE_BANNER).exists()).toBe(true)
+    expect(lastRendered(wrapper)).toBe(true)
+  })
+
+  it('never puts the jobs slot in that fallback, which is what left the band blank', async () => {
+    // Edward's app report: the fallback mounted JobsDaSlot, whose own list was empty, so
+    // the band was reserved and showed nothing. jobs defaults true, so this was the
+    // default shape rather than an edge case.
+    setRuntimeConfig({ ISAPP: true, USE_COOKIES: false })
+    const wrapper = createWrapper({ jobs: true })
     await flushPromises()
 
+    expect(wrapper.find(JOBS).exists()).toBe(false)
     expect(wrapper.find(DONATE_BANNER).exists()).toBe(true)
   })
 
-  it('does not render the jobs slot there, which is what left the band blank', async () => {
-    // Edward's app case: the fallback mounted JobsDaSlot, whose own list was empty, so the
-    // band was reserved and showed nothing at all. jobs defaults true, so this is the
-    // default shape, not an edge case.
-    const wrapper = createWrapper()
+  it('leaves video ads alone in the app, since a banner cannot stand in for one', async () => {
+    setRuntimeConfig({ ISAPP: true, USE_COOKIES: false })
+    const wrapper = createWrapper({ video: true })
     await flushPromises()
 
-    wrapper.vm.fallbackAdVisible = true
+    expect(wrapper.find(DONATE_BANNER).exists()).toBe(false)
+  })
+})
+
+describe('logged out', () => {
+  it('draws nothing when there is no member and the slot is not for logged-out visitors', async () => {
+    mockMe.value = null
+    const wrapper = createWrapper({ showLoggedOut: false })
     await flushPromises()
 
-    expect(wrapper.find('.jobs-da-slot').exists()).toBe(false)
+    expect(noAdRequested(wrapper)).toBe(true)
   })
 })

--- a/iznik-nuxt3/tests/unit/components/JobsDaSlotRendered.spec.js
+++ b/iznik-nuxt3/tests/unit/components/JobsDaSlotRendered.spec.js
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { reactive, defineComponent, h, nextTick } from 'vue'
+import JobsDaSlot from '~/components/JobsDaSlot.vue'
+
+// Regression suite for the empty grey band at the bottom of the page (2026-08-13).
+//
+// Measured on dev-live before the fix: .sticky was 123px of $gray-200 with .jobs-slot
+// absent entirely, zero job cards, the "Hate ads?" CTA showing, and .aboveSticky padded
+// 125px to make room for an ad that never came.
+//
+// Two causes, both in this component:
+//   1. onMounted emitted an unconditional rendered:true, so ExternalDa believed an ad had
+//      rendered and LayoutCommon reserved the height and tinted it. The collapse path
+//      (.adNotShown, padding-bottom 0) needs stickyAdRendered === 0 and could never fire.
+//   2. The user was read non-reactively (`const me = authStore.user`, lat/lng as plain
+//      consts) and the fetch ran once at setup, so a session that hydrated later - the
+//      normal case in the app, which restores a token rather than a cookie - never
+//      triggered a fetch and nothing retried.
+
+// Reactive stand-ins for the stores, so a test can hydrate the session or land the jobs
+// AFTER mount and the component has to notice. A plain object would pass the old code.
+const authState = reactive({ user: null })
+const jobState = reactive({ list: [], blocked: false })
+const mockFetch = vi.fn().mockResolvedValue({})
+
+vi.mock('~/stores/auth', () => ({
+  useAuthStore: () => authState,
+}))
+
+vi.mock('~/stores/job', () => ({
+  useJobStore: () => ({
+    get list() {
+      return jobState.list
+    },
+    get blocked() {
+      return jobState.blocked
+    },
+    fetch: mockFetch,
+  }),
+}))
+
+vi.mock('~/composables/useJobsFollowUpModal', () => ({
+  useJobsFollowUpModal: () => ({
+    shouldShowModal: () => false,
+    recordShown: vi.fn(),
+  }),
+}))
+
+const JOB = {
+  id: 1,
+  job_reference: 'ref-1',
+  title: 'Warehouse operative',
+  location: 'Preston',
+  cpc: 0.5,
+  clickability: 1,
+}
+
+const stubs = {
+  JobOne: defineComponent({ render: () => h('div', { class: 'job-one' }) }),
+  JobsFollowUpModal: defineComponent({ render: () => h('div') }),
+  NoticeMessage: defineComponent({ render: () => h('div') }),
+  DonationButton: defineComponent({ render: () => h('div') }),
+  'v-icon': defineComponent({ render: () => h('i') }),
+  'nuxt-link': defineComponent({ render: () => h('a') }),
+}
+
+const AT = { id: 1, lat: 53.7, lng: -2.7, settings: { mylocation: { name: 'Preston' } } }
+
+async function mountSlot() {
+  const wrapper = mount(JobsDaSlot, { global: { stubs } })
+  await flushPromises()
+  await nextTick()
+  return wrapper
+}
+
+function lastRendered(wrapper) {
+  const emitted = wrapper.emitted('rendered') ?? []
+  expect(emitted.length).toBeGreaterThan(0)
+  return emitted[emitted.length - 1][0]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  authState.user = null
+  jobState.list = []
+  jobState.blocked = false
+})
+
+describe('JobsDaSlot — reports what it actually rendered', () => {
+  it('emits rendered=false with no location, so the reserved band can collapse', async () => {
+    authState.user = { id: 1, lat: 53.7, lng: -2.7 } // no settings.mylocation
+    jobState.list = [JOB]
+    const wrapper = await mountSlot()
+
+    expect(wrapper.find('.jobs-slot').exists()).toBe(false)
+    expect(lastRendered(wrapper)).toBe(false)
+  })
+
+  it('emits rendered=false when the jobs list is empty', async () => {
+    authState.user = AT
+    const wrapper = await mountSlot()
+
+    expect(wrapper.find('.jobs-slot').exists()).toBe(false)
+    expect(lastRendered(wrapper)).toBe(false)
+  })
+
+  it('emits rendered=true only when a job is actually on screen', async () => {
+    authState.user = AT
+    jobState.list = [JOB]
+    const wrapper = await mountSlot()
+
+    expect(wrapper.find('.jobs-slot').exists()).toBe(true)
+    expect(wrapper.findAll('.job-one').length).toBe(1)
+    expect(lastRendered(wrapper)).toBe(true)
+  })
+
+  it('re-emits when jobs arrive after mount, since the first answer is "nothing yet"', async () => {
+    authState.user = AT
+    const wrapper = await mountSlot()
+    expect(lastRendered(wrapper)).toBe(false)
+
+    jobState.list = [JOB]
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.find('.jobs-slot').exists()).toBe(true)
+    expect(lastRendered(wrapper)).toBe(true)
+  })
+})
+
+describe('JobsDaSlot — fetches when the session arrives late', () => {
+  it('does not fetch while there is no user', async () => {
+    await mountSlot()
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches once the session hydrates after mount', async () => {
+    // The app case exactly: the sticky slot mounts with the layout, before the token
+    // restore has produced a user. The old code captured lat/lng as undefined at setup
+    // and never looked again.
+    await mountSlot()
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    authState.user = {
+      id: 1,
+      lat: 53.86469,
+      lng: -2.624747,
+      settings: { mylocation: { name: 'PR3 2NX' } },
+    }
+    await flushPromises()
+
+    expect(mockFetch).toHaveBeenCalledWith(53.86469, -2.624747)
+  })
+
+  it('re-fetches when the member changes location', async () => {
+    authState.user = AT
+    await mountSlot()
+    expect(mockFetch).toHaveBeenCalledWith(53.7, -2.7)
+
+    authState.user = {
+      id: 1,
+      lat: 51.5074,
+      lng: -0.1278,
+      settings: { mylocation: { name: 'London' } },
+    }
+    await flushPromises()
+
+    expect(mockFetch).toHaveBeenCalledWith(51.5074, -0.1278)
+  })
+})


### PR DESCRIPTION
Reported on the app — no ads at all, but the space still taken. Reproduced in a plain browser on dev-live, so this is not app-specific.

## The collapse did not break. It was removed.

`8b8b18176` (2025-12-04, *"Show fallback donation ad when ads disabled or ad fails to load"*) replaced **every** "nothing rendered" signal with a claim that something did:

```js
-  adShown.value = rendered
-  emit('rendered', rendered)        // false → LayoutCommon collapsed the band
+  if (rendered) { ... } else {
+    fallbackAdVisible.value = true
+    adShown.value = true
+    emit('rendered', true)          // always true from here on
+  }
```

The same substitution went onto the prebid-blocked, TC-data-blocked and ads-disabled-in-config paths. `LayoutCommon` reserves space on a `true` and collapses only on `stickyAdRendered === 0` (`.adNotShown`, `padding-bottom: 0`), so from that commit onward nothing could collapse it again.

Its intent was "instead of empty space" — but the fallback it switched to is the **jobs** slot (`jobs` defaults true), so when the jobs list was *also* empty the band was reserved and drew nothing at all. Measured before the fix: `.sticky` 123px of `$gray-200`, `.jobs-slot` absent entirely, 0 job cards, CTA showing, `.aboveSticky` padded 125px.

## What this does

1. **All four no-ad paths report the truth again**, so the band collapses. The fallback block holds **only** the donate banner — where it was before `8b8b18176`, reached solely from the app-without-cookies path, in which no real ad is possible and a banner is genuine content rather than hole-filling.

2. **`JobsDaSlot` stops lying and stops racing.** It emitted `rendered: true` unconditionally from `onMounted` while its template needs `location && list.length`; and it read the member non-reactively (`const me = authStore.user`, lat/lng plain consts, `location` a `computed` over a captured object) and fetched once at setup. If the session had not hydrated when the sticky slot mounted, the fetch never ran and nothing retried. **That is why this worked sometimes — it is a race with session restore**, which the app loses more often because it restores a token rather than a cookie.

3. **System-account ad suppression revived.** Writing the test matrix turned up a path dead in production: the check was `myEmail.includes(userSite)`, and `USER_SITE` is `https://www.ilovefreegle.org` — the `config.js` default *and* the deployed value. No email address contains `https://`, so ads were never suppressed for our own accounts. It looked correct only because the existing spec's fixture sets a bare `ilovefreegle.org`, which the deployment never uses. It now compares the address's **domain** against the site's **host**, allowing subdomains: `bot@mail.ilovefreegle.org` counts, `someone@notilovefreegle.org` does not — the old substring test would have wrongly matched that second one had the value ever been a bare domain.

   **This is a live behaviour change**: staff accounts stop seeing ads, which is what `Ads disabled as system account` was always meant to do. Easy to drop if you would rather it stayed off.

## Coverage

19 cases in `ExternalDaCollapse.spec.js`, **8 RED against master's component, 19/19 green here**, container md5-matched at both ends of both runs:

| group | cases |
|---|---|
| supporter | web · app-without-cookies (no banner either) · system account with the deployed URL-shaped `USER_SITE` · subdomain address · ordinary member left alone |
| job ads vs other ads | jobs slot when on · network when off · switch after `borednow` · Google when AdSense · Prebid when neither |
| fallback | failed fill collapses with no fallback at all · ads-disabled-in-config collapses and emits `disabled` · banner only in app-without-cookies · never the jobs slot there · video untouched |
| logged out | nothing drawn |

Plus 7 in `JobsDaSlotRendered.spec.js` (**1 pass / 6 fail** against the old component, 7/7 here): no location, empty list, a job on screen, re-emit when jobs arrive late, no fetch without a user, fetch when the session hydrates after mount, re-fetch on a location change.

Full unit suite **15443** (was 15417).

## Browser A/B on dev-live

Same page, same account:

| | before | after |
|---|---|---|
| `.aboveSticky` padding-bottom | 125px | **0px** |
| `.aboveSticky` class | `stickyAdRendered` | **`adNotShown`** |
| `.sticky` background | `rgb(233,236,239)` | **transparent** |
| CTA visible | true | **false** |
| console | `Layout ad rendered true 1` | `Layout ad rendered false 0` |

`.sticky` itself keeps its 123px box, but it is `position: fixed`, now transparent and `pointer-events: none`, so it takes no layout space and no clicks — identical to pre-`8b8b18176`.

## Two harness facts recorded in the spec, because they silently neuter tests

- **`useRuntimeConfig` is a Nuxt auto-import that resolves to the GLOBAL installed by `tests/unit/setup.ts`**, not to `#app` or `#imports`. Mocking those modules does nothing, which is why the sibling spec's app-mode assertion had to be `fallbackAdVisible || find('.pointer').exists()` — always true, and it never exercised the branch. (My first read of this was wrong: I assumed `process.client` was compiled out. There is no such `define`; the global was the reason.)
- **`USER_SITE` must be non-empty in tests**: `''` makes `myEmail.includes(userSite)` match every address, so everything looks like a system account.

## An earlier commit on this branch is partly reversed by a later one

The first commit filled the reserved band with the donate banner rather than collapsing it, on the reading that the reservation was deliberate. It was not — it used to collapse — so the second commit removes that approach (`jobsEmpty`/`jobsRendered` went with it; they existed only to stop the fallback recursing into an empty jobs slot, and there is no jobs slot in the fallback now). The `JobsDaSlot` half of the first commit stands.

My first draft of the supporter assertions was also wrong: it required the network component to be absent. `OurPlaywireDa` mounts whenever the slot is visible and `renderAd: false` is what stops it requesting, so that assertion failed against correct behaviour. It now checks `renderAd`, the jobs slot and the banner.

## Checked, not the cause

- **Job ads are not dead.** Production returns 21-24 jobs, including 21 for the reporting member's own PR3 2NX. My first probes hit local apiv2 and `apiv2-live`, both wired to a spatial-KNN with no job data — withdrawn.
- **The grey-background commit is not the cause.** `0d595df5a` only made a long-standing hole visible, as its own message describes.
- **Not the donor path.** `recentDonor` is 31 days (41 for bank transfer); that account last donated 2026-04-03, so ads are correctly expected there. Donor suppression already worked and returns before any slot renders.
