### PR TITLE
Network-wide happiness without the join, and a cache a stranger cannot empty

### DIFF
--- a/iznik-server-go/dashboard/cache.go
+++ b/iznik-server-go/dashboard/cache.go
@@ -37,8 +37,9 @@ import (
 
 // componentCacheMaxEntries bounds the cache. Keys are per (component, group scope, date
 // range), so a busy estate with many moderator group-sets and custom ranges is the growth
-// case. Clear-on-overflow keeps the worst case bounded without an LRU's bookkeeping, the
-// same trade-off message.reachUniverseCache makes.
+// case. On reaching the limit, expired entries are dropped and anything that still does
+// not fit simply is not cached - see dropExpiredComponents for why entries that are still
+// live are never thrown out to make room.
 const componentCacheMaxEntries = 2000
 
 // componentNegativeTTL is how long an empty or nil answer is reused. Empty is what a
@@ -134,13 +135,19 @@ func cachedComponent(key string, ttl time.Duration, compute func() interface{}) 
 		delete(componentInflight, key)
 		if completed {
 			if len(componentCache) >= componentCacheMaxEntries {
-				componentCache = map[string]cachedComponentResult{}
+				dropExpiredComponents()
 			}
 			keep := ttl
 			if isEmptyComponentResult(call.val) {
 				keep = componentNegativeTTL
 			}
-			componentCache[key] = cachedComponentResult{val: call.val, expires: time.Now().Add(keep)}
+			// Only store if there is room. If the cache is full of entries that are all
+			// still live, this answer just isn't cached - the request is served normally,
+			// the next one recomputes. That is slower, but it is the safe way round: the
+			// alternative is throwing away entries other people are still using.
+			if len(componentCache) < componentCacheMaxEntries {
+				componentCache[key] = cachedComponentResult{val: call.val, expires: time.Now().Add(keep)}
+			}
 		}
 		componentMu.Unlock()
 		close(call.done)
@@ -150,6 +157,26 @@ func cachedComponent(key string, ttl time.Duration, compute func() interface{}) 
 	call.val = compute()
 	completed = true
 	return call.val
+}
+
+// dropExpiredComponents removes entries whose TTL has run out. Callers must hold
+// componentMu.
+//
+// This used to empty the whole map when it filled up, which is fine when it fills through
+// ordinary use but not when someone fills it on purpose. The date range and group are
+// free-text query parameters, and most of the dashboard's components answer without
+// needing a login, so anyone can walk through made-up values and push the cache past its
+// limit. Emptying it then would throw away every moderator's freshly-computed figures and
+// send the whole lot back to the database at once - which is the pile-up this cache was
+// added to prevent, turned into something a stranger can trigger.
+func dropExpiredComponents() {
+	now := time.Now()
+
+	for k, e := range componentCache {
+		if !now.Before(e.expires) {
+			delete(componentCache, k)
+		}
+	}
 }
 
 // isEmptyComponentResult reports whether a component produced nothing - which for every

