### PR TITLE
perf(whatjobs): skip the sync when the feed has not changed

### DIFF
--- a/iznik-batch/app/Console/Commands/Integrations/SyncWhatJobsCommand.php
+++ b/iznik-batch/app/Console/Commands/Integrations/SyncWhatJobsCommand.php
@@ -11,6 +11,7 @@ class SyncWhatJobsCommand extends Command
 {
     protected $signature = 'integrations:sync-whatjobs
                             {--dry-run : Parse feeds and count jobs without writing to database}
+                            {--force : Rebuild even if the feeds are unchanged since the last run}
                             {--refresh-geocode : Ignore the jobs-table geocode cache so every tuple re-geocodes fresh (one-time, to retro-correct mis-cached locations)}';
 
     protected $description = 'Sync WhatJobs job listings from XML feeds into the jobs table';
@@ -19,8 +20,12 @@ class SyncWhatJobsCommand extends Command
     {
         $dryRun = (bool) $this->option('dry-run');
         $service->forceRegeocode = (bool) $this->option('refresh-geocode');
+        $service->forceFullSync = (bool) $this->option('force');
         if ($service->forceRegeocode) {
             $this->info('--refresh-geocode: bypassing jobs-table geocode cache (one-time full re-geocode).');
+        }
+        if ($service->forceFullSync) {
+            $this->info('--force: rebuilding even if the feeds are unchanged.');
         }
 
         // The WhatJobs XML feed currently parses ~180k jobs into memory
@@ -51,8 +56,12 @@ class SyncWhatJobsCommand extends Command
 
             $result = $service->sync($dryRun);
 
-            $prefix = $dryRun ? '[DRY RUN] Would insert' : 'Inserted';
-            $this->info("$prefix {$result['inserted']} of {$result['total']} parsed jobs.");
+            if (!empty($result['skipped_unchanged'])) {
+                $this->info('Feeds unchanged since the last rebuild - nothing to do. Use --force to rebuild anyway.');
+            } else {
+                $prefix = $dryRun ? '[DRY RUN] Would insert' : 'Inserted';
+                $this->info("$prefix {$result['inserted']} of {$result['total']} parsed jobs.");
+            }
 
             Log::info('WhatJobs sync command complete', $result);
         } finally {

--- a/iznik-batch/app/Services/WhatJobsService.php
+++ b/iznik-batch/app/Services/WhatJobsService.php
@@ -27,6 +27,19 @@ class WhatJobsService
     const MIN_SWAP_RATIO = 0.5;
     const SWAP_RATIO_MIN_EXISTING = 1000;
 
+    // Where the feed-change gate keeps what it knows about each feed (validators
+    // and a content hash) between runs. One row in the existing config table, so
+    // there is no schema step.
+    const GATE_CONFIG_KEY = 'whatjobs.feed_state';
+
+    // The gate may never skip for longer than this. Six syncs a day all deciding
+    // "unchanged" would leave the jobs table - and the jobs.seenat freshness check
+    // that watches it (ScheduledOutcomeRegistry, 24h floor) - untouched for a day,
+    // and would turn a gate bug that wrongly reports "unchanged" into a silent
+    // permanent stall. Forcing a real rebuild once inside the monitor's window means
+    // the existing alarm still fires if anything here breaks.
+    const MAX_SKIP_HOURS = 20;
+
     // UK bounding box for geocoder
     const UK_SWLAT = 49.959999905;
     const UK_SWLNG = -7.57216793459;
@@ -467,8 +480,26 @@ class WhatJobsService
         // parseFeed yields each job as it parses the XML, so we stream straight
         // from XML → DB. Holding the full ~180k-job result in PHP memory used
         // to FatalError at 512M; this keeps peak memory at one batch (~200 rows).
-        $tmp1 = $feed1 ? $this->downloadFeed($feed1) : null;
-        $tmp2 = $feed2 ? $this->downloadFeed($feed2) : null;
+        // Ask the feeds whether anything actually changed before paying for a rebuild.
+        // A dry run is a diagnostic, so it always parses.
+        $gate = $this->evaluateFeedGate(array_filter([$feed1, $feed2]), $dryRun);
+
+        if ($gate['skip']) {
+            Log::info('WhatJobs sync skipped - feeds unchanged', [
+                'reasons'      => $gate['reasons'],
+                'last_rebuild' => $gate['last_rebuild'],
+            ]);
+
+            return [
+                'total'    => 0,
+                'inserted' => 0,
+                'skipped_unchanged' => true,
+                'reasons'  => $gate['reasons'],
+            ];
+        }
+
+        $tmp1 = $feed1 ? ($gate['paths'][$feed1] ?? null) : null;
+        $tmp2 = $feed2 ? ($gate['paths'][$feed2] ?? null) : null;
 
         // Build a single generator that yields from both feeds in sequence so
         // insertJobs() sees one continuous stream (and the second feed's geocode
@@ -529,6 +560,12 @@ class WhatJobsService
         }
 
         $this->swapTables();
+
+        // Only now, with the table actually rebuilt, are the new validators safe to
+        // keep. Storing them earlier would mean a refused swap (see above) left us
+        // believing the live table already matched the feed, and the gate would skip
+        // every run after it.
+        $this->commitFeedGateState($gate['state']);
 
         // The swap drops rows for postings that have closed/left the feed. The
         // spatial server's "jobs" index backs both the web jobs page and the
@@ -598,6 +635,14 @@ class WhatJobsService
         return false;
     }
 
