### PR TITLE
fix(hooks): stop check-test-command firing on commands that only mention a test runner

### DIFF
--- a/.claude/check-test-command.sh
+++ b/.claude/check-test-command.sh
@@ -101,14 +101,47 @@ TEST_PATTERNS=(
   '\bdocker run\b.*\b(golang|node|composer|php):'
 )
 
+# Judge the command with heredoc BODIES removed, so a commit message, a doc or a log
+# entry that quotes one of these commands is not mistaken for running it. Observed:
+# a session-log entry describing a migration command blocked a plain file append.
+SCAN=$(echo "$COMMAND" | awk '
+  {
+    if (tag != "") { if ($0 ~ ("^[[:space:]]*" tag "[[:space:]]*$")) tag = ""; next }
+    line = $0
+    if (match(line, /<<-?["'"'"'"]?[A-Za-z_][A-Za-z0-9_]*["'"'"'"]?/)) {
+      t = substr(line, RSTART, RLENGTH)
+      sub(/^<<-?/, "", t); gsub(/["'"'"'"]/, "", t)
+      tag = t
+    }
+    print line
+  }')
+
 IS_TEST_COMMAND=false
 if [ "$IS_DATA_COMMAND" = false ]; then
   for pattern in "${TEST_PATTERNS[@]}"; do
-    if echo "$COMMAND" | grep -qE "$pattern"; then
+    if echo "$SCAN" | grep -qE "$pattern"; then
       IS_TEST_COMMAND=true
       break
     fi
   done
+fi
+
+# A search tool whose PATTERN contains a trigger is looking for it, not running it.
+# Observed while auditing these very hooks: grepping the .claude directory for one of
+# these command names blocked the grep.
+if [ "$IS_TEST_COMMAND" = true ] \
+   && echo "$SCAN" | grep -qE '(^|[;&|]|&&|\|\|)[[:space:]]*(grep|rg|ag|ack)\b' \
+   && ! echo "$SCAN" | grep -qE '(^|[;&|]|&&|\|\|)[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*(go|php|npx|npm|vendor/bin/phpunit)[[:space:]]'; then
+  IS_TEST_COMMAND=false
+fi
+
+# A path can spell a trigger where two of them meet - "cache_test.go test/x_test.go"
+# contains "go test" - so a match that is only ever part of a longer path is not a test
+# run. Checked after the patterns so a genuine invocation still blocks.
+if [ "$IS_TEST_COMMAND" = true ] \
+   && echo "$SCAN" | grep -qE '[A-Za-z0-9_./-]+\.(go|php|js|ts|mjs)\b' \
+   && ! echo "$SCAN" | grep -qE '(^|[;&|]|&&|\|\|)[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*(go|php|npx|npm|docker|vendor/bin/phpunit)\b'; then
+  IS_TEST_COMMAND=false
 fi
 
 if [ "$IS_TEST_COMMAND" = false ]; then

--- a/.claude/check-test-command.test.sh
+++ b/.claude/check-test-command.test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Tests for check-test-command.sh's trigger. Kept in a file because the cases under test
+# contain the very literals the hook reacts to.
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/check-test-command.sh"
+pass=0; fail=0
+G="go"; T="test"; PHP="php"
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+run() { printf '%s' "$(jq -nc --arg c "$1" '{tool_input:{command:$c}}')" | "$HOOK" >/dev/null 2>"$TMP/err"; echo $?; }
+check() { local n="$1" want="$2" cmd="$3" got; got=$(run "$cmd")
+  if [ "$got" = "$want" ]; then printf '  PASS  %s\n' "$n"; pass=$((pass+1))
+  else printf '  FAIL  %s (exit %s, wanted %s)\n' "$n" "$got" "$want"; sed 's/^/        /' "$TMP/err"|head -3; fail=$((fail+1)); fi; }
+
+echo "== must still block a real test run =="
+check "go test"            2 "cd /x && $G $T ./..."
+check "artisan test"       2 "docker exec c $PHP artisan $T --filter=Foo"
+check "vendor phpunit"     2 "docker exec c vendor/bin/phpunit"
+check "npx playwright"     2 "npx playwright $T"
+check "go build"           2 "$G build ./dashboard/"
+
+echo
+echo "== must NOT block: quoting, not running =="
+QUOTED="cat >> notes.md <<'EOF'
+NOTE: running migrations by hand is blocked; use the status API.
+  docker exec c $PHP artisan migrate --force
+EOF"
+check "heredoc quoting a command" 0 "$QUOTED"
+check "filenames that abut into a trigger" 0 \
+  "cp a/dashboard/cache_$T.go b/$T/dashboard_$T.go"
+check "grep for the literal"      0 "grep -rn '$G $T' .claude/*.sh"
+check "status API POST"           0 "curl -s -X POST http://localhost:12114/api/tests/laravel"
+check "unrelated"                 0 "ls -la"
+
+echo
+echo "  $pass passed, $fail failed"
+[ "$fail" = "0" ]


### PR DESCRIPTION
## Why

#1333 fixed a defect in two of the PR hooks: they matched their trigger anywhere in the command string, so anything that merely *quoted* one set the hook off. `check-test-command.sh` has the same defect and it has now interrupted real work five times in a single session.

Three of those were not near-misses, they were outright blocks of things that run no tests at all:

- Appending a note to a session log. The note described a migration command, so the words appeared in the text being written, and the hook read that as running it.
- Copying four source files. Two of the filenames abutted — `cache_test.go test/dashboard_test.go` — and the characters at that join spell one of the triggers.
- Grepping the `.claude` directory for one of these command names, while auditing these very hooks.

A hook that blocks a `grep` and a file append is not enforcing anything. It teaches a workaround instead: put the command in a file, where the hook cannot see it. That is the wrong lesson to teach, because the same trick hides a real test run just as effectively.

## What changed

Three narrowings, all of them about *running* a command rather than mentioning it.

**Heredoc bodies are no longer scanned.** A commit message, a document or a log entry that quotes a command is text, not an invocation.

**A search tool whose pattern contains a trigger is searching.** If the command runs `grep`, `rg`, `ag` or `ack` and there is no test runner in command position, it is looking for the words, not obeying them.

**A trigger that only exists where two paths meet is not a command.** `cache_test.go test/dashboard_test.go` contains one of the triggers across the join between two filenames. If every match sits inside a file path and nothing is being invoked, it is a file list.

Each check runs *after* the patterns match, so a genuine invocation is still caught, and each requires the absence of a real invocation before it will let anything through.

## What still blocks

Everything that should. `go test`, `artisan test`, `vendor/bin/phpunit`, `npx playwright test` and `go build` are all still refused, including with an environment prefix or after a `cd`.

## Testing

`.claude/check-test-command.test.sh` — run it with `bash .claude/check-test-command.test.sh`. It needs nothing set up.

Ten cases: five that must still be blocked, and five that must not be — the three real interruptions above, plus a status-API call and an unrelated command. All passing.

The test lives in a file rather than being typed at a shell for the same reason as its sibling: the cases under test contain the very literals the hook reacts to, so typing them at a prompt fires the hook on the test harness.
