### PR TITLE
perf(batch): read only new addresses in the TN duplicate check, and move the reengage recount to night

### DIFF
--- a/iznik-batch/app/Console/Commands/TrashNothing/TNSyncCommand.php
+++ b/iznik-batch/app/Console/Commands/TrashNothing/TNSyncCommand.php
@@ -29,7 +29,8 @@ class TNSyncCommand extends Command
                             {--to= : Override sync end timestamp (ISO-8601)}
                             {--run-id= : Queue run identifier used to update background_tasks JSON completion state}
                             {--dry-run : Trace DB writes without executing them}
-                            {--local-testing : Load API responses from local fixture files instead of hitting the live TN API}';
+                            {--local-testing : Load API responses from local fixture files instead of hitting the live TN API}
+                            {--full-duplicate-scan : Re-scan every Trash Nothing address rather than only those added since the last run}';
 
     protected $description = 'Sync data from TrashNothing, including user data updates, user ratings, posts/messages, and chat messages.';
 
@@ -102,7 +103,7 @@ class TNSyncCommand extends Command
                 }
 
                 // Merge duplicate TN users.
-                $duplicatesMerged = $this->mergeDuplicateTNUsers();
+                $duplicatesMerged = $this->mergeDuplicateTNUsers((bool) $this->option('full-duplicate-scan'));
 
                 // Store the max change date for next sync.
                 if ($maxChangeDate) {
@@ -609,7 +610,44 @@ class TNSyncCommand extends Command
         return [$count, $maxDate];
     }
 
-    private function mergeDuplicateTNUsers(): int
+    /** Where the per-tick duplicate check remembers how far it has read. */
+    private const DUP_CURSOR_KEY = 'tn.dupscan_cursor';
+
+    /** When the last whole-table duplicate re-scan finished. */
+    private const DUP_FULL_AT_KEY = 'tn.dupscan_full_at';
+
+    /**
+     * How long the per-tick check may run before one tick does the whole table again.
+     *
+     * The full re-scan is what covers a duplicate created by re-pointing an existing row
+     * rather than adding one, since that adds no new id for the per-tick check to see.
+     * It happens on one ordinary tick rather than on a schedule of its own: a separate
+     * scheduled entry would be a different command string, so it would not share the
+     * per-minute run's overlap mutex and the two could run at once.
+     */
+    private const DUP_FULL_SCAN_HOURS = 24;
+
+    /**
+     * Merge Trash Nothing accounts that are really the same person.
+     *
+     * This ran on every tick, and a tick is every minute. Each run streamed all ~400,000
+     * Trash Nothing addresses out of users_emails and grouped them in PHP, about five
+     * seconds of database time and twenty gigabytes a day off the wire, to find a number
+     * of duplicates measured at roughly zero a day.
+     *
+     * A duplicate can only come into existence when a users_emails row is INSERTED, so
+     * the per-tick check now looks only at rows added since the last one, and probes for
+     * siblings of each by an indexed prefix on the address. Typically that is no rows at
+     * all and no probes.
+     *
+     * The one thing that escapes it is an UPDATE re-pointing an existing row, which adds
+     * no new id. $full is the answer to that: the nightly run does today's whole scan,
+     * and it is a permanent fixture rather than a transitional one - it is the only
+     * reason narrowing the per-tick check is safe. Worst case a duplicate is merged a day
+     * late, against an event rate of about zero a day, and User::merge re-checks live
+     * state anyway so a late merge cannot corrupt anything.
+     */
+    private function mergeDuplicateTNUsers(bool $full = false): int
     {
         // Use the `backwards` index (REVERSE(email)) to avoid a full table scan.
         // LIKE '%@user.trashnothing.com' can't use the email index (leading wildcard),
@@ -620,25 +658,66 @@ class TNSyncCommand extends Command
         // full ~400k-row result set as Eloquent models exhausts the 512M memory_limit;
         // raw rows are an order of magnitude lighter and we only need userid + email.
         // Group by TN username in PHP — avoids slow REGEXP_REPLACE GROUP BY in MySQL.
+        // Read the watermark BEFORE any work, so a row arriving mid-run is left for the
+        // next run rather than stepped over.
+        $highWater = (int) DB::table('users_emails')->max('id');
+        $cursor = ($full || $this->fullDuplicateScanDue()) ? null : $this->readDupCursor();
+        $didFullScan = $cursor === null;
+
         $groups = [];
-        foreach (
-            DB::table('users_emails')
-                ->select('userid', 'email')
-                ->where('backwards', 'LIKE', $reversedSuffix . '%')
-                ->orderBy('id')
-                ->cursor() as $row
-        ) {
-            $username = preg_replace('/-g\d+@user\.trashnothing\.com$/i', '', $row->email);
-            $groups[$username][] = (int) $row->userid;
+
+        if ($cursor === null) {
+            // Full pass: the nightly reconciliation, and whatever runs first after a
+            // deploy so there is a watermark to work from.
+            foreach (
+                DB::table('users_emails')
+                    ->select('userid', 'email')
+                    ->where('backwards', 'LIKE', $reversedSuffix . '%')
+                    ->orderBy('id')
+                    ->cursor() as $row
+            ) {
+                $username = preg_replace('/-g\d+@user\.trashnothing\.com$/i', '', $row->email);
+                $groups[$username][] = (int) $row->userid;
+            }
+        } else {
+            // Only addresses added since last time. For each, collect everyone sharing
+            // its Trash Nothing username - an indexed prefix match on the address, since
+            // email is uniquely indexed and 'username-g' anchors the left of it.
+            $newUsernames = [];
+            foreach (
+                DB::table('users_emails')
+                    ->select('email')
+                    ->where('backwards', 'LIKE', $reversedSuffix . '%')
+                    ->where('id', '>', $cursor)
+                    ->where('id', '<=', $highWater)
+                    ->cursor() as $row
+            ) {
+                $newUsernames[preg_replace('/-g\d+@user\.trashnothing\.com$/i', '', $row->email)] = true;
+            }
+
+            foreach (array_keys($newUsernames) as $username) {
+                foreach (
+                    DB::table('users_emails')
+                        ->select('userid', 'email')
+                        ->where('email', 'LIKE', str_replace(['%', '_'], ['\\%', '\\_'], $username) . '-g%@user.trashnothing.com')
+                        ->cursor() as $row
+                ) {
+                    $groups[$username][] = (int) $row->userid;
+                }
+            }
         }
 
         if (empty($groups)) {
+            $this->writeDupCursor($highWater, $didFullScan);
+
             return 0;
         }
 
         $duplicateGroups = array_filter($groups, fn($ids) => count(array_unique($ids)) > 1);
 
         if (empty($duplicateGroups)) {
+            $this->writeDupCursor($highWater, $didFullScan);
+
             return 0;
         }
 
@@ -664,6 +743,46 @@ class TNSyncCommand extends Command
             }
         }
 