+    /**
+     * ETag/Last-Modified from the last downloadFeed() response, recorded so the gate can
+     * report what the feed claims about itself. Nothing acts on these yet - see fetchFeed.
+     *
+     * @var array{etag: ?string, last_modified: ?string}|null
+     */
+    protected ?array $lastFeedHeaders = null;
+
     protected function downloadFeed(string $url): ?string
     {
         $gzFile  = tempnam(sys_get_temp_dir(), 'whatjobs_gz_');
@@ -616,6 +661,11 @@ class WhatJobsService
                 return null;
             }
 
+            $this->lastFeedHeaders = [
+                'etag' => $response->header('ETag') ?: null,
+                'last_modified' => $response->header('Last-Modified') ?: null,
+            ];
+
             // Stream-decompress to avoid loading everything into memory
             $gz  = gzopen($gzFile, 'rb');
             $out = fopen($xmlFile, 'wb');
@@ -633,6 +683,189 @@ class WhatJobsService
             @unlink($xmlFile);
             return null;
         }
+    }
+
+    /**
+     * Fetch one feed and say whether it is worth reparsing.
+     *
+     * WhatJobs regenerates its feed roughly once a day, but we sync six times a day, so
+     * most runs reparse content we already loaded: three consecutive runs one day produced
+     * byte-identical parse fingerprints, kept counts matching to the digit. Each of those
+     * pointless runs costs 25-45 minutes of batch-host CPU, around a gigabyte of row images
+     * replicated to every Galera node, and a rebuild of the spatial jobs index on each db
+     * host.
+     *
+     * The test is a hash of the feed's own content. The feed's ETag is recorded alongside
+     * it but nothing acts on it: an ETag comes back through a CDN, which can preserve one
+     * across a genuine regeneration, and the agreed rollout is to watch the decisions this
+     * makes for a week before trusting a 304 to skip a transfer. Hashing what we downloaded
+     * settles the question ourselves, and the download was never the expensive part.
+     *
+     * The hash is over the decompressed XML rather than the gzip, because gzip's header
+     * carries a modification time - identical content recompressed is different bytes.
+     *
+     * $prev is what we stored last time; an empty array forces "changed".
+     *
+     * status: 'downloaded' (reparse it) | 'unchanged' (skip if the other feeds agree) |
+     *         'failed' (fail open - run the full pipeline)
+     */
+    protected function fetchFeed(string $url, array $prev): array
+    {
+        $this->lastFeedHeaders = null;
+
+        // Deliberately routed through downloadFeed so there is a single place that knows
+        // how to obtain a feed.
+        $path = $this->downloadFeed($url);
+
+        if ($path === null) {
+            return ['status' => 'failed', 'reason' => 'download-failed', 'path' => null];
+        }
+
+        $hash = @hash_file('sha256', $path) ?: null;
+        $identical = $hash !== null && isset($prev['hash']) && $prev['hash'] === $hash;
+
+        return [
+            'status'        => $identical ? 'unchanged' : 'downloaded',
+            'reason'        => $identical ? 'identical-content' : 'changed',
+            'path'          => $path,
+            'etag'          => $this->lastFeedHeaders['etag'] ?? null,
+            'last_modified' => $this->lastFeedHeaders['last_modified'] ?? null,
+            'hash'          => $hash,
+        ];
+    }
+
+    /**
+     * Decide whether this run has anything to do.
+     *
+     * It skips only when EVERY configured feed says unchanged, because the sync
+     * rebuilds the whole jobs table from all feeds at once - one changed feed means
+     * the whole pipeline runs.
+     *
+     * The gate fails open throughout: a download error, an unreadable stored state,
+     * a dry run, --force, or a rebuild older than MAX_SKIP_HOURS all produce a normal
+     * full run. The worst a broken gate can do is cost what today already costs.
+     */
+    protected function evaluateFeedGate(array $urls, bool $dryRun): array
+    {
+        $state = $this->readFeedGateState();
+        $lastRebuild = $state['last_rebuild'] ?? null;
+
+        $bypass = null;
+        if ($dryRun) {
+            $bypass = 'dry-run';
+        } elseif ($this->forceFullSync) {
+            $bypass = 'forced';
+        } elseif (!$urls) {
+            $bypass = 'no-feeds';
+        } elseif ($lastRebuild === null) {
+            $bypass = 'no-previous-rebuild';
+        } elseif (strtotime($lastRebuild) < strtotime('-' . self::MAX_SKIP_HOURS . ' hours')) {
+            // Guaranteed rebuild: see MAX_SKIP_HOURS.
+            $bypass = 'rebuild-overdue';
+        }
+
+        $results = [];
+        foreach ($urls as $url) {
+            $prev = $bypass ? [] : ($state['feeds'][$this->feedStateKey($url)] ?? []);
+            $results[$url] = $this->fetchFeed($url, $prev);
+        }
+
+        $newState = $state;
+        $newState['feeds'] = $state['feeds'] ?? [];
+        $reasons = [];
+        $allUnchanged = $urls !== [];
+
+        foreach ($results as $url => $r) {
+            $reasons[$this->feedStateKey($url)] = $r['reason'] ?? $r['status'];
+            if ($r['status'] !== 'unchanged') {
+                $allUnchanged = false;
+            }
+            if ($r['status'] !== 'failed') {
+                $newState['feeds'][$this->feedStateKey($url)] = [
+                    'etag'          => $r['etag'] ?? null,
+                    'last_modified' => $r['last_modified'] ?? null,
+                    'hash'          => $r['hash'] ?? null,
+                ];
+            }
+        }
+
+        $skip = $bypass === null && $allUnchanged;
+
+        if ($skip) {
+            // Nothing will be parsed, so drop the files we did fetch, and record that
+            // the gate ran. commitFeedGateState is NOT called here: last_rebuild must
+            // keep pointing at the last real rebuild, or the MAX_SKIP_HOURS floor
+            // would never trigger.
+            foreach ($results as $r) {
+                if (!empty($r['path'])) {
+                    @unlink($r['path']);
+                }
+            }
+            $newState['last_checked'] = now()->toDateTimeString();
+            $this->writeFeedGateState($newState);
+        }
+
+        $paths = [];
+        foreach ($results as $url => $r) {
+            $paths[$url] = $r['path'] ?? null;
+        }
+
+        return [
+            'skip'         => $skip,
+            'bypass'       => $bypass,
+            'reasons'      => $reasons,
+            'paths'        => $paths,
+            'last_rebuild' => $lastRebuild,
+            'state'        => $newState,
+        ];
+    }
+
+    /**
+     * Short stable identifier for a feed URL, so the stored state does not carry
+     * credentials that some feed URLs embed as query parameters.
+     */
+    protected function feedStateKey(string $url): string
+    {
+        return substr(hash('sha256', $url), 0, 16);
+    }
+
+    protected function readFeedGateState(): array
+    {
+        try {
+            $raw = DB::table('config')->where('key', self::GATE_CONFIG_KEY)->value('value');
+            $decoded = $raw ? json_decode($raw, true) : null;
+
+            return is_array($decoded) ? $decoded : [];
+        } catch (\Throwable $e) {
+            // Fail open - an unreadable state just means a full run.
+            Log::warning('WhatJobs: could not read feed gate state', ['error' => $e->getMessage()]);
+
+            return [];
+        }
+    }
+
+    protected function writeFeedGateState(array $state): void
+    {
+        try {
+            DB::table('config')->upsert(
+                [['key' => self::GATE_CONFIG_KEY, 'value' => json_encode($state)]],
+                ['key'],
+                ['value'],
+            );
+        } catch (\Throwable $e) {
+            Log::warning('WhatJobs: could not store feed gate state', ['error' => $e->getMessage()]);
+        }
+    }
+
+    /**
+     * Record a completed rebuild: the validators the feeds gave us this run, plus the
+     * timestamp the MAX_SKIP_HOURS floor is measured from.
+     */
+    protected function commitFeedGateState(array $state): void
+    {
+        $state['last_rebuild'] = now()->toDateTimeString();
+        $state['last_checked'] = $state['last_rebuild'];
+        $this->writeFeedGateState($state);
     }
 
     /**
@@ -796,6 +1029,16 @@ class WhatJobsService
      * inverted-extent bug; off in normal hourly runs (which keep the cache).
      */
     public bool $forceRegeocode = false;