--- a/iznik-server-go/dashboard/cache_test.go
+++ b/iznik-server-go/dashboard/cache_test.go
@@ -6,6 +6,7 @@ package dashboard
 // of an expensive query onto db3.
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -258,4 +259,60 @@ func TestSortedHappiness_EmptyIsEmptySlice(t *testing.T) {
 	got := sortedHappiness(map[string]int{})
 	assert.NotNil(t, got)
 	assert.Empty(t, got)
+}
+
+// A stranger can fill the cache: the date range and group come straight from the query
+// string, and most components answer without a login, so unique keys are free to generate.
+// Emptying the cache when it fills would hand that stranger the power to throw away every
+// moderator's freshly-computed figures and send the lot back to the database at once,
+// which is the pile-up the cache exists to prevent.
+func TestCachedComponent_FullCacheOfLiveEntriesIsNotThrownAway(t *testing.T) {
+	componentMu.Lock()
+	componentCache = map[string]cachedComponentResult{}
+	componentInflight = map[string]*inflightComponent{}
+	for i := 0; i < componentCacheMaxEntries; i++ {
+		componentCache[fmt.Sprintf("live-%d", i)] = cachedComponentResult{
+			val:     []map[string]interface{}{{"n": i}},
+			expires: time.Now().Add(time.Hour),
+		}
+	}
+	componentMu.Unlock()
+
+	got := cachedComponent("flood-key", time.Minute, func() interface{} {
+		return []map[string]interface{}{{"x": 1}}
+	})
+	assert.NotNil(t, got, "the answer is still computed and returned, it just isn't stored")
+
+	componentMu.Lock()
+	remaining := len(componentCache)
+	componentMu.Unlock()
+
+	assert.GreaterOrEqual(t, remaining, componentCacheMaxEntries,
+		"entries that were still live were discarded to make room")
+}
+
+// Expired entries are fair game, so an honestly-busy cache still turns over.
+func TestCachedComponent_ExpiredEntriesAreReclaimedWhenFull(t *testing.T) {
+	componentMu.Lock()
+	componentCache = map[string]cachedComponentResult{}
+	componentInflight = map[string]*inflightComponent{}
+	for i := 0; i < componentCacheMaxEntries; i++ {
+		componentCache[fmt.Sprintf("stale-%d", i)] = cachedComponentResult{
+			val:     []map[string]interface{}{{"n": i}},
+			expires: time.Now().Add(-time.Hour),
+		}
+	}
+	componentMu.Unlock()
+
+	cachedComponent("fresh-key", time.Minute, func() interface{} {
+		return []map[string]interface{}{{"x": 1}}
+	})
+
+	componentMu.Lock()
+	_, cached := componentCache["fresh-key"]
+	remaining := len(componentCache)
+	componentMu.Unlock()
+
+	assert.True(t, cached, "a new answer must be cached once expired entries have been cleared out")
+	assert.Less(t, remaining, componentCacheMaxEntries, "expired entries should have been dropped")
 }

