### PR TITLE
fix(monitoring): drop kernel versions from the reboot-required text

### DIFF
--- a/iznik-batch/app/Monitoring/Checks/HostHealthCheck.php
+++ b/iznik-batch/app/Monitoring/Checks/HostHealthCheck.php
@@ -116,7 +116,15 @@ SH;
         if (preg_match('/^REBOOT:yes$/m', $output)) {
             $pkgs = '';
             if (preg_match('/^REBOOT_PKGS:(.+)$/m', $output, $m) && trim($m[1]) !== '') {
-                $pkgs = ' (' . trim($m[1]) . ')';
+                // Versioned kernel package names (linux-image-5.15.0-186-generic) say
+                // nothing a mod acts on and change every kernel: strip the version
+                // segments so the modal reads "linux-image-generic", and dedupe in
+                // case two kernel versions are pending at once.
+                $names = array_unique(array_map(
+                    fn (string $pkg): string => preg_replace('/-\d+(?:\.\d+)*(?:-\d+)?/', '', $pkg),
+                    preg_split('/\s+/', trim($m[1]))
+                ));
+                $pkgs = ' (' . implode(' ', $names) . ')';
             }
             $warnings[] = "reboot required{$pkgs}";
         }

--- a/iznik-batch/tests/Feature/Monitor/HostHealthCheckTest.php
+++ b/iznik-batch/tests/Feature/Monitor/HostHealthCheckTest.php
@@ -98,6 +98,18 @@ class HostHealthCheckTest extends TestCase
         $this->assertStringContainsString('linux-base libc6', $result->message);
     }
 
+    public function test_reboot_package_names_lose_their_version_and_dedupe(): void
+    {
+        $result = $this->evaluate($this->probeOutput(
+            reboot: 'yes',
+            rebootPkgs: 'linux-image-5.15.0-186-generic linux-base libc6 linux-image-5.15.0-181-generic',
+        ));
+
+        $this->assertTrue($result->isBreach());
+        $this->assertStringContainsString('(linux-image-generic linux-base libc6)', $result->message);
+        $this->assertStringNotContainsString('5.15', $result->message);
+    }
+
     public function test_pending_security_updates_are_a_warning_with_the_count(): void
     {
         $result = $this->evaluate($this->probeOutput(security: 3));


### PR DESCRIPTION
The ModTools status modal's reboot warnings read like a changelog: `reboot required (libc6 linux-base linux-image-5.15.0-186-generic)`. The kernel version tells a mod nothing actionable and changes with every kernel. This strips version segments from the package names and dedupes, so the same breach now reads `reboot required (libc6 linux-base linux-image-generic)` — verified live on batch-prod via the bind mount before committing.

Companion operational change (config only, not in this diff, by design — estate topology stays out of the repo): the docker host itself is now on the monitored estate (`FREEGLE_MONITORING_HOSTS` + `extra_hosts` in the git-ignored override + monitoring key authorized), and it duly reports its own pending reboot on the dot.

Test added: versioned kernel names lose their versions and dedupe; existing reboot/security/monit tests unchanged. Local suite cannot run on this host (production profile); CI validates.