### PR TITLE
Stop the AI usage-count runs overlapping, and two smaller review fixes

### DIFF
--- a/iznik-batch/app/Console/Commands/AI/UpdateAIImageUsageCountsCommand.php
+++ b/iznik-batch/app/Console/Commands/AI/UpdateAIImageUsageCountsCommand.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands\AI;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -37,7 +38,35 @@ class UpdateAIImageUsageCountsCommand extends Command
     // config table, so there is no schema step.
     private const CURSOR_KEY = 'ai.usage_counts_cursor';
 
+    // Both modes take this same lock, so the nightly full run and an hourly incremental
+    // one can never be in flight together. Laravel's own withoutOverlapping() cannot do
+    // this: it keys the mutex on the command string, and "ai:usage-counts:update" and
+    // "ai:usage-counts:update --full" are different strings, so each only ever excludes
+    // another copy of itself. Without a shared lock the nightly run - which takes long
+    // enough that the next hourly tick fires while it is still going - finishes last and
+    // stores the cursor it read at the start, moving it backwards. The incremental pass
+    // adds to the counts rather than setting them, so everything between the two cursor
+    // positions gets counted twice, and it stays wrong until the following night.
+    private const RUN_LOCK_KEY = 'ai:usage-counts:run';
+
     public function handle(): int
