### PR TITLE
fix(hooks): make the PR text check read the PR text, and check the English

### DIFF
--- a/.claude/check-pr-text.sh
+++ b/.claude/check-pr-text.sh
@@ -1,48 +1,247 @@
 #!/bin/bash
-# PreToolUse hook: block PR titles/descriptions that read as a NARRATIVE of how
-# the work happened, or that assert numbers nobody has re-checked.
+# PreToolUse hook: guard the text that goes into a PR title/description.
 #
 # Why: a PR description is read by a reviewer who was not there. It should
 # describe the END STATE of the branch - what it does, what it deliberately does
-# not do, what the limits are. It should not recount the order things were
-# discovered in, and it must not carry counts inherited from an earlier version
-# of the branch. Both failures look fine to the person who wrote them and waste
-# the reviewer's time or, worse, mislead them.
+# not do, what the limits are - in language they can read at speed. It should not
+# recount the order things were discovered in, must not carry counts inherited
+# from an earlier version of the branch, and must not be written in the
+# vocabulary of the code it describes.
 #
 # Fires on: gh pr create / gh pr edit / gh api ... /pulls/N (PATCH or POST).
 #
-# Two independent checks:
-#   1. NARRATIVE phrasing  -> override with ALLOW_PR_NARRATIVE=1 (should be rare;
+# Four independent checks:
+#   1. BODY IS READABLE   -> no override. See the note below; this one is the
+#      reason the other three are worth anything.
+#   2. PLAIN ENGLISH      -> override with PR_PLAIN_ENGLISH_OK=1
+#   3. NARRATIVE phrasing -> override with ALLOW_PR_NARRATIVE=1 (should be rare;
 #      if you are reaching for it, the sentence probably wants rewriting).
-#   2. NUMERIC claims      -> override with PR_TEXT_VERIFIED=1, meaning "I have
+#   4. NUMERIC claims     -> override with PR_TEXT_VERIFIED=1, meaning "I have
 #      re-derived each of these numbers from the branch as it is now". Stale
 #      counts are the specific failure this catches: a description written when
 #      the branch had 15 gates and 1 manifest, still saying so after it grew.
+#
+# ON FAILING CLOSED (check 1). This hook used to read the body only from a
+# literal --body-file path. Two extremely common shapes defeated that and it
+# passed silently, having inspected nothing:
+#
+#     gh pr create --body-file $SP/body.md         # path is a shell variable
+#     gh api ... -f body="$(cat body.md)"          # body inlined by the shell
+#
+# The hook receives the command BEFORE the shell expands it, so in both cases it
+# scanned the literal characters '$SP/body.md' or '$(cat body.md)' and found
+# nothing to complain about. Every PR written that way went through unchecked,
+# which is worse than having no hook at all - it looks like it passed. So when a
+# body-bearing flag is present and the text cannot be resolved, this now blocks
+# and asks for a form it can read.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 [ -z "$COMMAND" ] && exit 0
 
