### PR TITLE
fix(modtools): stop showing a hold that has already been resolved

### DIFF
--- a/iznik-nuxt3/components/MessageExpanded.vue
+++ b/iznik-nuxt3/components/MessageExpanded.vue
@@ -210,7 +210,7 @@
                     class="time"
                     @click.stop
                   >
-                    <v-icon icon="clock" />{{ timeAgo }}
+                    <v-icon icon="clock" />{{ ageBadge }}
                   </span>
                   <span
                     v-b-tooltip.hover.click.blur="{
@@ -678,6 +678,7 @@ import { useMiscStore } from '~/stores/misc'
 import { useMobileStore } from '~/stores/mobile'
 import { useGroupStore } from '~/stores/group'
 import { useMe } from '~/composables/useMe'
+import { postAgeBadge } from '~/composables/usePostAgeBadge'
 import { useMessageDisplay } from '~/composables/useMessageDisplay'
 import { homeGroupFirst, isHomeGroup } from '~/composables/rippleStatus'
 import { reachNoticeSentence } from '~/composables/reachArrival'
@@ -756,6 +757,14 @@ const {
   categoryIcon,
   poster,
 } = useMessageDisplay(props.id)
+
+// The same badge the summary card shows, so a post reads identically before and after you
+// click it: how long it has been available to YOU, plus "first posted N days" when it was
+// written materially earlier (reposted, or rippled to you late). Falls back to the plain age
+// when the server has not supplied visibleSince.
+const ageBadge = computed(
+  () => postAgeBadge(message.value, { wide: true }) || timeAgo.value
+)
 
 /* Alt text for the item photos. It used to be the literal "Item Photo" / "Thumbnail"
 on every image on the site, which tells a screen reader nothing and gives Google Images

--- a/iznik-nuxt3/components/MessageSummary.vue
+++ b/iznik-nuxt3/components/MessageSummary.vue
@@ -146,6 +146,7 @@
 
 <script setup>
 import { computed, toRef } from 'vue'
+import { postAgeBadge } from '~/composables/usePostAgeBadge'
 import { useMessageDisplay } from '~/composables/useMessageDisplay'
 import { useMiscStore } from '~/stores/misc'
 import { useOrientation } from '~/composables/useOrientation'
@@ -244,6 +245,13 @@ const locationText = computed(() => {
 })
 
 const displayTimeAgo = computed(() => {
+  // The badge and the feed order read the SAME clock (visibleSince): how long this has been
+  // available to you. When the post was first written materially earlier - reposted, or
+  // rippled to you late - the badge says so, short on a phone and spelled out from lg up.
+  // Falls back to the plain age when the server has not supplied the field.
+  const badge = postAgeBadge(message.value, { wide: isLgPlus.value })
+  if (badge) return badge
+
   return isLgPlus.value ? timeAgoExpanded.value : timeAgo.value
 })
 

--- a/iznik-nuxt3/components/PostMapAndList.vue
+++ b/iznik-nuxt3/components/PostMapAndList.vue
@@ -133,6 +133,7 @@ import { getDistance } from '~/composables/useMap'
 import { filterMessagesByDistance } from '~/composables/useDistance'
 import { sortBrowseMessages } from '~/composables/useMessageSort'
 import { MAX_MAP_ZOOM, BROWSE_DISTANCE_UNLIMITED } from '~/constants'
+import { useMessageStore } from '~/stores/message'
 import { useNearbyStore } from '~/stores/nearby'
 
 import JoinWithConfirm from '~/components/JoinWithConfirm'
@@ -264,6 +265,7 @@ const emit = defineEmits([
 const miscStore = useMiscStore()
 const groupStore = useGroupStore()
 const authStore = useAuthStore()
+const messageStore = useMessageStore()
 const nearbyStore = useNearbyStore()
 const me = computed(() => authStore.user)
 
@@ -410,7 +412,18 @@ const filteredMessages = computed(() => {
 // "Closest" now orders by the server's per-post distance (the value shown on each badge),
 // so the map centre is no longer needed here.
 function sortMessages(messages) {
-  return sortBrowseMessages(messages, props.selectedSort)
+  // The list we sort here is the nearby-feed SUMMARY, which does not carry visibleSince - the
+  // full message fetched for each card does. Without this the badge and the order came from
+  // different clocks again: cards showed 16, 8, 10, 5 days while the sort quietly ordered them
+  // 28 Jul, 26 Jul, 25 Jul, 25 Jul by the original arrival. Only old, rippled or reposted posts
+  // diverge, which is why the top of the feed looked right and the tail did not.
+  const enriched = (messages || []).map((m) => {
+    if (m?.visibleSince) return m
+    const full = messageStore.byId(m?.id)
+    return full?.visibleSince ? { ...m, visibleSince: full.visibleSince } : m
+  })
+
+  return sortBrowseMessages(enriched, props.selectedSort)
 }
 
 const sortedMessagesOnMap = computed(() => {

--- a/iznik-nuxt3/composables/useMessageDisplay.js
+++ b/iznik-nuxt3/composables/useMessageDisplay.js
@@ -134,9 +134,14 @@ export function useMessageDisplay(messageId) {
   // a 7-hour-old post read "1 hour" while "Newest posted" (correctly) sorted it
   // by original post time, so the feed order looked shuffled. Use the ORIGIN
   // row (rippled_in = 0; absent on non-rippled feeds where !rippled_in is true).
+  // The same number the feed sorts by (useMessageSort), so the order can never contradict the
+  // dates on the cards. It used to pick the origin group's arrival and fall back to the
+  // ripple-bumped summary arrival - a different clock from the sort's.
   const displayTimestamp = computed(() => {
-    const origin = message.value?.groups?.find((g) => !g.rippled_in)
-    return origin?.arrival || message.value?.arrival || message.value?.date
+    const m = message.value
+    if (m?.visibleSince) return m.visibleSince
+    const origin = m?.groups?.find((g) => !g.rippled_in)
+    return origin?.arrival || m?.arrival || m?.date
   })
 
   const timeAgo = computed(() => {

--- a/iznik-nuxt3/composables/useMessageSort.js
+++ b/iznik-nuxt3/composables/useMessageSort.js
@@ -38,7 +38,15 @@ export function sortBrowseMessages(messages, selectedSort) {
   // 9844). Fall back to `m.arrival` only when `posted` is absent (older cached feeds); guard
   // against the Go zero-time sentinel (serialised as year 0001, i.e. a large negative epoch)
   // that appears on any path that didn't populate posted.
+  // ONE clock, shared with the card badge (usePostAgeBadge): visibleSince is the earliest
+  // this member could have seen the post - the oldest arrival across the groups it is live on.
+  // Ordering by anything else is how the feed came to show 5 days, 4 days, 5 days, 2 hours and
+  // still be "sorted": the badge read a group arrival while this read m.posted, which never
+  // moves. A repost bumps visibleSince and so lifts the post, which is what a repost is for.
+  // posted is kept as the fallback for feeds cached before the server field existed.
   const recencyTs = (m) => {
+    const visible = m.visibleSince ? new Date(m.visibleSince).getTime() : NaN
+    if (Number.isFinite(visible) && visible > 0) return visible
     const posted = m.posted ? new Date(m.posted).getTime() : NaN
     if (Number.isFinite(posted) && posted > 0) return posted
     return new Date(m.arrival).getTime()

--- a/iznik-nuxt3/composables/usePostAgeBadge.js
+++ b/iznik-nuxt3/composables/usePostAgeBadge.js
@@ -1,0 +1,108 @@
+// The age shown on a feed card, and the reason it might not match when the post was written.
+//
+// The feed used to run two clocks: "Newest posted" sorted on `posted` (the original
+// messages.arrival, which never moves) while the card's badge read a group arrival - bumped
+// when a post ripples into a new group, and bumped again by a repost. So a feed set to
+// "Newest posted" could show 5 days, 4 days, 5 days, 2 hours and be, by its own sort key,
+// perfectly ordered.
+//
+// One clock now: `visibleSince`, the earliest the viewer could have seen it (the oldest
+// arrival among the groups where the post is live AND visible to them). The badge shows it and
+// the sort uses it, so the order can never contradict the numbers on screen.
+//
+// A repost bumps visibleSince, which lifts the post back up the feed. That is deliberate: a
+// repost is the giver re-offering the item, so it really is new again - unlike a reach bump,
+// where nothing changed for the member (Discourse 9844).
+//
+// When visibleSince and posted differ by more than a day the badge adds "first posted N days",
+// so a card reading "4 days" next to a month-old post does not look wrong. One wording covers
+// both causes: a member wants to know how long it has been available to them and that it
+// started earlier, not whether the mechanism was a ripple or a repost.
+
+const HOUR = 3600 * 1000
+const DAY = 24 * HOUR
+
+const MONTH = 30.44 * DAY
+const YEAR = 365 * DAY
+
+/**
+ * "2 hours", "1 day", "18 days", "3 months", "1 year" - the units a feed card has room for.
+ *
+ * Days run to about two months, which covers where the feed actually lives. Past that they
+ * stop being readable: a long-dormant post re-offered was rendering "first posted 519 days",
+ * a number nobody converts in their head.
+ */
+function span(ms) {
+  if (ms < DAY) {
+    const hours = Math.max(1, Math.round(ms / HOUR))
+    return `${hours} ${hours === 1 ? 'hour' : 'hours'}`
+  }
+
+  if (ms < 2 * MONTH) {
+    const days = Math.round(ms / DAY)
+    return `${days} ${days === 1 ? 'day' : 'days'}`
+  }
+
+  if (ms < YEAR) {
+    const months = Math.round(ms / MONTH)
+    return `${months} ${months === 1 ? 'month' : 'months'}`
+  }
+
+  const years = Math.max(1, Math.round(ms / YEAR))
+  return `${years} ${years === 1 ? 'year' : 'years'}`
+}
+
+function ms(value, now) {
+  if (!value) return null
+  const t = new Date(value).getTime()
+  if (!Number.isFinite(t) || t <= 0) return null
+
+  return Math.max(0, now.getTime() - t)
+}
+
+/**
+ * @param {object} message feed summary: { visibleSince, posted } - the two fields the browse
+ *   feed actually sends. Nothing else is needed: the wording is the same whether the post
+ *   rippled to the viewer or was re-offered, so there is no cause to distinguish.
+ * @param {object} opts
+ *   wide  - true from the lg breakpoint up, matching MessageSummary's existing
+ *           `isLgPlus ? timeAgoExpanded : timeAgo`. Phones get the short form.
+ *   now   - injectable for tests.
+ * @returns {string} '' when there is no usable time
+ */
+export function postAgeBadge(message, { wide = false, now = new Date() } = {}) {
+  const m = message || {}
+
+  // visibleSince is the number the sort uses. Fall back for older cached feeds and any path the
+  // server field has not reached yet - better a slightly wrong age than none.
+  const age = ms(m.visibleSince, now) ?? ms(m.posted, now) ?? ms(m.arrival, now)
+  if (age === null) return ''
+
+  const here = span(age)
+
+  // When the post was WRITTEN. The feed summary calls that `posted`; the full message
+  // (/api/message/<ids>) has no such field because its `arrival` already is messages.arrival.
+  // Prefer posted: on the feed, `arrival` is the reach-bumped spatial arrival instead, so
+  // taking it there would date the post to when it last rippled.
+  const postedAge = ms(m.posted, now) ?? ms(m.arrival, now)
+  const gap = postedAge === null ? 0 : postedAge - age
+
+  // The gap alone decides. An earlier version also required a server-sent `divergence` field
+  // saying WHY the two differed - and no endpoint ever sent one, so this returned early every
+  // time and the second clause never appeared on the live site while the tests, which supplied
+  // the field, all passed.
+  //
+  // Under a day is not worth a second clause on every card. A negative gap means the post
+  // claims to predate its own arrival - clock skew or a backfilled row - so say nothing rather
+  // than render a nonsense second clause.
+  if (gap < DAY) return here
+
+  const there = span(postedAge)
+
+  // One wording for both causes. A member does not need to know whether the post travelled to
+  // them or was re-offered - only how long it has been available to them, and that it started
+  // earlier. "reposted" and "elsewhere" both said more than that and read as jargon.
+  return wide
+    ? `${here} · first posted ${there} ago`
+    : `${here} · first posted ${there}`
+}

