### PR TITLE
fix(rippling): guard the reply-ETA drive-time calls with a cap, cache and breaker

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1080,12 +1080,25 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 		if len(reachBlocked) > 0 {
 			hazard := rippling.LoadHazardHours(db)
 
+			// Per-request backstop on top of FetchDriveTime's process-wide cap, cache
+			// and breaker: "blocked posts are a small minority of any feed" is false for
+			// a viewer outside the reach of many rippling posts (2026-08-13: one viewer's
+			// polls drove ~600 routing searches/min and a load-31 spike on the routing
+			// host). Past the cap the remaining blocked posts simply carry no ETA — the
+			// hold itself is still reported.
+			const maxCoverageLookups = 24
+			lookups := 0
+
 			var covMu sync.Mutex
 			var covWg sync.WaitGroup
 			for msgid, origin := range reachBlocked {
 				if !origin.Ok || origin.Arrival == nil || len(origin.Schedule) == 0 {
 					continue
 				}
+				if lookups >= maxCoverageLookups {
+					break
+				}
+				lookups++
 				covWg.Add(1)
 				go func(msgid uint64, origin ReachOrigin) {
 					defer covWg.Done()

--- a/iznik-server-go/rippling/drivetime.go
+++ b/iznik-server-go/rippling/drivetime.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -15,6 +17,62 @@ import (
 // milliseconds on the UK graph. If the routing server is slow or down we would rather
 // show no estimate than hold the whole response.
 var driveTimeHTTPClient = &http.Client{Timeout: 2 * time.Second}
+
+// The routing server shares db3 with mysqld and apiv2, and each drive-time answer is a
+// Dijkstra whose cost scales with the budget. Left unbounded, the per-blocked-post
+// fan-out in the feed path stacked hundreds of concurrent searches for a single viewer
+// (2026-08-13: ~600 timed-out calls/minute during a load-31 spike), and the 2s client
+// timeout does not shed that load — the routing server still works every abandoned
+// request to completion. Three guards keep the estimate strictly best-effort:
+//
+//   - a process-wide concurrency cap, so feed traffic can never queue more searches
+//     than the routing host is sized for;
+//   - a TTL cache keyed on the exact question, because both ends repeat: origins are
+//     per-post constants and a polling viewer re-asks for the same blocked posts every
+//     refresh;
+//   - a failure breaker, so when the routing server is already drowning we stop asking
+//     entirely for a cooldown instead of feeding the spiral two-second timeouts.
+const driveTimeMaxConcurrent = 8
+
+var driveTimeSem = make(chan struct{}, driveTimeMaxConcurrent)
+
+// Tunable for tests only.
+var (
+	driveTimeCacheTTL       = 15 * time.Minute
+	driveTimeBreakerAfter   = int32(3)
+	driveTimeBreakerCooloff = 30 * time.Second
+)
+
+type driveTimeCacheEntry struct {
+	dt      DriveTime
+	expires time.Time
+}
+
+var driveTimeCache sync.Map // string key -> driveTimeCacheEntry
+var driveTimeCacheSize atomic.Int64
+
+// driveTimeCacheSweepAt bounds memory: past this many entries a put sweeps expired
+// ones first. Entries are ~100 bytes; 20k ≈ 2MB worst case.
+const driveTimeCacheSweepAt = 20000
+
+var driveTimeFailStreak atomic.Int32
+var driveTimeBreakerUntil atomic.Int64 // unix nanos; 0 = closed
+
+func driveTimeBreakerOpen() bool {
+	until := driveTimeBreakerUntil.Load()
+	return until != 0 && time.Now().UnixNano() < until
+}
+
+func driveTimeRecordFailure() {
+	if driveTimeFailStreak.Add(1) >= driveTimeBreakerAfter {
+		driveTimeBreakerUntil.Store(time.Now().Add(driveTimeBreakerCooloff).UnixNano())
+	}
+}
+
+func driveTimeRecordSuccess() {
+	driveTimeFailStreak.Store(0)
+	driveTimeBreakerUntil.Store(0)
+}
 
 // routingInternalURL is the ROUTING server's INTERNAL, no-auth port. Three env vars point
 // at three different things here and only this one is right:
@@ -66,8 +124,27 @@ func FetchDriveTime(fromLat, fromLng, toLat, toLng, maxMinutes float64) (DriveTi
 		base, fromLat, fromLng, toLat, toLng, maxMinutes,
 	)
 
+	// The formatted URL is the cache key: it already encodes the whole question at the
+	// %f precision the routing server would see, so equal keys are equal questions.
+	if v, hit := driveTimeCache.Load(url); hit {
+		entry := v.(driveTimeCacheEntry)
+		if time.Now().Before(entry.expires) {
+			return entry.dt, true
+		}
+		driveTimeCache.Delete(url)
+		driveTimeCacheSize.Add(-1)
+	}
+
+	if driveTimeBreakerOpen() {
+		return DriveTime{}, false
+	}
+
+	driveTimeSem <- struct{}{}
+	defer func() { <-driveTimeSem }()
+
 	resp, err := driveTimeHTTPClient.Get(url)
 	if err != nil {
+		driveTimeRecordFailure()
 		log.Printf("rippling: drive-time fetch failed: %v", err)
 		return DriveTime{}, false
 	}
@@ -75,20 +152,40 @@ func FetchDriveTime(fromLat, fromLng, toLat, toLng, maxMinutes float64) (DriveTi
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		driveTimeRecordFailure()
 		log.Printf("rippling: drive-time read failed: %v", err)
 		return DriveTime{}, false
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		driveTimeRecordFailure()
 		log.Printf("rippling: drive-time HTTP %d", resp.StatusCode)
 		return DriveTime{}, false
 	}
 
 	var r driveTimeResponse
 	if err := json.Unmarshal(body, &r); err != nil {
+		driveTimeRecordFailure()
 		log.Printf("rippling: drive-time JSON parse failed: %v", err)
 		return DriveTime{}, false
 	}
 
-	return DriveTime{Minutes: r.DriveMin, Reachable: r.Reachable}, true
+	driveTimeRecordSuccess()
+
+	dt := DriveTime{Minutes: r.DriveMin, Reachable: r.Reachable}
+	if driveTimeCacheSize.Load() >= driveTimeCacheSweepAt {
+		now := time.Now()
+		driveTimeCache.Range(func(k, v interface{}) bool {
+			if now.After(v.(driveTimeCacheEntry).expires) {
+				driveTimeCache.Delete(k)
+				driveTimeCacheSize.Add(-1)
+			}
+			return true
+		})
+	}
+	if _, loaded := driveTimeCache.LoadOrStore(url, driveTimeCacheEntry{dt: dt, expires: time.Now().Add(driveTimeCacheTTL)}); !loaded {
+		driveTimeCacheSize.Add(1)
+	}
+
+	return dt, true
 }

--- a/iznik-server-go/rippling/drivetime_test.go
+++ b/iznik-server-go/rippling/drivetime_test.go
@@ -1,0 +1,100 @@
+package rippling
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func resetDriveTimeGuards() {
+	driveTimeCache.Range(func(k, _ interface{}) bool {
+		driveTimeCache.Delete(k)
+		return true
+	})
+	driveTimeCacheSize.Store(0)
+	driveTimeFailStreak.Store(0)
+	driveTimeBreakerUntil.Store(0)
+}
+
+func withRoutingStub(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	old := os.Getenv("ROUTING_EVAL_URL")
+	os.Setenv("ROUTING_EVAL_URL", srv.URL)
+	t.Cleanup(func() {
+		srv.Close()
+		os.Setenv("ROUTING_EVAL_URL", old)
+		resetDriveTimeGuards()
+	})
+	resetDriveTimeGuards()
+	return srv
+}
+
+// A repeated question must be answered from the cache: the feed path re-asks the same
+// (origin, viewer, budget) triple on every poll, and each upstream answer is a Dijkstra
+// on a host shared with mysqld.
+func TestFetchDriveTimeCachesAnswers(t *testing.T) {
+	var hits atomic.Int32
+	withRoutingStub(t, func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Write([]byte(`{"reachable":true,"drive_min":12.5}`))
+	})
+
+	dt1, ok1 := FetchDriveTime(53.5, -2.2, 53.6, -2.3, 30)
+	dt2, ok2 := FetchDriveTime(53.5, -2.2, 53.6, -2.3, 30)
+
+	assert.True(t, ok1)
+	assert.True(t, ok2)
+	assert.Equal(t, dt1, dt2)
+	assert.Equal(t, int32(1), hits.Load(), "second identical question must not reach the routing server")
+
+	// A different question is a different key.
+	_, ok3 := FetchDriveTime(53.5, -2.2, 53.6, -2.3, 45)
+	assert.True(t, ok3)
+	assert.Equal(t, int32(2), hits.Load())
+}
+
+// After consecutive failures the breaker opens and calls stop reaching the routing
+// server at all for the cooldown — timing out two seconds per blocked post is exactly
+// how an overloaded routing host gets buried deeper.
+func TestFetchDriveTimeBreakerOpensAndRecovers(t *testing.T) {
+	var hits atomic.Int32
+	var failing atomic.Bool
+	failing.Store(true)
+	withRoutingStub(t, func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if failing.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(`{"reachable":true,"drive_min":5}`))
+	})
+
+	oldCooloff := driveTimeBreakerCooloff
+	driveTimeBreakerCooloff = 50 * time.Millisecond
+	defer func() { driveTimeBreakerCooloff = oldCooloff }()
+
+	for i := 0; i < int(driveTimeBreakerAfter); i++ {
+		_, ok := FetchDriveTime(50.0, -1.0, 50.1, float64(i)*0.01, 30)
+		assert.False(t, ok)
+	}
+	assert.Equal(t, int32(driveTimeBreakerAfter), hits.Load())
+
+	// Breaker open: no upstream call.
+	_, ok := FetchDriveTime(50.0, -1.0, 50.9, -1.9, 30)
+	assert.False(t, ok)
+	assert.Equal(t, int32(driveTimeBreakerAfter), hits.Load(), "open breaker must not call upstream")
+
+	// After the cooldown a healthy server closes it again.
+	failing.Store(false)
+	time.Sleep(60 * time.Millisecond)
+	dt, ok := FetchDriveTime(50.0, -1.0, 50.9, -1.9, 30)
+	assert.True(t, ok)
+	assert.True(t, dt.Reachable)
+	assert.Equal(t, int32(0), driveTimeFailStreak.Load())
+}