+# Decide whether to fire from the command with heredoc BODIES stripped. A commit
+# message or a doc routinely quotes an example PR command, and matching that
+# fires this hook on a git commit - which it did, on the commit that added this.
+TRIGGER=$(echo "$COMMAND" | awk '
+  {
+    if (tag != "") { if ($0 ~ ("^[[:space:]]*" tag "[[:space:]]*$")) tag = ""; next }
+    line = $0
+    if (match(line, /<<-?["'"'"'"]?[A-Za-z_][A-Za-z0-9_]*["'"'"'"]?/)) {
+      t = substr(line, RSTART, RLENGTH)
+      sub(/^<<-?/, "", t); gsub(/["'"'"'"]/, "", t)
+      tag = t
+    }
+    print line
+  }')
+
 # Only fire for commands that set PR title/body.
-echo "$COMMAND" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+(create|edit)\b|\bgh[[:space:]]+api\b[^|]*\bpulls?/[0-9]+' || exit 0
+echo "$TRIGGER" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+(create|edit)\b|\bgh[[:space:]]+api\b[^|]*\bpulls?/[0-9]+' || exit 0
 # gh pr edit that only changes labels/reviewers/base has no text to check.
-if echo "$COMMAND" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+edit\b' \
-   && ! echo "$COMMAND" | grep -qE '\-\-(title|body|body-file)\b'; then
+if echo "$TRIGGER" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+edit\b' \
+   && ! echo "$TRIGGER" | grep -qE '\-\-(title|body|body-file)\b'; then
   exit 0
 fi
+# Reading a PR is not writing one.
+echo "$TRIGGER" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+view\b' && exit 0
 
-# Assemble the text under review: the command itself (catches inline --title/
-# --body) plus the contents of any file passed by --body-file or -F body=@file.
+# --------------------------------------------------------------------------
+# Resolve the body text
+# --------------------------------------------------------------------------
 TEXT="$COMMAND"
-for f in $(echo "$COMMAND" | grep -oE '(--body-file[= ]|-F[[:space:]]+body=@|--body-file[[:space:]]+)[^[:space:]]+' \
-           | sed -E 's/^(--body-file[= ]|-F[[:space:]]+body=@|--body-file[[:space:]]+)//' | tr -d '"'"'"''); do
-  [ -f "$f" ] && TEXT="$TEXT
+BODY_RESOLVED=0
+UNREADABLE=""
+
+add_file() {
+  local f="$1"
+  # Strip one layer of surrounding quotes.
+  f="${f%\"}"; f="${f#\"}"; f="${f%\'}"; f="${f#\'}"
+  [ -z "$f" ] && return
+  if [ -f "$f" ]; then
+    TEXT="$TEXT
 $(cat "$f")"
-done
+    BODY_RESOLVED=1
+  else
+    UNREADABLE="$UNREADABLE $f"
+  fi
+}
+
+# --body-file PATH | --body-file=PATH | -F body=@PATH | -f body=@PATH
+while IFS= read -r f; do
+  [ -n "$f" ] && add_file "$f"
+done < <(echo "$COMMAND" \
+  | grep -oE '(--body-file[=[:space:]]+|-[fF][[:space:]]+body=@)[^[:space:]]+' \
+  | sed -E 's/^(--body-file[=[:space:]]+|-[fF][[:space:]]+body=@)//')
+
+# -f body="$(cat PATH)" / --field body="$(cat PATH)" - the shell would expand
+# this, but the hook sees it raw, so dig the path out of the substitution.
+while IFS= read -r f; do
+  [ -n "$f" ] && add_file "$f"
+done < <(echo "$COMMAND" | grep -oE '\$\((cat|<)[[:space:]]+[^)]+\)' \
+  | sed -E 's/^\$\((cat|<)[[:space:]]+//; s/\)$//')
+
+# An inline body written straight into the command is already in TEXT.
+if echo "$COMMAND" | grep -qE '\-\-body[[:space:]]+["'"'"']' \
+   || echo "$COMMAND" | grep -qE '\-[fF][[:space:]]+body=["'"'"']' ; then
+  BODY_RESOLVED=1
+fi
+# A heredoc body is in the command text too.
+echo "$COMMAND" | grep -qE '<<[-]?['"'"'"]?(EOF|MSG|BODY|PR)' && BODY_RESOLVED=1
+
+HAS_BODY_FLAG=0
+echo "$COMMAND" | grep -qE '\-\-body(-file)?\b|\-[fF][[:space:]]+body=' && HAS_BODY_FLAG=1
+
+if [ "$HAS_BODY_FLAG" = "1" ] && [ "$BODY_RESOLVED" = "0" ]; then
+  {
+    echo "STOP. This command sets a PR body, but the hook cannot read it, so none of"
+    echo "the PR text checks can run."
+    [ -n "$UNREADABLE" ] && echo "" && echo "  could not open:$UNREADABLE"
+    echo ""
+    echo "The hook sees the command BEFORE the shell expands it, so a path built from a"
+    echo "variable (--body-file \$SP/body.md) or a body inlined by the shell"
+    echo "(-f body=\"\$(cat body.md)\") both arrive here as literal text with no content"
+    echo "behind them. Passing silently in that case is worse than no hook at all."
+    echo ""
+    echo "Use a form the hook can read:"
+    echo "  gh pr create --body-file /absolute/path/to/body.md"
+    echo "  gh api -X PATCH repos/O/R/pulls/N -F body=@/absolute/path/to/body.md"
+  } >&2
+  exit 2
+fi
+
+# --------------------------------------------------------------------------
+# Prose under review: drop fenced code blocks and inline code spans.
+# Pasted command output and identifiers in backticks are evidence, not writing,
+# and holding them to prose rules produces exactly the noise that gets a hook
+# switched off.
+# --------------------------------------------------------------------------
+PROSE=$(echo "$TEXT" | awk '
+  /^[[:space:]]*```/ { infence = !infence; next }
+  infence { next }
+  # A markdown table row is structured reference rather than writing. A glossary
+  # of "instead of X, say Y" necessarily contains X, and flagging it would make
+  # the hook unable to describe itself.
+  /^[[:space:]]*\|/ { next }
+  { print }
+' | sed -E 's/`[^`]*`//g')
 
 FAILED=0
 
-# --- Check 1: narrative / process-diary phrasing ---------------------------
+# --- Check 2: plain English ------------------------------------------------
+# Terms lifted from the code, the runbook or the incident channel. Each is fine
+# in a comment next to the thing it names; in a PR description it makes the
+# reader stop and translate. The replacement is the point - if a term genuinely
+# carries meaning nothing else does, say it once in plain words and then use it.
+declare -a JARGON_TERMS=(
+  'single[- ]flight'      'callers asking the same question at once share one answer'
+  'fan[- ]out'            'how many calls this makes at once'
+  'no[- ]op(s| write| update|ped)?' 'a write that changes nothing'
+  're-?upsert'            'writing the same row back'
+  'upsert'                'insert or update'
+  'watermark'             'where we got to last time'
+  'delta set'             'the things that changed'
+  '\bseam\b'              'the one place that does X'
+  'fail[- ]open'          'when in doubt it does the full work'
+  'shed load'             'turn work away'
+  'UX class'              'what a member sees'
+  'row images'            'the changes copied to every database node'
+  'backstop'              'safety net'
+  'native[- ]distinct'    'counted once per group it was posted to'
+  'sargable'              'able to use the index'
+  'thundering herd'       'everyone retrying at once'
+  'tail latency'          'the slowest requests'
+  '\bp(50|95|99)\b'       'the slowest N% of requests'
+  'Dijkstra'              'a route search'
+  'kswapd'                'the kernel reclaiming memory'
+  'goroutine'             'a concurrent request'
+  'semaphore'             'a cap on how many run at once'
+  'memoi[sz]e'            'remember the answer'
+  'idempotent'            'safe to run twice'
+  'hot path'              'the code every request goes through'
+  'cardinality'           'how many distinct values'
+  '\bTTL\b'               'how long the answer is kept'
+  '\bcursors?\b'          'where we got to last time'
+  '\bdecrements?\b'       'the count going down'
+  '\bincrements?\b'       'the count going up'
+  'primary[- ]key range'  'a short run of consecutive rows'
+  'cron move'             'running it at a different time'
+)
+JARGON_HITS=""
+for ((i=0; i<${#JARGON_TERMS[@]}; i+=2)); do
+  term="${JARGON_TERMS[$i]}"; plain="${JARGON_TERMS[$i+1]}"
+  if echo "$PROSE" | grep -qiE "$term"; then
+    example=$(echo "$PROSE" | grep -ioE ".{0,45}${term}.{0,45}" | head -1)
+    JARGON_HITS="$JARGON_HITS
+  $example
+     -> try: $plain"
+  fi
+done
+
+# Deliberately NOT checked: bare (un-backticked) code identifiers in prose. It
+# sounds like a good rule and it is not. Measured across 25 merged descriptions
+# plus the two worst offenders this hook was written for, the highest count in
+# any body was ONE, and 24 of 27 had none - people here already backtick their
+# identifiers. Every hit it produced was incidental (localStorage, versionCode,
+# max_minutes), so at any threshold it was all false positives and no signal.
+#
+# The related failure it CANNOT catch is an ordinary English word used as a term
+# of art - "the walkers' deadline", where "walkers" names something in
+# dashboard.go. No pattern distinguishes that from normal prose; it needs a
+# reader.
+#
+# Telegraphic list items: a bullet that ends in a semicolon is a fragment with
+# the verb removed, and a description written that way has to be reassembled
+# into claims before it can be reviewed.
+FRAGMENTS=$(echo "$PROSE" | grep -nE '^[[:space:]]*[-*][[:space:]]+.*;[[:space:]]*$' \
+  | awk 'length($0) <= 100' | head -4)
+
+if { [ -n "$JARGON_HITS" ] || [ -n "$FRAGMENTS" ]; } \
+   && ! echo "$COMMAND" | grep -qE '\bPR_PLAIN_ENGLISH_OK=1\b' && [ "${PR_PLAIN_ENGLISH_OK:-}" != "1" ]; then
+  {
+    echo "STOP. This PR text is not in plain English."
+    echo ""
+    echo "It is read by someone who has not read the branch. Every term they have to"
+    echo "translate is a term you could have translated for them once."
+    if [ -n "$JARGON_HITS" ]; then
+      echo ""
+      echo "Jargon that needs saying in words:"
+      echo "$JARGON_HITS" | grep -v '^$'
+    fi
+    if [ -n "$FRAGMENTS" ]; then
+      echo ""
+      echo "List items ending in ';' - these are fragments with the verb taken out."
+      echo "Write each as a sentence that makes a claim:"
+      echo "$FRAGMENTS" | sed 's/^/  /'
+    fi
+    echo ""
+    echo "Fenced code blocks and \`backticked\` spans are exempt - paste output freely."
+    echo ""
+    echo "If a term really is the clearest word available, prefix with"
+    echo "PR_PLAIN_ENGLISH_OK=1 - but prefer explaining it once in the text."
+  } >&2
+  FAILED=1
+fi
+
+# --- Check 3: narrative / process-diary phrasing ---------------------------
 # Each pattern describes the WRITING PROCESS or the order of discovery rather
 # than the state of the branch.
 NARRATIVE_PATTERNS=(
@@ -63,7 +262,7 @@ NARRATIVE_PATTERNS=(
 )
 NARRATIVE_HITS=""
 for p in "${NARRATIVE_PATTERNS[@]}"; do
-  hit=$(echo "$TEXT" | grep -inE "$p" | head -2)
+  hit=$(echo "$PROSE" | grep -inE "$p" | head -2)
   [ -n "$hit" ] && NARRATIVE_HITS="$NARRATIVE_HITS
 $hit"
 done
@@ -85,10 +284,10 @@ if [ -n "$NARRATIVE_HITS" ] \
   FAILED=1
 fi
 
-# --- Check 2: numeric claims that may be stale -----------------------------
+# --- Check 4: numeric claims that may be stale -----------------------------
 # Counts are the thing that silently rots when a branch grows after the
 # description was written.
-CLAIMS=$(echo "$TEXT" | grep -oiE '\b[0-9][0-9,]* (sites?|tests?|gates?|assertions?|files?|commits?|conversions?|passing|passed|failing|errors?)\b' \
+CLAIMS=$(echo "$PROSE" | grep -oiE '\b[0-9][0-9,]* (sites?|tests?|gates?|assertions?|files?|commits?|conversions?|passing|passed|failing|errors?)\b' \
          | sort -u | head -20)
 
 if [ -n "$CLAIMS" ] \
@@ -105,6 +304,16 @@ if [ -n "$CLAIMS" ] \
     echo ""
     echo "Check them against the manifest / test output / git, then prefix the command"
     echo "with PR_TEXT_VERIFIED=1 to confirm you have done so."
+  } >&2
+  FAILED=1
+fi
+
+# --- Check 5: AI attribution ------------------------------------------------
+if echo "$TEXT" | grep -qiE 'Generated with \[?Claude Code|🤖 Generated with'; then
+  {
+    echo "STOP. PR descriptions here do not carry AI attribution footers."
+    echo "Remove the 'Generated with Claude Code' block. (Commit message trailers are"
+    echo "a separate thing and are fine.)"
   } >&2
   FAILED=1
 fi

--- a/.claude/check-pr-text.test.sh
+++ b/.claude/check-pr-text.test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Tests for check-pr-text.sh. Self-contained: writes its own fixtures.
+#
+#   bash .claude/check-pr-text.test.sh
+#
+# The command strings under test contain "gh pr create", so this lives in a file
+# rather than being typed at a shell - sibling hooks react to that literal on a
+# command line and would fire on the test harness itself.
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/check-pr-text.sh"
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+G="gh"; PRC="$G pr create"
+pass=0; fail=0
+
+run() { printf '%s' "$(jq -nc --arg c "$1" '{tool_input:{command:$c}}')" | "$HOOK" >/dev/null 2>"$TMP/err"; echo $?; }
+
+check() { # name  want_exit  command  [must_contain]
+  local name="$1" want="$2" cmd="$3" needle="${4:-}" got ok=1
+  got=$(run "$cmd")
+  [ "$got" = "$want" ] || ok=0
+  [ -n "$needle" ] && ! grep -qi -- "$needle" "$TMP/err" && ok=0
+  if [ "$ok" = "1" ]; then
+    printf '  PASS  %s\n' "$name"; pass=$((pass+1))
+  else
+    printf '  FAIL  %s (exit %s, wanted %s%s)\n' "$name" "$got" "$want" "${needle:+, needle '$needle'}"
+    sed 's/^/          /' "$TMP/err" | head -6; fail=$((fail+1))
+  fi
+}
+
+echo "== the body must be readable, or nothing else here means anything =="
+check "unreadable \$VAR path blocks" 2 \
+  "$PRC --base master --head x --title t --body-file \$SP/body.md" "cannot read"
+printf 'We added single-flight so callers share the work.\n' > "$TMP/jargon.md"
+check "body inlined by \$(cat FILE) is still read" 2 \
+  "$G api -X PATCH repos/O/R/pulls/1 -f body=\"\$(cat $TMP/jargon.md)\"" "single-flight"
+check "-F body=@FILE is read" 2 \
+  "$G api -X PATCH repos/O/R/pulls/1 -F body=@$TMP/jargon.md" "single-flight"
+
+echo
+echo "== plain English =="
+check "jargon caught, with a plain replacement offered" 2 \
+  "$PRC --base master --head x --title t --body-file $TMP/jargon.md" "callers asking the same question"
+
+printf 'Three guards:\n\n- process-wide concurrency cap;\n- a cache keyed on the URL;\n' > "$TMP/frag.md"
+check "short semicolon fragments caught" 2 \
+  "$PRC --base master --head x --title t --body-file $TMP/frag.md" "verb taken out"
+
+# A complete sentence may legitimately end in a semicolon inside a list. Measured
+# at 202 chars in a real merged PR versus 55 for the fragments this targets.
+{ printf -- '- '; printf 'the poll fires every minute whether or not anything changed, and refetching then would put every browsing member reach query back onto the server every single minute of the day;\n'; } > "$TMP/longsemi.md"
+check "long sentence ending in ';' not flagged" 0 \
+  "PR_TEXT_VERIFIED=1 $PRC --base master --head x --title t --body-file $TMP/longsemi.md"
+
+printf 'It remembers the answer.\n\n```\nNo cursor stored yet - upsert watermark no-op\n```\n' > "$TMP/fence.md"
+check "fenced output exempt" 0 \
+  "PR_TEXT_VERIFIED=1 $PRC --base master --head x --title t --body-file $TMP/fence.md"
+
+printf 'The `users_expected` table and the `cursor` column are named in backticks.\n' > "$TMP/ticks.md"
+check "backticked spans exempt" 0 \
+  "PR_TEXT_VERIFIED=1 $PRC --base master --head x --title t --body-file $TMP/ticks.md"
+
+check "override works" 0 \
+  "PR_PLAIN_ENGLISH_OK=1 PR_TEXT_VERIFIED=1 $PRC --base master --head x --title t --body-file $TMP/jargon.md"
+
+echo
+echo "== house style and stale claims =="
+printf 'A clear description.\n\nGenerated with [Claude Code](https://claude.com/claude-code)\n' > "$TMP/ai.md"
+check "AI attribution caught" 2 "$PRC --base master --head x --title t --body-file $TMP/ai.md" "AI attribution"
+
+printf 'This converts 42 sites and adds 7 tests.\n' > "$TMP/counts.md"
+check "counts caught" 2 "$PRC --base master --head x --title t --body-file $TMP/counts.md" "asserts counts"
+
+printf 'I then discovered the cause and eventually fixed it.\n' > "$TMP/narr.md"
+check "narrative caught" 2 "$PRC --base master --head x --title t --body-file $TMP/narr.md" "narrative"
+
+echo
+echo "== must not fire =="
+# A commit message, doc or fixture routinely quotes an example PR command. This
+# fired on a git commit before the trigger learned to ignore heredoc bodies.
+QUOTED="git commit -F - <<'MSG'
+fix: read the body
+
+    $PRC --body-file \$SP/body.md
+    $G api ... -f body=\"\$(cat body.md)\"
+
+That used no-op writes and an upsert watermark.
+MSG"
+check "git commit quoting a PR command ignored" 0 "$QUOTED"
+check "gh pr view ignored"        0 "$G pr view 1328 --json body"
+check "unrelated command ignored" 0 "ls -la"
+check "label-only edit ignored"   0 "$G pr edit 1328 --add-label perf"
+printf 'A plain description of what the branch does and how to check it.\n' > "$TMP/good.md"
+check "clean body passes"         0 "$PRC --base master --head x --title t --body-file $TMP/good.md"
+
+echo
+echo "  $pass passed, $fail failed"
+[ "$fail" = "0" ]

--- a/.claude/check-pr-uncommitted.sh
+++ b/.claude/check-pr-uncommitted.sh
@@ -16,11 +16,32 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 [ -z "$COMMAND" ] && exit 0
 
-# Only fire for `gh pr create`.
-echo "$COMMAND" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+create\b' || exit 0
+# Decide whether to fire from the command with heredoc BODIES stripped, and skip
+# commands that merely QUOTE the trigger rather than run it. A grep whose pattern
+# contains the words, or a commit message showing an example, is not opening a PR.
+# Both were observed firing this hook before this guard existed.
+TRIGGER=$(echo "$COMMAND" | awk '
+  {
+    if (tag != "") { if ($0 ~ ("^[[:space:]]*" tag "[[:space:]]*$")) tag = ""; next }
+    line = $0
+    if (match(line, /<<-?["'"'"'"]?[A-Za-z_][A-Za-z0-9_]*["'"'"'"]?/)) {
+      t = substr(line, RSTART, RLENGTH)
+      sub(/^<<-?/, "", t); gsub(/["'"'"'"]/, "", t)
+      tag = t
+    }
+    print line
+  }')
+
+# Only fire for an actual `gh pr create` invocation.
+echo "$TRIGGER" | grep -qE '(^|[;&|]|&&|\|\|)[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+create\b' || exit 0
+
+# A grep/rg/awk whose PATTERN contains the trigger is searching, not creating.
+echo "$TRIGGER" | grep -qE '\b(grep|rg|ag|ack|awk|sed)\b' \
+  && ! echo "$TRIGGER" | grep -qE '(^|[;&|])[[:space:]]*(cd[[:space:]]+[^;&|]+[[:space:]]*(&&|;)[[:space:]]*)?([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+create\b' \
+  && exit 0
 
 # Explicit override (env in the command, or already exported).
-if echo "$COMMAND" | grep -qE '\bALLOW_DIRTY_PR=1\b' || [ "${ALLOW_DIRTY_PR:-}" = "1" ]; then
+if echo "$TRIGGER" | grep -qE '\bALLOW_DIRTY_PR=1\b' || [ "${ALLOW_DIRTY_PR:-}" = "1" ]; then
   exit 0
 fi
 

--- a/.claude/check-pr-uncommitted.test.sh
+++ b/.claude/check-pr-uncommitted.test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Tests for check-pr-uncommitted.sh. Self-contained: builds its own dirty repo.
+#
+#   bash .claude/check-pr-uncommitted.test.sh
+#
+# In a file rather than typed at a shell because the commands under test contain
+# the literal the hook triggers on - which is the whole point of half of them.
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/check-pr-uncommitted.sh"
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+REPO="$TMP/repo"
+mkdir -p "$REPO" && cd "$REPO" || exit 1
+git init -q . && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+echo "wip" > wip.txt          # leave it dirty
+
+G="gh"; PRC="$G pr create"
+pass=0; fail=0
+run() {
+  printf '%s' "$(jq -nc --arg c "$1" --arg d "$REPO" '{tool_input:{command:$c},cwd:$d}')" \
+    | "$HOOK" >/dev/null 2>"$TMP/err"; echo $?
+}
+check() { local name="$1" want="$2" cmd="$3" got; got=$(run "$cmd")
+  if [ "$got" = "$want" ]; then printf '  PASS  %s\n' "$name"; pass=$((pass+1))
+  else printf '  FAIL  %s (exit %s, wanted %s)\n' "$name" "$got" "$want"
+       sed 's/^/        /' "$TMP/err" | head -3; fail=$((fail+1)); fi; }
+
+echo "== must fire: opening a PR from a dirty tree =="
+check "plain invocation"  2 "$PRC --base master --head x --title t --body b"
+check "with env prefix"   2 "PR_TEXT_VERIFIED=1 $PRC --base master --head x --title t"
+
+echo
+echo "== must not fire: quoting or searching for the trigger =="
+# Both of these were observed blocking real work before the trigger was tightened:
+# a read-only grep, and a git commit whose message showed an example.
+check "grep whose pattern quotes it" 0 "grep -rn '$PRC' .claude/*.sh"
+check "grep -l over hook scripts"    0 "grep -ln 'gh pr create' .claude/*.sh"
+QUOTED="git commit -F - <<'MSG'
+docs: explain the flow
+
+    $PRC --body-file body.md
+MSG"
+check "commit message quoting it"    0 "$QUOTED"
+check "override honoured"            0 "ALLOW_DIRTY_PR=1 $PRC --title t --body b"
+check "unrelated command"            0 "ls -la"
+
+echo
+echo "== must not fire: clean tree =="
+git add -A && git -c user.email=t@t -c user.name=t commit -q -m wip
+check "clean tree passes" 0 "$PRC --base master --head x --title t --body b"
+
+echo
+echo "  $pass passed, $fail failed"
+[ "$fail" = "0" ]


### PR DESCRIPTION
## Why

`check-pr-text.sh` was meant to guard what goes into a PR description. It was not doing it, for a reason that made it worse than having no check at all: it looked like it passed.

The hook reads the body out of the command it is given. It only knew how to open a literal `--body-file` path. Two very ordinary shapes defeated that:

```
gh pr create --body-file $SP/body.md        # path is a shell variable
gh api ... -f body="$(cat body.md)"         # body inlined by the shell
```

A hook sees the command *before* the shell expands it. So in both cases it scanned the characters `$SP/body.md` or `$(cat body.md)`, found no prose in them, and exited happily having inspected nothing. Both shapes are what you get from any script that builds a path in a variable, which is most of them.

Replaying the exact commands used for four PRs today: all passed, all inspected an empty string. The same commands with a literal path are caught immediately.

## What changed

**It now fails closed.** If a command sets a PR body and the hook cannot resolve the text, it stops and asks for a form it can read. It also learned to dig the path out of `$(cat FILE)` and to accept `-F body=@FILE`, so most cases now just work instead of being refused.

**It checks the writing.** There was no rule about how a description reads — only about narrative phrasing and stale counts. There is now a list of terms that need saying in words, and each one offers the plain replacement rather than just complaining:

| instead of | say |
|---|---|
| no-op write | a write that changes nothing |
| upsert | insert or update |
| watermark, cursor | where we got to last time |
| fan-out | how many calls this makes at once |
| idempotent | safe to run twice |
| memoise | remember the answer |
| backstop | safety net |
| TTL | how long the answer is kept |

It also catches short list items that end in a semicolon, which are fragments with the verb taken out, and the AI attribution footer, which house style leaves off.

Fenced code blocks and backticked spans are exempt. Pasted command output is evidence, not writing, and holding it to prose rules is how a hook earns its way into being switched off.

## What it deliberately does not check

Bare code identifiers in prose — naming `analyseClickability` as if it were an English word. It sounds like a good rule. Measured across 25 merged descriptions plus the two worst bodies this was written for, the highest count in any single body was one, and 24 of 27 had none. Every hit was incidental (`localStorage`, `versionCode`, `max_minutes`). All false positives, no signal, so it is not in the hook and there is a comment saying why, to stop it being added back on a hunch.

The related failure it cannot catch at all is an ordinary English word used as a term of art — "the walkers' deadline", where *walkers* names something in `dashboard.go`. Nothing distinguishes that from normal prose without a reader.

## Does it fire too often?

That was the thing to get wrong, so it is measured rather than guessed. Against the last 25 merged descriptions, with the narrative and count rules turned off so only the writing is judged: it stops 15 of them. Five of those carry the AI footer; the rest genuinely say `no-op`, `idempotent`, `upsert`, `memoised`, `backstop`, `Dijkstra` or `fan-out`.

Tuning was driven by that sample rather than by taste. A complete sentence can legitimately end in a semicolon inside a list, so only short items are treated as fragments — the real ones being targeted measure about 55 characters, the false positive was 202.

## A second hook with the same defect

`check-pr-uncommitted.sh` matched its trigger anywhere in the command string too, so anything that merely mentioned the words set it off. Two cases hit real work while this was being written: a read-only `grep` whose pattern contained them, and a `git commit` whose message showed them as an example. Neither opens a PR.

It gets the same treatment — decide from the command with heredoc bodies removed, require the trigger in command position rather than anywhere, and skip a command that is running a search tool over text containing it. It still refuses a genuine PR creation from a dirty tree, which is its job.

## Testing

Two suites, each writing its own fixtures so nothing needs setting up:

```
bash .claude/check-pr-text.test.sh          # 17 cases
bash .claude/check-pr-uncommitted.test.sh   #  8 cases
```

The first covers both shapes that used to slip through, each rule firing on text that deserves it, the exemptions for code blocks and backticks, the long-sentence case that must not be treated as a fragment, each override, and the commands that must be ignored — including a commit message quoting an example. The second builds a dirty repository and checks both misfires, the clean-tree case, the override, and that a genuine PR creation from a dirty tree is still refused. All passing.

The test lives in a file rather than being typed at a shell because the commands under test contain the literal `gh pr create`, and sibling hooks react to that on a command line — they fire on the harness itself.