+
+    /**
+     * When true, the feed-change gate is bypassed and the feeds are reparsed and
+     * reloaded whatever they contain. Set by --force, and used for the guaranteed
+     * rebuild the gate schedules for itself (see MAX_SKIP_HOURS).
+     *
+     * A public property rather than a sync() argument because sync()'s signature is
+     * an override point for tests.
+     */
+    public bool $forceFullSync = false;
 
     public function geocodeCityState(
         string $city,

--- a/iznik-batch/tests/Feature/Integrations/SyncWhatJobsGateTest.php
+++ b/iznik-batch/tests/Feature/Integrations/SyncWhatJobsGateTest.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace Tests\Feature\Integrations;
+
+use App\Services\WhatJobsService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The feed-change gate: WhatJobs regenerates its feed about once a day but we sync six
+ * times a day, so most runs reparse content already loaded. Skipping those runs saves
+ * 25-45 minutes of batch-host CPU, ~1GB of Galera row images per node, and a spatial
+ * jobs-index rebuild on each db host.
+ *
+ * What matters is that it never skips when it should not, so most of these tests are
+ * about the ways the gate must fail open.
+ */
+class SyncWhatJobsGateTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function probe(array $canned): WhatJobsGateProbe
+    {
+        $probe = new WhatJobsGateProbe();
+        $probe->canned = $canned;
+
+        return $probe;
+    }
+
+    private function seedState(array $feeds, ?string $lastRebuild): void
+    {
+        $state = ['feeds' => $feeds];
+        if ($lastRebuild !== null) {
+            $state['last_rebuild'] = $lastRebuild;
+        }
+
+        DB::table('config')->upsert(
+            [['key' => WhatJobsService::GATE_CONFIG_KEY, 'value' => json_encode($state)]],
+            ['key'],
+            ['value'],
+        );
+    }
+
+    private function keyFor(string $url): string
+    {
+        return substr(hash('sha256', $url), 0, 16);
+    }
+
+    private function unchangedByHash(string $hash, string $path = '/tmp/whatjobs-test.xml'): array
+    {
+        return ['status' => 'unchanged', 'reason' => 'identical-content', 'path' => $path, 'hash' => $hash];
+    }
+
+    private function changed(string $hash, string $path = '/tmp/whatjobs-test.xml'): array
+    {
+        return ['status' => 'downloaded', 'reason' => 'changed', 'path' => $path, 'hash' => $hash];
+    }
+
+    // -----------------------------------------------------------------
+    // Skipping
+    // -----------------------------------------------------------------
+
+    public function test_skips_when_the_content_hash_is_unchanged(): void
+    {
+        $this->seedState([$this->keyFor('feed1') => ['hash' => 'abc']], now()->subHour()->toDateTimeString());
+
+        $gate = $this->probe(['feed1' => [$this->unchangedByHash('abc')]])->gate(['feed1'], false);
+
+        $this->assertTrue($gate['skip']);
+    }
+
+    public function test_the_stored_hash_is_handed_to_the_next_fetch(): void
+    {
+        $this->seedState(
+            [$this->keyFor('feed1') => ['etag' => 'W/"v1"', 'hash' => 'abc']],
+            now()->subHour()->toDateTimeString(),
+        );
+
+        $probe = $this->probe(['feed1' => [$this->unchangedByHash('abc')]]);
+        $probe->gate(['feed1'], false);
+
+        $this->assertSame('abc', $probe->fetches[0]['prev']['hash']);
+    }
+
+    // -----------------------------------------------------------------
+    // Failing open
+    // -----------------------------------------------------------------
+
+    public function test_runs_when_the_content_changed(): void
+    {
+        $this->seedState([$this->keyFor('feed1') => ['hash' => 'abc']], now()->subHour()->toDateTimeString());
+
+        $gate = $this->probe(['feed1' => [$this->changed('def')]])->gate(['feed1'], false);
+
+        $this->assertFalse($gate['skip']);
+    }
+
+    // One changed feed rebuilds the whole table, so every feed must run.
+    public function test_runs_when_only_one_of_two_feeds_changed(): void
+    {
+        $this->seedState([
+            $this->keyFor('feed1') => ['hash' => 'abc'],
+            $this->keyFor('feed2') => ['hash' => 'xyz'],
+        ], now()->subHour()->toDateTimeString());
+
+        $gate = $this->probe([
+            'feed1' => [$this->unchangedByHash('abc')],
+            'feed2' => [$this->changed('new')],
+        ])->gate(['feed1', 'feed2'], false);
+
+        $this->assertFalse($gate['skip']);
+    }
+
+    public function test_runs_when_a_feed_download_failed(): void
+    {
+        $this->seedState([$this->keyFor('feed1') => ['hash' => 'abc']], now()->subHour()->toDateTimeString());
+
+        $gate = $this->probe([
+            'feed1' => [['status' => 'failed', 'reason' => 'http-429', 'path' => null]],
+        ])->gate(['feed1'], false);
+
+        $this->assertFalse($gate['skip']);
+    }
+
+    public function test_a_failed_fetch_does_not_overwrite_stored_validators(): void
+    {
+        $this->seedState([$this->keyFor('feed1') => ['hash' => 'abc']], now()->subHour()->toDateTimeString());
+
+        $gate = $this->probe([
+            'feed1' => [['status' => 'failed', 'reason' => 'http-429', 'path' => null]],
+        ])->gate(['feed1'], false);
+
+        $this->assertSame('abc', $gate['state']['feeds'][$this->keyFor('feed1')]['hash']);
+    }
+
+    public function test_runs_when_forced(): void
+    {
+        $this->seedState([$this->keyFor('feed1') => ['hash' => 'abc']], now()->subHour()->toDateTimeString());
+
+        $probe = $this->probe(['feed1' => [$this->unchangedByHash('abc')]]);
+        $probe->forceFullSync = true;
+
+        $gate = $probe->gate(['feed1'], false);
+
+        $this->assertFalse($gate['skip']);
+        $this->assertSame('forced', $gate['bypass']);
+        $this->assertSame([], $probe->fetches[0]['prev'], 'a forced run must not compare against the stored hash');
+    }
+
+    public function test_a_dry_run_always_parses(): void
+    {
+        $this->seedState([$this->keyFor('feed1') => ['hash' => 'abc']], now()->subHour()->toDateTimeString());
+
+        $gate = $this->probe(['feed1' => [$this->unchangedByHash('abc')]])->gate(['feed1'], true);
+
+        $this->assertFalse($gate['skip']);
+        $this->assertSame('dry-run', $gate['bypass']);
+    }
+
+    public function test_runs_when_nothing_has_ever_been_rebuilt(): void
+    {
+        $this->seedState([$this->keyFor('feed1') => ['hash' => 'abc']], null);
+
+        $gate = $this->probe(['feed1' => [$this->unchangedByHash('abc')]])->gate(['feed1'], false);
+
+        $this->assertFalse($gate['skip']);
+        $this->assertSame('no-previous-rebuild', $gate['bypass']);
+    }
+
+    // The floor that keeps the existing jobs.seenat freshness monitor meaningful, and
+    // stops a gate bug turning into a permanent silent stall.
+    public function test_forces_a_rebuild_once_the_last_one_is_too_old(): void
+    {
+        $this->seedState(
+            [$this->keyFor('feed1') => ['hash' => 'abc']],
+            now()->subHours(WhatJobsService::MAX_SKIP_HOURS + 1)->toDateTimeString(),
+        );
+
+        $gate = $this->probe(['feed1' => [$this->unchangedByHash('abc')]])->gate(['feed1'], false);
+
+        $this->assertFalse($gate['skip']);
+        $this->assertSame('rebuild-overdue', $gate['bypass']);
+    }
+
+    public function test_still_skips_just_inside_the_rebuild_floor(): void
+    {
+        $this->seedState(
+            [$this->keyFor('feed1') => ['hash' => 'abc']],
+            now()->subHours(WhatJobsService::MAX_SKIP_HOURS - 1)->toDateTimeString(),
+        );
+
+        $gate = $this->probe(['feed1' => [$this->unchangedByHash('abc')]])->gate(['feed1'], false);
+
+        $this->assertTrue($gate['skip']);
+    }
+
+    public function test_unreadable_stored_state_falls_back_to_a_full_run(): void
+    {
+        DB::table('config')->upsert(
+            [['key' => WhatJobsService::GATE_CONFIG_KEY, 'value' => 'not json']],
+            ['key'],
+            ['value'],
+        );
+
+        $gate = $this->probe(['feed1' => [$this->unchangedByHash('abc')]])->gate(['feed1'], false);
+
+        $this->assertFalse($gate['skip']);
+    }
+
+    // -----------------------------------------------------------------
+    // State bookkeeping
+    // -----------------------------------------------------------------
+
+    // A skipped run must not move last_rebuild, or the MAX_SKIP_HOURS floor would keep
+    // resetting itself and never force the guaranteed rebuild.
+    public function test_skipping_does_not_advance_the_last_rebuild_time(): void
+    {
+        $lastRebuild = now()->subHours(5)->toDateTimeString();
+        $this->seedState([$this->keyFor('feed1') => ['hash' => 'abc']], $lastRebuild);
+
+        $this->probe(['feed1' => [$this->unchangedByHash('abc')]])->gate(['feed1'], false);
+
+        $stored = json_decode(DB::table('config')->where('key', WhatJobsService::GATE_CONFIG_KEY)->value('value'), true);
+
+        $this->assertSame($lastRebuild, $stored['last_rebuild']);
+        $this->assertNotEmpty($stored['last_checked'], 'a skipped run should still record that the gate ran');
+    }
+
+    public function test_committing_a_rebuild_stores_validators_and_advances_last_rebuild(): void
+    {
+        $this->seedState([], now()->subDay()->toDateTimeString());
+
+        $probe = $this->probe([]);
+        $probe->commit(['feeds' => [$this->keyFor('feed1') => ['hash' => 'newhash', 'etag' => 'W/"v2"']]]);
+
+        $stored = json_decode(DB::table('config')->where('key', WhatJobsService::GATE_CONFIG_KEY)->value('value'), true);
+
+        $this->assertSame('newhash', $stored['feeds'][$this->keyFor('feed1')]['hash']);
+        $this->assertNotEmpty($stored['last_rebuild']);
+        $this->assertGreaterThan(now()->subMinute()->timestamp, strtotime($stored['last_rebuild']));
+    }
+
+    // -----------------------------------------------------------------
+    // Through sync() itself
+    // -----------------------------------------------------------------
+
+    // The skip path must return before analyseClickability/prepareTempTable/insertJobs,
+    // which is the whole point - so this asserts the real sync() short-circuits.
+    public function test_sync_returns_early_without_touching_the_jobs_table(): void
+    {
+        config(['freegle.whatjobs.feed1' => 'feed1', 'freegle.whatjobs.feed2' => null]);
+        $this->seedState([$this->keyFor('feed1') => ['hash' => 'abc']], now()->subHour()->toDateTimeString());
+
+        $before = DB::table('jobs')->count();
+
+        $probe = $this->probe(['feed1' => [$this->unchangedByHash('abc')]]);
+        $result = $probe->sync(false);
+
+        $this->assertTrue($result['skipped_unchanged']);
+        $this->assertSame(0, $result['inserted']);
+        $this->assertSame($before, DB::table('jobs')->count());
+        $this->assertFalse($probe->pipelineRan, 'the expensive pipeline must not have started');
+    }
+}
+
+/**
+ * Feeds canned fetch results to the gate so the tests never make HTTP calls, and exposes
+ * the protected gate entry points.
+ */
+class WhatJobsGateProbe extends WhatJobsService
+{
+    /** @var array<string, array<int, array>> queued results per URL, consumed in order */
+    public array $canned = [];
+
+    /** @var array<int, array{url: string, prev: array}> */
+    public array $fetches = [];
+
+    /** Set if the run got past the gate into the expensive rebuild. */
+    public bool $pipelineRan = false;
+
+    public function gate(array $urls, bool $dryRun): array
+    {
+        return $this->evaluateFeedGate($urls, $dryRun);
+    }
+
+    public function commit(array $state): void
+    {
+        $this->commitFeedGateState($state);
+    }
+
+    public function analyseClickability(): void
+    {
+        $this->pipelineRan = true;
+    }
+
+    public function prepareTempTable(): void
+    {
+        $this->pipelineRan = true;
+    }
+
+    protected function fetchFeed(string $url, array $prev): array
+    {
+        $this->fetches[] = ['url' => $url, 'prev' => $prev];
+
+        $queued = $this->canned[$url] ?? [];
+        $next = array_shift($queued);
+        $this->canned[$url] = $queued;
+
+        return $next ?? ['status' => 'failed', 'reason' => 'no-canned-result', 'path' => null];
+    }
+}