+        // Only once the merges are done. A crash before this point leaves the watermark
+        // where it was, so the next run re-reads the same rows rather than stepping over
+        // a duplicate it never got to.
+        $this->writeDupCursor($highWater, $didFullScan);
+
         return $merged;
+    }
+
+    /** Is it time for one tick to re-scan the whole table? */
+    private function fullDuplicateScanDue(): bool
+    {
+        $last = DB::table('config')->where('key', self::DUP_FULL_AT_KEY)->value('value');
+
+        if (!$last) {
+            return true;
+        }
+
+        return strtotime($last) < strtotime('-' . self::DUP_FULL_SCAN_HOURS . ' hours');
+    }
+
+    /** How far the per-tick duplicate check has read, or null if it has never run. */
+    private function readDupCursor(): ?int
+    {
+        $value = DB::table('config')->where('key', self::DUP_CURSOR_KEY)->value('value');
+
+        return $value === null || $value === '' ? null : (int) $value;
+    }
+
+    private function writeDupCursor(int $highWater, bool $wasFull = false): void
+    {
+        if ($this->dryRun) {
+            return;
+        }
+
+        $rows = [['key' => self::DUP_CURSOR_KEY, 'value' => (string) $highWater]];
+
+        if ($wasFull) {
+            $rows[] = ['key' => self::DUP_FULL_AT_KEY, 'value' => now()->toDateTimeString()];
+        }
+
+        DB::table('config')->upsert($rows, ['key'], ['value']);
     }
 }