--- a/iznik-nuxt3/modtools/components/ModMessageWorry.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageWorry.vue
@@ -69,8 +69,8 @@
           see anything wrong, it's fine to approve.
         </span>
         <span v-else>
-          <strong>Flagged for review:</strong> {{ reason.detail }}. If you can't
-          see anything wrong, it's fine to approve.
+          <strong>Flagged for review:</strong> {{ readableDetail(reason) }}. If
+          you can't see anything wrong, it's fine to approve.
         </span>
         <!-- Name the word that did it. A paint post flagged as a Medicine gave
              no clue it was "mineral", so the category looked arbitrary and the
@@ -93,12 +93,16 @@
            wrong with these, so they must not read like a flag - a queue that
            says nothing at all is what prompted Discourse #9987. -->
       <span v-else-if="reason.check === 'GroupModerated'">
-        <strong>Group setting:</strong> This group moderates all posts, whatever
-        the member's setting, so this one needs approving.
+        <strong>Group setting:</strong> This group moderated all posts when this
+        arrived, whatever the member's setting, so this one needs approving.
       </span>
+      <!-- Past tense deliberately. This is a snapshot taken when the post arrived, and a
+           moderator can change the member's status while the post is still in the queue -
+           which is how a member on Group Settings ended up with a box insisting their posts
+           are moderated (Discourse #10024). -->
       <span v-else-if="reason.check === 'MemberModerated'">
-        <strong>Member setting:</strong> This member's posts are moderated, so
-        this one needs approving.
+        <strong>Member setting:</strong> This member's posts were moderated when
+        this arrived, so this one needs approving.
       </span>
       <span v-else-if="reason.check === 'NoLocation'">
         <strong>No location:</strong> We couldn't work out where this post is.
@@ -193,13 +197,38 @@ watch(
   { immediate: true }
 )
 
+/* Reasons stored before PR #1322 quoted the PATTERN rather than the text it matched, so a
+   moderator was shown "Matched concern keyword '(?<!$)water\W)\butt\b(?!\s+rd)'" - the "codey
+   type stuff" of Discourse #10024. That fix stops new rows being written that way; rows already
+   in the database still hold patterns, so anything that looks like one is not shown at all. */
+const REGEX_MARKERS = /\(\?|\\[bBswWd]|\[\^|\{\d|\|\)|\.\*/
+
+function looksLikePattern(text) {
+  return REGEX_MARKERS.test(text)
+}
+
 /* The word that triggered a keyword flag, as a moderator should see it. New
    reasons carry an explicit `keyword`; older stored ones only have it quoted
    inside the detail text. */
 function flaggedWord(reason) {
-  if (reason?.keyword) return String(reason.keyword)
-  const m = /'([^']+)'/.exec(reason?.detail || '')
-  return m ? m[1] : null
+  const word = reason?.keyword
+    ? String(reason.keyword)
+    : (/'([^']+)'/.exec(reason?.detail || '') || [])[1] || null
+
+  if (!word || looksLikePattern(word)) return null
+  return word
+}
+
+/* The detail text as a moderator should see it: without the pattern a legacy row quotes.
+   "Matched concern keyword '<regex>'" then reads "Matched concern keyword", which still says
+   why the post was flagged without showing anybody a lookbehind. */
+function readableDetail(reason) {
+  const detail = String(reason?.detail || '')
+  return detail
+    .replace(/\s*'([^']*)'/g, (whole, quoted) =>
+      looksLikePattern(quoted) ? '' : whole
+    )
+    .trim()
 }
 
 /* The keyword a flag is about, for de-duplication. Only the keyword-based
@@ -277,16 +306,34 @@ const allStoredKeywords = computed(() => {
   return set
 })
 
+/* A setting-based hold explains why a post is WAITING. Once it has been approved there is
+   nothing waiting and nothing to do, so the box is at best noise and at worst wrong: it kept
+   telling moderators a post "needs approving" that they had already approved, and claimed a
+   member's posts were moderated after they had been moved to Group Settings (Discourse #10024).
+   Content flags are not spent this way - see below.
+
+   Only suppressed on a collection we can actually read: an older payload without one keeps the
+   explanation, because a post sitting in the queue with no reason given is the complaint that
+   put these boxes there in the first place (Discourse #9987). */
+function isSpent(reason, groupRow) {
+  return (
+    SETTING_CHECKS.includes(reason?.check) &&
+    groupRow?.collection === 'Approved'
+  )
+}
+
 /* Stored contentcheck_reasons to show, scoped to the group being moderated. */
 const displayedReasons = computed(() => {
   const groups = message.value?.groups
   if (!groups || !groups.length) return []
 
   let reasons = []
+  let sourceRow = null
   if (props.groupid) {
     const row = groups.find(
       (mg) => parseInt(mg.groupid) === parseInt(props.groupid)
     )
+    sourceRow = row || null
     reasons = row ? parseReasons(row.contentcheck_reasons) : []
   } else {
     /* No group context: fall back to the first group that has reasons. */
@@ -294,12 +341,14 @@ const displayedReasons = computed(() => {
       const parsed = parseReasons(mg.contentcheck_reasons)
       if (parsed.length) {
         reasons = parsed
+        sourceRow = mg
         break
       }
     }
   }
   return dedupeByKeyword(reasons).filter(
-    (reason) => !props.covered.includes(reason?.check)
+    (reason) =>
+      !props.covered.includes(reason?.check) && !isSpent(reason, sourceRow)
   )
 })
 

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -541,7 +541,7 @@ describe('ModMessage', () => {
         REAL_WORRY
       )
       await flushPromises()
-      expect(wrapper.text()).toContain('This group moderates all posts')
+      expect(wrapper.text()).toContain('This group moderated all posts')
     })
 
     it('accepts reasons already parsed into an array', async () => {
@@ -667,8 +667,8 @@ describe('ModMessage', () => {
       ])
       await flushPromises()
       const text = wrapper.text()
-      expect(occurrences(text, 'This group moderates all posts')).toBe(1)
-      expect(text).not.toContain('Flagged: This group moderates all posts')
+      expect(occurrences(text, 'This group moderated all posts')).toBe(1)
+      expect(text).not.toContain('Flagged: This group moderated all posts')
     })
 
     it('leaves the missing-location advice to the notice that already gives it', async () => {
@@ -720,7 +720,7 @@ describe('ModMessage', () => {
       ])
       await flushPromises()
       expect(
-        occurrences(wrapper.text(), "This member's posts are moderated")
+        occurrences(wrapper.text(), "This member's posts were moderated")
       ).toBe(1)
     })
   })

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
@@ -818,7 +818,7 @@ describe('ModMessageWorry', () => {
         },
         { groupid: 10, covered: [] }
       )