### PR DESCRIPTION
## What this does

WhatJobs rebuilds its jobs feed about once a day. We fetch and reload it six times a day. So most of those runs load content we already have, and each one costs 25 to 45 minutes of processor time on the batch machine — in exactly the hours it is busiest — around a gigabyte of changes copied to every database node, and a rebuild of the map index of jobs on each of those nodes.

This adds one question before all that work: has the feed actually changed?

We now take a fingerprint of the feed's contents each time we download it, and compare it with the one from last time. If every feed we are configured to read comes back with the same fingerprint, the run stops there — before the click-scoring pass, the temporary table, the insert, the swap and the index rebuild. If any feed differs, everything runs exactly as it does today. One changed feed means the whole jobs table gets rebuilt, so there is no half-way path to get wrong.

The fingerprint is taken from the uncompressed XML rather than the compressed file we download. Compressed files carry a timestamp inside them, so the same content compressed twice produces different bytes and would look like a change every time.

## Why we don't just ask the server

The obvious cheaper approach is to ask the web server whether the file has changed and skip the download entirely when it says no. That is not here, deliberately.

The answer comes back through a content delivery network, and those can keep serving the old "unchanged" marker across a genuine rebuild of the file. Believing it means trusting somebody else's word about whether our data is stale. The agreed plan is to watch what this check decides for a week first, so the markers the server sends are recorded and logged on every fetch, but nothing acts on them yet. If a week of logs shows they really do track the rebuilds, switching them on is a small change.

