### PR TITLE
perf(batch): work out what is due for repost in SQL, and scan for languishing posts daily

### DIFF
--- a/iznik-batch/app/Console/Commands/Message/ChaseUpCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/ChaseUpCommand.php
@@ -12,7 +12,9 @@ class ChaseUpCommand extends Command
     use GracefulShutdown;
 
     protected $signature = 'messages:chase-up
-                            {--dry-run : Show what would be chased up without actually updating}';
+                            {--dry-run : Show what would be chased up without actually updating}
+                            {--skip-languishing : Leave the languishing-posts scan to its own daily run}
+                            {--languishing-only : Run only the languishing-posts scan}';
 
     protected $description = 'Send chase-up emails for messages with replies but no outcome after max reposts reached';
 
@@ -26,9 +28,31 @@ class ChaseUpCommand extends Command
             $this->info('DRY RUN — no changes will be made.');
         }
 
-        Log::info('Starting chase-up processing', ['dry_run' => $dryRun]);
+        $languishingOnly = (bool) $this->option('languishing-only');
+        $skipLanguishing = (bool) $this->option('skip-languishing');
+
+        Log::info('Starting chase-up processing', [
+            'dry_run' => $dryRun,
+            'languishing_only' => $languishingOnly,
+            'skip_languishing' => $skipLanguishing,
+        ]);
+
+        // The languishing scan finds the same posts every hour and can only raise one
+        // notification per person per day anyway (notifyLanguishing checks for a recent
+        // OpenPosts notification before adding another), so 23 of the 24 daily scans
+        // could never do anything. It runs once a day on its own schedule instead.
+        if ($languishingOnly) {
+            $this->info('Notifying about languishing posts...');
+            $languishing = $service->notifyLanguishing($dryRun);
+            $this->info("  Found {$languishing} languishing posts");
+
+            Log::info('Chase-up languishing scan complete', ['languishing' => $languishing]);
+
+            return Command::SUCCESS;
+        }
 
         // V1: chaseup.php calls these three operations before the main chaseUp().
+        // The first two are cheap and bounded, so they stay hourly.
         $this->info('Tidying dull outcome comments...');
         $tidied = $service->tidyOutcomes($dryRun);
         $this->info("  Tidied {$tidied} outcomes");
@@ -37,9 +61,11 @@ class ChaseUpCommand extends Command
         $intended = $service->processIntendedOutcomes($dryRun);
         $this->info("  Processed {$intended} intended outcomes");
 
-        $this->info('Notifying about languishing posts...');
-        $languishing = $service->notifyLanguishing($dryRun);
-        $this->info("  Found {$languishing} languishing posts");
+        if (!$skipLanguishing) {
+            $this->info('Notifying about languishing posts...');
+            $languishing = $service->notifyLanguishing($dryRun);
+            $this->info("  Found {$languishing} languishing posts");
+        }
 
         $this->info('Processing messages for chase-up...');
 

--- a/iznik-batch/app/Services/AutoRepostService.php
+++ b/iznik-batch/app/Services/AutoRepostService.php
@@ -120,7 +120,7 @@ class AutoRepostService
         // V1 query: approved messages with no outcome, no promise, source=Platform,
         // not deleted, poster still a member (not PROHIBITED), poster not deleted,
         // no deadline or future deadline.
-        $messages = $this->getCandidates($group->id, $mindate);
+        $messages = $this->getCandidates($group->id, $mindate, $reposts);
 
         $now = time();
 
@@ -140,9 +140,6 @@ class AutoRepostService
                 ? ($reposts['offer'] ?? 3)
                 : ($reposts['wanted'] ?? 7);
 
-            // V1: check for recent replies in chat about this message.
-            $recentReply = $this->hasRecentReply($msg->msgid, $interval);
-
             // V1: max age check — messages older than interval * (max + 1) days.
             $maxAge = $interval * (($reposts['max'] ?? 5) + 1);
             if ($msg->hoursago >= $maxAge * 24) {
@@ -158,7 +155,14 @@ class AutoRepostService
                 continue;
             }
 
