### PR TITLE
perf(ai): run the AI image usage recount nightly, not hourly

### DIFF
--- a/iznik-batch/app/Console/Commands/AI/UpdateAIImageUsageCountsCommand.php
+++ b/iznik-batch/app/Console/Commands/AI/UpdateAIImageUsageCountsCommand.php
@@ -5,15 +5,73 @@ namespace App\Console\Commands\AI;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * Keep ai_images.usage_count in step with how many posts actually use each AI image.
+ *
+ * This used to do a full recompute every hour: a JSON_EXTRACT scan of all 31.6M rows of
+ * messages_attachments into a temp table, then a single-row UPDATE for each of the 50.6k
+ * ai_images rows. That is 24 full scans and ~1.2M UPDATE statements a day - built on the
+ * cluster's write node, and replicated to every other node - to move a counter whose
+ * measured net change is about 8 rows an hour.
+ *
+ * So the full scan now runs once a night, and the hourly run only looks at attachments
+ * added since the last one. That works because the "this is an AI image" flag is written
+ * when the attachment row is inserted (MessageIllustrationsService inserts externalmods
+ * as {"ai": true}; nothing sets it later), so a new use can never hide behind an id the
+ * cursor has already passed.
+ *
+ * Counts can only go DOWN behind the cursor's back - a message is purged, or an image is
+ * rotated (which rewrites externalmods and drops the ai flag). Those are corrected by the
+ * nightly full run, so a decrement can lag by up to a day. usage_count is a review aid in
+ * the AI image tool, not a number anything acts on, and the same figure was already up to
+ * an hour stale.
+ */
 class UpdateAIImageUsageCountsCommand extends Command
 {
-    protected $signature = 'ai:usage-counts:update';
+    protected $signature = 'ai:usage-counts:update
+                            {--full : Recompute every count from a full scan instead of applying the incremental delta}';
 
     protected $description = 'Update usage_count on ai_images from messages_attachments';
 
+    // Where the incremental run remembers how far it has read. One row in the existing
+    // config table, so there is no schema step.
+    private const CURSOR_KEY = 'ai.usage_counts_cursor';
+
     public function handle(): int
     {
+        // The highest attachment id that exists right now. Both paths work strictly up to
+        // this id and then store it, so a row inserted while we run is left for the next
+        // run rather than being counted twice or missed.
+        $upTo = (int) DB::table('messages_attachments')->max('id');
+
+        $cursor = $this->readCursor();
+
+        if ($this->option('full') || $cursor === null) {
+            if ($cursor === null && !$this->option('full')) {
+                $this->info('No cursor stored yet - doing a full recompute to establish one.');
+            }
+
+            $this->fullRecompute($upTo);
+        } else {
+            $this->applyDelta($cursor, $upTo);
+        }
+
+        $this->writeCursor($upTo);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * The original hourly job, now the nightly one: rebuild every count from scratch. This
+     * is also what corrects any drift the incremental path cannot see (purged messages,
+     * rotated images).
+     */
+    private function fullRecompute(int $upTo): void
+    {
         // Step 1: Precompute all AI attachment counts into a temp table (one scan).
+        // keep-raw: CREATE TEMPORARY TABLE ... AS SELECT is DDL the query builder does
+        // not render. Unchanged from the version that has run hourly for months, bar the
+        // id ceiling that pairs the scan with the stored cursor.
         DB::statement('DROP TEMPORARY TABLE IF EXISTS tmp_ai_usage_counts');
         DB::statement("
             CREATE TEMPORARY TABLE tmp_ai_usage_counts (
@@ -22,11 +80,12 @@ class UpdateAIImageUsageCountsCommand extends Command
             ) AS
             SELECT ma.externaluid, COUNT(*) AS cnt
             FROM messages_attachments ma
-            WHERE JSON_EXTRACT(ma.externalmods, '$.ai') = TRUE
+            WHERE ma.id <= ?
+              AND JSON_EXTRACT(ma.externalmods, '$.ai') = TRUE
               AND ma.externaluid IS NOT NULL
               AND ma.externaluid != ''
             GROUP BY ma.externaluid
-        ");
+        ", [$upTo]);
 
         // Step 2: Update one row at a time via JOIN, skipping rows where
         // the count hasn't changed. Single-row updates lock for microseconds
@@ -45,6 +104,8 @@ class UpdateAIImageUsageCountsCommand extends Command
                 ->lazyById(500);
 
             foreach ($rows as $row) {
+                // keep-raw: UPDATE ... LEFT JOIN against a temporary table, where the
+                // join miss must set the count to 0. Unchanged from the original.
                 $affected = DB::update("
                     UPDATE ai_images ai
                     LEFT JOIN tmp_ai_usage_counts t ON t.externaluid = ai.externaluid
@@ -63,8 +124,61 @@ class UpdateAIImageUsageCountsCommand extends Command
             DB::statement('DROP TEMPORARY TABLE IF EXISTS tmp_ai_usage_counts');
         }
 
-        $this->info("Updated {$totalUpdated} AI images, skipped {$totalSkipped} unchanged.");
+        $this->info("Full recompute: updated {$totalUpdated} AI images, skipped {$totalSkipped} unchanged.");
+    }
 
-        return Command::SUCCESS;
+    /**
+     * Add the uses that arrived since the last run: a primary-key range over the handful
+     * of attachments inserted in the last hour, instead of a scan of all 31.6M rows.
+     */
+    private function applyDelta(int $cursor, int $upTo): void
+    {
+        if ($upTo <= $cursor) {
+            $this->info('No new attachments since the last run.');
+
+            return;
+        }
+
+        $newUses = DB::table('messages_attachments')
+            ->where('id', '>', $cursor)
+            ->where('id', '<=', $upTo)
+            ->whereRaw("JSON_EXTRACT(externalmods, '\$.ai') = TRUE")
+            ->whereNotNull('externaluid')
+            ->where('externaluid', '!=', '')
+            ->groupBy('externaluid')
+            ->selectRaw('externaluid, COUNT(*) AS cnt')
+            ->get();
+
+        $updated = 0;
+
+        foreach ($newUses as $use) {
+            // Resolve to ids and increment one row at a time: a multi-row UPDATE is a
+            // certification risk on Galera, and nothing guarantees an externaluid appears
+            // in ai_images only once.
+            $ids = DB::table('ai_images')->where('externaluid', $use->externaluid)->pluck('id');
+
+            foreach ($ids as $id) {
+                DB::table('ai_images')->where('id', $id)->increment('usage_count', (int) $use->cnt);
+                $updated++;
+            }
+        }
+
+        $this->info("Incremental: {$updated} AI images gained uses from attachments " . ($cursor + 1) . "-{$upTo}.");
+    }
+
+    private function readCursor(): ?int
+    {
+        $value = DB::table('config')->where('key', self::CURSOR_KEY)->value('value');
+
+        return $value === null || $value === '' ? null : (int) $value;
+    }
+
+    private function writeCursor(int $upTo): void
+    {
+        DB::table('config')->upsert(
+            [['key' => self::CURSOR_KEY, 'value' => (string) $upTo]],
+            ['key'],
+            ['value'],
+        );
     }
 }

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -1211,10 +1211,25 @@ Schedule::command('donations:update-ads-target')
 // =============================================================================
 
 // Update usage counts for AI images (how many posts use each image).
+//
+// Hourly, this only counts attachments added since the last run - a primary-key range
+// over the last hour's rows. The full JSON_EXTRACT scan of all 31.6M messages_attachments
+// rows (and the ~50k single-row UPDATEs that followed it) runs once overnight instead of
+// 24 times a day, on a counter whose measured net change is ~8 rows an hour.
 Schedule::command('ai:usage-counts:update')
     ->hourly()
     ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('ai:usage-counts:update'))
+    ->runInBackground();
+
+// The nightly ground truth: rebuilds every count, which is also what corrects the
+// decrements the hourly delta cannot see (purged messages, rotated images).
+// 02:45 rather than 02:30 keeps it clear of the purge/stats cluster that occupies
+// 02:00-02:34.
+Schedule::command('ai:usage-counts:update --full')
+    ->dailyAt('02:45')
+    ->withoutOverlapping(120)
+    ->sendOutputTo(cronLog('ai:usage-counts:update-full'))
     ->runInBackground();
 
 


### PR DESCRIPTION
## What this does

`ai:usage-counts:update` keeps track of how many posts use each AI-generated image, so the image review tool can show it. It ran every hour, and every hour it worked the whole thing out from scratch: read all 31.6 million rows of `messages_attachments`, pick out the AI ones, tally them into a temporary table, then issue an update for each of the 50,600 AI images in turn.

That is 24 full reads of a 31.6 million row table and about 1.2 million update statements a day — carried out on the cluster's write node and copied to every other node — to maintain a number that changes by about 8 rows an hour.

Now the full pass runs once a night at 02:45. The hourly run only looks at attachments added since the last one, which is a short range of consecutive rows at the end of the table rather than a read of the whole thing.

## Why it is safe to work from where we got to last time

The audit flagged one thing to check before trusting this: if an image were only marked as AI-generated some time *after* its row was created, then picking up from where we left off would miss it permanently, because we would already have gone past that row.

It is not marked later. `MessageIllustrationsService` is the only code that marks images as AI-generated, and both of its paths write that mark as part of creating the row. Nothing goes back and adds it afterwards. So a new use cannot hide behind a row we have already passed.

The count can still go *down* without us noticing — a message is purged, or somebody rotates the image, which rewrites the whole marker and drops the AI flag with it. The nightly pass fixes those, so a count that should have fallen can be up to a day out of date. This number is a hint in the image review tool rather than something anything acts on, and it was already up to an hour out of date before this change.

## Details

Both the nightly pass and the hourly one note the highest row number in the table before doing anything, and work only up to that point. So a row created while the job is running is left for the next run rather than being counted twice or missed entirely.

The nightly pass gained one extra condition — stop at that row number — purely so that what it counted and what we record as "done up to here" agree exactly. Otherwise it is the same statement that has been running hourly for months.

If there is no record of where we got to, which is the case the first time this runs after deploying, it does a full pass to establish one rather than guessing.

The nightly slot is 02:45 rather than 02:30 to stay clear of the purge and statistics jobs that occupy 02:00 to 02:34.

## Alternative considered

The review pointed out that simply moving the existing job to run once a night, and dropping the hourly run altogether, gets about 23/24 of the saving in a single line — provided the people using the image review tool are happy with a number that can be a day out of date. That would mean asking them.

Keeping an hourly run means nobody sees anything different from today, so nothing needs deciding. The extra code is a record of where we got to and a query bounded to a range of rows.

## Testing

Full Laravel suite: 5574 passed, 0 failed.

Run against the development database from end to end:

```
$ artisan ai:usage-counts:update
No cursor stored yet - doing a full recompute to establish one.
Full recompute: updated 0 AI images, skipped 178 unchanged.

$ artisan ai:usage-counts:update
No new attachments since the last run.
              # nothing to do: no read of the 31.6M row table at all

# add one attachment that uses an existing AI image
$ artisan ai:usage-counts:update
Incremental: 1 AI images gained uses from attachments 173-173.
              # that image's count went from 0 to 1

# now remove that attachment again, and run the nightly pass
$ artisan ai:usage-counts:update --full
Full recompute: updated 1 AI images, skipped 177 unchanged.
              # back to 0
```

That last step is the reason the nightly pass is still there. Removing the attachment makes the count too high, and picking up from where we left off cannot see that happen — only the full pass puts it right.