### PR DESCRIPTION
## What went wrong

The reply-hold ETA that shipped in #1320 asks the routing server how long it would take to drive to the viewer. It asks once for every reach-blocked post in the batch, and it does that inside `GetMessagesByIds` — which the feed listing calls. Nothing limited how many of those questions could be in flight at once, nothing remembered an answer, and nothing noticed when the routing server stopped coping. The only protection was a two-second timeout on our side.

For most people that is fine, because only a handful of posts in their feed are held. For someone sitting outside the reach of a lot of rippling posts it is not: every refresh of their feed fires off hundreds of route searches, and each one is real work for the routing server rather than a lookup.

**It is asking too early.** The estimate is only ever shown when a member opens a post or the reply pane — `reachesyouat` is read in `MessageExpanded.vue` and `ChatReplyPane.vue` and nowhere else. Working it out while building the feed means paying for posts nobody opens, which for this viewer was nearly all of them. The code says as much in a comment next to the loop: "Only blocked posts pay it, which is a small minority of any feed." That assumption is what broke.

Caught live on 2026-08-13 around 09:00 UTC:

- Roughly 600 drive-time calls timed out in each of the 08:58 and 08:59 minutes, and they were all for **one viewer** — the destination coordinates were identical throughout. The same pattern had appeared twice the evening before, at 17:04–17:07 and 23:44 on 12 August, the evening the ETA was deployed.
- The routing server was at 87% CPU on db3, and db3's one-minute load was 24–31. MySQL's process list was nearly empty at the time, so this was not database work: it was the routing server burning CPU, with the machine short of memory behind it — 5.7 GB had been pushed out to swap, and the kernel was spending 31% of a core just shuffling memory around.

