### PR TITLE
perf(dashboard): serve the MT trend widgets from cache and the stats rollup

### DIFF
--- a/iznik-server-go/dashboard/cache.go
+++ b/iznik-server-go/dashboard/cache.go
@@ -1,0 +1,181 @@
+package dashboard
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// The MT dashboard's trend widgets are the most expensive read path apiv2 serves, and the
+// expense is almost entirely REPEATED work. A 6.15h daytime sample of >=1s calls showed
+// UsersReplying 17 calls/204s, PopularPosts 16/95s, Happiness 13/63s, RecentCounts 9/34s,
+// UsersPosting 5/28s - 438 DB-bound seconds, and segmented by (range, scope) it was
+// (7d, allgroups) 67 slow calls, (365d, allgroups) 24, (365d, systemwide) 7. That is many
+// moderators asking the same handful of questions, not one user doing something unusual.
+// Because db3's apiv2 reads from db3's own mysqld, every one of those seconds lands on the
+// cluster's write node.
+//
+// Two separate problems, two mechanisms here:
+//
+//   - Repeats across time: a moderator reloading the dashboard, or several moderators of the
+//     same groups loading it within minutes, re-derive an identical answer. A TTL cache fixes
+//     that.
+//   - Repeats at the same instant: a component that outruns the 50s gateway timeout is
+//     retried by the client while the original is still running, so copies STACK. That is how
+//     ModeratorsActive once pinned db3 with 19+ concurrent copies (see getModeratorsActive).
+//     A TTL cache does NOT help here, because nothing is in the cache yet - the first call has
+//     not returned. Single-flight fixes that: concurrent callers asking the identical question
+//     wait for the one in-flight computation instead of starting their own.
+//
+// Deliberately NOT cached: /group/work and anything moderators act on. These are trend
+// widgets - "who replied most this month", "how many posts arrived" - where minutes of
+// staleness is invisible and re-deriving it from raw tables on every page load is the bug.
+
+// componentCacheMaxEntries bounds the cache. Keys are per (component, group scope, date
+// range), so a busy estate with many moderator group-sets and custom ranges is the growth
+// case. Clear-on-overflow keeps the worst case bounded without an LRU's bookkeeping, the
+// same trade-off message.reachUniverseCache makes.
+const componentCacheMaxEntries = 2000
+
+// componentNegativeTTL is how long an empty or nil answer is reused. Empty is what a
+// component returns when it hit its deadline or errored, so it must expire quickly - a
+// moderator should not stare at an empty widget for half an hour because one query timed
+// out. Single-flight still collapses any storm that follows.
+const componentNegativeTTL = 60 * time.Second
+
+type cachedComponentResult struct {
+	val     interface{}
+	expires time.Time
+}
+
+// inflightComponent is one computation other callers can wait on. val is written before
+// done is closed, so a waiter that has received from done is guaranteed to see it.
+type inflightComponent struct {
+	done chan struct{}
+	val  interface{}
+}
+
+var (
+	componentMu       sync.Mutex
+	componentCache    = map[string]cachedComponentResult{}
+	componentInflight = map[string]*inflightComponent{}
+)
+
+// componentTTL is how long each component's answer may be reused.
+//
+// The widths are chosen against what the number MEANS, not against how expensive it is:
+// a leaderboard or a count over a month is a trend, and a wider range is more of a trend
+// still, so a year-range view tolerates more staleness than a week-range one.
+// DiscourseTopics is an external Discourse fetch (~1,100 identical calls/day) with no DB
+// involvement, so its TTL is about being a good citizen upstream rather than DB relief.
+func componentTTL(comp string, rangeDays int) time.Duration {
+	switch comp {
+	case "DiscourseTopics":
+		return 120 * time.Second
+	case "RecentCounts", "PopularPosts", "UsersPosting", "UsersReplying", "ModeratorsActive", "Happiness":
+		if rangeDays > 31 {
+			return 30 * time.Minute
+		}
+		return 5 * time.Minute
+	}
+	// Everything else already reads the nightly stats rollup and is cheap; leave it alone
+	// rather than adding staleness for no gain.
+	return 0
+}
+
+// componentCacheKey identifies one answer. The group scope is hashed rather than listed
+// because a systemwide scope is ~440 ids; sha256 rather than a cheap non-cryptographic hash
+// because a collision here would serve one moderator's groups' figures to another's.
+func componentCacheKey(comp string, groupIDs []uint64, startQ, endQ string, systemwide bool) string {
+	sorted := make([]uint64, len(groupIDs))
+	copy(sorted, groupIDs)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	h := sha256.New()
+	buf := make([]byte, 8)
+	for _, id := range sorted {
+		binary.BigEndian.PutUint64(buf, id)
+		h.Write(buf)
+	}
+
+	return fmt.Sprintf("%s|%s|%s|%t|%s", comp, startQ, endQ, systemwide, hex.EncodeToString(h.Sum(nil)[:16]))
+}
+
+// cachedComponent serves comp's answer from cache, joins an identical in-flight
+// computation, or runs compute itself - in that order. ttl <= 0 runs compute directly.
+func cachedComponent(key string, ttl time.Duration, compute func() interface{}) interface{} {
+	if ttl <= 0 {
+		return compute()
+	}
+
+	componentMu.Lock()
+	if e, ok := componentCache[key]; ok && time.Now().Before(e.expires) {
+		componentMu.Unlock()
+		return e.val
+	}
+	if call, ok := componentInflight[key]; ok {
+		componentMu.Unlock()
+		<-call.done
+		return call.val
+	}
+	call := &inflightComponent{done: make(chan struct{})}
+	componentInflight[key] = call
+	componentMu.Unlock()
+
+	// The cleanup is deferred so that a panic inside compute still releases every waiter
+	// (with a nil answer) instead of parking them on a channel that never closes.
+	completed := false
+	defer func() {
+		componentMu.Lock()
+		delete(componentInflight, key)
+		if completed {
+			if len(componentCache) >= componentCacheMaxEntries {
+				componentCache = map[string]cachedComponentResult{}
+			}
+			keep := ttl
+			if isEmptyComponentResult(call.val) {
+				keep = componentNegativeTTL
+			}
+			componentCache[key] = cachedComponentResult{val: call.val, expires: time.Now().Add(keep)}
+		}
+		componentMu.Unlock()
+		close(call.done)
+	}()
+
+	// Run outside the lock: two different components must not serialise against each other.
+	call.val = compute()
+	completed = true
+	return call.val
+}
+
+// isEmptyComponentResult reports whether a component produced nothing - which for every
+// component here means either "no data in range" or "the query failed or hit its deadline".
+// The two are indistinguishable from the outside, so both get the short negative TTL.
+func isEmptyComponentResult(v interface{}) bool {
+	switch t := v.(type) {
+	case nil:
+		return true
+	case []map[string]interface{}:
+		return len(t) == 0
+	case map[string]int64:
+		return len(t) == 0
+	case map[string]interface{}:
+		return len(t) == 0
+	case string:
+		return t == ""
+	}
+	return false
+}
+
+// resetComponentCache drops all cached and in-flight state. Tests only: package-level
+// caches otherwise leak answers between cases.
+func resetComponentCache() {
+	componentMu.Lock()
+	defer componentMu.Unlock()
+	componentCache = map[string]cachedComponentResult{}
+	componentInflight = map[string]*inflightComponent{}
+}

