### PR TITLE
perf(ripple): index rippling_reach(updated_at) so the reach poll stops scanning 28GB

### DIFF
--- a/iznik-batch/database/migrations/2026_08_13_000001_add_rippling_reach_updated_at_index.php
+++ b/iznik-batch/database/migrations/2026_08_13_000001_add_rippling_reach_updated_at_index.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * rippling_reach(updated_at) — for the spatial server's reach delta poll.
+ *
+ * iznik-spatial-go asks, every two minutes, on every node:
+ *
+ *   SELECT msgid, status, ST_AsWKB(polygon) FROM rippling_reach WHERE updated_at > ?
+ *
+ * There is no index on updated_at, so each poll is a full scan of a ~29GB table
+ * (EXPLAIN reports type=ALL over ~48k rows, and the rows are large because each carries
+ * a polygon). Measured executions of 51s on db3 and 52s on db2 — with a two-minute
+ * poll interval that is close to a 43% duty cycle per instance, roughly 0.4–0.9 mysqld
+ * cores per node, continuously, day and night. It is the largest steady-state database
+ * cost in the rippling family, and being 24/7 it is the one thing no amount of moving
+ * work to the night can help.
+ *
+ * PRODUCTION NOTE. rippling_reach is large and hot, and prod is Percona/Galera with
+ * wsrep_OSU_method=TOI, so a plain ALTER serialises cluster-wide writes for the whole
+ * index build. Deploy the companion _migration.sql node-by-node under RSU instead of the
+ * auto-migrate path if that stall is unacceptable.
+ *
+ * The build itself is fully online: ALGORITHM=INPLACE, LOCK=NONE is accepted on this
+ * table, verified against Percona 8.0.43 (prod runs 8.0.45). That is worth stating
+ * because the table carries two SPATIAL indexes and spatial indexes cannot themselves be
+ * built with LOCK=NONE — but that restriction is about adding a spatial index, not about
+ * adding a plain one to a table that has some.
+ *
+ * Idempotent: guarded on information_schema so a re-run is a no-op.
+ */
+return new class extends Migration
+{
+    private const TABLE = 'rippling_reach';
+
+    private const INDEX = 'rippling_reach_updated_at';
+
+    public function up(): void
+    {
+        // The table is created by the reach engine's own migration; if this runs in an
+        // environment that has not got there yet, there is nothing to index.
+        if (!$this->tableExists()) {
+            return;
+        }
+
+        if ($this->indexExists()) {
+            return;
+        }
+
+        DB::statement(
+            'ALTER TABLE ' . self::TABLE . ' ADD INDEX ' . self::INDEX . ' (updated_at), ALGORITHM=INPLACE, LOCK=NONE'
+        );
+    }
+
+    public function down(): void
+    {
+        if (!$this->tableExists() || !$this->indexExists()) {
+            return;
+        }
+
+        DB::statement('ALTER TABLE ' . self::TABLE . ' DROP INDEX ' . self::INDEX);
+    }
+
+    private function tableExists(): bool
+    {
+        $row = DB::selectOne(
+            'SELECT COUNT(*) AS n FROM information_schema.tables
+             WHERE table_schema = DATABASE() AND table_name = ?',
+            [self::TABLE]
+        );
+
+        return (int) ($row->n ?? 0) > 0;
+    }
+
+    private function indexExists(): bool
+    {
+        $row = DB::selectOne(
+            'SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?',
+            [self::TABLE, self::INDEX]
+        );
+
+        return (int) ($row->n ?? 0) > 0;
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_13_000001_add_rippling_reach_updated_at_index_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_13_000001_add_rippling_reach_updated_at_index_migration.sql
@@ -1,0 +1,45 @@
+-- Production idempotent SQL: rippling_reach(updated_at).
+--
+-- WHY. iznik-spatial-go polls, every two minutes, on every node:
+--
+--   SELECT msgid, status, ST_AsWKB(polygon) FROM rippling_reach WHERE updated_at > ?
+--
+-- With no index on updated_at that is a full scan of a ~29GB table every time
+-- (EXPLAIN: type=ALL, ~48k large rows). Measured executions of 51s on db3 and 52s on
+-- db2 against a two-minute interval — close to a 43% duty cycle per instance, roughly
+-- 0.4–0.9 mysqld cores per node, continuously, day and night. It is the largest
+-- steady-state database cost in the rippling family and, being 24/7, the one that
+-- moving work to the night cannot touch.
+--
+-- HOW TO RUN. rippling_reach is large and hot, and prod is Galera with
+-- wsrep_OSU_method=TOI, so a plain ALTER serialises cluster-wide writes for the whole
+-- index build. Run this node by node under RSU so no single node blocks the cluster:
+--
+--   SET SESSION wsrep_OSU_method = 'RSU';
+--   -- run the guarded ALTER below on this node
+--   SET SESSION wsrep_OSU_method = 'TOI';
+--
+-- Avoid db1's 04:00–04:17 backup window, when that node is intentionally desynced.
+--
+-- LOCKING. The build is fully online: ALGORITHM=INPLACE, LOCK=NONE is accepted here,
+-- verified against Percona 8.0.43 (prod runs 8.0.45). Worth saying explicitly because
+-- the table carries two SPATIAL indexes (rippling_reach_outer, rippling_reach_polygon)
+-- and a spatial index cannot itself be built with LOCK=NONE — but that restriction is
+-- about ADDING a spatial index, not about adding a plain one to a table that has some.
+-- If a future MySQL disagrees, the ALTER will refuse rather than silently block writes;
+-- rerun it with LOCK=SHARED and expect writes to that table to wait.
+--
+-- Guarded on information_schema so a re-run is a no-op.
+SET @idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'rippling_reach'
+      AND index_name = 'rippling_reach_updated_at');
+SET @ddl := IF(@idx_exists = 0,
+    'ALTER TABLE rippling_reach ADD INDEX rippling_reach_updated_at (updated_at), ALGORITHM=INPLACE, LOCK=NONE',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- AFTERWARDS. The poll should stop scanning. Expect EXPLAIN to change from type=ALL to
+-- type=range with key=rippling_reach_updated_at:
+--
+--   EXPLAIN SELECT msgid, status, ST_AsWKB(polygon) FROM rippling_reach
+--   WHERE updated_at > NOW() - INTERVAL 2 MINUTE;

--- a/iznik-batch/database/migrations/2026_08_13_000001_add_rippling_reach_updated_at_index_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_13_000001_add_rippling_reach_updated_at_index_migration.sql
@@ -38,8 +38,18 @@ SET @ddl := IF(@idx_exists = 0,
     'SELECT 1');
 PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
--- AFTERWARDS. The poll should stop scanning. Expect EXPLAIN to change from type=ALL to
--- type=range with key=rippling_reach_updated_at:
+-- AFTERWARDS. Give the optimizer figures for the new index before judging it. Until it has
+-- them, it is guessing at how many rows the poll's window matches, and on a table whose rows
+-- average around 600KB it can reasonably guess that reading the whole thing is cheaper:
+--
+--   ANALYZE TABLE rippling_reach;
+--
+-- Then confirm the poll has actually stopped scanning. This is a check to run, not a result
+-- to assume - if it still says type=ALL then the index is not being used and the change has
+-- bought nothing, so say so rather than closing the ticket:
 --
 --   EXPLAIN SELECT msgid, status, ST_AsWKB(polygon) FROM rippling_reach
 --   WHERE updated_at > NOW() - INTERVAL 2 MINUTE;
+--
+-- Wanted: type=range, key=rippling_reach_updated_at, and a rows estimate in the hundreds
+-- rather than the tens of thousands.


### PR DESCRIPTION
## What this does

Adds an index on `rippling_reach(updated_at)`.

The spatial server asks every node, every two minutes:

```sql
SELECT msgid, status, ST_AsWKB(polygon) FROM rippling_reach WHERE updated_at > ?
```

There is no index on that column, so it is a full scan. Measured on production just now:

| | |
|---|---|
| Index on `updated_at` | none |
| Table | 64,426 rows, **28.0 GB** of data |
| The poll's plan | `type=ALL`, `possible_keys=NULL`, 54,124 rows examined |
| Rows the poll actually returns in a two-minute window | **3** |

So every two minutes, on every node, it reads 28GB of polygons to hand back three rows. Measured executions run 51s on db3 and 52s on db2 against a two-minute interval, which is close to a 43% duty cycle per instance — roughly 0.4 to 0.9 of a mysqld core per node, continuously.

That makes it the largest steady-state database cost in the rippling family, and because it runs day and night it is the one thing that moving work to the small hours cannot help with.

## How to deploy it

`rippling_reach` is large and hot and production is Galera with `wsrep_OSU_method=TOI`, so a plain `ALTER` serialises cluster-wide writes for the whole index build. The companion `_migration.sql` is meant to be run node by node under `RSU` instead of through auto-migrate, and says so. It also says to avoid db1's 04:00–04:17 backup window, when that node is deliberately desynced.

Both the migration and the SQL check `information_schema` first, so running either a second time does nothing at all.

## One correction to the plan this came from

The audit specified `LOCK=SHARED`, on the grounds that the table's spatial indexes rule out `LOCK=NONE`. That is not the case, and it matters, because `SHARED` blocks writes to the table for the duration of the build.

I tested it: `ALGORITHM=INPLACE, LOCK=NONE` is accepted on this table on Percona 8.0.43, which is a patch release behind production's 8.0.45. The restriction being remembered is about *adding* a spatial index, not about adding a plain one to a table that happens to have some — and this table has two, `rippling_reach_outer` and `rippling_reach_polygon`.

So the build is fully online. If a future MySQL disagrees, the `ALTER` refuses rather than quietly blocking writes, and the SQL file says to rerun with `LOCK=SHARED` and expect writes to wait.

## Checking it worked

Give the optimiser figures for the new index first. Until it has them it is guessing how many rows the two-minute window matches, and on a table whose rows average around 600KB it can quite reasonably guess that reading the whole thing is cheaper:

```sql
ANALYZE TABLE rippling_reach;
```

Then check the plan for the poll. This is a check to run afterwards, not a result to assume: if it still says a full scan then the index is not being used and the change has bought nothing, which is worth saying rather than closing quietly.

```sql
EXPLAIN SELECT msgid, status, ST_AsWKB(polygon) FROM rippling_reach
WHERE updated_at > NOW() - INTERVAL 2 MINUTE;
```

`type` should read `range` and `key` should read `rippling_reach_updated_at`, where today it is `ALL` and `NULL`.

## Testing

Full Laravel suite green, which is what exercises the migration — the suite rebuilds the schema from scratch twice before it runs.

I could not compare plans in the development database in any meaningful way, because its `rippling_reach` is empty and the optimiser has nothing to choose between. The plan evidence above is from production.

