### PR TITLE
perf(chat): only re-check reply expectations for chats where something happened

### DIFF
--- a/iznik-batch/app/Console/Commands/Chat/UpdateChatExpectedCommand.php
+++ b/iznik-batch/app/Console/Commands/Chat/UpdateChatExpectedCommand.php
@@ -13,7 +13,8 @@ class UpdateChatExpectedCommand extends Command
     use GracefulShutdown, LogsBatchJob;
 
     protected $signature = 'chats:update-expected
-                            {--dry-run : Show what would be done without actually changing}';
+                            {--dry-run : Show what would be done without actually changing}
+                            {--full : Re-check every waiting message rather than only chats with recent activity}';
 
     protected $description = 'Update chat reply-expectation tracking and per-user reply-time metrics';
 
@@ -22,22 +23,24 @@ class UpdateChatExpectedCommand extends Command
         $this->registerShutdownHandlers();
 
         $dryRun = (bool) $this->option('dry-run');
+        $full = (bool) $this->option('full');
 
         if ($dryRun) {
             $this->info('DRY RUN — counting changes but not writing.');
         }
 
-        return $this->runWithLogging(function () use ($service, $dryRun) {
+        return $this->runWithLogging(function () use ($service, $dryRun, $full) {
             if (!$dryRun) {
                 Log::info('Starting chat expected update');
             }
 
-            $stats = $service->updateChatExpected($dryRun);
+            $stats = $service->updateChatExpected($dryRun, $full);
 
             $verb = $dryRun ? 'Would clear' : 'Cleared';
             $verb2 = $dryRun ? 'Would update' : 'Expected update:';
             $this->info("{$verb} replyexpected for {$stats['deleted_cleared']} deleted-user messages, {$stats['spam_cleared']} spam messages.");
-            $this->info("{$verb2} {$stats['waiting']} waiting, {$stats['received']} received.");
+            $scope = $stats['full'] ? 'all waiting messages' : 'chats with recent activity';
+            $this->info("{$verb2} checked {$stats['checked']} messages across {$scope} - {$stats['waiting']} waiting, {$stats['received']} received.");
 
             if (!$dryRun) {
                 Log::info('Chat expected update complete', $stats);

--- a/iznik-batch/app/Services/ChatExpectedService.php
+++ b/iznik-batch/app/Services/ChatExpectedService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\ChatMessage;
 use App\Models\ChatRoom;
 use App\Services\Ripple\RippleReplyService;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -27,17 +28,27 @@ class ChatExpectedService
     /** Days back to look when computing reply-time statistics. */
     private const REPLY_TIME_LOOKBACK_DAYS = 90;
 
+    /** Where the incremental run remembers how far it has read. */
+    private const CURSOR_KEY = 'chat.expected_cursor';
+
+    /**
+     * How far back before the last run's start time to look for released replies. The job
+     * runs every five minutes, so this is generous room for a long run or a clock that has
+     * been nudged, at the cost of re-checking a few chats.
+     */
+    private const RELEASE_OVERLAP_MINUTES = 15;
+
     /**
      * Orchestrates the full expected-reply update cycle.
      * Mirrors V1 cron/chat_expected.php top-level flow.
      *
-     * @return array{deleted_cleared: int, spam_cleared: int, waiting: int, received: int}
+     * @return array{deleted_cleared: int, spam_cleared: int, waiting: int, received: int, checked: int, full: bool}
      */
-    public function updateChatExpected(bool $dryRun = false): array
+    public function updateChatExpected(bool $dryRun = false, bool $full = false): array
     {
         $deleted = $this->tidyDeletedUsersReplies($dryRun);
         $spam = $this->tidySpamUsersReplies($dryRun);
-        $stats = $this->updateExpected($dryRun);
+        $stats = $this->updateExpected($dryRun, $full);
 
         return array_merge(['deleted_cleared' => $deleted, 'spam_cleared' => $spam], $stats);
     }
@@ -123,23 +134,67 @@ class ChatExpectedService
      *
      * Mirrors V1 ChatRoom::updateExpected().
      *
-     * @return array{waiting: int, received: int}
+     * Every five minutes this used to re-ask the same question about all ~1,925 messages
+     * still waiting for a reply - a chat_messages count per message - and then write the
+     * same value=-1 row back for every one of them that was still waiting, which is where
+     * the ~550k no-op writes a day came from. Both are avoidable:
+     *
+     *   - A waiting message can only stop waiting when a reply becomes deliverable, so only
+     *     chats that have had something happen need re-checking.
+     *   - A row whose value is already what we are about to write does not need writing.
+     *
+     * "Something happened" means a new chat message, OR a rippling-held reply being
+     * released: a held reply is already in chat_messages but does not count until release,
+     * so releasing one makes a reply deliverable without any new message arriving. Every
+     * release path stamps rippling_held_replies.releasedat, so both are covered by a
+     * bounded query and no release path has to remember to tell us.
+     *
+     * $full re-checks every waiting message. That is what the nightly run does, and it is
+     * the backstop for anything the two triggers above cannot see.
+     *
+     * @return array{waiting: int, received: int, checked: int, full: bool}
      */
-    public function updateExpected(bool $dryRun = false): array
+    public function updateExpected(bool $dryRun = false, bool $full = false): array
     {
-        $oldest = now()->subDays(self::LOOKBACK_DAYS)->startOfDay()->toDateTimeString();
+        // Both watermarks are taken BEFORE any work, so anything that arrives while we run
+        // is left for the next run rather than being skipped by a cursor that moved past it.
+        $startedAt = now();
+        $highWater = (int) DB::table('chat_messages')->max('id');
 
-        $pending = DB::select(
-            "SELECT cm.id, cm.userid, cm.chatid, cm.date,
-                    cr.user1, cr.user2
-             FROM chat_messages cm
-             INNER JOIN chat_rooms cr ON cr.id = cm.chatid
-             WHERE cm.date >= ?
-               AND cm.replyexpected = 1
-               AND cm.replyreceived = 0
-               AND cr.chattype = ?",
-            [$oldest, ChatRoom::TYPE_USER2USER]
-        );
+        $oldest = now()->subDays(self::LOOKBACK_DAYS)->startOfDay()->toDateTimeString();
+        $cursor = $this->readCursor();
+
+        // No cursor yet means we have never run incrementally, so there is no safe delta to
+        // take - do the whole thing and establish one.
+        $doFull = $full || $cursor === null;
+
+        $query = DB::table('chat_messages as cm')
+            ->join('chat_rooms as cr', 'cr.id', '=', 'cm.chatid')
+            ->where('cm.date', '>=', $oldest)
+            ->where('cm.replyexpected', 1)
+            ->where('cm.replyreceived', 0)
+            ->where('cr.chattype', ChatRoom::TYPE_USER2USER)
+            ->select('cm.id', 'cm.userid', 'cm.chatid', 'cm.date', 'cr.user1', 'cr.user2');
+
+        if (!$doFull) {
+            $chatids = $this->chatsWithActivitySince($cursor);
+
+            if (empty($chatids)) {
+                if (!$dryRun) {
+                    $this->writeCursor($startedAt, $highWater);
+                }
+
+                return ['waiting' => 0, 'received' => 0, 'checked' => 0, 'full' => false];
+            }
+
+            $query->whereIn('cm.chatid', $chatids);
+        }
+
+        $pending = $query->get();
+
+        // What users_expected already says about these messages, so we only write where the
+        // answer has actually changed.
+        $existing = $this->existingExpectedValues($pending->pluck('id')->all());
 
         $waiting = 0;
         $received = 0;
@@ -156,34 +211,115 @@ class ChatExpectedService
                 ->whereRaw(RippleReplyService::deliveryGateSql('chat_messages.id'))
                 ->count();
 
-            if ($replyCount > 0) {
-                if (!$dryRun) {
-                    DB::update('UPDATE chat_messages SET replyreceived = 1 WHERE id = ?', [$msg->id]);
+            $value = $replyCount > 0 ? 1 : -1;
 
-                    DB::statement(
-                        'INSERT IGNORE INTO users_expected (expecter, expectee, chatmsgid, value)
-                         VALUES (?, ?, ?, 1)
-                         ON DUPLICATE KEY UPDATE value = 1',
-                        [$msg->userid, $other, $msg->id]
-                    );
+            if (!$dryRun) {
+                if ($value === 1) {
+                    DB::update('UPDATE chat_messages SET replyreceived = 1 WHERE id = ?', [$msg->id]);
                 }
 
+                if (($existing[$msg->id] ?? null) !== $value) {
+                    // keep-raw: INSERT ... ON DUPLICATE KEY UPDATE against the chatmsgid
+                    // unique key. upsert() would name every column in the update clause;
+                    // this must only ever touch value.
+                    DB::statement(
+                        'INSERT INTO users_expected (expecter, expectee, chatmsgid, value)
+                         VALUES (?, ?, ?, ?)
+                         ON DUPLICATE KEY UPDATE value = VALUES(value)',
+                        [$msg->userid, $other, $msg->id, $value]
+                    );
+                }
+            }
+
+            if ($value === 1) {
                 $received++;
             } else {
-                if (!$dryRun) {
-                    DB::statement(
-                        'INSERT IGNORE INTO users_expected (expecter, expectee, chatmsgid, value)
-                         VALUES (?, ?, ?, -1)
-                         ON DUPLICATE KEY UPDATE value = -1',
-                        [$msg->userid, $other, $msg->id]
-                    );
-                }
-
                 $waiting++;
             }
         }
 
-        return compact('waiting', 'received');
+        if (!$dryRun) {
+            $this->writeCursor($startedAt, $highWater);
+        }
+
+        return ['waiting' => $waiting, 'received' => $received, 'checked' => $pending->count(), 'full' => $doFull];
+    }
+
+    /**
+     * Chats where a reply could have become deliverable since the last run: one that had a
+     * new message, and one whose held reply was released.
+     *
+     * @return int[]
+     */
+    private function chatsWithActivitySince(array $cursor): array
+    {
+        $chatids = DB::table('chat_messages')
+            ->where('id', '>', $cursor['chatmsgid'])
+            ->distinct()
+            ->pluck('chatid')
+            ->all();
+
+        $releasedSince = Carbon::parse($cursor['at'])->subMinutes(self::RELEASE_OVERLAP_MINUTES)->toDateTimeString();
+
+        $released = DB::table('rippling_held_replies')
+            ->where('status', 'released')
+            ->where('releasedat', '>=', $releasedSince)
+            ->distinct()
+            ->pluck('chatid')
+            ->all();
+
+        return array_values(array_unique(array_merge($chatids, $released)));
+    }
+
+    /**
+     * Current users_expected values for these chat message ids, keyed by chatmsgid.
+     *
+     * @param  int[]  $chatmsgids
+     * @return array<int, int>
+     */
+    private function existingExpectedValues(array $chatmsgids): array
+    {
+        $values = [];
+
+        foreach (array_chunk($chatmsgids, 1000) as $chunk) {
+            foreach (DB::table('users_expected')->whereIn('chatmsgid', $chunk)->select('chatmsgid', 'value')->get() as $row) {
+                $values[(int) $row->chatmsgid] = (int) $row->value;
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array{chatmsgid: int, at: string}|null
+     */
+    private function readCursor(): ?array
+    {
+        $raw = DB::table('config')->where('key', self::CURSOR_KEY)->value('value');
+        $decoded = $raw ? json_decode($raw, true) : null;
+
+        if (!is_array($decoded) || !isset($decoded['chatmsgid'], $decoded['at'])) {
+            return null;
+        }
+
+        return ['chatmsgid' => (int) $decoded['chatmsgid'], 'at' => (string) $decoded['at']];
+    }
+
+    /**
+     * Store where this run got to, using the watermarks taken before the work started.
+     */
+    private function writeCursor(Carbon $startedAt, int $highWater): void
+    {
+        $value = json_encode([
+            'chatmsgid' => $highWater,
+            'at' => $startedAt->toDateTimeString(),
+        ]);
+
+        DB::table('config')->upsert(
+            [['key' => self::CURSOR_KEY, 'value' => $value]],
+            ['key'],
+            ['value'],
+        );
     }
 
     /**

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -455,10 +455,24 @@ Schedule::command('users:update-lastaccess')
 
 // Update chat reply-expectation tracking and per-user reply-time metrics.
 // V1: cron/chat_expected.php (every 5 minutes)
+//
+// Every five minutes this only looks at chats that have had a new message, or a
+// rippling-held reply released, since the last run - a waiting message cannot stop
+// waiting otherwise. It used to re-ask about all ~1,925 waiting messages each time and
+// rewrite the same answer back, which is where ~550k no-op writes a day came from.
 Schedule::command('chats:update-expected')
     ->everyFiveMinutes()
     ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('chats:update-expected'))
+    ->runInBackground();
+
+// The nightly backstop: re-check every waiting message, catching anything the two
+// triggers above cannot see. 04:30 sits in the quiet gap after the purge/stats cluster
+// and clear of db1's 04:00-04:17 backup window.
+Schedule::command('chats:update-expected --full')
+    ->dailyAt('04:30')
+    ->withoutOverlapping(60)
+    ->sendOutputTo(cronLog('chats:update-expected-full'))
     ->runInBackground();
 
 // Send calendar invites and chat reminders for arranged handover trysts.

--- a/iznik-batch/tests/Unit/Commands/Chat/UpdateExpectedCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Chat/UpdateExpectedCommandTest.php
@@ -13,8 +13,8 @@ class UpdateExpectedCommandTest extends TestCase
         $service = $this->createMock(ChatExpectedService::class);
         $service->expects($this->once())
             ->method('updateChatExpected')
-            ->with(true)
-            ->willReturn(['deleted_cleared' => 0, 'spam_cleared' => 0, 'waiting' => 0, 'received' => 0]);
+            ->with(true, false)
+            ->willReturn(['deleted_cleared' => 0, 'spam_cleared' => 0, 'waiting' => 0, 'received' => 0, 'checked' => 0, 'full' => false]);
 
         $this->app->instance(ChatExpectedService::class, $service);
 

--- a/iznik-batch/tests/Unit/Services/ChatExpectedServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChatExpectedServiceTest.php
@@ -175,6 +175,148 @@ class ChatExpectedServiceTest extends TestCase
         $this->assertEquals(-1, $row->value);
     }
 
+    // -------------------------------------------------------------------------
+    // updateExpected: incremental behaviour
+    // -------------------------------------------------------------------------
+
+    /**
+     * The whole point of the delta: a message that is still waiting, in a chat where
+     * nothing has happened, must not be re-examined or rewritten on every run.
+     */
+    public function test_second_run_skips_chats_with_no_activity(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'date'          => now()->subDays(2),
+            'replyexpected' => 1,
+            'replyreceived' => 0,
+        ]);
+
+        $first = $this->service->updateExpected();
+        $this->assertTrue($first['full'], 'the first run has no cursor so must do everything');
+        $this->assertEquals(1, $first['checked']);
+
+        $second = $this->service->updateExpected();
+
+        $this->assertFalse($second['full']);
+        $this->assertEquals(0, $second['checked'], 'nothing happened in that chat, so nothing to re-check');
+
+        // The answer is still on record, it just was not written again.
+        $this->assertEquals(-1, DB::table('users_expected')->where('chatmsgid', $msg->id)->value('value'));
+    }
+
+    public function test_a_new_message_brings_its_chat_back_into_the_delta(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'date'          => now()->subDays(2),
+            'replyexpected' => 1,
+            'replyreceived' => 0,
+        ]);
+
+        $this->service->updateExpected();
+
+        // The reply the message was waiting for.
+        $this->createTestChatMessage($room, $user2, ['date' => now()->subHour()]);
+
+        $stats = $this->service->updateExpected();
+
+        $this->assertFalse($stats['full']);
+        $this->assertEquals(1, $stats['received']);
+        $this->assertEquals(1, $msg->fresh()->replyreceived);
+        $this->assertEquals(1, DB::table('users_expected')->where('chatmsgid', $msg->id)->value('value'));
+    }
+
+    /**
+     * The hazard this design has to cover: a rippling-held reply is already in
+     * chat_messages, so releasing it makes a reply deliverable without any new message
+     * arriving. A cursor that only watched message ids would miss it, and the expecter
+     * would keep being told nobody had replied.
+     */
+    public function test_releasing_a_held_reply_brings_its_chat_back_into_the_delta(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'date'          => now()->subDays(2),
+            'replyexpected' => 1,
+            'replyreceived' => 0,
+        ]);
+
+        // user2's reply exists but is held by rippling, so it does not count yet.
+        $reply = $this->createTestChatMessage($room, $user2, ['date' => now()->subDays(1)]);
+        $post = $this->createTestMessage($user1, $this->createTestGroup());
+        DB::table('rippling_held_replies')->insert([
+            'chatid'         => $room->id,
+            'chatmsgid'      => $reply->id,
+            'msgid'          => $post->id,
+            'replieruserid'  => $user2->id,
+            'status'         => 'held',
+        ]);
+
+        $first = $this->service->updateExpected();
+        $this->assertEquals(1, $first['waiting'], 'a held reply must not count as received');
+
+        // Release it - no new chat message is created, only the status changes.
+        DB::table('rippling_held_replies')->where('chatmsgid', $reply->id)->update([
+            'status'     => 'released',
+            'releasedat' => now(),
+        ]);
+
+        $stats = $this->service->updateExpected();
+
+        $this->assertFalse($stats['full']);
+        $this->assertEquals(1, $stats['received'], 'the released reply must be picked up');
+        $this->assertEquals(1, DB::table('users_expected')->where('chatmsgid', $msg->id)->value('value'));
+    }
+
+    public function test_full_run_rechecks_everything_regardless_of_activity(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $this->createTestChatMessage($room, $user1, [
+            'date'          => now()->subDays(2),
+            'replyexpected' => 1,
+            'replyreceived' => 0,
+        ]);
+
+        $this->service->updateExpected();
+
+        $stats = $this->service->updateExpected(false, true);
+
+        $this->assertTrue($stats['full']);
+        $this->assertEquals(1, $stats['checked']);
+    }
+
+    public function test_a_dry_run_does_not_move_the_cursor(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $this->createTestChatMessage($room, $user1, [
+            'date'          => now()->subDays(2),
+            'replyexpected' => 1,
+            'replyreceived' => 0,
+        ]);
+
+        $this->service->updateExpected(true);
+
+        // Still no cursor, so the next real run must do the full pass.
+        $this->assertNull(DB::table('config')->where('key', 'chat.expected_cursor')->value('value'));
+        $this->assertTrue($this->service->updateExpected()['full']);
+    }
+
     public function test_update_expected_skips_messages_older_than_lookback(): void
     {
         $user1 = $this->createTestUser();


### PR DESCRIPTION
## What this does

`chats:update-expected` keeps track of which chat messages are still waiting for a reply. Every five minutes it took all ~1,925 messages that were still waiting, ran a query for each one to see whether a reply had turned up, and then wrote the same "still waiting" row back for every one that still was.

That is where roughly 550,000 pointless writes a day came from — writes that get copied to every database node — on top of one query per message for messages in chats where nothing had happened at all.

Both are avoidable, for the same reason: a message that is waiting for a reply can only stop waiting when a reply actually becomes readable. So there is no point looking again at a chat where nothing has happened, and no point writing a row that already says what we are about to write. The current answers for the messages under consideration are now read in one go, and only genuine changes get written.

## The case this has to get right

"Nothing has happened" is not the same as "no new message arrived".

When rippling holds a reply back, that reply is already sitting in `chat_messages`. It simply does not count as received yet, because it has not reached the person waiting for it. Releasing it therefore makes a reply readable without any new message being created anywhere. If we only watched for new messages, we would sail straight past that, and the person waiting would go on being told nobody had replied — including in the chase-up email, which reads this same table.

Every code path that releases a held reply stamps the time it did so, and that table is indexed by chat. So each run looks at chats with a new message since last time, plus chats where a held reply was released since last time. No release path has to remember to notify this job, which also means a future one cannot forget to.

The release lookup reaches back 15 minutes further than strictly needed. The job runs every five minutes, so that is comfortable room for a slow run or a clock that has been adjusted, and the cost is re-checking a handful of chats.

## Is anything relying on the repeated write?

The review asked this before agreeing to remove it, on the grounds that something might be using the constantly-rewritten row as a sign of life.

Nothing can be. `users_expected` has no timestamp column at all — just who is waiting, who they are waiting for, which message, and whether a reply arrived. There is nothing there to read a date from. And because each row is tied to one chat message and created once, even its row number stays put when the value is rewritten. All three things that read this table (the reply-time figures in `userInfo.go`, `user.go`, and the chase-up email service) look the row up by chat message and read the value.

## The safety net

`chats:update-expected --full` runs at 04:30 and re-checks every waiting message, catching anything the two triggers above cannot see. 04:30 sits in the quiet stretch after the purge and statistics jobs, and clear of the 04:00–04:17 backup window on db1.

The first run after deploying has no record of where it got to, so it checks everything and establishes one rather than guessing. A dry run leaves that record alone.

Both the message number and the time are noted before any work starts, so a message that arrives while the job is running is left for the next run rather than being stepped over.

## Testing

The new tests cover: a second run leaving alone a chat where nothing happened, while the recorded answer stays intact; a new message bringing its chat back into consideration and the reply being picked up; a held reply being released bringing its chat back in with no new message involved at all; `--full` checking everything regardless; and a dry run leaving the stored position alone.

The tests that were already there pass unchanged — with nothing stored they check everything, which is the behaviour they always asserted.

Full Laravel suite: 5574 passed, 0 failed.

Run against the development database from end to end, with one message waiting for a reply:

```
$ artisan chats:update-expected           # nothing stored yet
Expected update: checked 1 messages across all waiting messages - 1 waiting, 0 received.
                                          # recorded as still waiting

$ artisan chats:update-expected           # nothing has happened in that chat
Expected update: checked 0 messages across chats with recent activity - 0 waiting, 0 received.
                                          # not looked at, not rewritten

# the reply arrives
$ artisan chats:update-expected
Expected update: checked 1 messages across chats with recent activity - 0 waiting, 1 received.
                                          # recorded as received
```