The two-second timeout does not help with any of this. When we give up waiting, the routing server carries on computing the answer we are no longer going to read, so an overloaded server keeps getting handed more work while it is already behind.

## What this changes

This stops the bleeding rather than moving the work to where it belongs — see the section after next. Three guards in `rippling/drivetime.go`, all of which keep the ETA strictly best-effort, since it was always allowed to be absent:

**A cap of 8 route searches in flight at once, across the whole process.** Feed traffic can no longer queue up more work than the routing host is sized for, however many blocked posts a viewer happens to be looking at.

**A 15-minute cache, keyed on the exact question being asked.** Both ends of the question repeat: a post's origin never moves, and someone polling their feed asks about the same blocked posts every time it refreshes. So the second and subsequent asks cost nothing. The cache is bounded — past 20,000 entries a write first sweeps out the expired ones — which at roughly 100 bytes an entry caps it around 2 MB.

**A breaker that stops asking when the routing server is already struggling.** Three failures in a row and we stop calling it for 30 seconds; the next success closes it again. The breaker is checked before we take a concurrency slot, so while it is open an ETA costs nothing at all. This is the part that stops us feeding a spiral: previously, the worse the routing server got, the more two-second timeouts we threw at it.

And one guard in `message/message.go`: **at most 24 ETA lookups per feed request.** The design assumed blocked posts would be a small minority of any feed, and for this viewer they were not. Past the cap, the remaining blocked posts still show as held — the member sees the same "this is held" state they see today — they just do not carry a time estimate alongside it.

## What a member notices

Nothing new, in the ordinary case. When one of the guards does bite, an affected post shows the hold without an estimate next to it, which is a state the UI already handles because the estimate could always fail.

## The fix this is not

The guards stop the incident recurring, and the per-request ceiling of 24 makes the worst case bounded. But the estimate is still worked out for posts in a feed listing, and it is only displayed when somebody opens one. Computing it when a member actually asks — on the expand or reply fetch — would take the common case from up to 24 route searches per feed page to one search when a post is opened, and the ceiling and cooldown would stop being load-bearing.

That is a change to where the work happens rather than how much of it is allowed at once, so it is worth doing deliberately and separately. Both callers of `GetMessagesByIds` share the code today, so it needs a way to say which caller wants the estimate.

## Testing

`rippling/drivetime_test.go` covers the two behaviours with real failure modes behind them, against a stubbed HTTP server: that a repeated question is answered from cache rather than re-asked, and that the breaker opens after consecutive failures and closes again on the next success.

The suites were not run locally before pushing. This host runs the production profile and has no dev containers, so the status API had nothing to run against and reported zero tests — worth being explicit about rather than implying a local run happened. CI has since passed on this commit (560b39dc3): `build-test-katapult` green, Coveralls green.
