### PR TITLE
feat(browse): collapse your own posts behind one line

### DIFF
--- a/iznik-nuxt3/components/MessageList.vue
+++ b/iznik-nuxt3/components/MessageList.vue
@@ -12,6 +12,57 @@
     <h2 class="visually-hidden">List of wanteds and offers</h2>
     <div id="visobserver" v-observe-visibility="visibilityChanged" />
 
+    <!-- The viewer's own posts, collapsed. They are still first in the feed order; this just
+         stops several of your own cards standing between you and everything new. -->
+    <div v-if="ownPostsRowLabel" class="ownposts">
+      <button
+        type="button"
+        class="ownposts__toggle"
+        :aria-expanded="ownPostsExpanded"
+        aria-controls="ownposts-list"
+        @click="ownPostsExpanded = !ownPostsExpanded"
+      >
+        <v-icon :icon="ownPostsExpanded ? 'chevron-down' : 'chevron-right'" />
+        {{ ownPostsRowLabel }}
+      </button>
+      <!-- Through ScrollGrid, not a plain v-for: the grid is what gives the cards the feed's
+           two-column tile layout (and one column in landscape/on desktop). Rendered directly
+           they came out full-width and stacked, twice the height of the cards below them.
+           initial-count is the whole set, since expanding is an explicit request to see them
+           all and there are only ever a handful. -->
+      <ScrollGrid
+        v-if="ownPostsExpanded"
+        id="ownposts-list"
+        :items="ownPosts"
+        key-field="id"
+        :loading="loading"
+        :distance="distance"
+        :initial-count="ownPosts.length"
+      >
+        <template #item="{ item: m, index: ix }">
+          <div
+            :id="'messagewrapper-' + m.id"
+            :ref="'messagewrapper-' + m.id"
+            class="messagewrapper"
+          >
+            <Suspense>
+              <OurMessage
+                :id="m.id"
+                :matchedon="m.matchedon"
+                :preload="ix < 2"
+                record-view
+                @view="onCardView(m.id)"
+                @not-found="messageNotFound(m.id)"
+              />
+              <template #fallback>
+                <MessageSkeleton />
+              </template>
+            </Suspense>
+          </div>
+        </template>
+      </ScrollGrid>
+    </div>
+
     <div
       v-if="
         initialFetchDone && selectedSort === 'Unseen' && showCountsUnseen && me
@@ -162,6 +213,10 @@ import { throttleFetches } from '~/composables/useThrottle'
 import { useMe } from '~/composables/useMe'
 import { useScrollDepth } from '~/composables/useScrollDepth'
 import { useFeedCountSync } from '~/composables/useFeedCountSync'
