### PR TITLE
feat(browse): shade the member's real drive-time reach, not a hull of posts

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-12
+last_reviewed: 2026-08-14
 covers:
   - iznik-batch/app/Services/Ripple/**
   - iznik-batch/app/Console/Commands/Ripple/**
@@ -7,6 +7,10 @@ covers:
   - iznik-server-go/rippling/**
   - iznik-server-go/density/**
   - iznik-nuxt3/composables/useReachDistance.js
+  - iznik-nuxt3/composables/useReachOverlay.js
+  - iznik-nuxt3/components/PostMap.vue
+  - iznik-routing-go/displaypolygon.go
+  - iznik-server-go/town/**
   - iznik-nuxt3/modtools/components/ModSysAdminRipplingDensity.vue
   - iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
 ---
@@ -104,15 +108,36 @@ this member inside the reach?" (`ST_Contains`). The conversion (`polygon.go`,
    `TestIsochronePolygon_DoesNotBridgeRiver`, guards the case we know about), and genuinely
    sparse road areas keep their holes - which is accurate, since nobody lives in them.
 4. **Trace the boundary - and stop.** The filled cells' outline becomes the polygon, with
-   only exactly-collinear points removed (lossless). There is **no shape smoothing anywhere**:
-   not server-side simplification, not client-side corner-rounding. The displayed boundary is
-   exactly the computed one.
+   only exactly-collinear points removed (lossless). The reach polygon gets **no shape
+   smoothing**: not server-side simplification, not client-side corner-rounding. The
+   displayed boundary is exactly the computed one.
 
 Why so strict about smoothing: the drawn reach is how moderators and developers debug
 rippling. Any smoothing step (server-side line simplification, client-side corner-rounding)
 moves the boundary by design - and where the boundary hugs a river bank, the rounded curve
 bulges across the water, showing the reach touching a far bank it cannot actually reach. A
 display that does not match the computation cannot be debugged against it.
+
+#### The one exception: the browse map's coverage overlay
+
+The browse map shades **the member's own travel-time reach** (see 7c), which is a different
+object from a post's reach: nothing is decided by it, nobody debugs rippling against it, and
+it has to cross the wire on every slider change. That one consumer asks for a **simplified**
+polygon, via `polygon_simplify_m` on `/v1/ripple-eval` (`displaypolygon.go`, `DisplayRing`):
+Douglas-Peucker at a caller-chosen tolerance, then coordinates rounded to 5dp (~1m).
+
+The saving is why it exists. A 45-minute drive reach traces ~27,000 vertices and ~1.2MB of
+GeoJSON; at 100m it is ~2,000 vertices and ~40KB, under 10KB gzipped.
+
+The cost is that the boundary moves, which is exactly the objection above - so the tolerance
+was measured rather than picked. Against the exact polygon for a 45-minute reach around
+Edinburgh, the simplified shape disagrees over 0.96% of its area at 50m, 1.66% at 100m, 2.84%
+at 200m, 4.85% at 400m; past 200m it also starts systematically inflating (area ratio 1.012 at
+400m) instead of just wobbling either side. `/town/near` uses **100m**.
+
+This is opt-in and off by default at every level - the request field, the `?polygon=1` query
+parameter, and the `withPolygon` option on `useReachDistance` - so nothing that needs the exact
+boundary can pick it up by accident.
 
 ### 2b. Rejected polygon approaches
 
@@ -132,7 +157,9 @@ display that does not match the computation cannot be debugged against it.
   the road graph, not the raster.
 - **Douglas-Peucker simplification + client corner-smoothing.** Rejected as above: any
   approximating step can move the boundary across a barrier. The cost of removing them is a
-  larger polygon (~4x the vertices), paid knowingly.
+  larger polygon (~4x the vertices), paid knowingly. (Still rejected for the reach polygon.
+  The browse coverage overlay does simplify, deliberately and separately - see the exception
+  above.)
 
 ## 3. Sizing the reach: the extent governor
 
@@ -634,6 +661,38 @@ budget=1, anchor=0` for both today - closeness × engagement-decay):
   (`config/freegle.php`).
 
 Design spec: `docs/superpowers/specs/2026-06-22-digest-rippling-score-ordering-design.md`.
+
+### 7c. The browse map's shaded area
+
+The browse map shades the area the distance slider describes: **the member's own drive-time
+reach**, traced over the road network from their location for the minutes the slider is set to.
+
+It comes back from `/town/near?polygon=1` as `reach_polygon`, and it is free. That endpoint
+already runs the routing pass - it is how the slider converts minutes into the mile radius it
+stores in `browseMaxDistance` (§7) - so asking for the shape as well costs only the boundary
+trace, never a second Dijkstra. Measured on the UK graph for Edinburgh: `/town/near` takes
+69ms / 109ms / 264ms at 20 / 30 / 45 minutes today, and 153ms / 337ms / 837ms with the shape.
+
+`useReachDistance({ withPolygon: true })` publishes it through `useReachOverlay`, a small piece
+of shared state, and `PostMap` subscribes. That indirection exists so the map does not route the
+reach a second time; the alternative was the map making its own identical call. `PostFilters`
+(browse) sets the flag. The Feed settings slider does not, and so pays nothing for a map it has
+not got. A sequence number in `useReachOverlay` drops out-of-order responses, so dragging the
+slider leaves the map showing the travel time the member settled on rather than whichever
+response landed last.
+
+**What it does NOT mean.** It is an illustration of how far the *member* can travel, not the set
+of posts they can see. A post ripples out from its OWN origin with its own budget (§3a), so a
+post can reach a member who could not have reached it in the same time - and at the no-limit stop
+the server's own reach governs, which is wider still. The list itself stays filtered by
+`browseMaxDistance`, the crow-flies radius, so the shading and the list are close but not
+identical. Never use `reach_polygon` for containment; it is also simplified (§2a).
+
+`PostMap` falls back to a convex hull of the posts currently shown whenever no reach has been
+published - pages with no slider (explore, the landing pages), a member with no known location,
+or a routing failure. That hull is what the overlay used to be in all cases. It answered "where
+did the posts we happen to have land", which drifts with whatever is on offer and says nothing
+about travel time, so the reach wins wherever we have it.
 
 ## 8. Kill switches and key config (`config/freegle.php` `ripple.*`)
 

--- a/iznik-nuxt3/.eslintrc.js
+++ b/iznik-nuxt3/.eslintrc.js
@@ -89,6 +89,9 @@ module.exports = {
     getCurrentInstance: 'readonly',
     useAsyncData: 'readonly',
     useLazyAsyncData: 'readonly',
+    useState: 'readonly',
+    // Test-only: tests/unit/setup.ts exposes this to reset keyed useState between cases.
+    clearNuxtState: 'readonly',
     createApp: 'readonly',
     useNuxtApp: 'readonly',
     useLoadingIndicator: 'readonly',

--- a/iznik-nuxt3/api/TownAPI.js
+++ b/iznik-nuxt3/api/TownAPI.js
@@ -5,7 +5,15 @@ export default class TownAPI extends BaseAPI {
   // (drive-time), furthest-selected and ordered biggest-first. Names only - no distance/time units.
   // Also returns reach_radius_miles (the crow-flies radius that travel time reaches) for the client
   // to store as settings.browseMaxDistance.
-  fetchNear(lat, lng, minutes) {
-    return this.$getv2('/town/near', { lat, lng, minutes })
+  //
+  // `polygon` additionally returns reach_polygon: the outline of that same travel time, for the
+  // browse map to shade. Off by default because it costs the routing server a boundary trace, and
+  // callers that only want the radius (Feed settings) never draw it.
+  fetchNear(lat, lng, minutes, polygon = false) {
+    const params = { lat, lng, minutes }
+    if (polygon) {
+      params.polygon = 1
+    }
+    return this.$getv2('/town/near', params)
   }
 }

--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -400,11 +400,15 @@ const maxDistance = computed(
 // saved it re-emits the derived mile cap (so parent feeds re-filter) and refreshes the unseen count.
 // maxMinutes is the member's own density-sized reach cap, so the slider's top stop is the furthest
 // travel the reach engine will actually honour for them - not a fixed 30 minutes.
+// withPolygon: these are the only /town/near calls the browse page makes, and the routing pass
+// behind them also produces the reach OUTLINE the map shades. Asking here means the map does not
+// route the same reach again.
 const { sliderValue, maxMinutes, onSliderChange } = useReachDistance(
   (miles) => {
     emit('update:selectedMaxDistance', miles)
     refetchCount()
-  }
+  },
+  { withPolygon: true }
 )
 
 // "Filters active" badge (#G): lights for ANY control that differs from its default -

--- a/iznik-nuxt3/components/PostMap.vue
+++ b/iznik-nuxt3/components/PostMap.vue
@@ -115,6 +115,7 @@ import {
   smoothGeoJSON,
   buildCoverageGeoJSON,
 } from '~/composables/useReachPolygon'
+import { useReachOverlay } from '~/composables/useReachOverlay'
 import {
   isWithinDistance,
   filterMessagesByDistance,
@@ -382,12 +383,17 @@ const messagesForMap = computed(() => {
     : []
 })
 
+// The member's real drive-time reach, traced over the road network by the routing server and
+// published by the distance slider (see useReachOverlay). Null on pages with no slider, when
+// there's no known location, or if routing was unavailable.
+const { reachGeoJSON } = useReachOverlay()
+
 // A smoothed convex hull enclosing the posts currently shown, as an indication
 // of the area covered. The true reach is travel-time-based (not a simple
 // radius), so this is only an approximation - but it shrinks as the slider is
 // pulled in, giving a visual sense of coverage. See buildCoverageGeoJSON for why
 // this is an outward-rounded hull rather than Chaikin smoothing.
-const coverageGeoJSON = computed(() => {
+const hullGeoJSON = computed(() => {
   // Drawn for BOTH the nearby and "all my communities" views (not gated on showIsochrones,
   // which is nearby-only). It is just a hull of the posts currently shown, so it adapts to the
   // distance slider the same way on either view. Falls back to null (no polygon) when there
@@ -396,6 +402,14 @@ const coverageGeoJSON = computed(() => {
     .filter((m) => m.lat != null || m.lng != null)
     .map((m) => [m.lng, m.lat])
   return buildCoverageGeoJSON(points)
+})
+
+// Prefer the real reach; fall back to the hull. The hull only ever answered "where did the
+// posts we happen to have land", which drifts with whatever is currently for offer and says
+// nothing about travel time. The reach answers the question the slider actually asks, so it
+// wins whenever we have it.
+const coverageGeoJSON = computed(() => {
+  return reachGeoJSON.value || hullGeoJSON.value
 })
 
 const isochrones = computed(() => {
@@ -429,13 +443,20 @@ const isochroneGEOJSONs = computed(() => {
 const isochroneOptions = computed(() => {
   // Faded fill so post pins remain clearly visible; soft border echoes the
   // rippling explorer's reach polygon style.
+  //
+  // The BORDER carries the shape, so it is nearly opaque. These settings were tuned for the
+  // old post hull, which was a small compact ring sitting right among the pins - there, a
+  // 0.5-opacity line read fine. The real travel-time reach is far bigger and more ragged,
+  // its boundary sits out among busy OSM tiles rather than next to the posts, and at 0.5 it
+  // disappeared into them entirely (checked in a browser: the overlay was drawing correctly
+  // and was simply not visible). The fill stays low for the same reason it always was.
   return {
     fillColor: ISOCHRONE_COLOR,
     fill: true,
     fillOpacity: 0.12,
     color: ISOCHRONE_COLOR,
     weight: 2,
-    opacity: 0.5,
+    opacity: 0.9,
   }
 })
 

--- a/iznik-nuxt3/composables/useReachDistance.js
+++ b/iznik-nuxt3/composables/useReachDistance.js
@@ -1,6 +1,7 @@
 import { ref, computed, watch, getCurrentInstance, onMounted } from 'vue'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
+import { useReachOverlay } from '~/composables/useReachOverlay'
 import api from '~/api'
 import {
   BROWSE_DISTANCE_UNLIMITED,
@@ -23,11 +24,18 @@ import {
 // server for this member's own cap and tops out there. Until that answer arrives - and whenever
 // density cannot be measured - the flat cap applies, so the slider is never wider than something
 // the server will honour.
-export function useReachDistance(onPersisted) {
+//
+// `withPolygon` additionally asks /town/near for the OUTLINE of the chosen travel time and
+// publishes it via useReachOverlay, for the browse map to shade. It rides on these calls rather
+// than having its own because the routing pass that produces the shape is the one this composable
+// already makes; the Feed settings slider leaves it off, and so pays nothing for a map it has not
+// got. See useReachOverlay for why the shape is an illustration and never a containment test.
+export function useReachDistance(onPersisted, { withPolygon = false } = {}) {
   const authStore = useAuthStore()
   const { me } = useMe()
   const runtimeConfig = useRuntimeConfig()
   const apiInstance = api(runtimeConfig)
+  const { nextReachSeq, publishReach, clearReach } = useReachOverlay()
 
   // The top of the slider for this member. Starts at the flat cap and narrows or widens once the
   // server reports the band. BROWSE_MINUTES_MAX is the ceiling across all bands: a server that
@@ -60,14 +68,28 @@ export function useReachDistance(onPersisted) {
   async function fetchNear(minutes) {
     const lat = me.value?.lat
     const lng = me.value?.lng
-    if (!lat && !lng) return null
+    if (!lat && !lng) {
+      // No location means no reach to draw. Clear rather than leave the last member's
+      // shape shaded on the map after a logout.
+      if (withPolygon) clearReach()
+      return null
+    }
+    // Claim the sequence number BEFORE awaiting, so an earlier-issued call that lands later
+    // is recognised as stale and does not overwrite a newer shape.
+    const seq = withPolygon ? nextReachSeq() : null
     try {
-      const r = await apiInstance.town.fetchNear(lat, lng, minutes)
+      const r = await apiInstance.town.fetchNear(lat, lng, minutes, withPolygon)
       if (typeof r?.cap_minutes === 'number' && r.cap_minutes > 0) {
         maxMinutes.value = Math.min(r.cap_minutes, BROWSE_MINUTES_MAX)
       }
+      if (withPolygon) {
+        publishReach(seq, r?.reach_polygon ?? null)
+      }
       return r
     } catch (e) {
+      // A failed lookup leaves the cap and radius alone (best-effort), but the shape must
+      // not be left behind: it would shade a travel time the slider no longer shows.
+      if (withPolygon) publishReach(seq, null)
       return null
     }
   }
@@ -86,11 +108,23 @@ export function useReachDistance(onPersisted) {
   // same divergence that had members seeing only old posts. So we persist the correction once,
   // rather than displaying one thing and filtering by another.
   async function loadCap() {
-    await fetchNear(savedMinutes.value)
+    const asked = savedMinutes.value
+    await fetchNear(asked)
 
     const saved = me.value?.settings?.browseMaxMinutes
     if (typeof saved === 'number' && saved > maxMinutes.value) {
       await onSliderChange(maxMinutes.value)
+      return
+    }
+
+    // A member who has never touched the slider sits at the top stop, and before the server
+    // answers we do not know where that is - so the first call had to ask for the flat
+    // fallback. Now that we know their real cap, the shape we drew is for the wrong travel
+    // time: a rural member's slider says 45 minutes over a 30-minute shape, a city member's
+    // says 20 over the same. Redraw it. Only the shape needs this; the cap and the radius are
+    // already right (the sentinel, or a value the member chose).
+    if (withPolygon && savedMinutes.value !== asked) {
+      await fetchNear(savedMinutes.value)
     }
   }
 
@@ -112,6 +146,10 @@ export function useReachDistance(onPersisted) {
       sliderValue.value = minutes
       await authStore.saveAndGet({ settings })
       if (onPersisted) onPersisted(BROWSE_DISTANCE_UNLIMITED)
+      // This branch skips the radius derivation because "no limit" needs no radius - but the
+      // map still has to be told, or dragging from 20 minutes to the top would leave the
+      // 20-minute shape shaded under a slider that now says no limit.
+      if (withPolygon) await fetchNear(minutes)
       return
     }
 

--- a/iznik-nuxt3/composables/useReachOverlay.js
+++ b/iznik-nuxt3/composables/useReachOverlay.js
@@ -1,0 +1,68 @@
+import { computed, markRaw } from 'vue'
+
+// The shaded area on the browse map: the member's real drive-time reach, as traced by the
+// routing server, rather than a hull drawn round wherever posts happen to be.
+//
+// It lives in shared state because of who can afford to ask for it. The shape comes from a
+// Dijkstra over the road network, and the distance slider ALREADY runs that Dijkstra on every
+// change (via /town/near, to convert the chosen minutes into a mile radius). So the slider
+// publishes the shape it gets for free and the map subscribes, instead of the map making a
+// second identical routing call.
+//
+// The consequence is that the overlay only appears where a slider is mounted (browse). On
+// explore and the landing pages PostMap falls back to its post hull, which is the right
+// answer there: those pages have no travel-time setting for a reach to be drawn from.
+//
+// The shape is an ILLUSTRATION of how far the member can travel, NOT the set of posts they
+// can see. Each post ripples outward from its OWN origin with its own budget, so a post can
+// reach a member who could not have reached it in the same time. Never use this for
+// containment.
+
+const STATE_KEY = 'reach-overlay'
+
+function emptyState() {
+  return { geojson: null, seq: 0 }
+}
+
+export function useReachOverlay() {
+  const state = useState(STATE_KEY, emptyState)
+
+  // The GeoJSON Feature to shade, or null when we have nothing (no location, routing
+  // unavailable, or a reach too small to trace). Callers fall back rather than draw nothing.
+  const reachGeoJSON = computed(() => state.value.geojson)
+
+  // nextReachSeq/publishReach are the out-of-order guard. Dragging the slider fires several
+  // overlapping /town/near calls, and without this the LAST to land wins rather than the
+  // LATEST asked for, which leaves the map showing a travel time the slider no longer says.
+  // Take a sequence number before fetching, hand it back on publish, and a stale answer is
+  // dropped.
+  function nextReachSeq() {
+    state.value = { ...state.value, seq: state.value.seq + 1 }
+    return state.value.seq
+  }
+
+  function publishReach(seq, geojson) {
+    if (seq !== state.value.seq) return
+    state.value = {
+      ...state.value,
+      // markRaw: the shape is inert data on its way to Leaflet, never something we mutate
+      // and re-render from. Without it Vue deep-proxies every one of the ~2,000 coordinate
+      // pairs in a wide reach, which costs allocations for reactivity nothing reads.
+      geojson: geojson ? markRaw(geojson) : null,
+    }
+  }
+
+  // Empty the overlay now. Counts as a newer event than anything already in flight - a
+  // clear happens because we have just learned there is no reach to draw (no location, a
+  // logout), so a response issued before it must not put the old shape back.
+  function clearReach() {
+    state.value = { ...emptyState(), seq: state.value.seq + 1 }
+  }
+
+  return {
+    reachGeoJSON,
+    nextReachSeq,
+    publishReach,
+    clearReach,
+  }
+}

--- a/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
@@ -551,7 +551,7 @@ describe('PostFilters', () => {
     // The sentinel defers to the server's own reach, which grows every post to the
     // widest band's budget - so it only means "as far as I would go" for a member whose
     // own band earns that ceiling. A sparse member at their top stop is exactly that case.
-    it('stores BROWSE_DISTANCE_UNLIMITED (and skips routing) at the top stop when the band is the ceiling', async () => {
+    it('stores BROWSE_DISTANCE_UNLIMITED (and derives no radius) at the top stop when the band is the ceiling', async () => {
       mockFetchNear.mockResolvedValue({
         cap_minutes: 45,
         density_band: 'sparse',
@@ -571,7 +571,12 @@ describe('PostFilters', () => {
       expect(mockMe.value.settings.browseMaxDistance).toBe(
         Number.MAX_SAFE_INTEGER
       )
-      expect(mockFetchNear).not.toHaveBeenCalled() // the top stop needs no reach lookup
+      // The top stop needs no RADIUS - it stores the sentinel and defers to the server's own
+      // reach. It does still need the reach SHAPE, or dragging to the top would leave the map
+      // shading the narrower travel time the member just dragged away from. So there is exactly
+      // one lookup, and it is the one that asks for the polygon.
+      expect(mockFetchNear).toHaveBeenCalledTimes(1)
+      expect(mockFetchNear).toHaveBeenCalledWith(51.5, -0.1, 45, true)
       const emitted = wrapper.emitted('update:selectedMaxDistance')
       expect(emitted[emitted.length - 1]).toEqual([Number.MAX_SAFE_INTEGER])
     })
@@ -584,7 +589,9 @@ describe('PostFilters', () => {
       input.element.value = 10
       await input.trigger('change')
       await flushPromises()
-      expect(mockFetchNear).toHaveBeenCalledWith(51.5, -0.1, 10)
+      // true = also fetch the reach outline: browse draws a map, so it takes the shape from
+      // the routing pass this lookup already runs rather than routing it again.
+      expect(mockFetchNear).toHaveBeenCalledWith(51.5, -0.1, 10, true)
       expect(mockMe.value.settings.browseMaxMinutes).toBe(10)
       expect(mockMe.value.settings.browseMaxDistance).toBe(4) // mocked reach_radius_miles
       expect(wrapper.emitted('update:selectedMaxDistance')[0]).toEqual([4])

--- a/iznik-nuxt3/tests/unit/components/PostMap.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostMap.spec.js
@@ -474,7 +474,9 @@ describe('PostMap', () => {
 
       // Swallowed, not propagated...
       expect(
-        logSpy.mock.calls.some((c) => String(c[0]).includes('Ignore leaflet exception'))
+        logSpy.mock.calls.some((c) =>
+          String(c[0]).includes('Ignore leaflet exception')
+        )
       ).toBe(true)
 
       // ...and the map is still live: it framed itself and the parent was told it is ready.
@@ -1202,6 +1204,83 @@ describe('PostMap', () => {
       // The near cluster should still be enclosed.
       ;[messages[0], messages[1], messages[2]].forEach((m) => {
         expect(pointInPolygon([m.lng, m.lat], ring)).toBe(true)
+      })
+    })
+
+    // The hull only ever answered "where did the posts we happen to have land". When the
+    // distance slider has published the member's real drive-time reach, that is what the
+    // map shades instead: it answers the question the slider actually asks.
+    describe('reach overlay preferred over the hull', () => {
+      const REACH = {
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-0.5, 51.2],
+              [0.3, 51.2],
+              [0.3, 51.9],
+              [-0.5, 51.9],
+              [-0.5, 51.2],
+            ],
+          ],
+        },
+      }
+
+      const HULL_MESSAGES = [
+        { id: 1, lat: 51.5, lng: -0.1, distance: 1, groupid: 1 },
+        { id: 2, lat: 51.6, lng: -0.2, distance: 2, groupid: 1 },
+        { id: 3, lat: 51.45, lng: -0.05, distance: 3, groupid: 1 },
+      ]
+      let useReachOverlay
+
+      beforeEach(async () => {
+        clearNuxtState()
+        ;({ useReachOverlay } = await import('~/composables/useReachOverlay'))
+      })
+
+      it('shades the published reach instead of the post hull', async () => {
+        const { nextReachSeq, publishReach } = useReachOverlay()
+        publishReach(nextReachSeq(), REACH)
+
+        const wrapper = await mountNearbyWithMessages(HULL_MESSAGES, {
+          selectedMaxDistance: 10,
+        })
+
+        const geoJsonEls = wrapper.findAllComponents({ name: 'LGeoJson' })
+        expect(geoJsonEls.length).toBe(1)
+        expect(geoJsonEls[0].props('geojson')).toEqual(REACH)
+      })
+
+      // Pages with no distance slider (explore, the landing pages) publish no reach, and
+      // there the hull is still the right answer - they have no travel-time setting for a
+      // reach to be drawn from.
+      it('falls back to the post hull when no reach has been published', async () => {
+        const wrapper = await mountNearbyWithMessages(HULL_MESSAGES, {
+          selectedMaxDistance: 10,
+        })
+
+        const geo = wrapper.findComponent({ name: 'LGeoJson' }).props('geojson')
+        expect(geo.type).toBe('Polygon')
+        HULL_MESSAGES.forEach((m) => {
+          expect(pointInPolygon([m.lng, m.lat], geo.coordinates[0])).toBe(true)
+        })
+      })
+
+      // A reach that was cleared (routing down, no location) must hand back to the hull
+      // rather than leave the map with nothing shaded.
+      it('returns to the hull when the reach is cleared', async () => {
+        const { nextReachSeq, publishReach, clearReach } = useReachOverlay()
+        publishReach(nextReachSeq(), REACH)
+        clearReach()
+
+        const wrapper = await mountNearbyWithMessages(HULL_MESSAGES, {
+          selectedMaxDistance: 10,
+        })
+
+        const geo = wrapper.findComponent({ name: 'LGeoJson' }).props('geojson')
+        expect(geo).not.toEqual(REACH)
+        expect(geo.type).toBe('Polygon')
       })
     })
   })

--- a/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
+++ b/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
@@ -115,7 +115,9 @@ describe('FeedSettingsSection', () => {
     const wrapper = mountWith()
     await slider(wrapper).vm.$emit('change', 10)
     await flushPromises()
-    expect(mockFetchNear).toHaveBeenCalledWith(51.5, -0.1, 10)
+    // false = no reach outline. Feed settings has no map to shade, so it must not make the
+    // routing server trace a boundary nobody draws; only browse asks for that.
+    expect(mockFetchNear).toHaveBeenCalledWith(51.5, -0.1, 10, false)
     expect(saveAndGet).toHaveBeenCalledTimes(1)
     expect(me.value.settings.browseMaxMinutes).toBe(10)
     expect(me.value.settings.browseMaxDistance).toBe(4)

--- a/iznik-nuxt3/tests/unit/composables/useReachDistance.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useReachDistance.spec.js
@@ -278,3 +278,207 @@ describe('useReachDistance density-aware maximum', () => {
     expect(maxMinutes.value).toBe(BROWSE_MINUTES_FALLBACK_MAX)
   })
 })
+
+// The browse map shades the member's real drive-time reach. Its shape comes from the very
+// same /town/near call this composable already makes for the radius, so the map never routes
+// the reach a second time - but only when the caller asks, so the Feed settings slider (which
+// draws no map) keeps paying nothing for it.
+describe('useReachDistance reach overlay', () => {
+  let useReachDistance
+  let useReachOverlay
+
+  const FEATURE = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 0],
+        ],
+      ],
+    },
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockMe.value = {
+      lat: 53.4,
+      lng: -1.3,
+      settings: { browseMaxMinutes: 15, browseMaxDistance: 6 },
+    }
+    clearNuxtState()
+    ;({ useReachDistance } = await import('~/composables/useReachDistance'))
+    ;({ useReachOverlay } = await import('~/composables/useReachOverlay'))
+  })
+
+  it('does not ask for the polygon by default', async () => {
+    mockFetchNear.mockResolvedValue({ reach_radius_miles: 8.5 })
+    const { onSliderChange } = useReachDistance()
+
+    await onSliderChange(25)
+
+    expect(mockFetchNear).toHaveBeenCalledWith(53.4, -1.3, 25, false)
+    expect(useReachOverlay().reachGeoJSON.value).toBeNull()
+  })
+
+  it('asks for the polygon and publishes it when the caller wants a map', async () => {
+    mockFetchNear.mockResolvedValue({
+      reach_radius_miles: 8.5,
+      reach_polygon: FEATURE,
+    })
+    const { onSliderChange } = useReachDistance(null, { withPolygon: true })
+
+    await onSliderChange(25)
+
+    expect(mockFetchNear).toHaveBeenCalledWith(53.4, -1.3, 25, true)
+    expect(useReachOverlay().reachGeoJSON.value).toEqual(FEATURE)
+  })
+
+  // Dragging to the far-right stop takes the "no limit" shortcut, which skips the radius
+  // derivation. Without an explicit refresh the map would keep shading the travel time the
+  // member just dragged away from.
+  it('refreshes the shape at the no-limit stop, where no radius is derived', async () => {
+    mockFetchNear.mockResolvedValue({
+      cap_minutes: BROWSE_MINUTES_MAX,
+      density_band: 'sparse',
+      reach_polygon: FEATURE,
+    })
+    const { onSliderChange, loadCap } = useReachDistance(null, {
+      withPolygon: true,
+    })
+    await loadCap()
+    mockFetchNear.mockClear()
+
+    await onSliderChange(BROWSE_MINUTES_MAX)
+
+    expect(mockFetchNear).toHaveBeenCalledWith(
+      53.4,
+      -1.3,
+      BROWSE_MINUTES_MAX,
+      true
+    )
+    expect(useReachOverlay().reachGeoJSON.value).toEqual(FEATURE)
+  })
+
+  it('clears the shape when the routing lookup fails, rather than leaving a stale one', async () => {
+    mockFetchNear.mockResolvedValue({
+      reach_radius_miles: 8.5,
+      reach_polygon: FEATURE,
+    })
+    const { onSliderChange } = useReachDistance(null, { withPolygon: true })
+    await onSliderChange(25)
+    expect(useReachOverlay().reachGeoJSON.value).toEqual(FEATURE)
+
+    mockFetchNear.mockRejectedValue(new Error('routing down'))
+    await onSliderChange(10)
+
+    expect(useReachOverlay().reachGeoJSON.value).toBeNull()
+  })
+
+  it('clears the shape when there is no location to draw a reach from', async () => {
+    mockFetchNear.mockResolvedValue({
+      reach_radius_miles: 8.5,
+      reach_polygon: FEATURE,
+    })
+    const { onSliderChange } = useReachDistance(null, { withPolygon: true })
+    await onSliderChange(25)
+    expect(useReachOverlay().reachGeoJSON.value).toEqual(FEATURE)
+
+    mockMe.value.lat = null
+    mockMe.value.lng = null
+    await onSliderChange(10)
+
+    expect(useReachOverlay().reachGeoJSON.value).toBeNull()
+  })
+
+  // A response with no shape (routing answered, but the reach traced nothing drawable) must
+  // leave nothing behind either.
+  it('clears the shape when the answer carries no polygon', async () => {
+    mockFetchNear.mockResolvedValue({
+      reach_radius_miles: 8.5,
+      reach_polygon: FEATURE,
+    })
+    const { onSliderChange } = useReachDistance(null, { withPolygon: true })
+    await onSliderChange(25)
+
+    mockFetchNear.mockResolvedValue({ reach_radius_miles: 4 })
+    await onSliderChange(10)
+
+    expect(useReachOverlay().reachGeoJSON.value).toBeNull()
+  })
+})
+
+// A member who has never touched the slider sits at the top stop, but the top stop is their
+// density band's cap and the client does not know it until the server says so. The first
+// call therefore has to guess (the flat fallback), and the shape it brings back describes
+// the wrong travel time for anyone whose band is not the fallback.
+describe('useReachDistance reach overlay for an unset slider', () => {
+  let useReachDistance
+  let useReachOverlay
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // No browseMaxMinutes: the slider sits at whatever the cap turns out to be.
+    mockMe.value = { lat: 53.4, lng: -1.3, settings: {} }
+    clearNuxtState()
+    ;({ useReachDistance } = await import('~/composables/useReachDistance'))
+    ;({ useReachOverlay } = await import('~/composables/useReachOverlay'))
+  })
+
+  function polygonFor(minutes) {
+    return {
+      type: 'Feature',
+      minutes,
+      geometry: { type: 'Polygon', coordinates: [] },
+    }
+  }
+
+  it('redraws the shape for the real cap once the server reports it', async () => {
+    mockFetchNear.mockImplementation((lat, lng, minutes) =>
+      Promise.resolve({
+        cap_minutes: 45,
+        density_band: 'sparse',
+        reach_polygon: polygonFor(minutes),
+      })
+    )
+    const { loadCap } = useReachDistance(null, { withPolygon: true })
+
+    await loadCap()
+
+    // First asked for the flat fallback, then again for the 45 the server reported.
+    expect(mockFetchNear).toHaveBeenCalledWith(
+      53.4,
+      -1.3,
+      BROWSE_MINUTES_FALLBACK_MAX,
+      true
+    )
+    expect(mockFetchNear).toHaveBeenLastCalledWith(53.4, -1.3, 45, true)
+    expect(useReachOverlay().reachGeoJSON.value.minutes).toBe(45)
+  })
+
+  it('does not redraw when the cap turns out to be the one we guessed', async () => {
+    mockFetchNear.mockResolvedValue({
+      cap_minutes: BROWSE_MINUTES_FALLBACK_MAX,
+      density_band: 'medium',
+      reach_polygon: polygonFor(BROWSE_MINUTES_FALLBACK_MAX),
+    })
+    const { loadCap } = useReachDistance(null, { withPolygon: true })
+
+    await loadCap()
+
+    expect(mockFetchNear).toHaveBeenCalledTimes(1)
+  })
+
+  // The extra call is for the map alone, so a caller that draws no map must not make it.
+  it('does not redraw for a caller that did not ask for a polygon', async () => {
+    mockFetchNear.mockResolvedValue({ cap_minutes: 45, density_band: 'sparse' })
+    const { loadCap } = useReachDistance()
+
+    await loadCap()
+
+    expect(mockFetchNear).toHaveBeenCalledTimes(1)
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useReachOverlay.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useReachOverlay.spec.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useReachOverlay } from '~/composables/useReachOverlay'
+
+// The browse map's shaded area is the member's real drive-time reach, handed over by the
+// distance slider (which already routes it) rather than fetched again by the map. The state
+// in between has one job that is easy to get wrong: dragging the slider fires overlapping
+// /town/near calls, and the map must end up showing the travel time the slider settled on,
+// not whichever response happened to land last.
+
+const FEATURE_20 = {
+  type: 'Feature',
+  geometry: {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 0],
+      ],
+    ],
+  },
+}
+const FEATURE_45 = {
+  type: 'Feature',
+  geometry: {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0],
+        [3, 0],
+        [3, 3],
+        [0, 0],
+      ],
+    ],
+  },
+}
+
+describe('useReachOverlay', () => {
+  beforeEach(() => {
+    clearNuxtState()
+  })
+
+  it('starts with nothing to draw, so the map falls back to its hull', () => {
+    const { reachGeoJSON } = useReachOverlay()
+    expect(reachGeoJSON.value).toBeNull()
+  })
+
+  it('publishes a shape and the travel time it describes', () => {
+    const { reachGeoJSON, nextReachSeq, publishReach } = useReachOverlay()
+
+    publishReach(nextReachSeq(), FEATURE_20)
+
+    expect(reachGeoJSON.value).toBe(FEATURE_20)
+  })
+
+  it('shares state between separate callers, so the map sees what the slider published', () => {
+    const slider = useReachOverlay()
+    const map = useReachOverlay()
+
+    slider.publishReach(slider.nextReachSeq(), FEATURE_20)
+
+    expect(map.reachGeoJSON.value).toBe(FEATURE_20)
+  })
+
+  it('drops a stale response that lands after a newer request was issued', () => {
+    const { reachGeoJSON, nextReachSeq, publishReach } = useReachOverlay()
+
+    // Slider dragged 20 -> 45: both calls issued, then the 45 answers first and the
+    // slower 20 answers second.
+    const seq20 = nextReachSeq()
+    const seq45 = nextReachSeq()
+
+    publishReach(seq45, FEATURE_45)
+    publishReach(seq20, FEATURE_20)
+
+    expect(reachGeoJSON.value).toBe(FEATURE_45)
+  })
+
+  it('lets the newest response overwrite an earlier one that already landed', () => {
+    const { reachGeoJSON, nextReachSeq, publishReach } = useReachOverlay()
+
+    const seq20 = nextReachSeq()
+    publishReach(seq20, FEATURE_20)
+    const seq45 = nextReachSeq()
+    publishReach(seq45, FEATURE_45)
+
+    expect(reachGeoJSON.value).toBe(FEATURE_45)
+  })
+
+  // A failed lookup must not leave the previous shape shaded: it would claim a travel time
+  // the slider no longer shows.
+  it('clears the shape when the newest response has none', () => {
+    const { reachGeoJSON, nextReachSeq, publishReach } = useReachOverlay()
+
+    publishReach(nextReachSeq(), FEATURE_20)
+    publishReach(nextReachSeq(), null)
+
+    expect(reachGeoJSON.value).toBeNull()
+  })
+
+  it('clearReach empties the overlay without resetting the staleness guard', () => {
+    const { reachGeoJSON, nextReachSeq, publishReach, clearReach } =
+      useReachOverlay()
+
+    const inFlight = nextReachSeq()
+    clearReach()
+    // The response that was already in flight when we cleared is not newer than the
+    // clear, so it must not repopulate the map.
+    publishReach(inFlight, FEATURE_20)
+
+    expect(reachGeoJSON.value).toBeNull()
+  })
+})

--- a/iznik-nuxt3/tests/unit/setup.ts
+++ b/iznik-nuxt3/tests/unit/setup.ts
@@ -138,8 +138,22 @@ const mockNuxtApp = {
 // Mock useCookie
 ;(globalThis as Record<string, unknown>).useCookie = () => ref(null)
 
-// Mock useState
-;(globalThis as Record<string, unknown>).useState = (key: string, init?: () => unknown) => ref(init ? init() : null)
+// Mock useState. Nuxt's useState is KEYED AND SHARED: two callers passing the same key get
+// the same ref, which is the whole point of it and what composables built on it rely on
+// (useReachOverlay hands the browse map a shape the distance slider fetched). Returning a
+// fresh ref per call, as this did, silently turned every such composable into per-caller
+// state, so a test could pass while the components never actually saw each other's writes.
+//
+// Real Nuxt scopes these per SSR request. Here the module is the scope, so a spec that
+// shares a key across cases must reset between them: call clearNuxtState() in beforeEach.
+const nuxtStateStore = new Map<string, unknown>()
+;(globalThis as Record<string, unknown>).useState = (key: string, init?: () => unknown) => {
+  if (!nuxtStateStore.has(key)) {
+    nuxtStateStore.set(key, ref(typeof init === 'function' ? init() : null))
+  }
+  return nuxtStateStore.get(key)
+}
+;(globalThis as Record<string, unknown>).clearNuxtState = () => nuxtStateStore.clear()
 
 // Mock useFetch
 ;(globalThis as Record<string, unknown>).useFetch = vi.fn().mockResolvedValue({ data: ref(null), pending: ref(false), error: ref(null) })

--- a/iznik-routing-go/bounds.go
+++ b/iznik-routing-go/bounds.go
@@ -154,8 +154,13 @@ func erode(grid [][]bool) {
 // keeping the result closed. The ring is split at its first vertex and the vertex
 // farthest from it, and each open chain is simplified independently, which is the
 // standard way to apply DP to a closed ring without collapsing it.
+//
+// A tolerance of zero or less means "do not simplify" and returns the ring untouched.
+// The sandwich bounds always pass a positive tolerance; the guard is for callers that
+// treat 0 as "off" (DisplayRing), where DP at tol=0 would still quietly drop collinear
+// points and so would not be the no-op the caller asked for.
 func simplifyRing(ring [][2]float64, tol float64) [][2]float64 {
-	if len(ring) <= 4 {
+	if len(ring) <= 4 || tol <= 0 {
 		return ring
 	}
 	// Drop the closing duplicate for processing.

--- a/iznik-routing-go/displaypolygon.go
+++ b/iznik-routing-go/displaypolygon.go
@@ -1,0 +1,99 @@
+package main
+
+import "math"
+
+// Display polygons: the same traced isochrone boundary, cut down to something a browser
+// can fetch and draw.
+//
+// IsochronePolygon deliberately does no approximating simplification, because the reach
+// containment tests must agree with the traced boundary exactly (see the comment there).
+// A map overlay has no such duty: it only has to look like the reach at map zoom. The
+// difference is large. A 45-minute drive isochrone traces ~27,000 vertices and encodes to
+// ~1.2MB of GeoJSON at full float64 precision; at a 100m tolerance and 5dp it is ~2,000
+// vertices and ~40KB, under 10KB gzipped, and indistinguishable on screen.
+//
+// Simplification is approximating, so the boundary MOVES - by up to the tolerance, which
+// near a barrier can mean cutting across it. That is the reason the exact polygon has none,
+// and the reason callers pick the tolerance deliberately rather than taking a default here.
+//
+// So display simplification is strictly opt-in, and lives here rather than in
+// IsochronePolygon, so that nothing which needs the exact boundary can pick it up by
+// accident.
+
+// displayCoordDP is the decimal places display coordinates are rounded to. 5dp is ~1m at
+// UK latitudes: far finer than any simplification tolerance worth using, and it halves
+// the encoded size, because Go otherwise prints float64 grid corners like
+// -3.4219791980743413 (19 characters to say -3.42198).
+const displayCoordDP = 5
+
+// DisplayRing prepares a traced ring for display: Douglas-Peucker at tolDegrees (0 or less
+// to skip), then coordinate rounding. The result is closed, has no zero-length segments,
+// and never departs from the input by more than tolDegrees plus the rounding step.
+func DisplayRing(ring [][2]float64, tolDegrees float64) [][2]float64 {
+	return roundRing(simplifyRing(ring, tolDegrees), displayCoordDP)
+}
+
+// MetresToDegrees converts a tolerance in metres to degrees of latitude, the unit the
+// tracer and the simplifier both work in. Longitude degrees are shorter than this away
+// from the equator, so a tolerance expressed this way is at its most generous
+// north-south and tighter east-west - which is the safe direction to be wrong in for a
+// tolerance, and avoids making it latitude-dependent.
+func MetresToDegrees(m float64) float64 {
+	return m / 111320.0
+}
+
+// displayPolygonFor traces the reach at its natural resolution and returns it ready to
+// draw, or nil when the reach traced nothing drawable (an origin with no roads near it).
+// The resolution is unchanged from the exact polygon's, so the shape is the real one and
+// only the vertex count is reduced; coarsening the grid instead would alter which gaps
+// get closed, and so would change what the overlay claims is reachable.
+func displayPolygonFor(g *Graph, reached map[NodeID]float32, mode Mode, simplifyM float64) *GeoJSONPolygon {
+	if len(reached) == 0 {
+		return nil
+	}
+	res := NetworkResolution(g, reached, mode)
+	poly := IsochronePolygon(g, reached, res)
+	if len(poly.Geometry.Coordinates) == 0 || len(poly.Geometry.Coordinates[0]) < 4 {
+		return nil
+	}
+	ring := DisplayRing(poly.Geometry.Coordinates[0], MetresToDegrees(simplifyM))
+	if len(ring) < 4 {
+		return nil
+	}
+	return &GeoJSONPolygon{
+		Type:     "Feature",
+		Geometry: geoGeometry{Type: "Polygon", Coordinates: [][][2]float64{ring}},
+	}
+}
+
+// roundRing rounds every coordinate to dp decimal places, dropping any consecutive
+// duplicates that rounding creates while keeping the ring closed. A ring that collapses
+// to fewer than a triangle is returned unrounded rather than emitted as something
+// undrawable.
+func roundRing(ring [][2]float64, dp int) [][2]float64 {
+	if len(ring) < 4 {
+		return ring
+	}
+	scale := math.Pow(10, float64(dp))
+	round := func(p [2]float64) [2]float64 {
+		return [2]float64{math.Round(p[0]*scale) / scale, math.Round(p[1]*scale) / scale}
+	}
+
+	out := make([][2]float64, 0, len(ring))
+	for i, p := range ring {
+		r := round(p)
+		if i > 0 && r == out[len(out)-1] {
+			continue
+		}
+		out = append(out, r)
+	}
+	// Rounding can collapse the closing point onto its predecessor, or the ring onto
+	// too few distinct points to draw. Re-close, and fall back if there is nothing left.
+	if len(out) > 1 && out[0] == out[len(out)-1] {
+		out = out[:len(out)-1]
+	}
+	if len(out) < 3 {
+		return ring
+	}
+	return append(out, out[0])
+}

--- a/iznik-routing-go/displaypolygon_test.go
+++ b/iznik-routing-go/displaypolygon_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+// staircaseRing builds a square whose south edge is drawn as many tiny steps - the shape
+// the grid tracer produces, where every cell boundary becomes two vertices.
+func staircaseRing(steps int, size, step float64) [][2]float64 {
+	var pts [][2]float64
+	for i := 0; i < steps; i++ {
+		x := size * float64(i) / float64(steps)
+		y := 0.0
+		if i%2 == 1 {
+			y = step
+		}
+		pts = append(pts, [2]float64{x, y})
+	}
+	pts = append(pts, [2]float64{size, 0})
+	pts = append(pts, [2]float64{size, size})
+	pts = append(pts, [2]float64{0, size})
+	pts = append(pts, pts[0])
+	return pts
+}
+
+// Deliberately built with exactly-collinear intermediate points on every edge: those are
+// what plain Douglas-Peucker drops even at a tolerance of zero, so a ring without them
+// cannot tell a working "0 means off" guard from a missing one.
+func collinearSquare(perEdge int) [][2]float64 {
+	corners := [][2]float64{{0, 0}, {1, 0}, {1, 1}, {0, 1}}
+	var pts [][2]float64
+	for i, a := range corners {
+		b := corners[(i+1)%len(corners)]
+		for s := 0; s < perEdge; s++ {
+			f := float64(s) / float64(perEdge)
+			pts = append(pts, [2]float64{a[0] + f*(b[0]-a[0]), a[1] + f*(b[1]-a[1])})
+		}
+	}
+	return append(pts, pts[0])
+}
+
+func TestSimplifyRing_ZeroOrNegativeToleranceIsANoOp(t *testing.T) {
+	ring := collinearSquare(8)
+	for _, tol := range []float64{0, -1} {
+		out := simplifyRing(ring, tol)
+		if len(out) != len(ring) {
+			t.Errorf("tolerance %g changed the ring: %d -> %d points", tol, len(ring), len(out))
+		}
+	}
+	// Guard the guard: a positive tolerance on the same ring must still simplify, so the
+	// no-op above is the tolerance being honoured rather than the ring being unsimplifiable.
+	if out := simplifyRing(ring, 0.1); len(out) >= len(ring) {
+		t.Errorf("positive tolerance did not simplify: %d -> %d points", len(ring), len(out))
+	}
+}
+
+func TestDisplayRing_KeepsRingClosedAndReducesPoints(t *testing.T) {
+	ring := staircaseRing(200, 1.0, 0.001)
+	out := DisplayRing(ring, 0.01)
+
+	if len(out) < 4 {
+		t.Fatalf("display ring has %d points, expected >=4", len(out))
+	}
+	if out[0] != out[len(out)-1] {
+		t.Errorf("display ring not closed: first=%v last=%v", out[0], out[len(out)-1])
+	}
+	if len(out) >= len(ring) {
+		t.Errorf("simplification did not reduce point count: %d -> %d", len(ring), len(out))
+	}
+}
+
+// The displayed boundary is allowed to depart from the traced one, but only by the
+// tolerance we asked for. Anything more and the shading would claim reach we do not have.
+func TestDisplayRing_StaysWithinTolerance(t *testing.T) {
+	ring := staircaseRing(400, 1.0, 0.002)
+	const tol = 0.02
+	out := DisplayRing(ring, tol)
+
+	// Rounding to 5dp can move a point by up to half a unit in the last place, on each axis.
+	const slack = 1e-5
+
+	for _, p := range ring {
+		d := math.MaxFloat64
+		for i := 0; i+1 < len(out); i++ {
+			if e := perpendicularDistance(p, out[i], out[i+1]); e < d {
+				d = e
+			}
+		}
+		if d > tol+slack {
+			t.Fatalf("point %v is %g from the display ring, tolerance %g", p, d, tol)
+		}
+	}
+}
+
+// The reason this exists is the wire size, so assert the order of magnitude we rely on.
+func TestDisplayRing_CollapsesStaircaseHard(t *testing.T) {
+	ring := staircaseRing(2000, 1.0, 0.0005)
+	out := DisplayRing(ring, 0.01)
+	if len(out) > len(ring)/20 {
+		t.Errorf("expected at least a 20x reduction, got %d -> %d points", len(ring), len(out))
+	}
+}
+
+func TestDisplayRing_ZeroToleranceStillRounds(t *testing.T) {
+	ring := [][2]float64{
+		{-3.4219791980743413, 55.709556579589844},
+		{-3.4189791980743410, 55.709856579589844},
+		{-3.4189791980743410, 55.710156579589844},
+		{-3.4219791980743413, 55.709556579589844},
+	}
+	out := DisplayRing(ring, 0)
+	if len(out) != len(ring) {
+		t.Fatalf("zero tolerance should not drop points: %d -> %d", len(ring), len(out))
+	}
+	assertRounded(t, out, 5)
+}
+
+func TestDisplayRing_DegenerateRingsUnchanged(t *testing.T) {
+	for _, ring := range [][][2]float64{
+		nil,
+		{{0, 0}},
+		{{0, 0}, {1, 1}, {0, 0}},
+	} {
+		out := DisplayRing(ring, 0.5)
+		if len(out) != len(ring) {
+			t.Errorf("degenerate ring of %d points changed to %d", len(ring), len(out))
+		}
+	}
+}
+
+func TestRoundRing_TrimsPrecisionButKeepsShapeAndClosure(t *testing.T) {
+	ring := [][2]float64{
+		{-3.4219791980743413, 55.709556579589844},
+		{-3.4189791980743410, 55.709856579589844},
+		{-3.4189791980743410, 55.710156579589844},
+		{-3.4219791980743413, 55.709556579589844},
+	}
+	out := roundRing(ring, 5)
+
+	if out[0] != out[len(out)-1] {
+		t.Errorf("rounded ring not closed: first=%v last=%v", out[0], out[len(out)-1])
+	}
+	assertRounded(t, out, 5)
+	for i := range ring {
+		if math.Abs(ring[i][0]-out[i][0]) > 1e-5 || math.Abs(ring[i][1]-out[i][1]) > 1e-5 {
+			t.Errorf("rounding moved point %d from %v to %v", i, ring[i], out[i])
+		}
+	}
+}
+
+// Rounding can make neighbouring points identical. Zero-length segments are wasted bytes
+// and upset consumers that assume distinct vertices, so they must be dropped - without
+// opening the ring.
+func TestRoundRing_DropsDuplicatesCreatedByRounding(t *testing.T) {
+	ring := [][2]float64{
+		{0.0000010, 0.0000010},
+		{0.0000012, 0.0000012},
+		{0.5, 0.5},
+		{1.0, 0.0},
+		{0.0000010, 0.0000010},
+	}
+	out := roundRing(ring, 5)
+	for i := 0; i+1 < len(out); i++ {
+		if out[i] == out[i+1] {
+			t.Errorf("duplicate consecutive point at %d: %v", i, out[i])
+		}
+	}
+	if out[0] != out[len(out)-1] {
+		t.Errorf("rounded ring not closed: first=%v last=%v", out[0], out[len(out)-1])
+	}
+}
+
+// Dropping duplicates must never eat the ring down below a drawable triangle.
+func TestRoundRing_KeepsDegenerateRingDrawable(t *testing.T) {
+	ring := [][2]float64{
+		{0.0000010, 0.0000010},
+		{0.0000012, 0.0000011},
+		{0.0000011, 0.0000013},
+		{0.0000010, 0.0000010},
+	}
+	out := roundRing(ring, 5)
+	if len(out) != len(ring) {
+		t.Errorf("a ring that rounds to a single point should be left alone, got %d points", len(out))
+	}
+}
+
+func assertRounded(t *testing.T, ring [][2]float64, dp int) {
+	t.Helper()
+	scale := math.Pow(10, float64(dp))
+	for _, p := range ring {
+		for _, v := range []float64{p[0], p[1]} {
+			if math.Abs(v*scale-math.Round(v*scale)) > 1e-6 {
+				t.Errorf("coordinate %v not rounded to %ddp", v, dp)
+			}
+		}
+	}
+}

--- a/iznik-routing-go/ripple.go
+++ b/iznik-routing-go/ripple.go
@@ -33,6 +33,13 @@ type rippleEvalRequest struct {
 	PointsOnly bool `json:"points_only,omitempty"`
 	// Frontier also returns the isochrone's road-distance reach range (frontier_{min,max}_miles).
 	Frontier bool `json:"frontier,omitempty"`
+	// PolygonSimplifyM, when positive, also returns the reach's SHAPE as a display polygon,
+	// simplified to that many metres (see displaypolygon.go). It exists because the browse
+	// map's coverage overlay wants the shape of the very same reach /town/near is already
+	// asking about: the Dijkstra below dominates the cost and has to run either way, so
+	// taking the polygon from it costs only the trace, and never a second routing pass.
+	// Omit it (or pass <= 0) and the response is byte-for-byte what it was.
+	PolygonSimplifyM float64 `json:"polygon_simplify_m,omitempty"`
 }
 
 type rippleEvalPoint struct {
@@ -48,6 +55,11 @@ type rippleEvalResponse struct {
 	// requested.
 	FrontierMedianMiles *float64 `json:"frontier_median_miles,omitempty"`
 	FrontierMaxMiles    *float64 `json:"frontier_max_miles,omitempty"`
+	// Polygon is the reach's outline for DISPLAY, present only when polygon_simplify_m was
+	// positive and the reach traced something drawable. It is an approximation of the
+	// boundary by construction, so it must never be used for containment - the exact
+	// polygon from /v1/catchment is what reach membership is decided on.
+	Polygon *GeoJSONPolygon `json:"polygon,omitempty"`
 }
 
 // handleRippleEval returns, for a post at (lat, lng), each input point's
@@ -173,6 +185,9 @@ func handleRippleEval(g *Graph, spatialURL string) fiber.Handler {
 			fmed, fmax := frontierMilesMedianMax(g, req.Lat, req.Lng, iso.DistM)
 			out.FrontierMedianMiles = &fmed
 			out.FrontierMaxMiles = &fmax
+		}
+		if req.PolygonSimplifyM > 0 {
+			out.Polygon = displayPolygonFor(g, iso.ReachedNodes, mode, req.PolygonSimplifyM)
 		}
 		return c.JSON(out)
 	}

--- a/iznik-routing-go/ripple_eval_polygon_test.go
+++ b/iznik-routing-go/ripple_eval_polygon_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// postRippleEval runs one /v1/ripple-eval request and returns the decoded body.
+func postRippleEval(t *testing.T, body map[string]interface{}) struct {
+	Results []struct {
+		DriveMin *float64 `json:"drive_min"`
+	} `json:"results"`
+	FrontierMedianMiles *float64        `json:"frontier_median_miles"`
+	Polygon             *GeoJSONPolygon `json:"polygon"`
+} {
+	t.Helper()
+	var out struct {
+		Results []struct {
+			DriveMin *float64 `json:"drive_min"`
+		} `json:"results"`
+		FrontierMedianMiles *float64        `json:"frontier_median_miles"`
+		Polygon             *GeoJSONPolygon `json:"polygon"`
+	}
+
+	app := newInternalApp(t)
+	enc, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/ripple-eval", bytes.NewReader(enc))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, 60000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode: %v (body %.300s)", err, raw)
+	}
+	return out
+}
+
+func rippleEvalBody(extra map[string]interface{}) map[string]interface{} {
+	body := map[string]interface{}{
+		"lat":         51.4545,
+		"lng":         -2.5879,
+		"mode":        "drive",
+		"max_minutes": 10,
+		"points":      [][2]float64{{-2.5879, 51.4545}},
+		"points_only": true,
+	}
+	for k, v := range extra {
+		body[k] = v
+	}
+	return body
+}
+
+// The browse overlay needs the reach's SHAPE, and /town/near already pays for the
+// Dijkstra that produces it. Asking for the polygon must therefore be an option on the
+// existing call rather than a second routing pass.
+func TestRippleEval_ReturnsDisplayPolygonWhenAsked(t *testing.T) {
+	out := postRippleEval(t, rippleEvalBody(map[string]interface{}{
+		"polygon_simplify_m": 200,
+	}))
+
+	if out.Polygon == nil {
+		t.Fatal("no polygon returned")
+	}
+	if len(out.Polygon.Geometry.Coordinates) == 0 {
+		t.Fatal("polygon has no rings")
+	}
+	ring := out.Polygon.Geometry.Coordinates[0]
+	if len(ring) < 4 {
+		t.Fatalf("polygon ring has %d points, expected >=4", len(ring))
+	}
+	if ring[0] != ring[len(ring)-1] {
+		t.Errorf("polygon ring not closed: first=%v last=%v", ring[0], ring[len(ring)-1])
+	}
+	// The origin must be inside its own reach.
+	if !pointInPolygon(-2.5879, 51.4545, ring) {
+		t.Error("origin is not inside the returned reach polygon")
+	}
+}
+
+// Omitting the option must leave the response exactly as it was, so the simulator and
+// every other ripple-eval caller keeps paying nothing for a shape it does not draw.
+func TestRippleEval_NoPolygonUnlessRequested(t *testing.T) {
+	for _, extra := range []map[string]interface{}{
+		nil,
+		{"polygon_simplify_m": 0},
+		{"polygon_simplify_m": -5},
+	} {
+		out := postRippleEval(t, rippleEvalBody(extra))
+		if out.Polygon != nil {
+			t.Errorf("polygon returned for %v when none was requested", extra)
+		}
+	}
+}
+
+// The point of the option is the wire size. A simplified polygon must be dramatically
+// smaller than the exact one the same reach traces, or there is no reason to ship it.
+func TestRippleEval_SimplifiedPolygonIsMuchSmallerThanExact(t *testing.T) {
+	g := getTestGraph(t)
+	iso := Isochrone(g, 51.4545, -2.5879, 10*60, Drive)
+	res := NetworkResolution(g, iso.ReachedNodes, Drive)
+	exact := IsochronePolygon(g, iso.ReachedNodes, res)
+	if len(exact.Geometry.Coordinates) == 0 {
+		t.Skip("test graph traced no exact polygon")
+	}
+	exactPts := len(exact.Geometry.Coordinates[0])
+
+	out := postRippleEval(t, rippleEvalBody(map[string]interface{}{
+		"polygon_simplify_m": 200,
+	}))
+	if out.Polygon == nil {
+		t.Fatal("no polygon returned")
+	}
+	gotPts := len(out.Polygon.Geometry.Coordinates[0])
+
+	t.Logf("exact %d points, simplified %d points", exactPts, gotPts)
+	if gotPts >= exactPts {
+		t.Errorf("simplified polygon is not smaller: exact %d, simplified %d", exactPts, gotPts)
+	}
+}
+
+// Asking for a polygon must not disturb the drive-times the same response carries, which
+// is what /town/near actually reads.
+func TestRippleEval_PolygonDoesNotChangeDriveTimes(t *testing.T) {
+	without := postRippleEval(t, rippleEvalBody(nil))
+	with := postRippleEval(t, rippleEvalBody(map[string]interface{}{"polygon_simplify_m": 200}))
+
+	if len(without.Results) != len(with.Results) {
+		t.Fatalf("result count changed: %d vs %d", len(without.Results), len(with.Results))
+	}
+	for i := range without.Results {
+		a, b := without.Results[i].DriveMin, with.Results[i].DriveMin
+		if (a == nil) != (b == nil) {
+			t.Fatalf("result %d nullness changed: %v vs %v", i, a, b)
+		}
+		if a != nil && *a != *b {
+			t.Errorf("result %d drive_min changed: %g vs %g", i, *a, *b)
+		}
+	}
+}
+
+// A reach that traced nothing must answer "no polygon" rather than an empty or malformed
+// one, so the client can fall back rather than draw a degenerate shape.
+func TestRippleEval_NoPolygonForUnroutableOrigin(t *testing.T) {
+	out := postRippleEval(t, rippleEvalBody(map[string]interface{}{
+		// Mid-Atlantic: on the graph, but nowhere near any road in it.
+		"lat": 40.0, "lng": -30.0,
+		"polygon_simplify_m": 200,
+	}))
+	if out.Polygon != nil && len(out.Polygon.Geometry.Coordinates) > 0 &&
+		len(out.Polygon.Geometry.Coordinates[0]) >= 4 {
+		t.Error("a reach with no roads should not produce a drawable polygon")
+	}
+}

--- a/iznik-server-go/test/town_near_polygon_test.go
+++ b/iznik-server-go/test/town_near_polygon_test.go
@@ -1,0 +1,128 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// Edinburgh: somewhere real, so the handler gets past its lat/lng guard and the routing
+// server has road network to work with.
+const townNearEdinburgh = "lat=55.9533&lng=-3.1883&minutes=30"
+
+// townNearTownID is well above any real towns row, so seeding it cannot collide with data
+// a future fixture adds.
+const townNearTownID = 990001
+
+// seedTownNearEdinburgh puts one town inside the handler's candidate box.
+//
+// Without it none of this exercises anything: the schema-only test database has an EMPTY
+// towns table, the handler returns its "no candidates" response before it ever calls the
+// routing server, and every assertion about routing quietly skips. That is how the first
+// version of this file passed while testing nothing.
+func seedTownNearEdinburgh(t *testing.T) {
+	t.Helper()
+	db := database.DBConn
+	db.Exec("INSERT IGNORE INTO towns (id, name, lat, lng) VALUES (?, ?, ?, ?)",
+		townNearTownID, "Testburgh", 55.95, -3.19)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM towns WHERE id = ?", townNearTownID)
+	})
+}
+
+func townNear(t *testing.T, query string) map[string]interface{} {
+	t.Helper()
+	resp, err := getApp().Test(httptest.NewRequest("GET", "/api/town/near?"+query, nil), 60000)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body map[string]interface{}
+	assert.Nil(t, json2.Unmarshal(rsp(resp), &body))
+	return body
+}
+
+// The browse map shades the member's reach, so /town/near has to be able to return its
+// shape. It rides on this call because the routing pass that produces it is the one this
+// call already makes.
+func TestTownNearReturnsReachPolygonWhenAsked(t *testing.T) {
+	seedTownNearEdinburgh(t)
+	body := townNear(t, townNearEdinburgh+"&polygon=1")
+
+	// frontier_median_miles proves the routing server answered. Without it there is no
+	// isochrone to have taken a shape from, and the polygon's absence is correct rather
+	// than a regression - so tie the assertion to routing actually being available.
+	// Deliberately NOT a skip: with a town seeded, the only way to get here is the routing
+	// server being down, and a silent skip is what hid this test doing nothing at all.
+	if _, routed := body["frontier_median_miles"].(float64); !routed {
+		t.Fatalf("routing server did not answer, so the polygon could not be tested: %v", keysOf(body))
+	}
+
+	poly, ok := body["reach_polygon"].(map[string]interface{})
+	assert.True(t, ok, "reach_polygon must be present when routing answered: %v", keysOf(body))
+
+	geom, ok := poly["geometry"].(map[string]interface{})
+	assert.True(t, ok, "reach_polygon must carry a geometry: %v", poly)
+	assert.Equal(t, "Polygon", geom["type"])
+
+	rings, ok := geom["coordinates"].([]interface{})
+	assert.True(t, ok, "geometry must carry coordinates")
+	assert.NotEmpty(t, rings)
+
+	ring, ok := rings[0].([]interface{})
+	assert.True(t, ok)
+	assert.GreaterOrEqual(t, len(ring), 4, "a drawable ring needs at least 4 points")
+
+	first := ring[0].([]interface{})
+	last := ring[len(ring)-1].([]interface{})
+	assert.Equal(t, first, last, "ring must be closed")
+
+	// The whole point of simplifying server-side is that this is small enough to ship on
+	// every slider change. A 30-minute reach traces tens of thousands of vertices exactly;
+	// anything approaching that here means the simplification was skipped.
+	assert.Less(t, len(ring), 5000, "reach polygon was not simplified: %d points", len(ring))
+
+	t.Logf("reach polygon: %d points", len(ring))
+}
+
+// Callers that only want the radius and the town names (the Feed settings slider, and the
+// browse slider's own cap lookup) must not be made to pay for a shape they never draw.
+func TestTownNearOmitsReachPolygonUnlessAsked(t *testing.T) {
+	seedTownNearEdinburgh(t)
+	for _, q := range []string{townNearEdinburgh, townNearEdinburgh + "&polygon=0", townNearEdinburgh + "&polygon=yes"} {
+		body := townNear(t, q)
+		assert.NotContains(t, body, "reach_polygon", "query %q should not return a polygon", q)
+	}
+}
+
+// Asking for the shape must not disturb the numbers the same response carries, which is
+// what the slider actually stores.
+func TestTownNearPolygonDoesNotChangeTheOtherFields(t *testing.T) {
+	seedTownNearEdinburgh(t)
+	without := townNear(t, townNearEdinburgh)
+	with := townNear(t, townNearEdinburgh+"&polygon=1")
+
+	// Without routing these are all absent and the comparison is vacuously true, which is
+	// exactly the failure mode this file already had once.
+	assert.Contains(t, without, "frontier_median_miles", "routing did not answer, so there was nothing to compare")
+
+	for _, k := range []string{"cap_minutes", "density_band", "reach_radius_miles", "frontier_median_miles", "frontier_max_miles", "towns"} {
+		assert.Equal(t, without[k], with[k], "field %s changed when the polygon was requested", k)
+	}
+}
+
+// A request with no usable location has no reach to draw, and must not invent one.
+func TestTownNearNoPolygonWithoutALocation(t *testing.T) {
+	body := townNear(t, "lat=0&lng=0&minutes=30&polygon=1")
+	assert.NotContains(t, body, "reach_polygon")
+}
+
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/iznik-server-go/test/town_near_polygon_test.go
+++ b/iznik-server-go/test/town_near_polygon_test.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	json2 "encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -9,20 +11,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Edinburgh: somewhere real, so the handler gets past its lat/lng guard and the routing
-// server has road network to work with.
+// The browse map shades the member's drive-time reach. /town/near can return that shape
+// because the routing pass it already runs to derive the mile radius has traced it anyway.
+//
+// These tests STUB the routing server rather than calling the real one. What is being tested
+// here is apiv2's plumbing: does it ask for the polygon only when the caller wants it, and does
+// it hand back what the routing server returned. The geometry itself is the routing server's
+// job and is covered by iznik-routing-go's own tests.
+//
+// Stubbing is not squeamishness. The real routing server needs the 2.5GB UK graph, which CI
+// does not have: it answers from a small fixture graph, so a request from Edinburgh comes back
+// with a null frontier and no polygon. An earlier version of this file skipped in that case and
+// therefore tested nothing; the version after that failed hard and broke CI. Neither is the
+// answer - not depending on the graph is.
+
 const townNearEdinburgh = "lat=55.9533&lng=-3.1883&minutes=30"
 
-// townNearTownID is well above any real towns row, so seeding it cannot collide with data
-// a future fixture adds.
+// townNearTownID is well above any real towns row, so seeding cannot collide with data a
+// future fixture adds.
 const townNearTownID = 990001
 
 // seedTownNearEdinburgh puts one town inside the handler's candidate box.
 //
-// Without it none of this exercises anything: the schema-only test database has an EMPTY
-// towns table, the handler returns its "no candidates" response before it ever calls the
-// routing server, and every assertion about routing quietly skips. That is how the first
-// version of this file passed while testing nothing.
+// Required, not incidental: the schema-only test database has an EMPTY towns table, and with no
+// candidate towns the handler returns its "no candidates" response BEFORE it ever calls the
+// routing server. Without this, every assertion below would pass against a response that never
+// exercised the code under test.
 func seedTownNearEdinburgh(t *testing.T) {
 	t.Helper()
 	db := database.DBConn
@@ -33,9 +47,68 @@ func seedTownNearEdinburgh(t *testing.T) {
 	})
 }
 
+// stubReachPolygon is what the stub routing server returns as the traced reach.
+var stubReachPolygon = map[string]interface{}{
+	"type": "Feature",
+	"geometry": map[string]interface{}{
+		"type": "Polygon",
+		"coordinates": []interface{}{
+			[]interface{}{
+				[]interface{}{-3.30, 55.90},
+				[]interface{}{-3.10, 55.90},
+				[]interface{}{-3.10, 56.00},
+				[]interface{}{-3.30, 56.00},
+				[]interface{}{-3.30, 55.90},
+			},
+		},
+	},
+}
+
+// stubRouting stands in for the routing server's /v1/ripple-eval. It records the request body
+// each call, and returns a polygon only when one was asked for - the same contract the real
+// server honours. Returns the recorder.
+func stubRouting(t *testing.T, withPolygon bool) *[]map[string]interface{} {
+	t.Helper()
+	var seen []map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json2.Unmarshal(body, &req)
+		seen = append(seen, req)
+
+		// One result per requested point, so the handler's length check passes.
+		n := 0
+		if pts, ok := req["points"].([]interface{}); ok {
+			n = len(pts)
+		}
+		results := make([]map[string]interface{}, n)
+		for i := range results {
+			results[i] = map[string]interface{}{"drive_min": 12.5}
+		}
+
+		resp := map[string]interface{}{
+			"results":               results,
+			"frontier_median_miles": 14.7,
+			"frontier_max_miles":    22.4,
+		}
+		// The real server ships `polygon` only when polygon_simplify_m was positive.
+		if simplify, ok := req["polygon_simplify_m"].(float64); ok && simplify > 0 && withPolygon {
+			resp["polygon"] = stubReachPolygon
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json2.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("ROUTING_EVAL_URL", srv.URL)
+
+	return &seen
+}
+
 func townNear(t *testing.T, query string) map[string]interface{} {
 	t.Helper()
-	resp, err := getApp().Test(httptest.NewRequest("GET", "/api/town/near?"+query, nil), 60000)
+	resp, err := getApp().Test(httptest.NewRequest("GET", "/api/town/near?"+query, nil), 30000)
 	assert.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
@@ -44,71 +117,80 @@ func townNear(t *testing.T, query string) map[string]interface{} {
 	return body
 }
 
-// The browse map shades the member's reach, so /town/near has to be able to return its
-// shape. It rides on this call because the routing pass that produces it is the one this
-// call already makes.
+// ?polygon=1 asks the routing server for the shape and hands it straight back.
 func TestTownNearReturnsReachPolygonWhenAsked(t *testing.T) {
 	seedTownNearEdinburgh(t)
+	seen := stubRouting(t, true)
+
 	body := townNear(t, townNearEdinburgh+"&polygon=1")
 
-	// frontier_median_miles proves the routing server answered. Without it there is no
-	// isochrone to have taken a shape from, and the polygon's absence is correct rather
-	// than a regression - so tie the assertion to routing actually being available.
-	// Deliberately NOT a skip: with a town seeded, the only way to get here is the routing
-	// server being down, and a silent skip is what hid this test doing nothing at all.
-	if _, routed := body["frontier_median_miles"].(float64); !routed {
-		t.Fatalf("routing server did not answer, so the polygon could not be tested: %v", keysOf(body))
-	}
+	// The routing server was asked for a simplified polygon, at a positive tolerance.
+	assert.Len(t, *seen, 1, "expected exactly one routing call")
+	simplify, ok := (*seen)[0]["polygon_simplify_m"].(float64)
+	assert.True(t, ok, "polygon_simplify_m must be sent: %v", (*seen)[0])
+	assert.Greater(t, simplify, 0.0)
 
-	poly, ok := body["reach_polygon"].(map[string]interface{})
-	assert.True(t, ok, "reach_polygon must be present when routing answered: %v", keysOf(body))
+	// And what came back was passed through unchanged.
+	assert.Equal(t, stubReachPolygon, body["reach_polygon"])
 
-	geom, ok := poly["geometry"].(map[string]interface{})
-	assert.True(t, ok, "reach_polygon must carry a geometry: %v", poly)
-	assert.Equal(t, "Polygon", geom["type"])
-
-	rings, ok := geom["coordinates"].([]interface{})
-	assert.True(t, ok, "geometry must carry coordinates")
-	assert.NotEmpty(t, rings)
-
-	ring, ok := rings[0].([]interface{})
-	assert.True(t, ok)
-	assert.GreaterOrEqual(t, len(ring), 4, "a drawable ring needs at least 4 points")
-
-	first := ring[0].([]interface{})
-	last := ring[len(ring)-1].([]interface{})
-	assert.Equal(t, first, last, "ring must be closed")
-
-	// The whole point of simplifying server-side is that this is small enough to ship on
-	// every slider change. A 30-minute reach traces tens of thousands of vertices exactly;
-	// anything approaching that here means the simplification was skipped.
-	assert.Less(t, len(ring), 5000, "reach polygon was not simplified: %d points", len(ring))
-
-	t.Logf("reach polygon: %d points", len(ring))
+	// The response is otherwise the usual one, so the shape is additive.
+	assert.Contains(t, body, "cap_minutes")
+	assert.Contains(t, body, "frontier_median_miles")
 }
 
-// Callers that only want the radius and the town names (the Feed settings slider, and the
-// browse slider's own cap lookup) must not be made to pay for a shape they never draw.
+// Callers that only want the radius and the town names (Feed settings, and the browse slider's
+// own cap lookup) must not make the routing server trace a boundary nobody draws.
 func TestTownNearOmitsReachPolygonUnlessAsked(t *testing.T) {
 	seedTownNearEdinburgh(t)
-	for _, q := range []string{townNearEdinburgh, townNearEdinburgh + "&polygon=0", townNearEdinburgh + "&polygon=yes"} {
+
+	for _, q := range []string{
+		townNearEdinburgh,
+		townNearEdinburgh + "&polygon=0",
+		townNearEdinburgh + "&polygon=yes",
+	} {
+		seen := stubRouting(t, true)
 		body := townNear(t, q)
+
 		assert.NotContains(t, body, "reach_polygon", "query %q should not return a polygon", q)
+		assert.Len(t, *seen, 1)
+		_, sent := (*seen)[0]["polygon_simplify_m"]
+		assert.False(t, sent, "query %q must not ask the routing server for a polygon", q)
 	}
 }
 
-// Asking for the shape must not disturb the numbers the same response carries, which is
-// what the slider actually stores.
+// A routing server that traced nothing drawable must leave the field off entirely, so the client
+// falls back to its own overlay rather than drawing a degenerate shape.
+func TestTownNearNoPolygonWhenRoutingReturnsNone(t *testing.T) {
+	seedTownNearEdinburgh(t)
+	stubRouting(t, false) // asked for, but the server has no shape to give
+
+	body := townNear(t, townNearEdinburgh+"&polygon=1")
+
+	assert.NotContains(t, body, "reach_polygon")
+	// The rest of the answer still arrives, so a missing shape costs nothing else.
+	assert.Contains(t, body, "frontier_median_miles")
+	assert.Contains(t, body, "reach_radius_miles")
+}
+
+// Asking for the shape must not disturb the numbers the same response carries, which is what
+// the slider actually stores.
 func TestTownNearPolygonDoesNotChangeTheOtherFields(t *testing.T) {
 	seedTownNearEdinburgh(t)
+
+	stubRouting(t, true)
 	without := townNear(t, townNearEdinburgh)
+
+	stubRouting(t, true)
 	with := townNear(t, townNearEdinburgh+"&polygon=1")
 
-	// Without routing these are all absent and the comparison is vacuously true, which is
-	// exactly the failure mode this file already had once.
-	assert.Contains(t, without, "frontier_median_miles", "routing did not answer, so there was nothing to compare")
+	// Guard against a vacuous comparison: if routing produced nothing, every field would be
+	// absent on both sides and this would pass while testing nothing.
+	assert.Contains(t, without, "frontier_median_miles")
 
-	for _, k := range []string{"cap_minutes", "density_band", "reach_radius_miles", "frontier_median_miles", "frontier_max_miles", "towns"} {
+	for _, k := range []string{
+		"cap_minutes", "density_band", "reach_radius_miles",
+		"frontier_median_miles", "frontier_max_miles", "towns",
+	} {
 		assert.Equal(t, without[k], with[k], "field %s changed when the polygon was requested", k)
 	}
 }
@@ -117,12 +199,4 @@ func TestTownNearPolygonDoesNotChangeTheOtherFields(t *testing.T) {
 func TestTownNearNoPolygonWithoutALocation(t *testing.T) {
 	body := townNear(t, "lat=0&lng=0&minutes=30&polygon=1")
 	assert.NotContains(t, body, "reach_polygon")
-}
-
-func keysOf(m map[string]interface{}) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	return out
 }

--- a/iznik-server-go/town/town.go
+++ b/iznik-server-go/town/town.go
@@ -107,14 +107,34 @@ type rippleEvalReq struct {
 	// setting reaches by road.
 	PointsOnly bool `json:"points_only"`
 	Frontier   bool `json:"frontier"`
+	// PolygonSimplifyM asks the routing server for the reach's SHAPE too, simplified to that
+	// many metres. Requested only when the caller passes ?polygon=1, so the Feed settings
+	// slider - which wants the radius and the towns, not a map - keeps paying nothing for it.
+	PolygonSimplifyM float64 `json:"polygon_simplify_m,omitempty"`
 }
 type rippleEvalResp struct {
 	Results []struct {
 		DriveMin *float64 `json:"drive_min"`
 	} `json:"results"`
-	FrontierMedianMiles *float64 `json:"frontier_median_miles"`
-	FrontierMaxMiles    *float64 `json:"frontier_max_miles"`
+	FrontierMedianMiles *float64        `json:"frontier_median_miles"`
+	FrontierMaxMiles    *float64        `json:"frontier_max_miles"`
+	Polygon             json.RawMessage `json:"polygon"`
 }
+
+// reachPolygonSimplifyM is the display tolerance for the browse map's reach overlay, in
+// metres. It turns a 45-minute reach from ~27,000 vertices and ~1.2MB of GeoJSON into
+// ~2,000 vertices and ~40KB, which gzip takes to under 10KB.
+//
+// 100m rather than something coarser because the boundary error is what is being bought.
+// Measured against the exact polygon for a 45-minute drive reach around Edinburgh, the
+// simplified shape disagrees with it over 0.96% of its area at 50m, 1.66% at 100m, 2.84%
+// at 200m and 4.85% at 400m - and past 200m it starts systematically inflating (area ratio
+// 1.012 at 400m) rather than just wobbling. 100m keeps the shape honest at a size worth
+// having, which matters because an approximated boundary can cut across a narrow barrier;
+// see docs/developers/reference/rippling-algorithm.md 2a for why the reach polygon proper
+// is never simplified. This shape illustrates how far the member can travel and is never
+// a containment test.
+const reachPolygonSimplifyM = 100
 
 // Near returns up to 5 town names reachable within the slider's TRAVEL TIME (minutes) from (lat,lng),
 // by travel, furthest-selected and population-ordered - for the "Near: ..." hint under the distance
@@ -133,6 +153,10 @@ type rippleEvalResp struct {
 // @Router /town/near [get]
 // @Summary Up to 5 towns the browse/feed distance slider reaches (by drive-time), names only
 // @Tags location
+// @Param lat query number true "Latitude to measure the travel time from"
+// @Param lng query number true "Longitude to measure the travel time from"
+// @Param minutes query number true "Travel-time budget in minutes (the slider position)"
+// @Param polygon query string false "Pass 1 to also return reach_polygon, the outline of that travel time as GeoJSON, for a map overlay. An illustration only - never a containment test."
 // @Produce json
 // @Success 200 {object} map[string]interface{}
 func Near(c *fiber.Ctx) error {
@@ -183,9 +207,17 @@ func Near(c *fiber.Ctx) error {
 	for i, r := range rows {
 		points[i] = [2]float64{r.Lng, r.Lat} // [lng, lat] GeoJSON order
 	}
+	// ?polygon=1 also asks for the reach outline, for the browse map's coverage overlay. It
+	// rides on this call rather than having its own endpoint because the Dijkstra it needs is
+	// the one this call already runs; a separate endpoint would route the same reach twice.
+	var simplifyM float64
+	if c.Query("polygon") == "1" {
+		simplifyM = reachPolygonSimplifyM
+	}
+
 	body, _ := json.Marshal(rippleEvalReq{
 		Lat: lat, Lng: lng, Mode: "drive", MaxMinutes: maxMin, Points: points,
-		PointsOnly: true, Frontier: true,
+		PointsOnly: true, Frontier: true, PolygonSimplifyM: simplifyM,
 	})
 	resp, err := routingClient.Post(routingEvalURL()+"/v1/ripple-eval", "application/json", bytes.NewReader(body))
 	if err != nil {
@@ -219,6 +251,20 @@ func Near(c *fiber.Ctx) error {
 	// treats the derivation as failed rather than storing a made-up cap.
 	if r.FrontierMedianMiles != nil {
 		out["reach_radius_miles"] = reachRadiusMiles(*r.FrontierMedianMiles)
+	}
+
+	// reach_polygon: the outline of that same travel time, as a GeoJSON Feature, for the
+	// browse map to shade. Passed straight through rather than re-encoded - we have nothing
+	// to add to it, and decoding thousands of coordinates only to re-encode them would be
+	// pure cost. Absent whenever the routing server had no drawable shape, so the client
+	// falls back rather than drawing a degenerate one.
+	//
+	// This is an ILLUSTRATION of the member's own travel time, not the set of posts they can
+	// see: each post ripples out from its OWN origin with its own budget, so a post can reach
+	// a member who could not have reached it in the same time. The list stays filtered by
+	// settings.browseMaxDistance (the crow-flies radius derived above); this only shades.
+	if len(r.Polygon) > 0 && string(r.Polygon) != "null" {
+		out["reach_polygon"] = r.Polygon
 	}
 
 	towns := SelectNear(cands, maxMin, 5)


### PR DESCRIPTION
## Summary

- The browse map's shaded area was a convex hull of whatever posts happened to be loaded. It now shades **the member's real drive-time reach**, traced over the road network.
- The shape is free: `/town/near` already runs the road-network search that finds everywhere reachable in the time budget (it is how the slider turns minutes into the mile radius it stores), so it now returns the boundary that search traced. No second routing call, no new endpoint.
- Opt-in at every level: `polygon_simplify_m` on `/v1/ripple-eval`, `?polygon=1` on `/town/near`, `withPolygon` on `useReachDistance`. The Feed settings slider draws no map and pays nothing.

### Screenshot

Browse filters, the member's own reach shaded on the map:

![Browse map showing the drive-time reach](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/browse-isochrone/browse-reach-overlay.png)

The shape follows roads rather than being a circle or a hull round the posts, which is the whole point of the change.

Two things worth knowing when looking at it:

- This is the dev container, whose routing graph is a cut-down extract rather than the full UK one, so the shape is sparser and more thread-like than it is in production.
- The map auto-fits to the posts, and at that zoom the reach is far larger than the visible map, so it fills the frame and reads as nothing at all. The screenshot is zoomed out to bring the boundary into view. Worth deciding whether the default view should fit the reach rather than the posts, since as it stands most members would never see the shape they are being shown.

The `pr-assets/browse-isochrone` branch only holds this image and can be deleted after merge.

## Cost, measured on the UK graph from Edinburgh

| Slider | `/town/near` today | with the shape | payload |
|---|---|---|---|
| 20 min | 69ms | 153ms | 3.8KB |
| 30 min | 109ms | 337ms | 10KB |
| 45 min | 264ms | 837ms | 40KB (5.3KB gzipped) |

The exact polygon was never shippable: a 45-minute reach traces ~27,000 vertices and ~1.2MB of GeoJSON. Douglas-Peucker at 100m plus 5dp coordinates makes it ~2,000 vertices.

### Why 100m

Measured against the exact polygon for a 45-minute reach around Edinburgh, as % of its area where the two disagree:

| Tolerance | Vertices | Disagreement | Area ratio |
|---|---|---|---|
| 50m | 3,748 | 0.96% | 0.9986 |
| 100m | 2,008 | 1.66% | 0.9982 |
| 200m | 1,119 | 2.84% | 0.9990 |
| 400m | 603 | 4.85% | 1.0123 |

Past 200m it starts systematically inflating rather than wobbling either side.

### The doc conflict, resolved rather than ignored

`rippling-algorithm.md` §2a stated there is **no** simplification anywhere and explicitly rejected Douglas-Peucker, because an approximated boundary can cut across a barrier and a display that does not match the computation cannot be debugged against it.

That still holds for the reach polygon, which decides containment and is what rippling is debugged against. This is a scoped exception for one display consumer that decides nothing. §2a now carries the exception with the measurements above, and a new §7c describes the overlay.

## Code Quality Review

- Display simplification lives in its own `displaypolygon.go`, not inside `IsochronePolygon`, so nothing needing the exact boundary can pick it up by accident.
- `reach_polygon` is passed through apiv2 as `json.RawMessage` — decoding thousands of coordinates only to re-encode them would be pure cost.
- `markRaw` on the published feature: without it Vue deep-proxies every one of ~2,000 coordinate pairs for reactivity nothing reads.
- A sequence number in `useReachOverlay` drops out-of-order responses, so dragging the slider leaves the map on the travel time the member settled on, not whichever response landed last.

Three bugs the tests caught, each a test that passed while testing nothing:

1. The test asserting that a tolerance of zero leaves the shape untouched used a staircase ring with no exactly-collinear points, so simplifying at zero left it untouched regardless. Deleting the guard it was meant to protect left it green. Rewritten with a collinear ring plus a positive-tolerance control.
2. The `towns` table is **empty** in the schema-only Go test database, so `/town/near` returns its "no candidates" response before ever calling routing. Every town test ran in 0.00s and the polygon assertion never ran. Seeding a town fixed that, but the replacement then failed in CI: CI does run a routing server, from a small fixture graph, so a request from Edinburgh returns a null frontier and no polygon. The test was wrong in both directions because it depended on the road graph at all. It now stubs the routing server and asserts the plumbing this PR actually adds. Proof it is not vacuous a third time: one test asserts `reach_polygon` **equals** a distinctive stub polygon and another asserts it is **absent** when the stub returns none, so the handler output demonstrably tracks the routing server.
3. `tests/unit/setup.ts`'s global `useState` returned a fresh ref per call. Nuxt's is keyed and shared, so any composable built on it was silently per-caller while its specs still passed.

## Two things worth your call

**Border opacity 0.5 → 0.9.** Those settings were tuned for a small compact hull sitting among the pins. The real reach is a big ragged boundary out in open country, and at 0.5 it drew correctly and was **invisible** over OSM tiles — confirmed in a browser. Fill left at 0.12 so pins stay visible. Say the word if you would rather it stayed subtle.

**The shading and the list are close but not identical.** The list stays filtered by `browseMaxDistance`, the crow-flies radius derived from the frontier median, so posts near the circle edge can sit outside the shading and vice versa. Filtering by point-in-polygon instead would make them agree and would be more accurate, but that is re-filtering the feed rather than drawing it, so it is not in this PR.

**And a consequence to be aware of:** the map auto-fits to the posts, which are usually much closer than the reach, so the polygon is often partly or wholly outside the viewport at the default zoom. The hull never had this problem because it was built from the visible posts. Fitting the bounds to the reach would change the default zoom for every browse user, so I have not done it.

## Test Plan

- `iznik-routing-go`: 103 pass, including 14 new covering `DisplayRing`, `roundRing` and the `/v1/ripple-eval` option (polygon absent unless asked, drive-times unchanged when asked, no polygon for an unroutable origin).
- `iznik-server-go`: 4,133 pass, including 5 new on `/town/near` against a stubbed routing server (asks for the polygon only when `?polygon=1`; passes it through unchanged; omits it for `polygon=0`/`polygon=yes`/absent; omits it when routing has no shape; leaves every other field identical).
- `iznik-nuxt3`: 15,501 pass, including new specs for `useReachOverlay` (staleness guard, shared state, clearing) and `PostMap` (prefers the reach, falls back to the hull).
- Verified in a browser on `freegle-dev-local`: the drawn shape follows the M8 west, crosses the Forth only at the bridges and runs east past Tranent — an isochrone, not a hull — at 945 vertices.