+    {
+        $lock = Cache::lock(self::RUN_LOCK_KEY, 3600);
+
+        if (!$lock->get()) {
+            $this->info('Another ai:usage-counts:update run is in progress; exiting.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            return $this->updateCounts();
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function updateCounts(): int
     {
         // The highest attachment id that exists right now. Both paths work strictly up to
         // this id and then store it, so a row inserted while we run is left for the next
@@ -175,6 +204,17 @@ class UpdateAIImageUsageCountsCommand extends Command
 
     private function writeCursor(int $upTo): void
     {
+        // Only ever forward. The run lock stops the two scheduled jobs overlapping, but
+        // the id this is called with comes from MAX(id) on a cluster that splits reads
+        // and writes, so a read from a node that is behind can hand back a smaller
+        // number than the cursor already holds. Storing it would make the next pass add
+        // the counts for that range a second time.
+        $current = $this->readCursor();
+
+        if ($current !== null && $upTo <= $current) {
+            return;
+        }
+
         DB::table('config')->upsert(
             [['key' => self::CURSOR_KEY, 'value' => (string) $upTo]],
             ['key'],

--- a/iznik-batch/app/Services/AutoRepostService.php
+++ b/iznik-batch/app/Services/AutoRepostService.php
@@ -136,12 +136,18 @@ class AutoRepostService
                 continue;
             }
 
+            // Cast the same way applyDueWindow does. The database is asked for candidates
+            // using a window built from whole numbers, and this decides what to do with
+            // them; if the two rounded a fraction differently, a post could pass the test
+            // here that the window had already excluded, and it would never be reposted.
+            // Every community stores whole numbers today, so this changes nothing now -
+            // it just stops the two halves being able to disagree.
             $interval = $msg->type === Message::TYPE_OFFER
-                ? ($reposts['offer'] ?? 3)
-                : ($reposts['wanted'] ?? 7);
+                ? (int) ($reposts['offer'] ?? 3)
+                : (int) ($reposts['wanted'] ?? 7);
 
             // V1: max age check — messages older than interval * (max + 1) days.
-            $maxAge = $interval * (($reposts['max'] ?? 5) + 1);
+            $maxAge = $interval * ((int) ($reposts['max'] ?? 5) + 1);
             if ($msg->hoursago >= $maxAge * 24) {
                 $stats['skipped']++;
                 continue;

--- a/iznik-batch/app/Services/ChatExpectedService.php
+++ b/iznik-batch/app/Services/ChatExpectedService.php
@@ -32,11 +32,22 @@ class ChatExpectedService
     private const CURSOR_KEY = 'chat.expected_cursor';
 
     /**
-     * How far back before the last run's start time to look for released replies. The job
-     * runs every five minutes, so this is generous room for a long run or a clock that has
-     * been nudged, at the cost of re-checking a few chats.
+     * How far back before the last run's start time to look for released replies.
+     *
+     * The other half of this job works from a message id, and an id is safe however late a
+     * row shows up: it is still higher than the last one we handled, so it is still picked
+     * up. A release has no such id - it is a time stamped on an existing row when it is
+     * updated - so it can only be found by looking back over a period. Anything that does
+     * not appear within that period is not late, it is missed, because the window has moved
+     * on by the next run.
+     *
+     * Hence hours rather than minutes. The job runs every five minutes, so this re-checks
+     * the same handful of chats many times over, which is cheap and settles on the same
+     * answer each time. What it buys is that a row would have to be delayed by three hours
+     * before anyone noticed the poster still being told nobody had replied, and the
+     * overnight pass rechecks everything outstanding regardless.
      */
-    private const RELEASE_OVERLAP_MINUTES = 15;
+    private const RELEASE_OVERLAP_MINUTES = 180;
 
     /**
      * Orchestrates the full expected-reply update cycle.

--- a/iznik-batch/tests/Unit/Commands/AI/UpdateAIImageUsageCountsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/AI/UpdateAIImageUsageCountsCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Commands\AI;
 
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -25,6 +26,50 @@ class UpdateAIImageUsageCountsCommandTest extends TestCase
         DB::table('ai_images')->where('name', 'LIKE', 'test-usage-%')->delete();
 
         parent::tearDown();
+    }
+
+    public function test_the_cursor_is_never_moved_backwards(): void
+    {
+        // The counts are added to, not set, so a cursor that slipped backwards would make
+        // the next pass count the same attachments again and the error would stick until
+        // the next full recompute. Two things can push a smaller number at it: the nightly
+        // full run finishing after an hourly one has already moved the cursor on, and
+        // MAX(id) coming back from a cluster node that is behind.
+        $key = 'ai.usage_counts_cursor';
+        $ahead = (int) DB::table('messages_attachments')->max('id') + 100000;
+
+        DB::table('config')->upsert(
+            [['key' => $key, 'value' => (string) $ahead]],
+            ['key'],
+            ['value'],
+        );
+
+        $this->artisan('ai:usage-counts:update')->assertSuccessful();
+
+        $this->assertEquals(
+            $ahead,
+            (int) DB::table('config')->where('key', $key)->value('value'),
+            'the cursor was moved backwards, so the next run would double-count'
+        );
+
+        DB::table('config')->where('key', $key)->delete();
+    }
+
+    public function test_a_second_run_exits_while_another_holds_the_lock(): void
+    {
+        // The hourly and nightly jobs are separate schedule entries, so Laravel's own
+        // overlap guard keys them separately and does not hold one off against the other.
+        // They take a shared lock instead.
+        $lock = Cache::lock('ai:usage-counts:run', 60);
+        $this->assertTrue($lock->get(), 'could not take the lock to set the test up');
+
+        try {
+            $this->artisan('ai:usage-counts:update')
+                ->expectsOutputToContain('Another ai:usage-counts:update run is in progress')
+                ->assertSuccessful();
+        } finally {
+            $lock->release();
+        }
     }
 
     public function test_updates_usage_counts_in_batches(): void


### PR DESCRIPTION
The hourly and overnight runs of the AI picture usage counts can trip over each other and count the same pictures twice.

## What was wrong

The job that keeps the "how many posts use this picture" figure up to date runs in two forms: a quick pass every hour that looks only at what has arrived since last time, and a full recount overnight. Both remember how far they have read in the same place.

Laravel's built-in guard against a job running twice matches on the command line, and these two are spelled differently, so each only ever holds itself off. Nothing stops the two of them running together, and they will, because the overnight recount takes long enough that the next hourly pass starts while it is still going.

When that happens the overnight run finishes last and writes down the position it read when it started, which by then is behind where the hourly pass has already got to. The next hourly pass re-reads a stretch that has already been done, and because it adds to the figures rather than setting them, everything in that stretch is counted twice. It stays wrong until the following night's recount corrects it, and can then happen again.

There is a second way in. The position comes from asking the database for the highest attachment number, and on a cluster that splits reads from writes that answer can come from a node that is behind.

## What this changes

Both forms now take the same lock, so they cannot run at the same time. The stored position also only ever moves forward, so a smaller number arriving from a lagging node is ignored instead of being written down.

The figure itself is only a review aid in the AI picture tool, so nothing acted on the wrong numbers. It was still wrong, and it would have kept going wrong.

## Also here: auto-repost settings read the same way in both places

The database is asked for posts that might be due a repost using a window built from whole numbers. The code that then decides what to do with each one was reading the same community settings without rounding them. If a community ever stored a fraction, the two halves would round it differently, and a post could pass the second test having already been left out of the first, so it would never be reposted at all.

Every community stores whole numbers today, so this changes nothing in practice. It stops the two halves being able to disagree.

## Also here: a wider window for spotting released replies

The job that works out whether a poster is still waiting for a reply looks for two things. New chat messages it finds by message number, and a number is safe however late a row turns up, because it is still higher than the last one handled. Released replies it finds by looking back over a period of time instead, because a release is a time stamped onto an existing row rather than a new row with a number.

That period only reached about twenty minutes back. Anything that did not appear within it was not late, it was missed, because by the next run the window had moved past it. The poster would carry on being told nobody had replied until the overnight pass rechecked everything.

The window is now three hours. It re-checks the same handful of chats many times over, which is cheap and settles on the same answer each time.

## How this was found

An adversarial review of the recent overnight-work changes, asked to refute the claims rather than confirm them.

## Testing

Full Laravel suite run locally against the worktree. Two new tests: that the stored position is never moved backwards, and that a second run exits while another holds the lock.
