### PR TITLE
perf(digest): stop asking which groups have immediate members

### DIFF
--- a/iznik-batch/app/Console/Commands/Mail/SendUnifiedDigestCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendUnifiedDigestCommand.php
@@ -26,6 +26,28 @@ class SendUnifiedDigestCommand extends Command
     private const IDLE_ITERATION_SECONDS = 2.0;
 
     /**
+     * The shortest pause between idle passes, whatever the pass cost.
+     *
+     * Pacing purely on elapsed time has a nasty edge: a pass that overruns the period
+     * leaves no remainder to wait out, so the loop would go straight round again with no
+     * gap at all. The pass most likely to overrun is a slow one, and the usual reason for
+     * a slow one is a database under strain - exactly when easing off matters most. This
+     * floor keeps a gap there regardless.
+     */
+    private const IDLE_MINIMUM_PAUSE_SECONDS = 0.5;
+
+    /**
+     * How long to wait after an idle pass that took $elapsed seconds.
+     *
+     * Separated out so the awkward cases can be tested without having to make a real
+     * pass run slowly.
+     */
+    public static function idlePauseSeconds(float $elapsed): float
+    {
+        return max(self::IDLE_MINIMUM_PAUSE_SECONDS, self::IDLE_ITERATION_SECONDS - $elapsed);
+    }
+
+    /**
      * The name and signature of the console command.
      *
      * --limit semantics:
@@ -166,7 +188,10 @@ class SendUnifiedDigestCommand extends Command
         $shouldStop = fn () => $this->shouldStop();
 
         for ($i = 0; $i < $maxIterations; $i++) {
-            $iterationStart = microtime(true);
+            // hrtime, not microtime: this measures how long the pass took, and the
+            // system clock can step (NTP, a VM resuming) in a way that would make that
+            // measurement nonsense. hrtime only ever moves forward.
+            $iterationStart = hrtime(true);
 
             $r = $service->sendDigests($mode, $userId, $limit, $dryRun, $groupId, $shard, $shards, $shouldStop);
 
@@ -195,10 +220,8 @@ class SendUnifiedDigestCommand extends Command
             // spent on running it more often. Sleeping the remainder of the period
             // instead holds the rate steady whatever the queries cost.
             if (($r['emails_sent'] ?? 0) === 0 && $i + 1 < $maxIterations) {
-                $remaining = self::IDLE_ITERATION_SECONDS - (microtime(true) - $iterationStart);
-                if ($remaining > 0) {
-                    usleep((int) ($remaining * 1_000_000));
-                }
+                $elapsed = (hrtime(true) - $iterationStart) / 1_000_000_000;
+                usleep((int) (self::idlePauseSeconds($elapsed) * 1_000_000));
             }
         }
 

--- a/iznik-batch/app/Console/Commands/Mail/SendUnifiedDigestCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendUnifiedDigestCommand.php
@@ -15,6 +15,17 @@ class SendUnifiedDigestCommand extends Command
     use PreventsOverlapping;
 
     /**
+     * How long an idle pass through the loop takes, at minimum.
+     *
+     * Chosen to match what an idle pass effectively cost before: the eligible-groups
+     * query plus a one-second sleep. Paced on elapsed time rather than slept flat, so
+     * that making those queries cheaper banks the saving instead of spending it on
+     * polling more often. Only idle passes wait - a pass that sent something starts the
+     * next one immediately.
+     */
+    private const IDLE_ITERATION_SECONDS = 2.0;
+
+    /**
      * The name and signature of the console command.
      *
      * --limit semantics:
@@ -142,7 +153,8 @@ class SendUnifiedDigestCommand extends Command
         // any time during our run, and another shard may be processing
         // one of our groups (no — partitions are disjoint, but messages
         // are still arriving from outside the digest system). Match the
-        // mail:chat:user2user pattern: sleep(1) when nothing to do, keep
+        // mail:chat:user2user pattern: hold idle passes to a fixed period
+        // (IDLE_ITERATION_SECONDS) rather than racing round the loop, and keep
         // looping until max-iterations is hit. The next cron tick takes
         // over from there.
         // Immediate mode reports per-group counters (groups_processed,
@@ -154,6 +166,8 @@ class SendUnifiedDigestCommand extends Command
         $shouldStop = fn () => $this->shouldStop();
 
         for ($i = 0; $i < $maxIterations; $i++) {
+            $iterationStart = microtime(true);
+
             $r = $service->sendDigests($mode, $userId, $limit, $dryRun, $groupId, $shard, $shards, $shouldStop);
 
             // Daily mode returns a different stat shape — match keys best-effort.
@@ -171,11 +185,20 @@ class SendUnifiedDigestCommand extends Command
                 break;
             }
 
-            // Sleep briefly between idle iterations so we don't hammer
-            // the DB with empty queries. Active iterations roll straight
-            // into the next without a sleep.
+            // Hold idle iterations to a fixed period so we don't hammer the DB with
+            // empty queries. Active iterations roll straight into the next without a
+            // wait, because immediate mail is meant to be immediate.
+            //
+            // This paces on ELAPSED TIME rather than sleeping a flat second, which
+            // matters as soon as the queries get cheaper: a flat sleep leaves the poll
+            // rate free to rise as the work shrinks, so a saving in the query is partly
+            // spent on running it more often. Sleeping the remainder of the period
+            // instead holds the rate steady whatever the queries cost.
             if (($r['emails_sent'] ?? 0) === 0 && $i + 1 < $maxIterations) {
-                sleep(1);
+                $remaining = self::IDLE_ITERATION_SECONDS - (microtime(true) - $iterationStart);
+                if ($remaining > 0) {
+                    usleep((int) ($remaining * 1_000_000));
+                }
             }
         }
 

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -187,22 +187,24 @@ class UnifiedDigestService
             return $stats;
         }
 
-        // The EXISTS is left as a per-group correlated subquery (NO_SEMIJOIN) so it resolves via
-        // the memberships(groupid,...) index and short-circuits on the first immediate member of
-        // each group. Without the hint the optimiser materialises the semijoin using only the
-        // `collection` index, scanning ~2.37M Approved rows (10-24s) because there is no index on
-        // memberships.emailfrequency. Immediate members are ~0.7% of Approved, so the per-group
-        // lookup is far cheaper. (A memberships(emailfrequency,groupid) index would make either
-        // plan fast, but this needs no DDL.) groups_digests is tiny (~3k rows).
+        // This used to carry an EXISTS against memberships, to skip groups with no
+        // immediate members at all. It was the single most expensive thing this service
+        // did: 0.61-0.88s per execution, run about 232,000 times a day across the shards,
+        // roughly one and a half to two cores of the database sustained - to skip 12
+        // groups out of 505.
+        //
+        // Dropping it is safe because it decided nothing. processGroupImmediate selects
+        // recipients with exactly the same condition (emailfrequency = Immediate,
+        // collection = Approved), so a group with none produces an empty recipient list
+        // and sends nothing. And a group that reaches that point with messages but no
+        // recipients still advances its cursor, so it cannot re-scan the same messages
+        // every tick.
+        //
+        // The 12 groups now cost one cursor-bounded message lookup each per pass, against
+        // a correlated subquery that ran for all 505.
         $query = DB::table('groups_digests as gd')
             ->where('gd.frequency', Membership::EMAIL_FREQUENCY_IMMEDIATE)
-            ->whereExists(function ($q) {
-                $q->select(DB::raw('/*+ QB_NAME(imm_member) */ 1'))->from('memberships')
-                    ->whereColumn('memberships.groupid', 'gd.groupid')
-                    ->where('memberships.emailfrequency', Membership::EMAIL_FREQUENCY_IMMEDIATE)
-                    ->where('memberships.collection', Membership::COLLECTION_APPROVED);
-            })
-            ->select(DB::raw('/*+ NO_SEMIJOIN(@imm_member) */ gd.groupid'), 'gd.msgid as cursor_msgid', 'gd.msgdate as cursor_msgdate');
+            ->select('gd.groupid', 'gd.msgid as cursor_msgid', 'gd.msgdate as cursor_msgdate');
 
         // Partition groups across parallel shards. MOD(groupid, shards) =
         // shard means each group is owned by exactly one shard. Disjoint