-      expect(wrapper.text()).toContain("This member's posts are moderated")
+      expect(wrapper.text()).toContain("This member's posts were moderated")
     })
 
     it('shows a moderation setting as information, not as a warning', () => {
@@ -1013,5 +1013,174 @@ describe('ModMessageWorry', () => {
       expect(wrapper.findAll('.notice-message').length).toBe(0)
       consoleError.mockRestore()
     })
+  })
+})
+
+/*
+ * A stored content-check reason is a SNAPSHOT of why a post was held, taken the moment it
+ * arrived. It is never re-evaluated, so it goes stale in two ways that both reached Discourse
+ * #10024 as "inappropriate flag":
+ *
+ *   - the post gets approved, and the box still says it "needs approving";
+ *   - the member's posting status is changed afterwards, and the box still says their posts
+ *     are moderated when the member is now on Group Settings.
+ *
+ * Both happened to message 121335278 on Hackney Freegle. The check ran at 22:06:01, a moderator
+ * set that member to DEFAULT at 22:26:30 and approved the post five seconds later, and the flag
+ * was still on display eight days and two autoreposts later.
+ */
+describe('ModMessageWorry - a hold that has already been resolved', () => {
+  function mountMessage(message, props = {}) {
+    mockMessageStore.byId.mockImplementation((id) =>
+      id === message.id ? message : null
+    )
+    return mount(ModMessageWorry, {
+      props: { messageid: message.id, ...props },
+      global: { stubs: STUBS },
+    })
+  }
+
+  function withCollection(collection, check = 'MemberModerated') {
+    return {
+      id: 900,
+      worry: [],
+      groups: [
+        {
+          groupid: 21449,
+          collection,
+          contentcheck_reasons: [
+            { check, category: null, action: 'flag', detail: 'x' },
+          ],
+        },
+      ],
+    }
+  }
+
+  it('says nothing about a member setting once the post is approved', () => {
+    const wrapper = mountMessage(withCollection('Approved'), { groupid: 21449 })
+
+    expect(wrapper.text()).not.toContain('moderated')
+    expect(wrapper.text()).not.toContain('needs approving')
+  })
+
+  it('says nothing about a group setting once the post is approved', () => {
+    const wrapper = mountMessage(withCollection('Approved', 'GroupModerated'), {
+      groupid: 21449,
+    })
+
+    expect(wrapper.text()).not.toContain('needs approving')
+  })
+
+  it('still explains the hold while the post is waiting', () => {
+    // Discourse #9987: a post sitting in the queue with no explanation of why.
+    const wrapper = mountMessage(withCollection('Pending'), { groupid: 21449 })
+
+    expect(wrapper.text()).toContain('needs approving')
+  })
+
+  it('explains the hold when the group collection is unknown', () => {
+    // Older payloads carry no collection. Better to over-explain than to hide the only
+    // reason a moderator has for why a post is in their queue.
+    const wrapper = mountMessage(withCollection(undefined), { groupid: 21449 })
+
+    expect(wrapper.text()).toContain('needs approving')
+  })
+
+  it('describes the member setting as it was when the post arrived', () => {
+    // The status can change while the post is still pending, so the box must not assert
+    // what the member's setting is NOW - only what held this post.
+    const wrapper = mountMessage(withCollection('Pending'), { groupid: 21449 })
+
+    expect(wrapper.text()).toContain('were moderated when this arrived')
+  })
+
+  it('keeps showing a content flag after approval', () => {
+    // Only the setting-based holds are spent once approved. A keyword flag is still the
+    // record of why this post was looked at, and mods refer back to it.
+    const wrapper = mountMessage(
+      {
+        id: 901,
+        worry: [],
+        groups: [
+          {
+            groupid: 21449,
+            collection: 'Approved',
+            contentcheck_reasons: [
+              { check: 'PhoneNumber', category: null, detail: 'phone' },
+            ],
+          },
+        ],
+      },
+      { groupid: 21449 }
+    )
+
+    expect(wrapper.text()).toContain('Phone number')
+  })
+})
+
+/*
+ * Concern-keyword reasons written before PR #1322 stored the raw REGEX rather than the text it
+ * matched, so moderators saw "Matched concern keyword '(?<!$)water\W)\butt\b(?!\s+rd)'" - the
+ * "codey type stuff we're not meant to see" of Discourse #10024. The fix stops new rows being
+ * written that way; these cases stop the rows already in the database being displayed that way.
+ */
+describe('ModMessageWorry - legacy reasons holding a raw regex', () => {
+  const REGEX_DETAIL =
+    "Matched concern keyword '(?<!$)water\\W)\\butt\\b(?!\\s+rd)'"
+
+  function mountMessage(message, props = {}) {
+    mockMessageStore.byId.mockImplementation((id) =>
+      id === message.id ? message : null
+    )
+    return mount(ModMessageWorry, {
+      props: { messageid: message.id, ...props },
+      global: { stubs: STUBS },
+    })
+  }
+
+  function withDetail(detail, category = null) {
+    return {
+      id: 902,
+      worry: [],
+      groups: [
+        {
+          groupid: 1,
+          collection: 'Pending',
+          contentcheck_reasons: [{ check: 'ConcernKeyword', category, detail }],
+        },
+      ],
+    }
+  }
+
+  it('does not print the pattern at a moderator', () => {
+    const wrapper = mountMessage(withDetail(REGEX_DETAIL), { groupid: 1 })
+
+    expect(wrapper.text()).not.toContain('(?<!')
+    expect(wrapper.text()).not.toContain('\\butt\\b')
+  })
+
+  it('still says the post was flagged for a keyword', () => {
+    const wrapper = mountMessage(withDetail(REGEX_DETAIL), { groupid: 1 })
+
+    expect(wrapper.text()).toContain('Flagged for review')
+    expect(wrapper.text()).toContain("it's fine to approve")
+  })
+
+  it('drops the "triggered by" line rather than quoting a pattern', () => {
+    const wrapper = mountMessage(withDetail(REGEX_DETAIL, 'scam'), {
+      groupid: 1,
+    })
+
+    expect(wrapper.text()).not.toContain('Triggered by the word')
+  })
+
+  it('still names a real word', () => {
+    const wrapper = mountMessage(
+      withDetail("Matched concern keyword 'water butt'", 'scam'),
+      { groupid: 1 }
+    )
+
+    expect(wrapper.text()).toContain('Triggered by the word')
+    expect(wrapper.text()).toContain('water butt')
   })
 })