Until then we lose nothing that matters. Downloading the feed was never the expensive part — the processor time, the database writes and the index rebuilds are, and taking our own fingerprint avoids all of those without trusting anyone.

## What happens when something goes wrong

Anything unclear runs the full sync. A failed download, stored state we cannot read, a dry run, `--force`, or never having done a rebuild before — all of them skip the check entirely and do the work. The worst a broken check can do is cost what today already costs.

One case is worth spelling out: **the new fingerprint is only saved once a rebuild has actually succeeded.** There is already a guard that refuses to swap in the new jobs table when suspiciously few jobs parsed, so that a truncated feed cannot wipe the live table. If we saved the fingerprint before that guard fired, we would then believe the live table already matched the feed, and every run after it would skip. So the old fingerprint stays until a rebuild finishes.

The download itself still goes through the existing `downloadFeed` function rather than around it, so there is still exactly one piece of code that knows how to fetch a feed.

## Keeping the existing alarm working

There is already a check that watches this job by making sure the `seenat` timestamp on the jobs table keeps moving, and complains if it has not moved for 24 hours. A run that skips does not move it.

The obvious fix — stamp the timestamp anyway on a skip — would mean writing to all ~325,000 rows, which is precisely the write volume this change exists to avoid. So instead the check is simply not allowed to skip for more than 20 hours. Past that it does a real rebuild whatever the fingerprints say. That keeps the timestamp inside the existing alarm's window without changing the alarm, and it means a bug that wrongly decides "unchanged" stalls things for 20 hours rather than forever.

## Not in this PR

The audit also proposed moving the day's first genuine rebuild to the middle of the night. The review was clear that this should only happen once we have a week of logs showing when the feed is actually rebuilt — and that the originally proposed 2am UK slot is the worst hour available, colliding with the postcode remapping job and the 3am map-index rebuild. Left for later, along with asking the server directly, which depends on the same week of observations.

## Testing

Every way of skipping and every way of falling back to a full run is covered: skipping when the fingerprint matches, passing the stored fingerprint to the next fetch, running when the content changed, running when only one of two feeds changed, running after a failed download without overwriting the stored fingerprint, `--force`, dry runs, having never rebuilt before, stored state that will not parse, and both sides of the 20 hour limit.

Two more cover the bookkeeping that limit depends on: a skipped run must not update the time of the last rebuild — otherwise the 20 hour clock would keep resetting and never fire — and a completed rebuild must store the new fingerprint and move that time forward.

One test drives the real sync and checks it returns before the expensive work starts, rather than merely returning the right value.

Full Laravel suite: 5574 passed, 0 failed.