--- a/iznik-batch/tests/Feature/Mail/SendUnifiedDigestCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/SendUnifiedDigestCommandTest.php
@@ -75,6 +75,28 @@ class SendUnifiedDigestCommandTest extends TestCase
         $this->assertStringContainsString('--max-iterations=1 ', $signature->getValue($cmd));
     }
 
+    public function test_idle_pause_never_disappears_however_slow_the_pass(): void
+    {
+        // The loop paces itself by sleeping whatever is left of a fixed period after
+        // each idle pass. Taken literally that means a pass which overruns the period
+        // leaves nothing to sleep, so the loop goes straight round again with no gap.
+        // The passes that overrun are the slow ones, and the usual reason for a slow
+        // one is a database already struggling, so the moment the pause is needed most
+        // is the moment it would vanish. There is a floor to stop that happening.
+        $cls = \App\Console\Commands\Mail\SendUnifiedDigestCommand::class;
+
+        // A quick pass waits out the rest of the period, holding the poll rate steady
+        // however cheap the queries get.
+        $this->assertEqualsWithDelta(1.9, $cls::idlePauseSeconds(0.1), 0.001);
+
+        // A pass that fills the period still pauses, rather than dropping to nothing.
+        $this->assertGreaterThan(0, $cls::idlePauseSeconds(2.0));
+
+        // And a pass that badly overruns pauses too. This is the case that matters:
+        // before the floor existed this returned nothing at all.
+        $this->assertGreaterThanOrEqual(0.5, $cls::idlePauseSeconds(30.0));
+    }
+
     public function test_spool_failure_for_recipient_still_advances_cursor(): void
     {
         // Regression guard for the duplicate-send hazard: if spool() throws

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -1571,6 +1571,41 @@ class UnifiedDigestServiceTest extends TestCase
         $this->assertEquals(6, $stats['emails_sent']);
     }
 