+import {
+  partitionOwnPosts,
+  ownPostsLabel,
+} from '~/composables/useOwnPostsGroup'
 import {
   deduplicateMessages,
   findDuplicates,
@@ -469,7 +524,7 @@ function isOnMyGroup(message) {
 // on a group the viewer belongs to (Discourse 9733 / 9729); firstSeenMessage always wins.
 // Delegates to the pure deduplicateMessages, whose member-group swap is O(1) (id->index
 // Map) rather than the previous ret.findIndex() scan.
-const deDuplicatedMessages = computed(() =>
+const allDeDuplicatedMessages = computed(() =>
   deduplicateMessages(filteredMessagesToShow.value, {
     getMessage: (id) => filteredMessagesInStore.value[id],
     exclude: props.exclude,
@@ -477,6 +532,26 @@ const deDuplicatedMessages = computed(() =>
     isOnMyGroup,
     failedIds: failedIds.value,
   })
+)
+
+// The viewer's own posts come out of the feed and into one collapsed row above it. They are
+// still pinned first by sortBrowseMessages (Discourse 9933) - that is what makes them the
+// leading run here - but shown in full they meant anyone with a few live posts scrolled past
+// their own before reaching anything new.
+//
+// Taking them out of the split below is deliberate, not incidental: your own post is not "new
+// to you", so counting it as unseen put it above the YOU'RE UP TO DATE divider and into the
+// new-post tally.
+const ownPosts = computed(
+  () => partitionOwnPosts(allDeDuplicatedMessages.value).own
+)
+const deDuplicatedMessages = computed(
+  () => partitionOwnPosts(allDeDuplicatedMessages.value).others
+)
+
+const ownPostsExpanded = ref(false)
+const ownPostsRowLabel = computed(() =>
+  ownPostsLabel(ownPosts.value.length, ownPostsExpanded.value)
 )
 
 // For each rendered card, the ids of the crosspost/repost copies that deduplicateMessages
@@ -703,9 +778,39 @@ onBeforeUnmount(() => {
 })
 </script>
 <style scoped lang="scss">
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'assets/css/_color-vars.scss';
+
 .messagewrapper {
   flex: 1;
   display: flex;
   flex-direction: column;
+}
+
+.ownposts {
+  margin-bottom: 0.5rem;
+}
+
+/* A full-width row rather than a link: the whole thing is the target, which matters most on
+   a phone, and a button carries the expanded state for a screen reader without extra ARIA. */
+.ownposts__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid $gray-300;
+  background: $gray-200;
+  color: $gray-700;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: left;
+
+  &:hover,
+  &:focus-visible {
+    background: $gray-300;
+    color: $gray-800;
+  }
 }
 </style>

--- a/iznik-nuxt3/composables/useOwnPostsGroup.js
+++ b/iznik-nuxt3/composables/useOwnPostsGroup.js
@@ -1,0 +1,56 @@
+// The viewer's own posts, collapsed out of the browse feed.
+//
+// They are pinned to the top of every sort (see sortBrowseMessages - Discourse 9933, so
+// members can find their own posts rather than losing them in the reach order), but shown in
+// full that meant anyone with a few live posts scrolled past their own before reaching
+// anything new. Same information, one line instead of several cards, expandable on click.
+//
+// Pure, and separate from MessageList for the same reason sortBrowseMessages is: that
+// component carries ScrollGrid, async cards and visibility observers, none of which this
+// logic needs in order to be tested.
+
+/**
+ * Split a feed into the viewer's own posts and everyone else's.
+ *
+ * Order is preserved on both sides: sortBrowseMessages has already put own posts
+ * newest-first and the rest in the chosen sort, and neither should be disturbed here.
+ *
+ * A missing `mine` flag counts as not the viewer's - older cached feeds, and any path that
+ * did not populate it, must not have their posts hidden behind the collapsed row.
+ *
+ * @param {Array} messages feed summaries
+ * @returns {{own: Array, others: Array}} new arrays; the input is not mutated
+ */
+export function partitionOwnPosts(messages) {
+  const own = []
+  const others = []
+
+  for (const m of messages || []) {
+    if (m?.mine) {
+      own.push(m)
+    } else {
+      others.push(m)
+    }
+  }
+
+  return { own, others }
+}
+
+/**
+ * The text of the collapsed row.
+ *
+ * Says what it does when clicked, because the row is the only affordance - there is no
+ * separate chevron to read as "expandable".
+ *
+ * @param {number} count how many of the viewer's posts are in the feed
+ * @param {boolean} expanded whether they are currently shown
+ * @returns {string|null} null when there are none, so the caller can omit the row
+ */
+export function ownPostsLabel(count, expanded) {
+  if (!count) return null
+
+  const noun = count === 1 ? 'post' : 'posts'
+  const action = expanded ? 'hide' : 'show'
+
+  return `${count} ${noun} by you - click to ${action}`
+}

--- a/iznik-nuxt3/tests/unit/composables/ownPostsGroup.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/ownPostsGroup.spec.js
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import {
+  partitionOwnPosts,
+  ownPostsLabel,
+} from '~/composables/useOwnPostsGroup'
+
+// The viewer's own posts were pinned to the top of every browse sort (Discourse 9933, so
+// members could find them) but shown in full, so on a feed where you have several live posts
+// you scrolled past your own before reaching anything new. They are now collapsed behind a
+// single line, expandable on click.
+//
+// Pure functions, extracted for the same reason sortBrowseMessages was: MessageList is heavy
+// with ScrollGrid, async cards and observers, and the interesting logic deserves a test that
+// does not have to mount any of it.
+
+const mine = (id, extra = {}) => ({ id, mine: true, ...extra })
+const theirs = (id, extra = {}) => ({ id, mine: false, ...extra })
+
+describe('partitionOwnPosts', () => {
+  it('splits the viewer’s posts out from the rest, keeping each order', () => {
+    const { own, others } = partitionOwnPosts([
+      mine(1),
+      theirs(2),
+      mine(3),
+      theirs(4),
+    ])
+
+    expect(own.map((m) => m.id)).toEqual([1, 3])
+    expect(others.map((m) => m.id)).toEqual([2, 4])
+  })
+
+  it('preserves the incoming order within each side', () => {
+    // sortBrowseMessages has already ordered own posts newest-first and the rest by the
+    // chosen sort. Partitioning must not disturb either.
+    const { own, others } = partitionOwnPosts([
+      mine(9),
+      mine(7),
+      theirs(5),
+      theirs(3),
+    ])
+
+    expect(own.map((m) => m.id)).toEqual([9, 7])
+    expect(others.map((m) => m.id)).toEqual([5, 3])
+  })
+
+  it('treats a missing mine flag as not the viewer’s', () => {
+    // Older cached feeds, and any path that did not populate the flag.
+    const { own, others } = partitionOwnPosts([{ id: 1 }, mine(2)])
+
+    expect(own.map((m) => m.id)).toEqual([2])
+    expect(others.map((m) => m.id)).toEqual([1])
+  })
+
+  it('copes with an empty or absent list', () => {
+    expect(partitionOwnPosts([])).toEqual({ own: [], others: [] })
+    expect(partitionOwnPosts(null)).toEqual({ own: [], others: [] })
+    expect(partitionOwnPosts(undefined)).toEqual({ own: [], others: [] })
+  })
+
+  it('returns new arrays rather than mutating the input', () => {
+    const input = [mine(1), theirs(2)]
+    const { own, others } = partitionOwnPosts(input)
+
+    expect(input.map((m) => m.id)).toEqual([1, 2])
+    expect(own).not.toBe(input)
+    expect(others).not.toBe(input)
+  })
+})
+
+describe('ownPostsLabel', () => {
+  it('reads as the collapsed invitation when closed', () => {
+    expect(ownPostsLabel(3, false)).toBe('3 posts by you - click to show')
+  })
+
+  it('offers to put them away again when open', () => {
+    expect(ownPostsLabel(3, true)).toBe('3 posts by you - click to hide')
+  })
+
+  it('says post, not posts, for one', () => {
+    expect(ownPostsLabel(1, false)).toBe('1 post by you - click to show')
+    expect(ownPostsLabel(1, true)).toBe('1 post by you - click to hide')
+  })
+
+  it('says nothing when there are none, so the row can be left out entirely', () => {
+    expect(ownPostsLabel(0, false)).toBeNull()
+  })
+})


### PR DESCRIPTION
Your own posts pin to the top of every browse sort (`sortBrowseMessages`, added for Discourse 9933 so members could find them rather than lose them in the reach order). Shown in full, anyone with a few live posts scrolled past their own before reaching anything new — on a phone that is most of the first screen.

They are now one row, expanding to the same cards:

| state | row | feed |
|---|---|---|
| collapsed | `2 posts by you - click to show` | 3 of 5 cards |
| expanded | `2 posts by you - click to hide` | 5 cards, both own ones in the tile grid |

Taken on the real feed with two posts flagged `mine`:

![Own posts collapsed to a single row above the feed](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/collapse-own-posts/ownposts-collapsed.png)

![Expanded, in the same two-column tile grid as the feed](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/collapse-own-posts/ownposts-expanded.png)

The row says what clicking does, because the row **is** the affordance — there is no separate chevron to read as "expandable". It is a `<button>`, so a screen reader gets the expanded state without extra ARIA, and the whole width is the target, which matters on a phone.

## Two decisions worth flagging

**Own posts come out of the unseen/seen split.** Deliberate, not incidental: your own post is not new to *you*, so counting it as unseen put it above the YOU'RE UP TO DATE divider and into the new-post tally. The collapsed row now sits above that divider and the tally counts other people's posts.

**Expanded posts render through `ScrollGrid`, not a plain `v-for`.** The grid is what gives them the feed's two-column tile layout; rendered directly they came out full-width and stacked, about twice the height of the cards below them. That one was caught in the browser, not by the tests. `initial-count` is the whole set, since expanding is an explicit request to see them all and there are only ever a handful.

## Structure

The partition and the label are pure functions in `composables/useOwnPostsGroup.js`, extracted for the same reason `sortBrowseMessages` was: `MessageList` carries ScrollGrid, async cards and visibility observers, none of which this logic needs in order to be tested.

## Verification

TDD — `ownPostsGroup.spec.js` written first and failing on the missing module, then **9 green**:

- partition keeps each side's incoming order (the sort has already put own posts newest-first)
- a missing `mine` flag counts as not yours, so older cached feeds do not get posts hidden behind the row
- empty, `null` and `undefined` input
- input not mutated, new arrays returned
- label wording show/hide, singular "1 post", and `null` at zero so the row can be omitted

Full unit suite **15426** (master's 15417 + these 9).

Browser check on the real feed with two posts flagged `mine`: collapsed row reads "2 posts by you - click to show" with 3 of 5 cards; expanded reads "click to hide" with both own cards present and 5 shown; clicking again returns to 3. `aria-expanded` tracks throughout.

## Not done

The open/closed state is not remembered between visits — it starts collapsed each time, which is the point of the change. Easy to persist in the misc store if you would rather it stuck.

---

Screenshots live on the throwaway `pr-assets/collapse-own-posts` branch, which keeps the binaries out of the code diff and can be deleted after merge.