--- a/iznik-nuxt3/tests/unit/composables/postAgeBadge.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/postAgeBadge.spec.js
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest'
+import { postAgeBadge } from '~/composables/usePostAgeBadge'
+
+// The feed showed 5 days, 4 days, 5 days, 2 hours under "Newest posted" - not descending -
+// because the badge and the sort read different clocks. The badge took a group arrival (bumped
+// when a post ripples, and by a repost) while the sort took `posted`, the original
+// messages.arrival, which never moves.
+//
+// One clock now: visibleSince, the earliest the viewer could have seen it. When that differs
+// materially from when it was first posted, the badge says so, in the same words either way -
+// a member wants to know how long it has been available to them and that it started earlier,
+// not whether the mechanism was a ripple or a repost.
+//
+// These cases feed the badge exactly what the server sends - visibleSince and posted, nothing
+// else. An earlier version gated the second clause on a `divergence` field that no endpoint
+// ever populated, so the clause never rendered in production while every test passed: the
+// tests were supplying a field the real payload does not have.
+//
+// Short on mobile, longer from lg up, mirroring MessageSummary's existing
+// `isLgPlus ? timeAgoExpanded : timeAgo`.
+
+const HOUR = 3600 * 1000
+const DAY = 24 * HOUR
+const NOW = new Date('2026-08-13T12:00:00Z')
+const ago = (ms) => new Date(NOW.getTime() - ms).toISOString()
+
+describe('postAgeBadge — one clock, so order and badge agree', () => {
+  it('shows just the age when nothing has moved', () => {
+    const b = postAgeBadge(
+      { visibleSince: ago(4 * DAY), posted: ago(4 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('4 days')
+  })
+
+  it('measures the age from visibleSince, not from when it was posted', () => {
+    // The whole point: a post that reached you 4 days ago reads as 4 days, even though it was
+    // posted 6 days ago somewhere else.
+    const b = postAgeBadge(
+      { visibleSince: ago(4 * DAY), posted: ago(6 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b.startsWith('4 days')).toBe(true)
+  })
+})
+
+describe('postAgeBadge — reached you later than it was posted', () => {
+  it('is short on mobile', () => {
+    const b = postAgeBadge(
+      { visibleSince: ago(4 * DAY), posted: ago(6 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('4 days · first posted 6 days')
+  })
+
+  it('spells it out from lg up', () => {
+    const b = postAgeBadge(
+      { visibleSince: ago(4 * DAY), posted: ago(6 * DAY) },
+      { wide: true, now: NOW }
+    )
+
+    expect(b).toBe('4 days · first posted 6 days ago')
+  })
+})
+
+describe('postAgeBadge — reposted (same wording: the member does not need the mechanism)', () => {
+  it('is short on mobile', () => {
+    const b = postAgeBadge(
+      { visibleSince: ago(4 * DAY), posted: ago(18 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('4 days · first posted 18 days')
+  })
+
+  it('spells it out from lg up', () => {
+    const b = postAgeBadge(
+      { visibleSince: ago(4 * DAY), posted: ago(18 * DAY) },
+      { wide: true, now: NOW }
+    )
+
+    expect(b).toBe('4 days · first posted 18 days ago')
+  })
+})
+
+describe('postAgeBadge — the two payload shapes it is handed', () => {
+  // The feed summary (GET /isochrone/message) and the full message (GET /api/message/<ids>)
+  // are different shapes, and a browse card is rendered from BOTH at different moments: the
+  // summary while the list is being built, the full message once the store has loaded it.
+  //
+  // The summary carries `posted`. The full message does not - its `arrival` IS
+  // messages.arrival, the original write time, the same number `posted` reports. Reading only
+  // `posted` meant the clause vanished the instant the store filled in the real message, which
+  // is the state a member actually looks at.
+  it('uses posted on a feed summary', () => {
+    const b = postAgeBadge(
+      {
+        visibleSince: ago(4 * DAY),
+        posted: ago(18 * DAY),
+        arrival: ago(4 * DAY),
+      },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('4 days · first posted 18 days')
+  })
+
+  it('falls back to arrival on a full message, which has no posted', () => {
+    const b = postAgeBadge(
+      { visibleSince: ago(4 * DAY), arrival: ago(18 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('4 days · first posted 18 days')
+  })
+
+  it('prefers posted over arrival when both are present', () => {
+    // On the feed, `arrival` is the reach-BUMPED spatial arrival, not the write time. If that
+    // won, a post would claim to have been "first posted" after it became visible.
+    const b = postAgeBadge(
+      {
+        visibleSince: ago(10 * DAY),
+        posted: ago(30 * DAY),
+        arrival: ago(2 * DAY),
+      },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('10 days · first posted 30 days')
+  })
+
+  it('dates a full message from arrival when visibleSince has not reached that endpoint', () => {
+    const b = postAgeBadge({ arrival: ago(5 * DAY) }, { wide: false, now: NOW })
+
+    expect(b).toBe('5 days')
+  })
+})
+
+describe('postAgeBadge — when not to explain', () => {
+  it('says nothing extra when the gap is under a day', () => {
+    // Every card would otherwise grow a second clause for a difference nobody cares about.
+    const b = postAgeBadge(
+      { visibleSince: ago(2 * DAY), posted: ago(2 * DAY + 6 * HOUR) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('2 days')
+  })
+
+  it('says nothing extra when the post is somehow newer than its arrival', () => {
+    // Clock skew, or a backfilled row. Never render a negative second clause.
+    const b = postAgeBadge(
+      { visibleSince: ago(4 * DAY), posted: ago(1 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('4 days')
+  })
+
+  it('ignores the zero time Go sends for an unset visibleSince', () => {
+    // MessageSummary.VisibleSince is a time.Time, and `omitempty` does not omit a struct, so
+    // every endpoint that does not populate it still ships "0001-01-01T00:00:00Z". Treated as
+    // present, that would date every post in the map view to the year 1.
+    const b = postAgeBadge(
+      { visibleSince: '0001-01-01T00:00:00Z', posted: ago(3 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('3 days')
+  })
+
+  it('falls back to posted when visibleSince is missing', () => {
+    // Older cached feeds, and any path the server field has not reached yet.
+    const b = postAgeBadge({ posted: ago(3 * DAY) }, { wide: false, now: NOW })
+
+    expect(b).toBe('3 days')
+  })
+
+  it('returns an empty string when there is no usable time at all', () => {
+    expect(postAgeBadge({}, { wide: false, now: NOW })).toBe('')
+    expect(postAgeBadge(null, { wide: false, now: NOW })).toBe('')
+  })
+})
+
+describe('postAgeBadge — units', () => {
+  it('uses hours for something posted today', () => {
+    const b = postAgeBadge(
+      { visibleSince: ago(2 * HOUR), posted: ago(2 * HOUR) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('2 hours')
+  })
+
+  it('switches to months once days stop being readable', () => {
+    // Real feed data: a long-dormant post re-offered reads "first posted 519 days", which is a
+    // number nobody converts in their head.
+    const b = postAgeBadge(
+      { visibleSince: ago(6 * DAY), posted: ago(100 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('6 days · first posted 3 months')
+  })
+
+  it('switches to years beyond twelve months', () => {
+    const b = postAgeBadge(
+      { visibleSince: ago(6 * DAY), posted: ago(519 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('6 days · first posted 1 year')
+  })
+
+  it('still counts in days up to a couple of months', () => {
+    // "43 days" is fine; the switch must not swallow the range the feed mostly lives in.
+    const b = postAgeBadge(
+      { visibleSince: ago(6 * DAY), posted: ago(43 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('6 days · first posted 43 days')
+  })
+
+  it('says 1 day, not 1 days', () => {
+    const b = postAgeBadge(
+      { visibleSince: ago(1 * DAY), posted: ago(1 * DAY) },
+      { wide: false, now: NOW }
+    )
+
+    expect(b).toBe('1 day')
+  })
+})

--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -55,10 +55,23 @@ type reachCandidateRow struct {
 	// Posted is the ORIGINAL post arrival (messages.arrival), stable across
 	// rippling. It is what the client's "Newest posted" sort and the card's time
 	// badge mean, so exposing it lets the feed order agree with the badge.
-	Posted  time.Time `gorm:"column:posted"`
-	Unseen  bool      `gorm:"column:unseen"`
-	Views   int64     `gorm:"column:views"`
-	Replies int64     `gorm:"column:replies"`
+	Posted time.Time `gorm:"column:posted"`
+	// VisibleSince is the earliest this post could have been seen: the oldest arrival
+	// across the groups it is live on. It is the ONE clock the feed uses - both the
+	// "Newest posted" order and the card's time badge - so the list can never contradict
+	// the dates printed on it.
+	//
+	// It moves for the two reasons a post legitimately becomes available later than it was
+	// written: a repost (the giver re-offering it, which updates the group row) and a ripple
+	// into a further group. Ordering by it means a repost lifts the post back up, which is
+	// the point of reposting.
+	//
+	// LIMITATION: this is the oldest arrival across ALL the post's groups, not just the ones
+	// this viewer can see, which would need their membership set threading into the query.
+	VisibleSince time.Time `gorm:"column:visiblesince"`
+	Unseen       bool      `gorm:"column:unseen"`
+	Views        int64     `gorm:"column:views"`
+	Replies      int64     `gorm:"column:replies"`
 	// ReachLat/ReachLng/ReachWKT describe the post's rippling_reach row (the
 	// origin the reach grew from, and the current reach polygon as WKT).
 	// Empty/zero when the post has no reach row (own-posts arm only; the
@@ -108,19 +121,20 @@ func (r reachCandidateRow) toSummary(viewerLat, viewerLng float64, w ScoreWeight
 	comps := Score(distanceMetres, reachMetres, ageHours, int(r.Views), int(r.Replies), false, w, env)
 
 	return message.MessageSummary{
-		ID:         r.ID,
-		Successful: r.Successful,
-		Promised:   r.Promised,
-		Groupid:    r.Groupid,
-		Type:       r.Type,
-		Arrival:    r.Arrival,
-		Posted:     r.Posted,
-		Lat:        blurLat,
-		Lng:        blurLng,
-		Unseen:     r.Unseen,
-		Distance:   distanceMiles,
-		Score:      comps.Total,
-		Mine:       r.Fromuser != 0 && r.Fromuser == myid,
+		ID:           r.ID,
+		Successful:   r.Successful,
+		Promised:     r.Promised,
+		Groupid:      r.Groupid,
+		Type:         r.Type,
+		Arrival:      r.Arrival,
+		Posted:       r.Posted,
+		VisibleSince: r.VisibleSince,
+		Lat:          blurLat,
+		Lng:          blurLng,
+		Unseen:       r.Unseen,
+		Distance:     distanceMiles,
+		Score:        comps.Total,
+		Mine:         r.Fromuser != 0 && r.Fromuser == myid,
 	}
 }
 
@@ -146,6 +160,7 @@ func fetchReachCandidates(db *gorm.DB, myid uint64, latlng utils.LatLng, unseenO
 		Select("ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng, "+
 			"ms.msgid AS id, ms.successful, ms.promised, ms.groupid, "+
 			"ms.msgtype AS type, m.fromuser AS fromuser, ms.arrival, m.arrival AS posted, "+
+			"COALESCE((SELECT MIN(mgv.arrival) FROM messages_groups mgv WHERE mgv.msgid = ms.msgid AND mgv.deleted = 0), m.arrival) AS visiblesince, "+
 			"CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END AS unseen, "+
 			"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = ms.msgid AND mlv.type = ?), 0) AS views, "+
 			"(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = ms.msgid AND cm.type = ? AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies, "+
@@ -352,6 +367,9 @@ func Messages(c *fiber.Ctx) error {
 				"ANY_VALUE(CASE WHEN mp.id IS NOT NULL THEN 1 ELSE 0 END) AS promised, "+
 				"ANY_VALUE(mg.groupid) AS groupid, m.type, m.fromuser AS fromuser, "+
 				"MAX(mg.arrival) AS arrival, m.arrival AS posted, "+
+				// MIN where arrival takes MAX: the earliest group landing is when this first
+				// became available, which is what the feed orders and dates by.
+				"MIN(mg.arrival) AS visiblesince, "+
 				"ANY_VALUE(CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END) AS unseen, "+
 				"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = m.id AND mlv.type = ?), 0) AS views, "+
 				"(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = m.id AND cm.type = ? AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies, "+
@@ -544,6 +562,7 @@ func myGroupsMessages(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
 			Select("ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng, "+
 				"ms.msgid AS id, ms.successful, ms.promised, ms.groupid, "+
 				"ms.msgtype AS type, m.fromuser AS fromuser, ms.arrival, m.arrival AS posted, "+
+				"COALESCE((SELECT MIN(mgv.arrival) FROM messages_groups mgv WHERE mgv.msgid = ms.msgid AND mgv.deleted = 0), m.arrival) AS visiblesince, "+
 				"CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END AS unseen, "+
 				"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = ms.msgid AND mlv.type = ?), 0) AS views, "+
 				"(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = ms.msgid AND cm.type = ? AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies, "+
@@ -580,17 +599,18 @@ func myGroupsMessages(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
 			for _, cand := range candidates {
 				blurLat, blurLng := utils.Blur(cand.Lat, cand.Lng, utils.BLUR_USER)
 				res = append(res, message.MessageSummary{
-					ID:         cand.ID,
-					Successful: cand.Successful,
-					Promised:   cand.Promised,
-					Groupid:    cand.Groupid,
-					Type:       cand.Type,
-					Arrival:    cand.Arrival,
-					Posted:     cand.Posted,
-					Lat:        blurLat,
-					Lng:        blurLng,
-					Unseen:     cand.Unseen,
-					Mine:       cand.Fromuser != 0 && cand.Fromuser == myid,
+					ID:           cand.ID,
+					Successful:   cand.Successful,
+					Promised:     cand.Promised,
+					Groupid:      cand.Groupid,
+					Type:         cand.Type,
+					Arrival:      cand.Arrival,
+					Posted:       cand.Posted,
+					VisibleSince: cand.VisibleSince,
+					Lat:          blurLat,
+					Lng:          blurLng,
+					Unseen:       cand.Unseen,
+					Mine:         cand.Fromuser != 0 && cand.Fromuser == myid,
 				})
 			}
 		}

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -206,8 +206,17 @@ func (Message) TableName() string {
 // Message represents a posting (offer or wanted)
 // swagger:model Message
 type Message struct {
-	ID                 uint64              `json:"id" gorm:"primary_key"`
-	Arrival            time.Time           `json:"arrival"`
+	ID      uint64    `json:"id" gorm:"primary_key"`
+	Arrival time.Time `json:"arrival"`
+	// VisibleSince is the earliest this post could have been seen: the oldest arrival across
+	// the groups it is live on. The feed orders by it and the card dates by it, so the list
+	// cannot contradict the dates printed on it.
+	//
+	// Arrival above is messages.arrival - when it was first written - which is NOT the same
+	// thing once a post has been reposted or has rippled: this browse view was ordering by
+	// Arrival while the card showed a group arrival, so a 20-day-old post displaying "5 days"
+	// sat above a 3-hour-old one.
+	VisibleSince       time.Time           `json:"visibleSince"`
 	Date               time.Time           `json:"date"`
 	Fromuser           uint64              `json:"fromuser"`
 	Subject            string              `json:"subject"`
@@ -497,6 +506,9 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 				// both proven by the retired ormharness (shapes.json /
 				// TestTier3Shapes_08bb471351a0, removed in d22ba1d6c).
 				selectCols := "messages.id, messages.arrival, messages.date, messages.fromuser, " +
+					// Oldest live-group arrival: when this first became available to anyone. A repost
+					// bumps that row, so this follows it, which is what makes a repost lift the post.
+					"COALESCE((SELECT MIN(mgv.arrival) FROM messages_groups mgv WHERE mgv.msgid = messages.id AND mgv.deleted = 0), messages.arrival) AS visible_since, " +
 					"messages.subject, messages.type, textbody, lat, lng, availablenow, availableinitially, locationid, " +
 					"deliverypossible, deadline, heldby, messages.source, messages.sourceheader, messages.fromaddr, messages.fromip, messages.fromcountry, messages.tnpostid, "
 				if isMod {

--- a/iznik-server-go/message/messageSummary.go
+++ b/iznik-server-go/message/messageSummary.go
@@ -19,10 +19,31 @@ type MessageSummary struct {
 	// spatial arrival used for the relevance score. Only populated on the browse
 	// feed; zero elsewhere (falls back to arrival client-side).
 	Posted time.Time `json:"posted,omitempty"`
-	Date   time.Time `json:"date"`
-	Lat    float64   `json:"lat"`
-	Lng    float64   `json:"lng"`
-	Unseen bool      `json:"unseen"`
+	// VisibleSince is the earliest this post could have been seen: the oldest
+	// arrival across the groups it is live on. It is the ONE clock the browse feed
+	// uses - both the "Newest posted" order and the card's time badge - so the list
+	// can never contradict the dates printed on it.
+	//
+	// Neither of the two fields above could do that job. Arrival is the reach-bumped
+	// spatial arrival, so it moves when a post merely ripples further. Posted is when
+	// the message was written, which is NOT when it became available: a post written
+	// on the 24th, approved onto its group on the 8th and rippled onward on the 12th
+	// showed "5 days" on the card while sorting as 20 days old, so the feed printed
+	// dates in an order its own sort key contradicted.
+	//
+	// It moves for the two reasons a post legitimately becomes available later than it
+	// was written: a repost (the giver re-offering it, which updates the group row) and
+	// a ripple into a further group. Ordering by it means a repost lifts the post back
+	// up, which is the point of reposting.
+	//
+	// LIMITATION: the oldest arrival across ALL the post's groups, not just the ones
+	// this viewer can see, which would need their membership set threading into the
+	// query. Zero outside the browse feed; the client falls back to posted there.
+	VisibleSince time.Time `json:"visibleSince,omitempty"`
+	Date         time.Time `json:"date"`
+	Lat          float64   `json:"lat"`
+	Lng          float64   `json:"lng"`
+	Unseen       bool      `json:"unseen"`
 	// Score is the rippling relevance score (see isochrone.Score) used to
 	// order the 'nearby' browse feed. Only populated on that path; zero/
 	// omitted elsewhere.

--- a/iznik-server-go/test/isochrone_visiblesince_test.go
+++ b/iznik-server-go/test/isochrone_visiblesince_test.go
@@ -1,0 +1,149 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/message"
+	"github.com/stretchr/testify/assert"
+)
+
+// The browse feed ran two clocks. It ORDERED by messages.arrival - when a post was written,
+// which never moves - while each card DATED itself from a group arrival, which moves when a post
+// ripples into a further group and again when it is reposted. So a feed set to "Newest posted"
+// printed 5 days, 4 days, 5 days, 2 hours and was, by its own sort key, in perfect order.
+//
+// VisibleSince is the one clock both ends now use: the oldest arrival across the groups the post
+// is live on, i.e. the earliest anyone could have seen it. These tests pin it to that definition
+// on the endpoints the browse card is built from - the feed summary and the full message.
+
+// TestFeedVisibleSinceIsOldestGroupArrival: a post written weeks ago whose group row arrived
+// recently (an autorepost) must date from the GROUP arrival, not from when it was written -
+// while Posted still reports the write time so the card can say "first posted N days".
+func TestFeedVisibleSinceIsOldestGroupArrival(t *testing.T) {
+	prefix := uniquePrefix("visiblesince")
+	userID := CreateTestUser(t, prefix+"_u", "User")
+	_, token := CreateTestSession(t, userID)
+	posterID := CreateTestUser(t, prefix+"_p", "User")
+	db := database.DBConn
+
+	group := CreateTestGroup(t, prefix+"_member")
+	db.Exec("INSERT INTO memberships (userid, groupid) VALUES (?, ?)", userID, group)
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings, '{}'), '$.browseView', 'mygroups') WHERE id = ?", userID)
+	defer db.Exec("DELETE FROM memberships WHERE userid = ? AND groupid = ?", userID, group)
+
+	msg := CreateTestMessage(t, posterID, group, prefix+" repostedpost", 55.9533, -3.1883)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msg)
+	defer db.Exec("DELETE FROM messages WHERE id = ?", msg)
+
+	// Written 30 days ago, but only landed on the group 3 days ago - the shape every
+	// autoreposted post has.
+	db.Exec("UPDATE messages SET arrival = DATE_SUB(NOW(), INTERVAL 30 DAY) WHERE id = ?", msg)
+	db.Exec("UPDATE messages_groups SET arrival = DATE_SUB(NOW(), INTERVAL 3 DAY) WHERE msgid = ?", msg)
+	db.Exec("UPDATE messages_spatial SET successful = 0 WHERE msgid = ?", msg)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/isochrone/message?browseView=mygroups&jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+
+	var found *message.MessageSummary
+	for i := range msgs {
+		if msgs[i].ID == msg {
+			found = &msgs[i]
+		}
+	}
+	assert.NotNil(t, found, "the reposted post is in the feed")
+	if found == nil {
+		return
+	}
+
+	daysAgo := time.Since(found.VisibleSince).Hours() / 24
+	assert.InDelta(t, 3, daysAgo, 1, "VisibleSince is the group arrival (3 days), not the write time (30 days)")
+
+	postedDaysAgo := time.Since(found.Posted).Hours() / 24
+	assert.InDelta(t, 30, postedDaysAgo, 1, "Posted still reports when the post was written, so the card can say how far back it started")
+}
+
+// TestFeedVisibleSinceTakesEarliestOfSeveralGroups: a post that has rippled onward is live on
+// several groups with different arrivals. The earliest is when it first became available to
+// anyone, so that - not the latest ripple - is what the feed dates and orders by. Taking the
+// latest is what made a long-standing post jump to the top of "Newest posted" every time its
+// reach grew.
+func TestFeedVisibleSinceTakesEarliestOfSeveralGroups(t *testing.T) {
+	prefix := uniquePrefix("visiblesincemulti")
+	userID := CreateTestUser(t, prefix+"_u", "User")
+	_, token := CreateTestSession(t, userID)
+	posterID := CreateTestUser(t, prefix+"_p", "User")
+	db := database.DBConn
+
+	origin := CreateTestGroup(t, prefix+"_origin")
+	rippled := CreateTestGroup(t, prefix+"_rippled")
+	db.Exec("INSERT INTO memberships (userid, groupid) VALUES (?, ?)", userID, rippled)
+	defer db.Exec("DELETE FROM memberships WHERE userid = ? AND groupid = ?", userID, rippled)
+
+	msg := CreateTestMessage(t, posterID, origin, prefix+" rippledpost", 55.9533, -3.1883)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msg)
+	defer db.Exec("DELETE FROM messages WHERE id = ?", msg)
+
+	// Landed on its origin group 10 days ago, rippled into the viewer's group 2 days ago.
+	db.Exec("UPDATE messages_groups SET arrival = DATE_SUB(NOW(), INTERVAL 10 DAY) WHERE msgid = ? AND groupid = ?", msg, origin)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) "+
+		"VALUES (?, ?, DATE_SUB(NOW(), INTERVAL 2 DAY), 'Approved', 0)", msg, rippled)
+	db.Exec("UPDATE messages_spatial SET successful = 0 WHERE msgid = ?", msg)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/isochrone/message?browseView=mygroups&jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+
+	var found *message.MessageSummary
+	for i := range msgs {
+		if msgs[i].ID == msg {
+			found = &msgs[i]
+		}
+	}
+	assert.NotNil(t, found, "the rippled-in post is in the feed")
+	if found == nil {
+		return
+	}
+
+	daysAgo := time.Since(found.VisibleSince).Hours() / 24
+	assert.InDelta(t, 10, daysAgo, 1, "VisibleSince is the EARLIEST group arrival, not the latest ripple")
+}
+
+// TestMessageVisibleSinceOnFullMessage: the browse card is re-rendered from the full message once
+// the store loads it, so that payload has to carry the same number. It did not, and the card's
+// age silently changed the moment the store filled in - the state a member actually looks at.
+func TestMessageVisibleSinceOnFullMessage(t *testing.T) {
+	prefix := uniquePrefix("visiblesincefull")
+	posterID := CreateTestUser(t, prefix+"_p", "User")
+	db := database.DBConn
+
+	group := CreateTestGroup(t, prefix)
+	msg := CreateTestMessage(t, posterID, group, prefix+" fullmessage", 55.9533, -3.1883)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msg)
+	defer db.Exec("DELETE FROM messages WHERE id = ?", msg)
+
+	db.Exec("UPDATE messages SET arrival = DATE_SUB(NOW(), INTERVAL 30 DAY) WHERE id = ?", msg)
+	db.Exec("UPDATE messages_groups SET arrival = DATE_SUB(NOW(), INTERVAL 3 DAY) WHERE msgid = ?", msg)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/"+fmt.Sprint(msg), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var m message.Message
+	json2.Unmarshal(rsp(resp), &m)
+	assert.Equal(t, msg, m.ID)
+
+	daysAgo := time.Since(m.VisibleSince).Hours() / 24
+	assert.InDelta(t, 3, daysAgo, 1, "the full message carries VisibleSince too, so the card's age does not change when the store loads")
+
+	arrivalDaysAgo := time.Since(m.Arrival).Hours() / 24
+	assert.InDelta(t, 30, arrivalDaysAgo, 1, "Arrival on the full message is still the write time - what the card calls 'first posted'")
+}

--- a/plans/active/2026-08-13-feed-time-badge-and-order.md
+++ b/plans/active/2026-08-13-feed-time-badge-and-order.md
@@ -1,0 +1,168 @@
+# The feed's time badge and its sort order disagree
+
+Reported 2026-08-13: browse set to Nearby + "Newest posted", and the visible times ran
+5 days, 4 days, 5 days, 2 hours. Not descending, so either the badge or the order is wrong.
+
+## What is actually happening
+
+Two different clocks.
+
+| | field the code uses | bumped when it ripples | bumped by a repost |
+|---|---|---|---|
+| sort ("Newest posted") | `posted` = `messages.arrival` | no | no |
+| badge | `groups.find(g => !g.rippled_in).arrival`, falling back to `arrival` = `messages_spatial.arrival` | **yes** | yes |
+
+`iznik-server-go/isochrone/message.go` states the intent plainly - `posted` "is what the
+client's Newest posted sort **and the card's time badge** mean, so exposing it lets the feed
+order agree with the badge" - but `useMessageDisplay.js` never used it. `displayTimestamp` is
+`origin?.arrival || message.arrival || message.date`, so the badge reads a group arrival, or
+falls through to the summary's ripple-bumped `arrival`.
+
+Live evidence (2026-08-13): "Archeology magazines" (121444381) sits on its origin group
+Malvern-Hills at 11:27:23 - equal to `messages.arrival` - and on **seven rippled-in groups at
+13:29:05**. One post, two hours apart, depending which group you read.
+
+Note: the exact figures in the original screenshot cannot be re-derived now, because spatial
+arrivals move (Marbles 121152650 is 22h at the time of writing; Post thumper 121177700 has no
+`messages_spatial` row at all). The mechanism above is what matters and is reproducible.
+
+## Proposal
+
+One clock, chosen to answer the question a member is actually asking: **how long could I have
+had this?**
+
+- **`visibleSince`** = MIN, over the groups where the post is live *and visible to this
+  viewer*, of that group's `messages_groups.arrival`. On the nearby/reach feed that is when it
+  entered their reach; on a group feed, when it landed on a group they are in. A repost
+  already bumps that column, so it is included by construction.
+- **Sort "Newest posted" by `visibleSince`**, and **show `visibleSince` on the badge**. Same
+  number, so the order cannot contradict what is on screen.
+- Keep `posted` (the original `messages.arrival`), used only to explain a difference.
+
+### When they differ, say why - the two causes read differently
+
+- Rippled: **"4 days here · 6 days elsewhere"**. It reached you later than it was posted.
+- Reposted: **"reposted 4 days ago · first posted 18 days ago"**. Nothing travelled; the
+  giver's post was refreshed.
+
+Suppress the second clause when the gap is under a day, or every card grows noise.
+
+### Server
+
+The feed summary already carries `arrival` and `posted`. Add `visibleSince` and a small enum
+(`rippled` | `reposted` | `same`) so the client picks the wording rather than re-deriving it.
+The viewer's group set is already joined for other purposes in that query.
+
+## Decided
+
+**A repost lifts the post back up the feed.** Ordering is by `visibleSince`, which a repost
+bumps, so a refreshed post is genuinely new to everyone again - which is the point of a
+repost. This is a deliberate departure from Discourse 9844's "don't float old posts", because
+there the bump came from the reach growing (nothing changed for the member) whereas here the
+giver's post has actively been re-offered.
+
+**The badge stays short on mobile.** The component already picks between a short and a longer
+form by breakpoint (`MessageSummary`: `isLgPlus ? timeAgoExpanded : timeAgo`), so the second
+clause follows the same rule:
+
+| breakpoint | rippled | reposted |
+|---|---|---|
+| mobile | `4 days · 6 days elsewhere` | `reposted 4 days · first posted 18 days` |
+| lg and up | `4 days here · first seen 6 days ago elsewhere` | `reposted 4 days ago · first posted 18 days ago` |
+
+Suppressed entirely when the gap is under a day.
+
+## Superseded: the decision, as originally put
+
+Ordering by `visibleSince` means **a repost lifts a post back up the feed**. That is what a
+repost is for, but it is a change, and it is the same shape of complaint as Discourse 9844
+(a days-old post floating to the top when its reach grew).
+
+1. **Repost lifts it** - simple, one clock, "newest to you" is honest.
+2. **Repost refreshes the badge only** - sort on the pre-repost arrival, so old items stay
+   down while the badge still reads "reposted 4 days ago".
+
+Awaiting a decision on which.
+
+## Not yet checked
+
+- Whether `messages.arrival` is ever itself bumped (a repost that rewrites the message rather
+  than the listing). Everything above assumes it is stable.
+- What the badge should say for a post visible through reach but on no group the viewer has
+  joined - "in your area 4 days" may read better than "here".
+
+---
+
+# STATUS at 2026-08-13 (handover)
+
+Nothing is committed. All of the below is uncommitted working-tree change on branch
+`feat/collapse-own-posts-in-browse` (which is otherwise master). Frontend unit suite passes
+at **15464**. There is no Go test for `visibleSince` yet - write one before any PR.
+
+## Done and verified
+
+- **Own posts collapsed** (PR #1336, MERGED to master). This was the *first* cause of the
+  "out of order" report: the viewer's own posts pin to the top of every sort (Discourse 9933),
+  so old posts sat above new. Confirmed fixed on dev-live.
+- **`visibleSince` on the bulk endpoint** `/api/message/<ids>` (`message/message.go`):
+  struct field + `COALESCE((SELECT MIN(mgv.arrival) ... ), messages.arrival) AS visible_since`.
+  Verified live on 121152650: written 24 Jul, origin group 8 Aug, rippled 12 Aug ->
+  `visibleSince` = 8 Aug, which matches the badge.
+- **Badge wired**: `MessageSummary.vue` and `MessageExpanded.vue` both call `postAgeBadge`.
+- **`usePostAgeBadge.js`** + 12 tests (TDD, real RED first). Wording, after two rounds of
+  feedback: mobile `4 days · first posted 6 days`; lg+ adds "ago". No "elsewhere", no
+  "reposted". Second clause suppressed when the gap is under a day or negative.
+- **Sort reads visibleSince** (`useMessageSort.js`), falling back to posted then arrival.
+- **`PostMapAndList.sortMessages`** enriches summaries from the message store when they lack
+  the field. Helps the top of the feed only - see below.
+
+## NOT fixed - the next thing to do
+
+The nearby feed's own payload has no `visibleSince`, so the sort still falls back to
+`arrival` for anything the message store has not loaded. Measured on dev-live: **17 ordering
+breaks in 71 cards**, all past card ~52 (e.g. 23d then 17d then 13d).
+
+`nearbyStore.messageList` <- `api/IsochroneAPI.js fetchMessages` <- **`GET /isochrone/message`**.
+Its response keys are:
+
+    id,hasoutcome,successful,promised,groupid,collection,type,arrival,posted,date,lat,lng,unseen,score,distance
+
+`score` and `distance` are NOT produced by any of the three selects patched in
+`isochrone/message.go`, so this endpoint marshals a **different struct** - find it (start from
+the `/isochrone/message` route handler, not the file name) and add the field there.
+
+**Second bug in my own change, fix at the same time:** the struct field I added carries only
+`gorm:"column:visiblesince"` and **no `json:"visibleSince"` tag**, so even on the paths I did
+patch it would not serialise under the name the client reads.
+
+Then: rebuild apiv2-live, reload the browse URL, and require **0 ordering breaks across all
+71 cards** - not just the first page.
+
+## Environment notes (these cost hours)
+
+- **`apiv2-live` has a baked source tree with no mount.** `docker cp` a single file and it will
+  not compile (its siblings are older: `spatialReachIDs`, `database.InsertSelect`,
+  `spatial.ReachContaining` all missing). Copy the whole `iznik-server-go/` (34MB), then
+  `docker restart` - it runs `go run main.go` in a loop, so restart = rebuild (~60-90s).
+  It reverts to the baked build on any real rebuild.
+- **dev-live `/app` is also a copy**: `docker cp` each changed frontend file individually.
+- **Switch dev-live to the local V2 API**:
+  `curl -X POST localhost:8081/api/container/toggle-live-v2 -d '{"target":"freegle","enable":true}'`
+- **Test URL** (impersonation): `http://freegle-dev-live.localhost/browse?u=37345781&k=...`
+  `*.localhost` needs `--host-resolver-rules=MAP *.localhost 127.0.0.1` in any Playwright probe.
+- **Probe discipline.** Three false greens happened here: reading rendered order without
+  capturing the payload; printing 16 of 71 cards; and an over-escaped regex (`\\d`) that made
+  every badge unparseable so the break counter reported 0. Working probe:
+  `/tmp/order.mjs <url>` - prints every break and the total.
+
+## Also parked
+
+- **Walkthrough video** (`pr-walkthrough/prs/howto-member/`, `make.sh` re-runs it). Blocked on
+  photos: fixture attachments have **no image bytes** (`data` empty, tusd uid 404s,
+  `IMAGE_DOMAIN` is the live host), so browse/My Posts render grey tiles. Outstanding asks:
+  frame shots in a phone (`PhoneFrame.jsx` written, `device:"phone"` added to ScreenshotScene),
+  plausible chat data, order give->reply->promise->taken->browse, drop the closing summary,
+  highlight buttons before modals, show the TAKEN form part-filled.
+- **`stash@{0}`** holds four `.claude` hook files that are NOT mine (`check-pr-text.sh`,
+  `check-pr-uncommitted.sh` + two `.test.sh`); backed up in `~/claude-hooks-backup-2026-08-13/`.
+  They blocked the master merge. Someone should decide whether master's versions supersede them.


### PR DESCRIPTION
Fixes the two complaints in [Flag warning messy](https://discourse.ilovefreegle.org/t/flag-warning-messy/10024).

## Neville's: "This member's posts are moderated" on approved posts

A stored content-check reason is a **snapshot** of why a post was held, taken when it arrived. It is never re-evaluated, so it goes stale in two ways at once.

Message 121335278 on Hackney Freegle, from the screenshot, shows both:

| Time (5 Aug) | Event |
|---|---|
| 22:05:46 | Post written |
| 22:06:01 | Content check runs, member was moderated, stores `MemberModerated` |
| 22:26:30 | Moderator sets that member to `DEFAULT` (Group Settings) - log `User/OurPostingStatus` |
| 22:26:35 | Moderator approves the post |
| 13 Aug | Flag still displayed, through two autoreposts |

So the box claimed a post "needs approving" that had been approved eight days earlier, and said a member's posts were moderated while the dropdown beside it read Group Settings. Confirmed against the production database: `messages_groups` for group 21449 holds `[{"check":"MemberModerated",...}]` with `collection = Approved`, and that membership's `ourPostingStatus` is now `DEFAULT`.

Two changes:

- **A setting-based hold is not shown once that group's copy is Approved.** `GroupModerated` and `MemberModerated` explain why a post is *waiting*; once it is approved there is nothing waiting and nothing to do. Suppressed only when the collection can actually be read - an older payload without one keeps the explanation, because a post sitting in the queue with nothing saying why is the complaint that put these boxes there in the first place (#9987). Content flags are **not** spent this way: a keyword flag is still the record of why a post was looked at, and it stays.
- **The wording moves to the past tense.** A moderator can change a member's status while the post is still pending, so the box now says what held *this post* rather than asserting what the member's setting is now.

## Carol's: "codey type stuff we're not meant to see"

The yellow box read:

> Matched concern keyword `'(?<!$)water\W)\butt\b(?!\s+rd)'`

PR #1322 (merged 12 Aug) stopped new rows storing the pattern instead of the matched text, but the rows already in the database still hold patterns, so moderators keep seeing them. Anything that looks like a pattern is now dropped from the detail text and never named as the triggering word - no migration needed, and a real word is still named as before.

## Tests

TDD, red first: five new cases failed against the old component, and four written alongside them passed from the start so the change could not over-correct - a pending post still explains itself, an unknown collection still explains itself, a keyword flag survives approval, and a genuine word is still quoted.

Frontend suite on this branch: **15482 passed**.

## Not changed

`isUserModerated` still treats a NULL `ourPostingStatus` as moderated. That matches apiv2 (`membership.go`: "NULL ourPostingStatus defaults to MODERATED") and the ModTools dropdown, which only ever writes `MODERATED`, `DEFAULT` or `PROHIBITED`. The bug here was displaying a stale snapshot, not classifying it wrongly.