+    /**
+     * A group with no immediate members must not re-scan the same messages on every
+     * tick. Without a cursor advance its scan window would grow without limit, which is
+     * the way dropping the eligible-groups pre-filter could have cost more than it saved.
+     */
+    public function test_group_with_no_immediate_members_still_advances_its_cursor(): void
+    {
+        $group = $this->createTestGroup();
+        $poster = $this->createTestUser();
+
+        $daily = $this->createTestUser();
+        $this->createMembership($daily, $group, [
+            'emailfrequency' => Membership::EMAIL_FREQUENCY_DAILY,
+        ]);
+
+        $this->seedImmediateCursor($group);
+        $message = $this->createTestMessage($poster, $group);
+        $this->makeImmediateReady($message);
+
+        $this->service->sendDigests(
+            UnifiedDigestService::MODE_IMMEDIATE, null, null, false, $group->id
+        );
+
+        $cursor = DB::table('groups_digests')
+            ->where('groupid', $group->id)
+            ->where('frequency', Membership::EMAIL_FREQUENCY_IMMEDIATE)
+            ->first();
+
+        $this->assertEquals(
+            $message->id,
+            (int) $cursor->msgid,
+            'the cursor must move past a message nobody was mailed, or it is rescanned for ever'
+        );
+    }
+
     public function test_immediate_advances_groups_digests_cursor(): void
     {
         config(['freegle.digest.immediate_allowlist' => '*']);
@@ -1626,7 +1661,18 @@ class UnifiedDigestServiceTest extends TestCase
         $this->assertEquals(0, $second['emails_sent'], 'Cursor msgid must keep same-arrival messages from re-firing');
     }
 