--- a/iznik-server-go/dashboard/cache_test.go
+++ b/iznik-server-go/dashboard/cache_test.go
@@ -1,0 +1,268 @@
+package dashboard
+
+// Tests for the dashboard component cache: the key (which must separate scopes that must not
+// see each other's figures), the TTL policy, the empty-result classification that drives the
+// short negative TTL, and the single-flight behaviour that stops retry storms stacking copies
+// of an expensive query onto db3.
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComponentCacheKey_SameScopeSameKeyRegardlessOfGroupOrder(t *testing.T) {
+	// resolveGroupIDs returns whatever order the DB hands back, so two loads by the same
+	// moderator must not miss the cache just because the rows came back differently.
+	a := componentCacheKey("UsersReplying", []uint64{7, 3, 91}, "2026-01-01", "2026-02-01", false)
+	b := componentCacheKey("UsersReplying", []uint64{91, 7, 3}, "2026-01-01", "2026-02-01", false)
+	assert.Equal(t, a, b)
+}
+
+func TestComponentCacheKey_DifferentGroupsDifferentKey(t *testing.T) {
+	// The important one: one moderator's groups must never key to another's.
+	a := componentCacheKey("UsersReplying", []uint64{1, 2}, "2026-01-01", "2026-02-01", false)
+	b := componentCacheKey("UsersReplying", []uint64{1, 3}, "2026-01-01", "2026-02-01", false)
+	assert.NotEqual(t, a, b)
+
+	// A subset must differ from its superset too.
+	c := componentCacheKey("UsersReplying", []uint64{1}, "2026-01-01", "2026-02-01", false)
+	assert.NotEqual(t, a, c)
+}
+
+func TestComponentCacheKey_ComponentRangeAndScopeAllSeparate(t *testing.T) {
+	base := componentCacheKey("UsersReplying", []uint64{1}, "2026-01-01", "2026-02-01", false)
+
+	assert.NotEqual(t, base, componentCacheKey("UsersPosting", []uint64{1}, "2026-01-01", "2026-02-01", false))
+	assert.NotEqual(t, base, componentCacheKey("UsersReplying", []uint64{1}, "2026-01-02", "2026-02-01", false))
+	assert.NotEqual(t, base, componentCacheKey("UsersReplying", []uint64{1}, "2026-01-01", "2026-02-02", false))
+	assert.NotEqual(t, base, componentCacheKey("UsersReplying", []uint64{1}, "2026-01-01", "2026-02-01", true))
+}
+
+func TestComponentTTL_WidensWithRange(t *testing.T) {
+	assert.Equal(t, 5*time.Minute, componentTTL("UsersReplying", 7))
+	assert.Equal(t, 5*time.Minute, componentTTL("UsersReplying", 31))
+	assert.Equal(t, 30*time.Minute, componentTTL("UsersReplying", 32))
+	assert.Equal(t, 30*time.Minute, componentTTL("PopularPosts", 365))
+}
+
+func TestComponentTTL_DiscourseIsIndependentOfRange(t *testing.T) {
+	assert.Equal(t, 120*time.Second, componentTTL("DiscourseTopics", 7))
+	assert.Equal(t, 120*time.Second, componentTTL("DiscourseTopics", 365))
+}
+
+// Components already served by the nightly stats rollup are cheap, so they stay uncached
+// rather than gaining staleness for no benefit.
+func TestComponentTTL_RollupBackedComponentsAreNotCached(t *testing.T) {
+	assert.Zero(t, componentTTL("Activity", 365))
+	assert.Zero(t, componentTTL("Donations", 365))
+	assert.Zero(t, componentTTL("MessageBreakdown", 365))
+}
+
+func TestRangeDaysBetween(t *testing.T) {
+	assert.Equal(t, 7, rangeDaysBetween("2026-01-01", "2026-01-08"))
+	assert.Equal(t, 365, rangeDaysBetween("2025-01-01", "2026-01-01"))
+	assert.Equal(t, 0, rangeDaysBetween("2026-01-08", "2026-01-01"), "a backwards range must not go negative")
+	assert.Equal(t, 0, rangeDaysBetween("not-a-date", "2026-01-01"))
+	assert.Equal(t, 0, rangeDaysBetween("2026-01-01", "not-a-date"))
+}
+
+func TestIsEmptyComponentResult(t *testing.T) {
+	assert.True(t, isEmptyComponentResult(nil))
+	assert.True(t, isEmptyComponentResult([]map[string]interface{}{}))
+	assert.True(t, isEmptyComponentResult(map[string]int64{}))
+	assert.True(t, isEmptyComponentResult(""))
+
+	assert.False(t, isEmptyComponentResult([]map[string]interface{}{{"id": 1}}))
+	assert.False(t, isEmptyComponentResult(map[string]int64{"newmessages": 0}),
+		"RecentCounts legitimately returns zeroes and must keep its full TTL")
+	assert.False(t, isEmptyComponentResult("{\"topics\":[]}"))
+}
+
+func TestCachedComponent_SecondCallIsServedFromCache(t *testing.T) {
+	resetComponentCache()
+
+	var calls int32
+	compute := func() interface{} {
+		atomic.AddInt32(&calls, 1)
+		return []map[string]interface{}{{"id": uint64(1)}}
+	}
+
+	first := cachedComponent("k", time.Minute, compute)
+	second := cachedComponent("k", time.Minute, compute)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	assert.Equal(t, first, second)
+}
+
+func TestCachedComponent_ZeroTTLAlwaysComputes(t *testing.T) {
+	resetComponentCache()
+
+	var calls int32
+	compute := func() interface{} {
+		atomic.AddInt32(&calls, 1)
+		return []map[string]interface{}{{"id": uint64(1)}}
+	}
+
+	cachedComponent("k", 0, compute)
+	cachedComponent("k", 0, compute)
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestCachedComponent_DifferentKeysDoNotShare(t *testing.T) {
+	resetComponentCache()
+
+	a := cachedComponent("a", time.Minute, func() interface{} { return "A" })
+	b := cachedComponent("b", time.Minute, func() interface{} { return "B" })
+
+	assert.Equal(t, "A", a)
+	assert.Equal(t, "B", b)
+}
+
+// The retry-storm case, and the reason a plain TTL cache is not enough: a slow component is
+// still running when the next request for it arrives, so nothing is cached yet. Without
+// single-flight each of those requests starts its own copy of the query — how the dashboard
+// once stacked 19+ concurrent copies onto db3.
+func TestCachedComponent_ConcurrentCallersShareOneComputation(t *testing.T) {
+	resetComponentCache()
+
+	var calls int32
+	release := make(chan struct{})
+	started := make(chan struct{})
+
+	compute := func() interface{} {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			close(started)
+		}
+		<-release
+		return []map[string]interface{}{{"id": uint64(42)}}
+	}
+
+	const callers = 20
+	results := make([]interface{}, callers)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		results[0] = cachedComponent("slow", time.Minute, compute)
+	}()
+
+	// Only let the others in once the first computation is genuinely in flight.
+	<-started
+
+	for i := 1; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = cachedComponent("slow", time.Minute, compute)
+		}(i)
+	}
+
+	// Give the waiters time to queue up behind the in-flight call before it finishes.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent callers must not each run the query")
+	for i := 0; i < callers; i++ {
+		assert.Equal(t, []map[string]interface{}{{"id": uint64(42)}}, results[i])
+	}
+}
+
+// An empty answer means the component errored or hit its deadline, so it must expire fast
+// rather than pinning a blank widget in front of moderators for the full TTL.
+func TestCachedComponent_EmptyResultGetsShortTTL(t *testing.T) {
+	resetComponentCache()
+
+	cachedComponent("empty", 30*time.Minute, func() interface{} {
+		return []map[string]interface{}{}
+	})
+
+	componentMu.Lock()
+	entry, ok := componentCache["empty"]
+	componentMu.Unlock()
+
+	assert.True(t, ok)
+	assert.LessOrEqual(t, time.Until(entry.expires), componentNegativeTTL)
+}
+
+func TestCachedComponent_ExpiredEntryRecomputes(t *testing.T) {
+	resetComponentCache()
+
+	var calls int32
+	compute := func() interface{} {
+		atomic.AddInt32(&calls, 1)
+		return "v"
+	}
+
+	cachedComponent("k", 20*time.Millisecond, compute)
+	time.Sleep(40 * time.Millisecond)
+	cachedComponent("k", 20*time.Millisecond, compute)
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+// A panicking compute must not leave waiters parked on a channel that never closes.
+func TestCachedComponent_PanicReleasesWaiters(t *testing.T) {
+	resetComponentCache()
+
+	done := make(chan struct{})
+	go func() {
+		defer func() {
+			_ = recover()
+			close(done)
+		}()
+		cachedComponent("boom", time.Minute, func() interface{} { panic("compute failed") })
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("panicking compute deadlocked the cache")
+	}
+
+	// The key must be left clean so the next request can try again.
+	componentMu.Lock()
+	_, inflight := componentInflight["boom"]
+	_, cached := componentCache["boom"]
+	componentMu.Unlock()
+
+	assert.False(t, inflight, "panic must clear the in-flight marker")
+	assert.False(t, cached, "a panic must not be cached as an answer")
+}
+
+func TestSortedHappiness_OrdersByCountThenLabel(t *testing.T) {
+	got := sortedHappiness(map[string]int{"Happy": 3, "Fine": 10, "Unhappy": 3})
+
+	assert.Equal(t, []map[string]interface{}{
+		{"count": 10, "happiness": "Fine"},
+		{"count": 3, "happiness": "Happy"},
+		{"count": 3, "happiness": "Unhappy"},
+	}, got)
+}
+
+func TestSortedHappiness_DropsZeroAndUnknownBuckets(t *testing.T) {
+	got := sortedHappiness(map[string]int{"Happy": 0, "Fine": 2, "Bogus": 9})
+
+	assert.Equal(t, []map[string]interface{}{
+		{"count": 2, "happiness": "Fine"},
+	}, got)
+}
+
+func TestSortedHappiness_EmptyIsEmptySlice(t *testing.T) {
+	got := sortedHappiness(map[string]int{})
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestNextDay(t *testing.T) {
+	assert.Equal(t, "2026-01-02", nextDay("2026-01-01"))
+	assert.Equal(t, "2026-03-01", nextDay("2026-02-28"))
+	assert.Equal(t, "2025-01-01", nextDay("2024-12-31"))
+	assert.Equal(t, "", nextDay("not-a-date"))
+}

--- a/iznik-server-go/dashboard/dashboard.go
+++ b/iznik-server-go/dashboard/dashboard.go
@@ -5,10 +5,12 @@ import (
 	json2 "encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/freegle/iznik-server-go/database"
@@ -164,28 +166,32 @@ func GetDashboard(c *fiber.Ctx) error {
 }
 
 func getComponent(comp string, groupIDs []uint64, startQ, endQ string, systemwide, isMod bool) interface{} {
+	// The moderator checks stay OUTSIDE the cache below: a non-moderator must never reach
+	// a cached moderator-only answer, and returning before compute is set guarantees it.
+	var compute func() interface{}
+
 	switch comp {
 	case "RecentCounts":
-		return getRecentCounts(groupIDs, startQ, endQ)
+		compute = func() interface{} { return getRecentCounts(groupIDs, startQ, endQ) }
 	case "PopularPosts":
-		return getPopularPosts(groupIDs, startQ, endQ, systemwide)
+		compute = func() interface{} { return getPopularPosts(groupIDs, startQ, endQ, systemwide) }
 	case "UsersPosting":
 		if !isMod {
 			return nil
 		}
-		return getUsersPosting(groupIDs, startQ, endQ)
+		compute = func() interface{} { return getUsersPosting(groupIDs, startQ, endQ) }
 	case "UsersReplying":
 		if !isMod {
 			return nil
 		}
-		return getUsersReplying(groupIDs, startQ, endQ)
+		compute = func() interface{} { return getUsersReplying(groupIDs, startQ, endQ) }
 	case "ModeratorsActive":
 		if !isMod {
 			return nil
 		}
-		return getModeratorsActive(groupIDs)
+		compute = func() interface{} { return getModeratorsActive(groupIDs) }
 	case "MessageBreakdown":
-		return getMessageBreakdown(groupIDs, startQ, endQ)
+		compute = func() interface{} { return getMessageBreakdown(groupIDs, startQ, endQ) }
 	case "Activity", "Replies", "ApprovedMessageCount",
 		"Weight", "Outcomes", "ActiveUsers", "ApprovedMemberCount":
 		// ApprovedMemberCount (community member counts) is public — group size is
@@ -195,21 +201,48 @@ func getComponent(comp string, groupIDs []uint64, startQ, endQ string, systemwid
 		if modOnly && !isMod {
 			return nil
 		}
-		return getStatsTimeSeries(comp, groupIDs, startQ, endQ)
+		compute = func() interface{} { return getStatsTimeSeries(comp, groupIDs, startQ, endQ) }
 	case "Donations":
-		return getDonations(groupIDs, startQ, endQ, systemwide)
+		compute = func() interface{} { return getDonations(groupIDs, startQ, endQ, systemwide) }
 	case "Happiness":
 		if !isMod {
 			return nil
 		}
-		return getHappiness(groupIDs, startQ, endQ, systemwide)
+		compute = func() interface{} { return getHappiness(groupIDs, startQ, endQ) }
 	case "DiscourseTopics":
 		if !isMod {
 			return nil
 		}
-		return getDiscourseTopics()
+		compute = func() interface{} { return getDiscourseTopics() }
 	}
-	return nil
+
+	if compute == nil {
+		return nil
+	}
+
+	ttl := componentTTL(comp, rangeDaysBetween(startQ, endQ))
+	if ttl <= 0 {
+		return compute()
+	}
+	return cachedComponent(componentCacheKey(comp, groupIDs, startQ, endQ, systemwide), ttl, compute)
+}
+
+// rangeDaysBetween is how many days the requested dashboard range spans, used only to pick
+// a cache TTL. Unparseable dates return 0, which lands on the shorter TTL - the safe side.
+func rangeDaysBetween(startQ, endQ string) int {
+	start, err := time.Parse("2006-01-02", startQ)
+	if err != nil {
+		return 0
+	}
+	end, err := time.Parse("2006-01-02", endQ)
+	if err != nil {
+		return 0
+	}
+	days := int(end.Sub(start).Hours() / 24)
+	if days < 0 {
+		return 0
+	}
+	return days
 }
 
 func getRecentCounts(groupIDs []uint64, startQ, endQ string) map[string]int64 {
@@ -449,7 +482,14 @@ const dashboardBatch = 1500
 // dashboardDeadline bounds each whole chunked walk. The fiber request context can't be used
 // for this (fasthttp only cancels it on server shutdown), so without an explicit deadline an
 // abandoned systemwide/wide-range request would keep stepping through every remaining window.
-const dashboardDeadline = 60 * time.Second
+//
+// It sits below the load balancer's 50s timeout ON PURPOSE. At the old 60s the two limits
+// were the wrong way round: the gateway gave up first, so a systemwide-year UsersReplying
+// (observed hitting the ceiling three times in one night) burned the full minute on db3 and
+// then delivered its answer to nobody, while the client - having seen a timeout, not an
+// answer - retried onto the same node. Finishing inside the gateway's window means the
+// caller always gets a reply, even an empty one, and stops retrying.
+const dashboardDeadline = 40 * time.Second
 
 // arrivalWindow is one bounded sub-range of a dashboard date range, as produced by
 // arrivalWindows: scan it as [Start, End) normally, or [Start, End] when LastInclusive - the
@@ -879,41 +919,169 @@ func getDonations(groupIDs []uint64, startQ, endQ string, systemwide bool) []map
 	return result
 }
 
-func getHappiness(groupIDs []uint64, startQ, endQ string, systemwide bool) []map[string]interface{} {
+// happinessTypes are the three stats rollup rows that together make the happiness
+// histogram. They match StatsGenerationService's TYPE_FEEDBACK_* constants and the
+// messages_outcomes.happiness enum.
+var happinessTypes = []string{"Happy", "Fine", "Unhappy"}
+
+// getHappiness returns the Happy/Fine/Unhappy histogram for the range.
+//
+// It reads the nightly stats rollup, which stats:generate-daily has been writing at 02:30
+// all along - Happiness was the last dashboard component still re-aggregating
+// messages_outcomes raw on every request, joining through messages and messages_groups
+// across the whole range. Every sibling component (Activity, Replies, Outcomes, Weight,
+// ActiveUsers...) already reads this table; see getStatsTimeSeries, whose shape this
+// deliberately mirrors.
+//
+// Two consequences worth knowing about, both making Happiness consistent with the rest of
+// the dashboard rather than special:
+//
+//   - Counts are now native-distinct. The rollup counts COUNT(DISTINCT msgid) per group over
+//     native posts (messages_groups.rippled_in = 0); the raw query counted one row per
+//     (outcome x messages_groups match), so a crossposted post counted once per group it was
+//     in, and a rippled-out copy counted again. Totals therefore drop slightly where
+//     crossposting or rippling is common.
+//   - Systemwide sums the same per-group rows as every other systemwide component, instead
+//     of being the one component that scanned messages_outcomes with no group join at all.
+//     It needs no branch of its own: resolveGroupIDs already expands a systemwide request
+//     into the full list of published groups.
+//
+// The rollup only reaches yesterday, so today is added from the raw table as one bounded
+// single-day query, and if the rollup is missing or behind the whole range falls back to
+// the raw query so a failed nightly run shows stale-but-present data rather than nothing.
+func getHappiness(groupIDs []uint64, startQ, endQ string) []map[string]interface{} {
+	if len(groupIDs) == 0 {
+		return []map[string]interface{}{}
+	}
+
 	db := database.DBConn
 
+	// How far the rollup actually reaches for this scope. DATE_FORMAT rather than a bare
+	// MAX(date) so the answer is a plain YYYY-MM-DD string whichever way the driver is
+	// configured to hand back DATE columns. NULL means the nightly job has never written
+	// for these groups.
+	type maxDateRow struct {
+		MaxDate *string
+	}
+	var maxRow maxDateRow
+	db.Table("stats").Select("DATE_FORMAT(MAX(date), '%Y-%m-%d') AS max_date").
+		Where("type IN ? AND groupid IN ? AND date >= ? AND date < ?", happinessTypes, groupIDs, startQ, endQ).
+		Scan(&maxRow)
+	rollupEnd := maxRow.MaxDate
+
+	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	if rollupEnd == nil || *rollupEnd == "" || (*rollupEnd < yesterday && *rollupEnd < endQ) {
+		// Either no rollup at all for this scope, or it has fallen behind. Serve the raw
+		// answer rather than a truncated one, and say so - a persistent gap here means
+		// stats:generate-daily is failing and should be visible.
+		logHappinessFallback(rollupEnd)
+		return happinessFromRaw(db, groupIDs, startQ, endQ)
+	}
+
+	totals := map[string]int{}
+
+	type StatsRow struct {
+		Type  string
+		Count *int64
+	}
+	var rows []StatsRow
+	db.Table("stats").Select("type, SUM(count) AS count").
+		Where("type IN ? AND groupid IN ? AND date >= ? AND date < ?", happinessTypes, groupIDs, startQ, endQ).
+		Group("type").Scan(&rows)
+	for _, r := range rows {
+		if r.Count != nil {
+			totals[r.Type] += int(*r.Count)
+		}
+	}
+
+	// Top up the days the rollup has not covered yet - normally just today. endQ is already
+	// the requested end date plus one day (see GetDashboard), so this is a half-open range.
+	topUpStart := nextDay(*rollupEnd)
+	if topUpStart != "" && topUpStart < endQ {
+		for _, r := range happinessFromRaw(db, groupIDs, topUpStart, endQ) {
+			happiness, _ := r["happiness"].(string)
+			count, _ := r["count"].(int)
+			totals[happiness] += count
+		}
+	}
+
+	return sortedHappiness(totals)
+}
+
+// happinessFromRaw aggregates messages_outcomes directly for [startQ, endQ). It is both the
+// today top-up and the fallback when the rollup is unusable, so it matches the rollup's
+// semantics: native posts only (rippled_in = 0) and each message counted once per group.
+func happinessFromRaw(db *gorm.DB, groupIDs []uint64, startQ, endQ string) []map[string]interface{} {
 	type HappyRow struct {
 		Count     int
 		Happiness string
 	}
 
 	var rows []HappyRow
-	if systemwide {
-		db.Table("messages_outcomes").
-			Select("COUNT(*) AS count, happiness").
-			Where("timestamp >= ? AND timestamp <= ? AND happiness IS NOT NULL", startQ, endQ).
-			Group("happiness").
-			Order("count DESC").
-			Scan(&rows)
-	} else if len(groupIDs) > 0 {
-		db.Table("messages_outcomes").
-			Select("COUNT(*) AS count, happiness").
-			Joins("INNER JOIN messages ON messages.id = messages_outcomes.msgid").
-			Joins("INNER JOIN messages_groups ON messages_groups.msgid = messages_outcomes.msgid").
-			Where("timestamp >= ? AND timestamp <= ? AND messages_groups.groupid IN (?) AND happiness IS NOT NULL", startQ, endQ, groupIDs).
-			Group("happiness").
-			Order("count DESC").
-			Scan(&rows)
-	}
+	db.Table("messages_outcomes").
+		Select("COUNT(DISTINCT messages_outcomes.msgid) AS count, messages_outcomes.happiness").
+		Joins("INNER JOIN messages_groups ON messages_groups.msgid = messages_outcomes.msgid AND messages_groups.rippled_in = 0").
+		Where("messages_outcomes.timestamp >= ? AND messages_outcomes.timestamp < ? AND messages_groups.groupid IN (?) AND messages_outcomes.happiness IS NOT NULL",
+			startQ, endQ, groupIDs).
+		Group("messages_outcomes.happiness").
+		Scan(&rows)
 
-	result := make([]map[string]interface{}, len(rows))
-	for i, r := range rows {
-		result[i] = map[string]interface{}{
-			"count":     r.Count,
-			"happiness": r.Happiness,
+	totals := map[string]int{}
+	for _, r := range rows {
+		totals[r.Happiness] += r.Count
+	}
+	return sortedHappiness(totals)
+}
+
+// sortedHappiness renders the histogram highest count first, with the happiness label as a
+// deterministic tie-break (the replaced ORDER BY count DESC had no secondary key, so ties
+// were never guaranteed an order). Zero buckets are dropped, as an aggregate produced none.
+func sortedHappiness(totals map[string]int) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(totals))
+	for _, h := range happinessTypes {
+		if totals[h] > 0 {
+			result = append(result, map[string]interface{}{"count": totals[h], "happiness": h})
 		}
 	}
+	sort.Slice(result, func(i, j int) bool {
+		ci := result[i]["count"].(int)
+		cj := result[j]["count"].(int)
+		if ci != cj {
+			return ci > cj
+		}
+		return result[i]["happiness"].(string) < result[j]["happiness"].(string)
+	})
 	return result
+}
+
+// nextDay returns the day after a "2006-01-02" date, or "" if it will not parse.
+func nextDay(date string) string {
+	d, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return ""
+	}
+	return d.AddDate(0, 0, 1).Format("2006-01-02")
+}
+
+// happinessFallbackMu throttles the fallback notice: if the nightly stats run stops, every
+// dashboard load takes this path, and one log line per request would bury the signal.
+var (
+	happinessFallbackMu   sync.Mutex
+	happinessFallbackLast time.Time
+)
+
+func logHappinessFallback(rollupEnd *string) {
+	happinessFallbackMu.Lock()
+	defer happinessFallbackMu.Unlock()
+	if time.Since(happinessFallbackLast) < 10*time.Minute {
+		return
+	}
+	happinessFallbackLast = time.Now()
+	if rollupEnd == nil {
+		log.Printf("dashboard: Happiness falling back to raw messages_outcomes - no stats rollup rows for this scope")
+	} else {
+		log.Printf("dashboard: Happiness falling back to raw messages_outcomes - stats rollup only reaches %s", *rollupEnd)
+	}
 }
 
 func getDiscourseTopics() interface{} {

--- a/iznik-server-go/test/dashboard_test.go
+++ b/iznik-server-go/test/dashboard_test.go
@@ -484,6 +484,52 @@ func TestGetDashboardHappiness(t *testing.T) {
 	assert.Greater(t, len(happy), 0, "Should have at least one happiness entry")
 }
 
+// Happiness reads the nightly stats rollup (the rows stats:generate-daily writes at 02:30)
+// and tops up only the days the rollup has not reached yet. This proves both halves: a
+// rollup row for yesterday plus a raw outcome recorded today must add up.
+func TestGetDashboardHappinessFromStatsRollupPlusToday(t *testing.T) {
+	prefix := uniquePrefix("DashHappyRollup")
+	db := database.DBConn
+	groupID, _, token := createModDashboardFixtures(t, prefix)
+
+	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	db.Exec("INSERT INTO stats (date, end, groupid, type, count) VALUES (?, ?, ?, 'Happy', 4)", yesterday, yesterday, groupID)
+	db.Exec("INSERT INTO stats (date, end, groupid, type, count) VALUES (?, ?, ?, 'Fine', 2)", yesterday, yesterday, groupID)
+
+	// One more Happy recorded today, which the rollup cannot know about yet.
+	var msgID uint64
+	db.Raw("SELECT msgid FROM messages_groups WHERE groupid = ? LIMIT 1", groupID).Scan(&msgID)
+	db.Exec("INSERT INTO messages_outcomes (msgid, outcome, happiness, timestamp) VALUES (?, 'Taken', 'Happy', NOW())", msgID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM stats WHERE groupid = ?", groupID)
+		db.Exec("DELETE FROM messages_outcomes WHERE msgid = ?", msgID)
+	})
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/dashboard?components=Happiness&group=%d&jwt=%s", groupID, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	comps := result["components"].(map[string]interface{})
+	rows, ok := comps["Happiness"].([]interface{})
+	assert.True(t, ok, "Happiness should be an array")
+
+	counts := map[string]float64{}
+	for _, r := range rows {
+		row := r.(map[string]interface{})
+		counts[row["happiness"].(string)] = row["count"].(float64)
+	}
+
+	assert.Equal(t, float64(5), counts["Happy"], "4 from the rollup plus 1 recorded today")
+	assert.Equal(t, float64(2), counts["Fine"], "rollup only")
+
+	// Highest count first.
+	first := rows[0].(map[string]interface{})
+	assert.Equal(t, "Happy", first["happiness"])
+}
+
 func TestGetDashboardPopularPostsWithGroup(t *testing.T) {
 	prefix := uniquePrefix("DashPP")
 	groupID, _, token := createModDashboardFixtures(t, prefix)


### PR DESCRIPTION
## What this does

Moderators keep asking the dashboard the same few questions, and it works out every answer from scratch every time. Because the copy of the API running on db3 reads from db3's own database, all of that effort lands on the cluster's write node — the one machine we least want busy.

Over a six-hour daytime sample, five widgets accounted for 438 seconds of database time in calls that each took more than a second: the top-repliers list (204s), popular posts (95s), the happiness chart (63s), the recent counts (34s) and the top-posters list (28s). What matters is the shape of it: 67 of those slow calls were "last 7 days, all my groups", 24 were "last year, all my groups" and 7 were "last year, everywhere". Lots of moderators asking the same handful of questions, rather than one person doing something unusual.

Three changes. The third is a correctness fix rather than a speed-up.

**The dashboard now remembers its answers for a few minutes.** Five minutes for a range up to a month, thirty minutes beyond that, because a year-long trend does not change meaningfully in half an hour. That covers a moderator reloading the page, and several moderators of the same groups looking within a few minutes of each other.

**Callers who ask the same question at the same moment now share one answer.** Remembering answers does not help when a widget is slow, because nothing has been remembered yet — the first request is still running. Meanwhile the browser has given up waiting and asked again, and that second request starts its own copy of the query. That is how the "active volunteers" widget once ended up with 19 copies of itself running at once and pinned db3. Now, if a question is already being worked on, later callers wait for that answer instead of starting again.

If a widget comes back empty — which is what happens when it fails or runs out of time — that empty answer is only kept for a minute. A moderator should not be looking at a blank chart for half an hour because one query timed out once.

The check on whether you are a moderator happens before any of this, and the remembered answer is filed under the exact set of groups it was computed for, so one moderator's figures can never be shown to another.

**The happiness chart counts ratings correctly.** It was multiplying every rating by the number of groups the post was on. That is the largest error on this dashboard, and the section below sets out the size of it.

**The time limit on the slower widgets drops from 60 seconds to 40.** The load balancer gives up at 50. At 60 those two limits were the wrong way round: the load balancer gave up first, so a "last year, everywhere" top-repliers query — seen hitting its limit three times in one night — spent the full minute working on db3 and then handed its answer to nobody. The browser, having seen a timeout rather than an answer, asked again, onto the same machine.

## A counting bug this fixes

A happiness rating is one member's view of how their post went. It is one vote, however many groups the post touched.

The old query did not treat it that way. It joined `messages_outcomes` to `messages_groups` and counted the join rows, so a rating was counted once for every group row the post had — and rippling adds a row for every group a post reaches. Measured against production over the last 90 days:

| | ratings counted |
|---|---|
| Old query | **110,885** |
| Actual ratings | **25,715** |

An overcount of more than four times, and one that has been growing as reach has, because crossposting only accounts for 3 of those extra rows. Rippling accounts for the rest.

Counting distinct `messages_outcomes` rows fixes it, with the join restricted to native rows so a post stays attributed to the group it was posted on. Two ratings left on the same post over its life still count as two, which is right and barely arises: of 25,704 rated posts in that window, 25,703 carry exactly one.

**This is why happiness does not read the nightly rollup**, even though the rest of the dashboard does. Those rows are per group, so summing them across a moderator's groups reintroduces exactly the multiplication being removed — a post on two of their groups would vote twice. Other components can sum that rollup because their figures are per group by definition. Happiness is not. The repeat cost is carried by the cache instead: a systemwide year measures 5.6s on production, paid once per scope per cache window rather than on every dashboard load.

## Screenshots

The happiness charts on ModTools → Members → Feedback:

![Happiness charts](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/mt-dashboard-db3/mt-happiness.png)

The dashboard itself, exercising the widgets that now remember their answers — popular posts, top posters, active volunteers and the recent counts:

![ModTools dashboard](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/mt-dashboard-db3/mt-dashboard.png)

The `pr-assets/mt-dashboard-db3` branch holds nothing but those two images and can be deleted after merge.

## Testing

Full Go suite: 4123 passed, 0 failed.

The new tests check that the same set of groups in a different order finds the same remembered answer, that two different sets of groups never collide, how long each widget's answer is kept, that an empty answer is recognised as empty and expires quickly, that a stale answer is recomputed, and that a widget which panics releases everyone waiting on it instead of leaving them stuck forever. One test runs 20 requests at once against a deliberately slow widget and checks the query really does run only once.

For the happiness chart there is a test that puts one rating on a post spanning three groups — two it was posted to, one it rippled into — and checks the answer is one, not three.

Checked by hand against the local containers as well: that same post returns 1 from the endpoint where the old query returns 3. Asking the same question twice dropped from 0.04s to 0.00s once cached.

## Not in this PR

The audit also proposed two new database tables of pre-computed figures for the top-repliers and popular-posts widgets. The review of that proposal concluded we should try remembering answers and bounding the queries first, because that needs no new tables, no nightly writer and no schema change applied by hand on production — and would capture most of the benefit. That is what this does. If the first, uncached load still bothers moderators in practice, those tables are the next step.