--- a/iznik-server-go/dashboard/dashboard.go
+++ b/iznik-server-go/dashboard/dashboard.go
@@ -84,6 +84,15 @@ func GetDashboard(c *fiber.Ctx) error {
 
 	groupIDs := resolveGroupIDs(myid, uint64(groupID), systemwide, allgroups)
 
+	// Asking for one community and for everything at once is a contradiction, and
+	// resolveGroupIDs settles it by taking the community. Settle it the same way here, so
+	// the components that branch on this agree with the groups they were handed. Left as
+	// it was, group=5&systemwide=true would work out the figures for the whole network
+	// and then file them under community 5.
+	if groupID > 0 {
+		systemwide = false
+	}
+
 	// Check if user is a moderator (for mod-only components).
 	isMod := false
 	if myid > 0 && len(groupIDs) > 0 {
@@ -206,7 +215,7 @@ func getComponent(comp string, groupIDs []uint64, startQ, endQ string, systemwid
 		if !isMod {
 			return nil
 		}
-		compute = func() interface{} { return getHappiness(groupIDs, startQ, endQ) }
+		compute = func() interface{} { return getHappiness(groupIDs, startQ, endQ, systemwide) }
 	case "DiscourseTopics":
 		if !isMod {
 			return nil
@@ -943,12 +952,19 @@ var happinessTypes = []string{"Happy", "Fine", "Unhappy"}
 // The repeat cost is handled by the component cache instead: measured at 5.6s for a
 // systemwide year on production, which is paid once per scope per cache window rather
 // than on every dashboard load.
-func getHappiness(groupIDs []uint64, startQ, endQ string) []map[string]interface{} {
-	if len(groupIDs) == 0 {
+func getHappiness(groupIDs []uint64, startQ, endQ string, systemwide bool) []map[string]interface{} {
+	if !systemwide && len(groupIDs) == 0 {
 		return []map[string]interface{}{}
 	}
 
-	db := database.DBConn
+	// Every other component that was slow enough to need caching also bounds itself, so
+	// that one stuck query can't hold up the request. That matters more now they share
+	// results: callers asking for the same figures wait on the first one to finish
+	// instead of each running their own, so without a limit they would all wait forever.
+	ctx, cancel := context.WithTimeout(context.Background(), dashboardDeadline)
+	defer cancel()
+
+	db := database.DBConn.WithContext(ctx)
 
 	type HappyRow struct {
 		Count     int
@@ -956,13 +972,28 @@ func getHappiness(groupIDs []uint64, startQ, endQ string) []map[string]interface
 	}
 
 	var rows []HappyRow
-	db.Table("messages_outcomes").
-		Select("COUNT(DISTINCT messages_outcomes.id) AS count, messages_outcomes.happiness").
-		Joins("INNER JOIN messages_groups ON messages_groups.msgid = messages_outcomes.msgid AND messages_groups.rippled_in = 0").
-		Where("messages_outcomes.timestamp >= ? AND messages_outcomes.timestamp < ? AND messages_groups.groupid IN (?) AND messages_outcomes.happiness IS NOT NULL",
-			startQ, endQ, groupIDs).
-		Group("messages_outcomes.happiness").
-		Scan(&rows)
+
+	q := db.Table("messages_outcomes").
+		Where("messages_outcomes.timestamp >= ? AND messages_outcomes.timestamp < ? AND messages_outcomes.happiness IS NOT NULL",
+			startQ, endQ)
+
+	if systemwide {
+		// Nothing to narrow by, so don't bring in the listings table at all. Each rating
+		// is one row here already, so a plain count is right and no de-duplicating is
+		// needed. It also means a rating still counts when the post it was left on has
+		// since been deleted or moved between communities, which the join would drop.
+		q = q.Select("COUNT(*) AS count, messages_outcomes.happiness")
+	} else {
+		// Per-community, the listings table is the only thing that says which community a
+		// rating belongs to, so the join has to be here. rippled_in = 0 picks the
+		// community the post was written in; counting the copies it rippled out to as
+		// well was what made these figures four times too high.
+		q = q.Select("COUNT(DISTINCT messages_outcomes.id) AS count, messages_outcomes.happiness").
+			Joins("INNER JOIN messages_groups ON messages_groups.msgid = messages_outcomes.msgid AND messages_groups.rippled_in = 0").
+			Where("messages_groups.groupid IN (?)", groupIDs)
+	}
+
+	q.Group("messages_outcomes.happiness").Scan(&rows)
 
 	totals := map[string]int{}
 	for _, r := range rows {


### PR DESCRIPTION
Three follow-ups on the moderator dashboard, all found by an adversarial review of the caching and happiness changes that went in earlier today.

## Happiness ratings across the whole network no longer go through the listings table

To work out the happiness figures for one community, we have to look at the listings table, because that is the only thing that says which community a rating belongs to. For the whole-network view there is nothing to narrow down by, so that lookup was pure cost.

It was also slightly wrong. Joining to the listings table means a rating only counts while the post it was left on still has a live listing, and a moderator deleting or moving a post removes that. I checked on production: over the last three years, two ratings out of 407,260 had lost their listing. So this was real but tiny, and worth fixing mainly because the fix is also the cheaper query.

The whole-network view now counts the ratings directly, with no join at all.

## The happiness query can now give up

Every other dashboard section that was slow enough to need caching also sets itself a time limit, so one stuck query cannot hold up the request. Happiness was the one that shipped without one.

That matters more now, because callers asking for the same figures at the same time wait for the first one to finish rather than each running their own. Without a limit, one stuck query means they all wait indefinitely. It now has the same forty seconds as the rest.

## A full cache is no longer emptied

The cache held a fixed number of answers and, on filling up, threw all of them away.

The date range and community come straight from the address bar, and most of these sections answer without needing a login, so anyone can ask for made-up combinations as fast as they like and never hit the cache. Once enough of those have gone through, the cache empties, and every moderator's freshly worked-out figures go with it. They all then have to be worked out again at once, which is the pile-up the cache was added to prevent, triggered by a stranger.

Now, when it fills up, only answers that have expired are cleared out. If everything still in there is current, the new answer simply is not stored. That request is served as normal and the next one works it out again, which is slower but does not take anything away from anybody else.

## Asking for one community and for everything at once

`group=5&systemwide=true` is a contradiction. It was already settled one way when working out which communities to read, and the other way when working out the figures, so it produced whole-network numbers filed under community 5. Both now settle it the same way, taking the community.

## Testing

Go suite run locally against the worktree. Two new tests on the cache: that a full cache of current answers is not thrown away, and that expired ones are still cleared out so the cache keeps turning over.
