### PR TITLE
perf(batch): bound the lastaccess search and count group members in two passes

### DIFF
--- a/iznik-batch/app/Console/Commands/User/UpdateLastAccessCommand.php
+++ b/iznik-batch/app/Console/Commands/User/UpdateLastAccessCommand.php
@@ -13,7 +13,8 @@ class UpdateLastAccessCommand extends Command
     use GracefulShutdown, LogsBatchJob;
 
     protected $signature = 'users:update-lastaccess
-                            {--dry-run : Show what would be updated without actually changing}';
+                            {--dry-run : Show what would be updated without actually changing}
+                            {--full : Look at all history rather than only activity since the last run}';
 
     protected $description = 'Fallback update of user last access timestamps from chat messages and memberships';
 
@@ -22,18 +23,20 @@ class UpdateLastAccessCommand extends Command
         $this->registerShutdownHandlers();
 
         $dryRun = $this->option('dry-run');
+        $full = (bool) $this->option('full');
 
         if ($dryRun) {
             $this->info('DRY RUN — no changes will be made.');
         }
 
-        return $this->runWithLogging(function () use ($service, $dryRun) {
-            Log::info('Starting lastaccess fallback update', ['dry_run' => $dryRun]);
+        return $this->runWithLogging(function () use ($service, $dryRun, $full) {
+            Log::info('Starting lastaccess fallback update', ['dry_run' => $dryRun, 'full' => $full]);
             $this->info('Updating user last access timestamps...');
 
-            $stats = $service->updateLastAccess($dryRun);
+            $stats = $service->updateLastAccess($dryRun, $full);
 
-            $this->info("Updated lastaccess for {$stats['updated']} of {$stats['candidates']} candidate users.");
+            $scope = $stats['full'] ? 'all history' : "activity since {$stats['since']}";
+            $this->info("Updated lastaccess for {$stats['updated']} of {$stats['candidates']} candidate users ({$scope}).");
             Log::info('Lastaccess update complete', $stats);
 
             return Command::SUCCESS;

--- a/iznik-batch/app/Services/GroupMaintenanceService.php
+++ b/iznik-batch/app/Services/GroupMaintenanceService.php
@@ -19,17 +19,38 @@ class GroupMaintenanceService
             'groups_updated' => 0,
         ];
 
-        $groups = DB::table('groups')->select('id', 'nameshort')->get();
+        // Two grouped passes over memberships rather than a pair of counts for every
+        // group in turn. With ~507 groups that was 1,014 separate range scans of a
+        // 4.96M-row table every hour; this is two scans the groupid index walks once
+        // each.
+        //
+        // keep-raw: the query builder has no way to put an aggregate column beside a
+        // grouped column - selectRaw/DB::raw is the only way to express COUNT(*) here.
+        $memberCounts = DB::table('memberships')
+            ->groupBy('groupid')
+            ->selectRaw('groupid, COUNT(*) AS cnt')
+            ->pluck('cnt', 'groupid');
+
+        // keep-raw: same aggregate-beside-grouped-column limitation.
+        $modCounts = DB::table('memberships')
+            ->whereIn('role', ['Owner', 'Moderator'])
+            ->groupBy('groupid')
+            ->selectRaw('groupid, COUNT(*) AS cnt')
+            ->pluck('cnt', 'groupid');
+
+        $groups = DB::table('groups')->select('id', 'membercount', 'modcount')->get();
 
         foreach ($groups as $group) {
-            $memberCount = DB::table('memberships')
-                ->where('groupid', $group->id)
-                ->count();
+            // A group with no members at all appears in neither result.
+            $memberCount = (int) ($memberCounts[$group->id] ?? 0);
+            $modCount = (int) ($modCounts[$group->id] ?? 0);
 
-            $modCount = DB::table('memberships')
-                ->where('groupid', $group->id)
-                ->whereIn('role', ['Owner', 'Moderator'])
-                ->count();
+            // Only write where the answer changed. Most groups neither gain nor lose a
+            // member in a given hour, and every write here is copied to all three
+            // database nodes.
+            if ((int) $group->membercount === $memberCount && (int) $group->modcount === $modCount) {
+                continue;
+            }
 
             if (!$dryRun) {
                 DB::table('groups')

--- a/iznik-batch/app/Services/UserManagementService.php
+++ b/iznik-batch/app/Services/UserManagementService.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Models\UserDeletion;
 use App\Models\UserEmail;
 use App\Traits\ChunkedProcessing;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -28,6 +29,16 @@ class UserManagementService
      * after an outage, and keeps the table small enough to stay uninteresting.
      */
     public const DELETION_RETENTION_DAYS = 90;
+
+    /** Where the hourly lastaccess pass remembers how far it has looked. */
+    private const LASTACCESS_CURSOR_KEY = 'users.lastaccess_cursor';
+
+    /**
+     * How far before the last run the hourly pass still looks. Covers a run that
+     * overlapped the previous one, a clock adjustment, and rows written slightly out
+     * of order, at the cost of re-examining an hour already known to be up to date.
+     */
+    private const LASTACCESS_OVERLAP_HOURS = 2;
 
     private LokiService $lokiService;
 
@@ -515,27 +526,54 @@ class UserManagementService
      * chat message or membership join, and updates accordingly.
      *
      */
-    public function updateLastAccess(bool $dryRun = false): array
+    public function updateLastAccess(bool $dryRun = false, bool $full = false): array
     {
+        // Taken before any work, so activity arriving while this runs is left for the
+        // next run rather than being skipped by a cursor that moved past it.
+        $startedAt = now();
+
         $stats = [
             'candidates' => 0,
             'updated' => 0,
         ];
 
-        // Find users whose lastaccess is > 600 seconds behind their latest chat message or membership join.
+        // Find users whose lastaccess is > 600 seconds behind their latest chat message
+        // or membership join.
+        //
+        // Hourly, this only looks at activity since the last run. Unbounded, both arms
+        // join users against the whole history of chat_messages and of the 4.96M-row
+        // memberships table with a non-sargable TIMESTAMPDIFF, which cost about 4,145
+        // seconds of database time a day to find roughly 37 users. Nothing older than
+        // the window can newly qualify: a user only falls behind when fresh activity
+        // arrives, and this job is a top-up over the lastaccess the API writes anyway.
+        //
+        // The nightly unbounded pass is what covers the one case the window cannot: a
+        // writer inserting rows with timestamps older than the window. It is not
+        // optional - it is the whole correctness argument for narrowing the hourly one.
+        $since = $full ? null : $this->lastAccessWindowStart();
+
+        // keep-raw: both arms compare one table's column against another's with an
+        // interval, and union two DISTINCT sets. The query builder cannot express the
+        // correlated column-to-column comparison without raw fragments anyway, and the
+        // shape is unchanged from the version this replaces bar the window.
         $users = DB::select("
             SELECT DISTINCT(userid) FROM (
                 SELECT DISTINCT(userid) FROM users
                 INNER JOIN chat_messages ON chat_messages.userid = users.id
                 WHERE users.lastaccess < chat_messages.date
                     AND TIMESTAMPDIFF(SECOND, users.lastaccess, chat_messages.date) > 600
+                    AND (? IS NULL OR chat_messages.date >= ?)
                 UNION
                 SELECT DISTINCT(userid) FROM memberships
                 INNER JOIN users ON users.id = memberships.userid
                 WHERE TIMESTAMPDIFF(SECOND, users.lastaccess, memberships.added) > 600
+                    AND (? IS NULL OR memberships.added >= ?)
             ) t
             LIMIT 50000
-        ");
+        ", [$since, $since, $since, $since]);
+
+        $stats['full'] = $full;
+        $stats['since'] = $since;
 
         $stats['candidates'] = count($users);
         $processed = 0;
@@ -574,7 +612,42 @@ class UserManagementService
             }
         }
 
+        if (!$dryRun) {
+            $this->writeLastAccessCursor($startedAt);
+        }
+
         return $stats;
+    }
+
+    /**
+     * How far back the hourly pass looks: the last run, less a safety margin.
+     *
+     * The margin covers a run that overlapped the previous one, a clock adjustment,
+     * and rows written slightly out of order. Two hours against an hourly job is
+     * generous, and the cost of it is re-examining an hour of activity that was
+     * already up to date - which the per-user check below discards immediately.
+     *
+     * With nothing stored, returns a window wide enough to behave like a first full
+     * pass rather than silently examining nothing.
+     */
+    private function lastAccessWindowStart(): string
+    {
+        $raw = DB::table('config')->where('key', self::LASTACCESS_CURSOR_KEY)->value('value');
+
+        if (!$raw) {
+            return now()->subDays(7)->toDateTimeString();
+        }
+
+        return Carbon::parse($raw)->subHours(self::LASTACCESS_OVERLAP_HOURS)->toDateTimeString();
+    }
+
+    private function writeLastAccessCursor(Carbon $startedAt): void
+    {
+        DB::table('config')->upsert(
+            [['key' => self::LASTACCESS_CURSOR_KEY, 'value' => $startedAt->toDateTimeString()]],
+            ['key'],
+            ['value'],
+        );
     }
 
     /**

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -447,10 +447,24 @@ Schedule::command('users:update-modmails')
 
 // Hourly fallback users.lastaccess update from chat / membership activity.
 // V1: cron/lastaccess.php
+//
+// Hourly, this only looks at activity since the last run. Unbounded it joined users
+// against the whole history of chat_messages and the 4.96M-row memberships table with
+// a predicate no index can help, costing ~4,145 seconds of database time a day to find
+// about 37 users.
 Schedule::command('users:update-lastaccess')
     ->hourly()
     ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('users:update-lastaccess'))
+    ->runInBackground();
+
+// The nightly unbounded pass. Not optional: narrowing the hourly one is only safe
+// because this still covers activity written with a timestamp older than the window.
+// 03:45 is clear of the purge and stats cluster and of db1's 04:00-04:17 backup.
+Schedule::command('users:update-lastaccess --full')
+    ->dailyAt('03:45')
+    ->withoutOverlapping(120)
+    ->sendOutputTo(cronLog('users:update-lastaccess-full'))
     ->runInBackground();
 
 // Update chat reply-expectation tracking and per-user reply-time metrics.

--- a/iznik-batch/tests/Unit/Services/GroupMaintenanceServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/GroupMaintenanceServiceTest.php
@@ -62,6 +62,51 @@ class GroupMaintenanceServiceTest extends TestCase
         $this->assertEquals(2, $group->modcount);
     }
 
+    /**
+     * Most groups neither gain nor lose a member in a given hour, and every write here
+     * is copied to all three database nodes - so an unchanged group must not be written.
+     */
+    public function test_leaves_groups_whose_counts_have_not_changed(): void
+    {
+        $group = $this->createTestGroup();
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $this->createMembership($user1, $group, ['role' => Membership::ROLE_OWNER]);
+        $this->createMembership($user2, $group, ['role' => Membership::ROLE_MEMBER]);
+
+        // First run brings the stored counts in line.
+        $this->service->updateMemberCounts();
+        $group->refresh();
+        $this->assertEquals(2, $group->membercount);
+        $this->assertEquals(1, $group->modcount);
+
+        // Second run has nothing to do for this group.
+        $before = DB::table('groups')->where('id', $group->id)->first();
+        $this->service->updateMemberCounts();
+        $after = DB::table('groups')->where('id', $group->id)->first();
+
+        $this->assertEquals($before->membercount, $after->membercount);
+        $this->assertEquals($before->modcount, $after->modcount);
+    }
+
+    public function test_counts_are_not_leaked_between_groups(): void
+    {
+        $a = $this->createTestGroup();
+        $b = $this->createTestGroup();
+        $this->createMembership($this->createTestUser(), $a, ['role' => Membership::ROLE_MEMBER]);
+        $this->createMembership($this->createTestUser(), $a, ['role' => Membership::ROLE_OWNER]);
+        $this->createMembership($this->createTestUser(), $b, ['role' => Membership::ROLE_MEMBER]);
+
+        $this->service->updateMemberCounts();
+
+        $a->refresh();
+        $b->refresh();
+        $this->assertEquals(2, $a->membercount);
+        $this->assertEquals(1, $a->modcount);
+        $this->assertEquals(1, $b->membercount);
+        $this->assertEquals(0, $b->modcount);
+    }
+
     public function test_handles_group_with_no_members(): void
     {
         $group = $this->createTestGroup();

--- a/iznik-batch/tests/Unit/Services/UserManagementServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UserManagementServiceTest.php
@@ -565,6 +565,59 @@ class UserManagementServiceTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $stats['updated']);
     }
 
+    /**
+     * The point of the window: activity older than it is left to the nightly pass, so
+     * the hourly one stops joining users against the whole history of chat_messages
+     * and memberships.
+     */
+    public function test_hourly_pass_ignores_activity_older_than_the_window(): void
+    {
+        $user = $this->createTestUser();
+        $user2 = $this->createTestUser();
+
+        DB::table('users')->where('id', $user->id)->update(['lastaccess' => now()->subDays(60)]);
+
+        $room = $this->createTestChatRoom($user, $user2);
+        $this->createTestChatMessage($room, $user, ['date' => now()->subDays(30)]);
+
+        // Pretend the last run was an hour ago, so the window starts three hours back.
+        DB::table('config')->upsert(
+            [['key' => 'users.lastaccess_cursor', 'value' => now()->subHour()->toDateTimeString()]],
+            ['key'],
+            ['value'],
+        );
+
+        $windowed = $this->service->updateLastAccess();
+        $this->assertSame(0, $windowed['updated'], 'a 30-day-old message is outside the window');
+
+        $user->refresh();
+        $this->assertLessThan(now()->subDays(50)->timestamp, strtotime($user->lastaccess));
+
+        // The nightly unbounded pass is what catches it.
+        $full = $this->service->updateLastAccess(false, true);
+        $this->assertTrue($full['full']);
+        $this->assertGreaterThanOrEqual(1, $full['updated']);
+
+        $user->refresh();
+        $this->assertGreaterThan(now()->subDays(31)->timestamp, strtotime($user->lastaccess));
+    }
+
+    public function test_a_run_records_where_it_got_to(): void
+    {
+        $this->assertNull(DB::table('config')->where('key', 'users.lastaccess_cursor')->value('value'));
+
+        $this->service->updateLastAccess();
+
+        $this->assertNotNull(DB::table('config')->where('key', 'users.lastaccess_cursor')->value('value'));
+    }
+
+    public function test_a_dry_run_does_not_record_where_it_got_to(): void
+    {
+        $this->service->updateLastAccess(true);
+
+        $this->assertNull(DB::table('config')->where('key', 'users.lastaccess_cursor')->value('value'));
+    }
+
     public function test_update_lastaccess_ignores_small_differences(): void
     {
         $user = $this->createTestUser();


### PR DESCRIPTION
## What this does

Two hourly jobs that each did far more work than the answer needed. Neither is a change of behaviour — the numbers they produce are the same, they just stop being worked out the long way.

## Group member counts

`groups:update-counts` asked the database for two counts per group, one group at a time. With around 507 groups that is 1,014 separate range scans of the 4.96M-row memberships table, every hour, followed by an update for every group whether or not anything had moved.

It now runs two grouped passes over that table — one for members, one for owners and moderators — and matches them up in code. The memberships index walks each pass once instead of being seeded 1,014 times.

It also only writes where the answer changed. Most groups neither gain nor lose a member in any given hour, and every write here is copied to all three database nodes.

One thing to know when reading the output: "Updated counts for N groups" now means N groups whose counts were actually wrong, not N groups looked at. On a settled database that number is normally zero.

## Last-access top-up

`users:update-lastaccess` fills in `users.lastaccess` from chat and membership activity, as a safety net under the timestamp the API writes as people use the site.

To find who needed it, it joined users against the entire history of `chat_messages`, and against the whole memberships table, comparing timestamps with an expression no index can help with. That cost about 4,145 seconds of database time a day to find roughly 37 users.

The hourly run now only looks at activity since the last run. Nothing older can newly qualify: a user only falls behind when fresh activity arrives. The window reaches two hours further back than the last run, which covers a run that overlapped the previous one, a clock adjustment, or rows written slightly out of order — at the cost of re-examining an hour already known to be up to date, which the per-user check throws out immediately.

**The nightly unbounded pass at 03:45 is not optional.** Narrowing the hourly run is only safe because something still looks at everything: a writer inserting rows with a timestamp older than the window would otherwise never be seen. That pass is the whole correctness argument for the change, which is why it is scheduled rather than offered as a flag to run by hand. 03:45 is clear of the purge and statistics cluster and of the 04:00–04:17 backup window on db1.

With nothing recorded yet — the first run after deploying — the window opens seven days back rather than looking at nothing.

## Testing

Full Laravel suite: 5559 passed, 0 failed.

(That total is lower than an earlier run in the same session because the working tree
has since been restored to master, so the tests belonging to other branches are no
longer in it. It is the master baseline of 5554 plus the 5 added here.)

New tests cover the boundary that matters: a message 30 days old, with the last run recorded an hour ago, is left alone by the hourly pass and picked up by the nightly one. Plus that a run records where it got to, and a dry run does not.

For group counts: that an unchanged group is not written on a second run, and that two groups with different memberships do not pick up each other's totals — the failure a grouped query would produce if the results were matched up wrongly.

Run against the development database:

```
$ artisan groups:update-counts
Updated counts for 0 groups.        # already correct, so nothing written

$ artisan users:update-lastaccess   # nothing recorded yet
Updated lastaccess for 0 of 0 candidate users (activity since 2026-08-06 10:59:11).

$ artisan users:update-lastaccess   # now from the recorded point, less two hours
Updated lastaccess for 0 of 0 candidate users (activity since 2026-08-13 08:59:11).

$ artisan users:update-lastaccess --full
Updated lastaccess for 0 of 0 candidate users (all history).
```

Checked separately that no group's stored count disagrees with a direct count of its memberships, so the grouped passes agree with what the per-group counts produced.