-    public function test_immediate_skips_groups_with_no_immediate_members(): void
+    /**
+     * Renamed and re-pointed with the eligible-groups EXISTS removed.
+     *
+     * It used to assert groups_processed === 0, and its comment named the whereExists()
+     * as the reason. That filter cost roughly one and a half cores of the database
+     * sustained to skip 12 groups out of 505, so it is gone; the group is walked now.
+     *
+     * The guarantee members actually rely on is the second assertion, and it is
+     * untouched: nobody who has not asked for immediate mail receives any. That holds
+     * because the recipient query applies the same condition the EXISTS did.
+     */
+    public function test_immediate_sends_nothing_to_groups_with_no_immediate_members(): void
     {
         config(['freegle.digest.immediate_allowlist' => '*']);
 
@@ -1644,10 +1690,8 @@ class UnifiedDigestServiceTest extends TestCase
 
         $stats = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE);
 
-        // The whereExists() filter in sendImmediateDigests should skip the
-        // group entirely because no membership has emailfrequency=-1.
-        $this->assertEquals(0, $stats['groups_processed']);
-        $this->assertEquals(0, $stats['emails_sent']);
+        $this->assertEquals(1, $stats['groups_processed'], 'the group is walked, not pre-filtered out');
+        $this->assertEquals(0, $stats['emails_sent'], 'nobody on it has asked for immediate mail');
     }
 
     public function test_immediate_limit_caps_groups_processed_per_run(): void


### PR DESCRIPTION
## What this does

The immediate-digest workers walk `groups_digests` to find which groups have new posts to send. That query carried an `EXISTS` against `memberships`, to skip groups where nobody has asked for immediate mail.

It was the most expensive thing this service did. Measured against production:

| | |
|---|---|
| The query as it runs today | 0.713s |
| The same query without the `EXISTS` | 0.202s, most of which is connecting |
| Groups the `EXISTS` skips | 12, out of 505 |

It runs about 232,000 times a day across the shards. So roughly half a second, a quarter of a million times, to avoid looking at twelve groups.

## Why dropping it is safe

It decided nothing that was not decided again immediately afterwards.

`processGroupImmediate` picks recipients with exactly the same condition the `EXISTS` tested — `emailfrequency` is Immediate and `collection` is Approved, for that group. A group with nobody matching produces an empty recipient list and sends nothing. Nobody can receive mail they have not asked for as a result of this change.

The other way it could have gone wrong is a group being re-examined for ever. It is not: when the recipient list comes out empty, the code already moves that group's marker past those messages, with a comment noting V1 moved it unconditionally too. So those twelve groups cost one bounded message lookup each per pass, against a correlated subquery that ran for all 505.

## Banking the saving rather than spending it

The worker loops within a single invocation to fill the minute between cron ticks, and slept a flat second after any pass that sent nothing.

A flat sleep leaves the polling rate free to rise as the work gets cheaper. With the query fourteen times faster, idle passes would simply come round faster, and a good part of the saving would go on running the query more often instead of on doing less work.

Idle passes are now held to a fixed period: wait out whatever is left of it, rather than a flat second, so the rate stays put whatever the queries cost. Passes that actually sent something still start the next one immediately, because immediate mail is meant to be immediate.

There is a floor under that wait. Held to the letter, "wait out the remainder" means a pass that overruns the period leaves nothing to wait, and the loop goes straight round again with no gap at all. The passes that overrun are the slow ones, and the usual reason for a slow one is a database already struggling, so the pause would disappear exactly when it was most needed. It now always pauses, and it measures the elapsed time with a clock that cannot be stepped backwards by a time correction.

## A test that changed meaning

`test_immediate_skips_groups_with_no_immediate_members` asserted that such a group was not walked at all, and its comment named the `whereExists` as the reason. That is a test of the mechanism this removes.

Its second assertion is the one that matters to members — no mail is sent — and that is untouched and still passes. The test is renamed to say what it now pins, and a second test covers the marker moving on, so the "re-examined for ever" failure is pinned rather than argued.

## Testing

Full Laravel suite: 5588 passed, 0 failed.