-            if ($recentReply) {
+            // V1: check for recent replies in chat about this message.
+            //
+            // This asks chat_messages about one message, and it used to be asked before
+            // the two checks above - so every open post on every group paid for it,
+            // around 2.4M lookups a day, the overwhelming majority for posts that were
+            // then discarded. It decides nothing that those checks do not already
+            // decide first, so asking it here instead changes cost, not behaviour.
+            if ($this->hasRecentReply($msg->msgid, $interval)) {
                 $stats['skipped']++;
                 continue;
             }
@@ -254,9 +258,67 @@ class AutoRepostService
      *
      * V1 query from autoRepostGroup().
      */
-    protected function getCandidates(int $groupid, string $mindate)
+    /**
+     * Narrow the candidates to those that could actually be warned about or reposted.
+     *
+     * When a post is due is arithmetic on its arrival and the group's settings, so the
+     * database can do it. It used to return every open post on the group - about 109.5k
+     * an hour across the estate - and PHP then discarded the ~98% that were not due yet,
+     * having already run a chat lookup for each one.
+     *
+     * The band that does anything is:
+     *
+     *   arrival older than (interval - 1) days   - below that, neither branch fires
+     *   arrival newer than interval * (max + 1)  - past that, the post has aged out
+     *
+     * The bounds are expressed against arrival rather than TIMESTAMPDIFF so the arrival
+     * index can be used. That also makes the lower bound very slightly WIDER than the
+     * PHP test, because TIMESTAMPDIFF truncates to whole hours: a post 71 hours 30
+     * minutes old reports 71. The extra rows are simply handed to the same PHP checks
+     * as before, so this can only admit more than it should, never fewer - which is the
+     * direction that cannot lose a repost. AutoRepostDueWindowTest pins that.
+     */
+    protected function applyDueWindow($query, array $reposts)
     {
-        return DB::table('messages_groups')
+        $max = (int) ($reposts['max'] ?? 5);
+
+        $bands = [];
+        foreach ([Message::TYPE_OFFER => 'offer', Message::TYPE_WANTED => 'wanted'] as $type => $key) {
+            $interval = (int) ($reposts[$key] ?? ($type === Message::TYPE_OFFER ? 3 : 7));
+
+            // Reposting off for this type: PHP skips every one of them anyway.
+            if ($interval <= 0 || $max <= 0) {
+                continue;
+            }
+
+            $bands[$type] = [
+                'earliest' => max(0, ($interval - 1) * 24),
+                'latest' => $interval * ($max + 1) * 24,
+            ];
+        }
+
+        if (empty($bands)) {
+            // Nothing on this group can be reposted; return a query that matches nothing
+            // rather than scanning for rows PHP would discard one by one.
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->where(function ($outer) use ($bands) {
+            foreach ($bands as $type => $band) {
+                $outer->orWhere(function ($q) use ($type, $band) {
+                    $q->where('messages.type', $type)
+                        // keep-raw: an interval expression against NOW() with a bound
+                        // parameter; the query builder has no interval helper.
+                        ->whereRaw('messages_groups.arrival <= DATE_SUB(NOW(), INTERVAL ? HOUR)', [$band['earliest']])
+                        ->whereRaw('messages_groups.arrival > DATE_SUB(NOW(), INTERVAL ? HOUR)', [$band['latest']]);
+                });
+            }
+        });
+    }
+
+    protected function getCandidates(int $groupid, string $mindate, ?array $reposts = null)
+    {
+        $query = DB::table('messages_groups')
             ->join('messages', 'messages.id', '=', 'messages_groups.msgid')
             ->join('users', 'messages.fromuser', '=', 'users.id')
             ->join('memberships', function ($join) {
@@ -302,8 +364,13 @@ class AutoRepostService
             ->where(function ($q) {
                 $q->whereNull('messages.deadline')
                     ->orWhereRaw('messages.deadline > DATE(NOW())');
-            })
-            ->get();
+            });
+
+        if ($reposts !== null) {
+            $query = $this->applyDueWindow($query, $reposts);
+        }
+
+        return $query->get();
     }
 
     /**

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -228,10 +228,23 @@ Schedule::command('messages:auto-repost')
 
 // Chase up messages with replies but no outcome.
 // V1: cron/chaseup.php
-Schedule::command('messages:chase-up')
+//
+// Without --skip-languishing this also scanned for languishing posts every hour. That
+// scan finds the same ~1,840 posts each time, and notifyLanguishing will only raise one
+// notification per person per day regardless, so 23 of the 24 daily scans could never
+// do anything. It has its own schedule below.
+Schedule::command('messages:chase-up --skip-languishing')
     ->hourly()
     ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('messages:chase-up'))
+    ->runInBackground();
+
+// The languishing-posts scan, once a day. It raises an in-app notification rather than
+// sending mail, so the time only needs to be somewhere sensible in the member's day.
+Schedule::command('messages:chase-up --languishing-only')
+    ->dailyAt('09:00')
+    ->withoutOverlapping(120)
+    ->sendOutputTo(cronLog('messages:chase-up-languishing'))
     ->runInBackground();
 
 // Deduplicate searches.

--- a/iznik-batch/tests/Unit/Commands/Message/ChaseUpCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Message/ChaseUpCommandTest.php
@@ -88,4 +88,56 @@ class ChaseUpCommandTest extends TestCase
 
         $this->artisan('messages:chase-up')->assertExitCode(Command::SUCCESS);
     }
+
+    /**
+     * The hourly run skips the languishing scan, which finds the same posts every time
+     * and can raise at most one notification per person per day. The other two cheap
+     * sub-passes must keep running hourly.
+     */
+    public function test_skip_languishing_leaves_the_other_passes_hourly(): void
+    {
+        $service = $this->createMock(ChaseUpService::class);
+        $service->expects($this->once())->method('tidyOutcomes')->willReturn(1);
+        $service->expects($this->once())->method('processIntendedOutcomes')->willReturn(2);
+        $service->expects($this->never())->method('notifyLanguishing');
+        $service->expects($this->once())->method('process')
+            ->willReturn(['chased' => 3, 'skipped' => 0, 'errors' => 0]);
+
+        $this->app->instance(ChaseUpService::class, $service);
+
+        $this->artisan('messages:chase-up', ['--skip-languishing' => true])
+            ->expectsOutputToContain('Tidied 1 outcomes')
+            ->expectsOutputToContain('Processed 2 intended outcomes')
+            ->expectsOutputToContain('Chased: 3')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    /** The daily run does the languishing scan and nothing else. */
+    public function test_languishing_only_runs_just_that_scan(): void
+    {
+        $service = $this->createMock(ChaseUpService::class);
+        $service->expects($this->never())->method('tidyOutcomes');
+        $service->expects($this->never())->method('processIntendedOutcomes');
+        $service->expects($this->once())->method('notifyLanguishing')->with(false)->willReturn(9);
+        $service->expects($this->never())->method('process');
+
+        $this->app->instance(ChaseUpService::class, $service);
+
+        $this->artisan('messages:chase-up', ['--languishing-only' => true])
+            ->expectsOutputToContain('Found 9 languishing posts')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_languishing_only_honours_dry_run(): void
+    {
+        $service = $this->createMock(ChaseUpService::class);
+        $service->expects($this->once())->method('notifyLanguishing')->with(true)->willReturn(0);
+        $service->expects($this->never())->method('process');
+
+        $this->app->instance(ChaseUpService::class, $service);
+
+        $this->artisan('messages:chase-up', ['--languishing-only' => true, '--dry-run' => true])
+            ->expectsOutputToContain('no changes will be made')
+            ->assertExitCode(Command::SUCCESS);
+    }
 }

--- a/iznik-batch/tests/Unit/Services/AutoRepostDueWindowTest.php
+++ b/iznik-batch/tests/Unit/Services/AutoRepostDueWindowTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Message;
+use App\Models\MessageGroup;
+use App\Services\AutoRepostService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The due window moved from PHP into the candidate query, so the two have to agree.
+ *
+ * The direction that matters is one-sided: the query may hand PHP more rows than it
+ * will act on, because PHP still applies every check afterwards. It must never hand
+ * over fewer, because a post the query drops is a repost that silently never happens.
+ *
+ * The bounds are written against arrival while the PHP test uses TIMESTAMPDIFF, which
+ * truncates to whole hours, so the query is deliberately a little wider at the lower
+ * edge. These tests walk the boundary hour by hour to pin that down rather than take
+ * it on trust.
+ */
+class AutoRepostDueWindowTest extends TestCase
+{
+    private AutoRepostService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new AutoRepostService();
+    }
+
+    /** Run the real candidate query for a group with these settings. */
+    private function candidateIds(int $groupid, array $reposts): array
+    {
+        $method = new \ReflectionMethod(AutoRepostService::class, 'getCandidates');
+        $method->setAccessible(true);
+        $mindate = now()->subDays(AutoRepostService::LOOKBACK_DAYS)->format('Y-m-d');
+
+        return collect($method->invoke($this->service, $groupid, $mindate, $reposts))
+            ->pluck('msgid')->map(fn ($id) => (int) $id)->all();
+    }
+
+    /**
+     * What the PHP logic would do with a post of this age: does either the warning or
+     * the repost branch fire? Mirrors processGroup's arithmetic exactly.
+     */
+    private function phpWouldAct(int $hoursAgo, int $interval, int $max): bool
+    {
+        if ($interval <= 0 || $max <= 0) {
+            return false;
+        }
+        if ($hoursAgo >= $interval * ($max + 1) * 24) {
+            return false;                                  // aged out
+        }
+        if ($hoursAgo <= $interval * 24 && $hoursAgo > ($interval - 1) * 24) {
+            return true;                                   // warning band
+        }
+
+        return $hoursAgo > $interval * 24;                 // repost band
+    }
+
+    private function postAged(int $groupid, int $userid, int $hoursAgo, string $type): int
+    {
+        $msgid = DB::table('messages')->insertGetId([
+            'type' => $type,
+            'fromuser' => $userid,
+            'subject' => ($type === Message::TYPE_OFFER ? 'OFFER' : 'WANTED') . ": window {$hoursAgo}h",
+            'textbody' => 'body',
+            'source' => Message::SOURCE_PLATFORM,
+            'fromaddr' => 'someone@ilovefreegle.org',
+            'date' => now()->subHours($hoursAgo),
+            'arrival' => now()->subHours($hoursAgo),
+        ]);
+
+        DB::table('messages_groups')->insert([
+            'msgid' => $msgid,
+            'groupid' => $groupid,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subHours($hoursAgo),
+            'autoreposts' => 0,
+        ]);
+
+        return $msgid;
+    }
+
+    /**
+     * The one that matters: nothing PHP would act on may be filtered out by the query.
+     */
+    public function test_the_query_never_drops_a_post_php_would_act_on(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser();
+        $this->createMembership($user, $group);
+        DB::table('users')->where('id', $user->id)->update(['lastaccess' => now()->subYear()]);
+
+        $reposts = ['offer' => 3, 'wanted' => 7, 'max' => 5, 'chaseups' => 5];
+
+        // Walk each boundary hour by hour either side, for both types.
+        $ages = [];
+        foreach ([3, 7] as $interval) {
+            foreach ([($interval - 1) * 24, $interval * 24, $interval * ($reposts['max'] + 1) * 24] as $edge) {
+                foreach ([-2, -1, 0, 1, 2] as $offset) {
+                    $age = $edge + $offset;
+                    if ($age > 0) {
+                        $ages[] = $age;
+                    }
+                }
+            }
+        }
+        $ages = array_values(array_unique($ages));
+
+        $expected = [];
+        foreach ($ages as $age) {
+            foreach ([Message::TYPE_OFFER => 3, Message::TYPE_WANTED => 7] as $type => $interval) {
+                $msgid = $this->postAged($group->id, $user->id, $age, $type);
+                if ($this->phpWouldAct($age, $interval, $reposts['max'])) {
+                    $expected[$msgid] = "{$type} at {$age}h";
+                }
+            }
+        }
+
+        $returned = $this->candidateIds($group->id, $reposts);
+
+        foreach ($expected as $msgid => $what) {
+            $this->assertContains(
+                $msgid,
+                $returned,
+                "the query dropped a post the PHP logic would have acted on: {$what}"
+            );
+        }
+    }
+
+    /**
+     * And it should genuinely narrow things, or it is not worth having: a post far too
+     * new to be due must not come back at all.
+     */
+    public function test_the_query_drops_posts_that_are_nowhere_near_due(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser();
+        $this->createMembership($user, $group);
+
+        $reposts = ['offer' => 3, 'wanted' => 7, 'max' => 5, 'chaseups' => 5];
+
+        $tooNew = $this->postAged($group->id, $user->id, 1, Message::TYPE_OFFER);
+        $due = $this->postAged($group->id, $user->id, 3 * 24 + 5, Message::TYPE_OFFER);
+
+        $returned = $this->candidateIds($group->id, $reposts);
+
+        $this->assertNotContains($tooNew, $returned, 'an hour-old post is not due for anything');
+        $this->assertContains($due, $returned);
+    }
+
+    public function test_a_post_past_its_maximum_age_is_dropped(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser();
+        $this->createMembership($user, $group);
+
+        $reposts = ['offer' => 3, 'wanted' => 7, 'max' => 5, 'chaseups' => 5];
+
+        // interval 3 x (max 5 + 1) = 18 days; a 20-day-old offer has aged out.
+        $agedOut = $this->postAged($group->id, $user->id, 20 * 24, Message::TYPE_OFFER);
+
+        $this->assertNotContains($agedOut, $this->candidateIds($group->id, $reposts));
+    }
+
+    /** Each type is bounded by its own interval, not by the other's. */
+    public function test_offer_and_wanted_use_their_own_intervals(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser();
+        $this->createMembership($user, $group);
+
+        $reposts = ['offer' => 3, 'wanted' => 7, 'max' => 5, 'chaseups' => 5];
+
+        // Four days: past an offer's 3-day interval, short of a wanted's 7.
+        $offer = $this->postAged($group->id, $user->id, 4 * 24, Message::TYPE_OFFER);
+        $wanted = $this->postAged($group->id, $user->id, 4 * 24, Message::TYPE_WANTED);
+
+        $returned = $this->candidateIds($group->id, $reposts);
+
+        $this->assertContains($offer, $returned);
+        $this->assertNotContains($wanted, $returned, 'a wanted is not due at 4 days when its interval is 7');
+    }
+
+    /** Reposting switched off for the group means no candidates at all. */
+    public function test_reposting_turned_off_returns_nothing(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser();
+        $this->createMembership($user, $group);
+
+        $this->postAged($group->id, $user->id, 30 * 24, Message::TYPE_OFFER);
+
+        $this->assertSame([], $this->candidateIds($group->id, ['offer' => 3, 'wanted' => 7, 'max' => 0]));
+        $this->assertSame([], $this->candidateIds($group->id, ['offer' => 0, 'wanted' => 0, 'max' => 5]));
+    }
+}


### PR DESCRIPTION
## What this does

Two hourly jobs asking the database far more than they need to.

### Auto-repost: work out what is due in SQL

`messages:auto-repost` fetched every open post on a group — around 109.5k an hour across the estate — and PHP then threw away the roughly 98% that were not due yet. Worse, it asked chat about each one *first*, so about 2.4M chat lookups a day were spent on posts that were then discarded.

When a post is due is arithmetic on its arrival and the group's settings, so the database can do it. The band that does anything is:

- older than `(interval - 1)` days, below which neither the warning nor the repost fires
- newer than `interval * (max + 1)` days, past which the post has aged out

Both bounds are written against `arrival` rather than `TIMESTAMPDIFF` so the arrival index can be used, and both are applied per message type, since offers and wanteds have their own intervals from the group's settings.

The chat lookup also moves to after the cheap checks. It decides nothing the max-age and last-active checks do not already decide first, so asking it later changes cost, not behaviour.

### Chase-up: stop rescanning for languishing posts every hour

`messages:chase-up` also scanned for languishing posts hourly. That scan finds the same ~1,840 posts every time, and `notifyLanguishing` will only raise one notification per person per day anyway — it checks for a recent `OpenPosts` notification before adding another. So 23 of the 24 daily scans could never do anything.

It now runs once a day on its own schedule. The two cheap bounded sub-passes, tidying dull outcome comments and processing intended outcomes, stay hourly. The notification is in-app rather than an email, so the time of day only needs to be somewhere sensible.

## The direction the window can be wrong in

`TIMESTAMPDIFF` truncates to whole hours, so a post 71 hours 30 minutes old reports 71. Writing the bound against `arrival` instead makes the lower edge very slightly wider than the PHP test.

That is the safe direction, and deliberately so: the query hands PHP a few rows it will then discard, and PHP still applies every check exactly as before. It can only ever admit more than it should, never fewer — and a post the query wrongly dropped would be a repost that silently never happens, which is the failure worth designing against.

`AutoRepostDueWindowTest` pins this rather than leaving it as an argument. It creates posts at every boundary hour and two hours either side, for both types, works out independently whether the PHP logic would act on each, and asserts the query returned every one of them.

## What is not here

The audit also proposed pushing a due window into the chase-up candidate query itself. That is left for now, on the review's own advice: its sizing came from extrapolating a single measured run across 24 hours, for a job whose runtime varies several-fold by time of day, so it asked for a few runs to be measured before committing to the change. The languishing cadence above is the part that was self-evidently safe — the notification dedupe makes 23 of 24 scans provably pointless regardless of what the timings turn out to be.

## Testing

Full Laravel suite: 5562 passed, 0 failed.

The new boundary tests cover both types at every edge, a post nowhere near due being dropped, a post past its maximum age being dropped, offers and wanteds using their own intervals rather than each other's, and reposting switched off returning nothing at all.

For the chase-up split: that the hourly run skips the languishing scan while still running the other two passes, that the daily run does the languishing scan and nothing else, and that it still honours a dry run. The tests that were already there call the command with no flags, which still runs everything, so they pass unchanged.