--- a/iznik-batch/app/Console/Commands/TrashNothing/TNSyncCommand.php
+++ b/iznik-batch/app/Console/Commands/TrashNothing/TNSyncCommand.php
@@ -699,7 +699,15 @@ class TNSyncCommand extends Command
                 foreach (
                     DB::table('users_emails')
                         ->select('userid', 'email')
-                        ->where('email', 'LIKE', str_replace(['%', '_'], ['\\%', '\\_'], $username) . '-g%@user.trashnothing.com')
+                        // Escape the escape character first, then the wildcards - doing it
+                        // the other way round would re-escape the backslashes just added.
+                        ->where('email', 'LIKE', str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $username) . '-g%@user.trashnothing.com')
+                        // Same ordering as the full pass above. Whichever account comes
+                        // first is the one kept when duplicates are merged, and it takes
+                        // its own name over the other's, so the order decides what the
+                        // member ends up called. Without this the answer would be
+                        // whatever order the address index happened to return.
+                        ->orderBy('id')
                         ->cursor() as $row
                 ) {
                     $groups[$username][] = (int) $row->userid;

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -865,8 +865,14 @@ Schedule::command('mail:reengage')
 // Record whether a tip drove a real action (login/reply/post within the window)
 // for onboarding sends, so per-tip/arm/segment effectiveness and control-arm
 // lift can be graphed in the sysadmin dashboard. Runs after the day's sends.
+// Moved off 16:30, which stacked it onto the tail of the day's engagement sends at the
+// busiest hour on the read node, for no reason: it sends nothing and only records
+// whether a tip drove an action. Each check queries the full outcome window anchored at
+// the send, so it is complete whenever it runs - an eleven-hour shift can delay a row's
+// first check but cannot lose an outcome, and the row is re-checked daily for 74 days.
+// 02:50 rather than 02:45 leaves the AI image recount that slot to itself.
 Schedule::command('mail:reengage-outcomes')
-    ->dailyAt('16:30')
+    ->dailyAt('02:50')
     ->withoutOverlapping(60)
     ->sendOutputTo(cronLog('mail:reengage-outcomes'))
     ->runInBackground();

--- a/iznik-batch/tests/Feature/TrashNothing/TNSyncCommandTest.php
+++ b/iznik-batch/tests/Feature/TrashNothing/TNSyncCommandTest.php
@@ -592,6 +592,94 @@ class TNSyncCommandTest extends TestCase
         );
     }
 
+    /**
+     * The per-tick duplicate check now reads only addresses added since last time,
+     * instead of streaming all ~400,000 Trash Nothing addresses every minute. A pair
+     * created after the last run must still be caught.
+     */
+    public function test_incremental_scan_catches_a_newly_created_duplicate(): void
+    {
+        // Establish a position first, so the next run is genuinely incremental.
+        Http::fake([
+            '*/ratings*' => Http::response(['ratings' => []], 200),
+            '*/user-changes*' => Http::response(['changes' => []], 200),
+        ]);
+        $this->artisan('tn:sync')->assertExitCode(0);
+        $this->assertNotNull(
+            DB::table('config')->where('key', 'tn.dupscan_cursor')->value('value'),
+            'the first run should record how far it read'
+        );
+
+        $user1 = $this->createTestUser(['fullname' => 'Bob']);
+        $user2 = $this->createTestUser(['fullname' => 'Bob']);
+        $tnBase = 'bob_' . uniqid('', true);
+
+        foreach ([[$user1->id, 'g101'], [$user2->id, 'g202']] as [$uid, $suffix]) {
+            $email = "{$tnBase}-{$suffix}@user.trashnothing.com";
+            DB::table('users_emails')->insert([
+                'userid' => $uid,
+                'email' => $email,
+                'backwards' => strrev($email),
+                'preferred' => 0,
+                'added' => now(),
+            ]);
+        }
+
+        $this->artisan('tn:sync')->assertExitCode(0);
+
+        $this->assertTrue(
+            (User::find($user1->id) !== null) xor (User::find($user2->id) !== null),
+            'a duplicate created since the last run must still be merged'
+        );
+    }
+
+    /**
+     * The hole the incremental check cannot see: a duplicate made by re-pointing an
+     * existing row, which adds no new id. One tick a day re-scans everything to catch
+     * those, which is the only reason narrowing the per-tick check is safe.
+     */
+    public function test_a_full_rescan_catches_a_duplicate_the_cursor_missed(): void
+    {
+        $user1 = $this->createTestUser(['fullname' => 'Carol']);
+        $user2 = $this->createTestUser(['fullname' => 'Carol']);
+        $tnBase = 'carol_' . uniqid('', true);
+
+        foreach ([[$user1->id, 'g101'], [$user2->id, 'g202']] as [$uid, $suffix]) {
+            $email = "{$tnBase}-{$suffix}@user.trashnothing.com";
+            DB::table('users_emails')->insert([
+                'userid' => $uid,
+                'email' => $email,
+                'backwards' => strrev($email),
+                'preferred' => 0,
+                'added' => now(),
+            ]);
+        }
+
+        // Pretend the per-tick check has already read past them, and that a whole-table
+        // re-scan happened recently - so only --full-duplicate-scan can find this pair.
+        DB::table('config')->upsert([
+            ['key' => 'tn.dupscan_cursor', 'value' => (string) ((int) DB::table('users_emails')->max('id') + 1)],
+            ['key' => 'tn.dupscan_full_at', 'value' => now()->toDateTimeString()],
+        ], ['key'], ['value']);
+
+        Http::fake([
+            '*/ratings*' => Http::response(['ratings' => []], 200),
+            '*/user-changes*' => Http::response(['changes' => []], 200),
+        ]);
+
+        // An ordinary tick sees nothing new and leaves them alone.
+        $this->artisan('tn:sync')->assertExitCode(0);
+        $this->assertNotNull(User::find($user1->id));
+        $this->assertNotNull(User::find($user2->id));
+
+        // The whole-table pass finds them.
+        $this->artisan('tn:sync --full-duplicate-scan')->assertExitCode(0);
+        $this->assertTrue(
+            (User::find($user1->id) !== null) xor (User::find($user2->id) !== null),
+            'the full re-scan must catch what the cursor stepped over'
+        );
+    }
+
     public function test_no_merge_when_no_duplicates(): void
     {
         $user1 = $this->createTestUser();


### PR DESCRIPTION
## What this does

Two jobs doing work every minute, or at the busiest hour, that did not need doing then.

### The Trash Nothing duplicate check

`tn:sync` runs every minute, and every run streamed all ~400,000 Trash Nothing addresses out of `users_emails` and grouped them in PHP to spot accounts that are really the same person. That is about five seconds of database time and twenty gigabytes a day off the wire, to find a number of duplicates measured at roughly zero a day.

A duplicate can only come into existence when a `users_emails` row is inserted, so the per-tick check now looks only at rows added since the last one, and probes for siblings of each by an indexed prefix on the address (`email` is uniquely indexed, and `username-g` anchors the left of it). Typically that is no rows and no probes.

### Recording whether a re-engagement tip worked

`mail:reengage-outcomes` ran at 16:30, stacking it onto the tail of the day's engagement sends at the busiest hour on the read node. It sends nothing — it only records whether a tip drove a login, reply or post. It runs at 02:50 now.

Each check queries the full outcome window anchored at the send, so it is complete whenever it runs. An eleven-hour shift can delay a row's first check but cannot lose an outcome, and every row is re-checked daily for 74 days. I checked the consumer side as well: neither the sysadmin page nor the endpoint behind it has a same-day predicate.

02:50 rather than 02:45 leaves the AI image recount that slot to itself.

## The hole in reading only new rows, and how it is covered

A duplicate can also be made by re-pointing an existing row, which adds no new id for the per-tick check to notice.

So one tick a day re-scans the whole table. That is a permanent fixture, not a transitional one — it is the only reason narrowing the per-tick check is safe. Worst case a duplicate is merged a day late, against an event rate of about zero a day, and `User::merge` re-checks live state at merge time so a late merge cannot corrupt anything.

**It deliberately is not a separate scheduled entry.** `tn:sync --full-duplicate-scan` is a different command string, so Laravel's `withoutOverlapping` would give it its own mutex and it could run at the same time as the per-minute `tn:sync`. Instead the command notices for itself that the last whole-table pass is over 24 hours old and does one on an ordinary tick. The flag is kept for running it by hand.

The position is only recorded once the merges have finished, so a crash re-reads those rows rather than stepping over a duplicate it never got to.

## Which of a duplicate pair survives

When two accounts turn out to be the same Trash Nothing member, one is kept and the other merged into it. The one that is kept takes its own name over the other, so which of them it is decides what the member ends up called.

The whole-table pass reads addresses oldest first, so the older account wins. The new every-tick pass, which is now the one that finds nearly all real duplicates, did not order its rows at all, leaving the answer to whatever order the address index happened to hand back. It now reads in the same order as the whole-table pass, so the older account wins in both.

While in there, the address match now also escapes a backslash in a username before escaping the wildcards. Trash Nothing usernames do not appear to contain them, so this is a latent problem rather than a live one, but doing it the other way round would silently stop matching.

## Testing

Full Laravel suite: 5588 passed, 0 failed.

Two new tests for the duplicate check: a pair created after the last run is still caught by the incremental path, and a pair that was already read past is invisible to an ordinary tick but found by the whole-table pass. The second one is the hole above, pinned rather than argued.

