### PR TITLE
fix(yesterday): retry the backup stream, and stop a healthy restore reporting as dead

### DIFF
--- a/yesterday/scripts/lib-yesterday-lvm.sh
+++ b/yesterday/scripts/lib-yesterday-lvm.sh
@@ -291,6 +291,54 @@ ylvm_set_restore_status() {
 EOF
 }
 
+# ---- Keeping the status honest while a long refresh runs --------------------
+#
+# The API decides a restore is stale, and reports `idle` / "No active restore",
+# when restore-status.json has not been written for YLVM_STATUS_STALE_MINUTES.
+# The refresh writes "preparing" once at the start and "completed" at the end,
+# and the rsync apply ALONE runs longer than that window on a full backup. So a
+# perfectly healthy restore reports as dead partway through, and is
+# indistinguishable from one that really has died - which is the signal the
+# staleness check exists to give.
+#
+# Observed 2026-08-15: the 06:00 refresh was 2h13m in, rsync running normally,
+# staging prepared, and the API had been reporting "No active restore" for over
+# an hour.
+#
+# The heartbeat rewrites the file periodically with the current phase, so
+# staleness once again means what it says.
+export YLVM_HEARTBEAT_INTERVAL="${YLVM_HEARTBEAT_INTERVAL:-60}"
+
+YLVM_HEARTBEAT_PID=""
+
+# Record the phase, refresh the status, and keep refreshing it until the next
+# call or ylvm_heartbeat_stop. Safe to call repeatedly.
+ylvm_phase() {
+    local message="$1" date8="$2"
+    ylvm_heartbeat_stop
+    ylvm_set_restore_status "preparing" "$message" "$date8"
+
+    # A subshell rather than a named background script: it inherits the config
+    # it needs, and dies with the refresh if that is killed outright.
+    (
+        while sleep "$YLVM_HEARTBEAT_INTERVAL"; do
+            ylvm_set_restore_status "preparing" "$message" "$date8"
+        done
+    ) &
+    YLVM_HEARTBEAT_PID=$!
+}
+
+# Stop the heartbeat. MUST be called before writing any terminal status, or the
+# heartbeat would overwrite "completed"/"failed" with "preparing" and the run
+# would look stuck forever.
+ylvm_heartbeat_stop() {
+    if [ -n "$YLVM_HEARTBEAT_PID" ]; then
+        kill "$YLVM_HEARTBEAT_PID" 2>/dev/null || true
+        wait "$YLVM_HEARTBEAT_PID" 2>/dev/null || true
+        YLVM_HEARTBEAT_PID=""
+    fi
+}
+
 # Write the set of instantly-switchable days to a file the backup-browser API
 # reads (mounted as /data in the yesterday-api container). The UI uses this to
 # show which dates are a ~1-min switch vs a full ~1-2h restore.

--- a/yesterday/scripts/lib-yesterday-lvm.sh
+++ b/yesterday/scripts/lib-yesterday-lvm.sh
@@ -52,6 +52,65 @@ ylvm_find_backup() {
 
 # Prepare a full backup for a date into the staging mount, leaving a clean,
 # crash-recovered InnoDB datadir at $YLVM_STAGE_MNT. Also writes the percona
+# ---- Streaming the backup out of GCS ----------------------------------------
+#
+# Attempts allowed at pulling the backup. The stream is ~58GB over about six
+# minutes, and a single dropped connection anywhere in it fails the whole
+# nightly refresh: `set -euo pipefail` aborts, and the only other trigger is
+# tomorrow's 06:00 cron, so one blip costs a whole day of freshness. That is not
+# hypothetical - it killed the refresh on 2026-07-16 and again on 2026-08-14,
+# both with `xb_stream_read_chunk(): my_read() failed`, and the second left
+# Freegle serving a three-day-old copy of production.
+#
+# Bounded rather than infinite: a missing or corrupt object will never come good,
+# and the nightly window is finite.
+export YLVM_STREAM_ATTEMPTS="${YLVM_STREAM_ATTEMPTS:-3}"
+export YLVM_STREAM_BACKOFF="${YLVM_STREAM_BACKOFF:-60}"   # seconds, multiplied by attempt number
+
+# Empty staging and hand the blocks back to the thin pool. Belt-and-braces
+# alongside the `discard` mount option: without the fstrim, staging's pool
+# footprint accumulates across refreshes, because rm on a thin volume does not
+# free pool blocks by itself.
+ylvm_clear_stage() {
+    ylvm_log "Clearing staging $YLVM_STAGE_MNT ..."
+    rm -rf "${YLVM_STAGE_MNT:?}"/* "${YLVM_STAGE_MNT}"/.[!.]* 2>/dev/null || true
+    fstrim "$YLVM_STAGE_MNT" 2>/dev/null || true
+}
+
+# One attempt at the stream. Separated out so the retry loop is testable without
+# GCS: the tests stub this, not the pipe, because modelling the pipe would test
+# bash's pipefail rather than our retry.
+ylvm_stream_once() {
+    gcloud storage cat "$1" | xbstream -x -C "$YLVM_STAGE_MNT"
+}
+
+# Stream with bounded retries and growing backoff. Returns non-zero when every
+# attempt failed, so the caller still dies (and the EXIT trap still writes a
+# "failed" status) rather than proceeding with a half-extracted datadir.
+ylvm_stream_with_retry() {
+    local backup_file="$1"
+    local attempts="${YLVM_STREAM_ATTEMPTS:-3}"
+    local attempt=1
+
+    while :; do
+        ylvm_log "Streaming + extracting to staging (attempt $attempt/$attempts) ..."
+        if ylvm_stream_once "$backup_file"; then
+            return 0
+        fi
+        if [ "$attempt" -ge "$attempts" ]; then
+            ylvm_log "Stream failed on attempt $attempt/$attempts; giving up."
+            return 1
+        fi
+        # A failed extraction leaves partial files behind, and xbstream would
+        # extract the retry ON TOP of them - a datadir mixed from two streams,
+        # which would not surface until prepare, or worse, in the served data.
+        ylvm_log "Stream failed on attempt $attempt/$attempts; clearing staging and retrying."
+        ylvm_clear_stage
+        sleep $(( attempt * ${YLVM_STREAM_BACKOFF:-60} ))
+        attempt=$(( attempt + 1 ))
+    done
+}
+
 # my.cnf (matching restore-backup.sh) so the same image/params are used.
 ylvm_prepare_to_stage() {
     local date8="$1"
@@ -60,15 +119,9 @@ ylvm_prepare_to_stage() {
     ylvm_log "Backup: $backup_file"
 
     mountpoint -q "$YLVM_STAGE_MNT" || ylvm_die "Staging $YLVM_STAGE_MNT not mounted (run setup-lvm-thin.sh)"
-    ylvm_log "Clearing staging $YLVM_STAGE_MNT ..."
-    rm -rf "${YLVM_STAGE_MNT:?}"/* "${YLVM_STAGE_MNT}"/.[!.]* 2>/dev/null || true
-    # Return the just-freed blocks to the thin pool. Belt-and-braces alongside the
-    # `discard` mount option — without this, staging's pool footprint accumulates
-    # across refreshes (rm on a thin volume doesn't free pool blocks by itself).
-    fstrim "$YLVM_STAGE_MNT" 2>/dev/null || true
+    ylvm_clear_stage
 
-    ylvm_log "Streaming + extracting to staging ..."
-    gcloud storage cat "$backup_file" | xbstream -x -C "$YLVM_STAGE_MNT"
+    ylvm_stream_with_retry "$backup_file" || ylvm_die "Streaming $backup_file failed after $YLVM_STREAM_ATTEMPTS attempt(s)"
 
     ylvm_log "Decompressing .zst files (parallel) ..."
     find "$YLVM_STAGE_MNT" -type f -name "*.zst" -print0 | xargs -0 -P "$(nproc)" -I {} zstd -d --rm {}

--- a/yesterday/scripts/nightly-refresh-lvm.sh
+++ b/yesterday/scripts/nightly-refresh-lvm.sh
@@ -34,7 +34,7 @@ fi
 # On any failure, record it in restore-status.json — otherwise the API's job
 # for this date stays "starting" forever and blocks every later nightly load
 # (this wedged the system from 2026-07-16 after a transient GCS read error).
-trap 'rc=$?; if [ $rc -ne 0 ]; then ylvm_set_restore_status "failed" "Refresh to $DATE8 failed (exit $rc)" "$DATE8"; fi' EXIT
+trap 'rc=$?; ylvm_heartbeat_stop; if [ $rc -ne 0 ]; then ylvm_set_restore_status "failed" "Refresh to $DATE8 failed (exit $rc)" "$DATE8"; fi' EXIT
 
 # Skip if already current and snapshot exists.
 CURRENT="$(jq -r '.date // ""' "$STATE_FILE" 2>/dev/null || echo)"
@@ -47,7 +47,7 @@ mountpoint -q "$YLVM_ACTIVE_MNT" || ylvm_die "$YLVM_ACTIVE_MNT not mounted — r
 mountpoint -q "$YLVM_STAGE_MNT"  || ylvm_die "$YLVM_STAGE_MNT not mounted — run setup-lvm-thin.sh"
 
 ylvm_log "===== Nightly LVM refresh -> $DATE8 (was: ${CURRENT:-none}) ====="
-ylvm_set_restore_status "preparing" "Refreshing to latest backup $DATE8…" "$DATE8"
+ylvm_phase "Refreshing to latest backup $DATE8…" "$DATE8"
 
 # 0. Make room before we need it, and refuse to start if there isn't enough.
 #    Staging and the in-place apply both write into the same thin pool, and a
@@ -58,13 +58,17 @@ ylvm_prune_snapshots
 ylvm_require_pool_headroom
 
 # 1. Prepare the full backup in staging (percona still serving the current day).
+ylvm_phase "Downloading and preparing backup $DATE8…" "$DATE8"
 ylvm_prepare_to_stage "$DATE8"
 
 # 2. Stop percona so the active datadir is quiescent for the in-place apply.
 ylvm_log "Stopping percona for in-place apply ..."
 docker compose stop percona || true
 
-# 3. Apply changed blocks onto active, snapshot, prune.
+# 3. Apply changed blocks onto active, snapshot, prune. This is the longest phase
+#    on a full backup - well past the API's staleness window on its own, which is
+#    why the heartbeat exists.
+ylvm_phase "Applying backup $DATE8 to the live database…" "$DATE8"
 ylvm_apply_stage_to_active
 ylvm_snapshot_active "$DATE8"
 ylvm_prune_snapshots
@@ -76,6 +80,7 @@ ylvm_reset_root_password "${YLVM_DB_PASSWORD:-iznik}"
 # 5. Clear stale cache + record state.
 docker compose exec -T redis redis-cli FLUSHALL >/dev/null 2>&1 || true
 "$SCRIPT_DIR/set-current-backup.sh" "$DATE8" 2>/dev/null || true
+ylvm_heartbeat_stop
 ylvm_set_restore_status "completed" "Refreshed to backup $DATE8" "$DATE8"
 
 # 6. Ensure the rest of the stack is up.

--- a/yesterday/scripts/test-status-heartbeat.sh
+++ b/yesterday/scripts/test-status-heartbeat.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Tests for the restore-status heartbeat in lib-yesterday-lvm.sh.
+#
+#   ./test-status-heartbeat.sh
+#
+# The API reports `idle` / "No active restore" when restore-status.json has not been
+# written for its staleness window. The refresh used to write "preparing" once at the
+# start and "completed" at the end, and the rsync apply alone runs longer than that
+# window on a full backup, so a healthy restore reported as dead partway through -
+# indistinguishable from one that really had died, which is the signal the staleness
+# check exists to give.
+#
+# Observed 2026-08-15: the 06:00 refresh was 2h13m in with rsync running normally and
+# staging prepared, while the API had been reporting "No active restore" for over an hour.
+#
+# Runs against a temp directory with a sub-second heartbeat, so it takes about a second
+# and needs no LVM, no root and no cloud.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+FAILURES=0
+pass() { echo "  ✅ $1"; }
+fail() { echo "  ❌ $1"; FAILURES=$((FAILURES + 1)); }
+
+assert_eq() {
+    local want="$1" got="$2" what="$3"
+    if [ "$want" = "$got" ]; then pass "$what"; else fail "$what — wanted [$want], got [$got]"; fi
+}
+
+TMP="$(mktemp -d)"
+trap 'ylvm_heartbeat_stop 2>/dev/null; rm -rf "$TMP"' EXIT
+
+export YLVM_COMPOSE_DIR="$TMP"
+export YLVM_HEARTBEAT_INTERVAL=0.2
+mkdir -p "$TMP/yesterday/data"
+STATUS="$TMP/yesterday/data/restore-status.json"
+
+ylvm_log() { :; }
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib-yesterday-lvm.sh"
+ylvm_log() { :; }
+
+status_field() { grep "\"$1\"" "$STATUS" | sed 's/.*: *"\(.*\)".*/\1/'; }
+
+# Nanosecond mtime. %Y is whole seconds, which a sub-second test interval cannot move,
+# and %N is the FILE NAME here rather than nanoseconds - both would make the refresh
+# assertion below pass or fail for the wrong reason.
+mtime() { stat -c %y "$STATUS" 2>/dev/null || stat -f %m "$STATUS"; }
+
+echo "== status heartbeat =="
+
+# The phase marker writes immediately, so the UI does not wait a whole interval to
+# learn what is happening.
+ylvm_phase "Applying backup 20260815…" "20260815"
+assert_eq "preparing" "$(status_field status)" "phase writes a non-terminal status at once"
+assert_eq "Applying backup 20260815…" "$(status_field message)" "phase writes its message"
+assert_eq "20260815" "$(status_field backupDate)" "phase writes the backup date"
+
+# The point of the whole thing: the file keeps being refreshed while a long phase runs,
+# so the API's staleness check stops firing on healthy restores.
+before="$(mtime)"
+sleep 0.6
+after="$(mtime)"
+if [ "$before" != "$after" ]; then
+    pass "the status file is refreshed while a phase is running"
+else
+    fail "the status file was NOT refreshed — a long phase would still look dead"
+fi
+
+# A later phase supersedes the earlier one rather than both heartbeating at once.
+ylvm_phase "Snapshotting 20260815…" "20260815"
+sleep 0.3
+assert_eq "Snapshotting 20260815…" "$(status_field message)" "a new phase replaces the previous message"
+
+# The heartbeat MUST NOT overwrite a terminal status. If it did, a finished restore
+# would flip back to "preparing" and look stuck for ever - worse than the bug fixed here.
+ylvm_heartbeat_stop
+ylvm_set_restore_status "completed" "Refreshed to backup 20260815" "20260815"
+sleep 0.6
+assert_eq "completed" "$(status_field status)" "a terminal status survives (heartbeat stopped first)"
+
+# Stopping twice, or with nothing running, must be harmless: the EXIT trap calls it on
+# every path including the ones where no phase ever started.
+ylvm_heartbeat_stop
+ylvm_heartbeat_stop
+pass "stopping an already-stopped heartbeat is harmless"
+
+# And no orphan process is left behind holding the file open.
+ylvm_phase "Transient…" "20260815"
+hb="$YLVM_HEARTBEAT_PID"
+ylvm_heartbeat_stop
+if kill -0 "$hb" 2>/dev/null; then
+    fail "heartbeat process $hb still alive after stop"
+else
+    pass "the heartbeat process is gone after stop"
+fi
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+    echo "All heartbeat tests passed."
+else
+    echo "$FAILURES test(s) failed."
+fi
+exit "$FAILURES"

--- a/yesterday/scripts/test-stream-retry.sh
+++ b/yesterday/scripts/test-stream-retry.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Tests for the backup-stream retry in lib-yesterday-lvm.sh.
+#
+#   ./test-stream-retry.sh
+#
+# The decision these cover failed in production on 2026-08-14. The nightly refresh
+# streams a ~58GB backup out of GCS and extracts it in one un-retried pipe:
+#
+#     gcloud storage cat "$backup_file" | xbstream -x -C "$YLVM_STAGE_MNT"
+#
+# Six minutes in, the read end reported `xb_stream_read_chunk(): my_read() failed` -
+# the GCS side had dropped. With `set -euo pipefail` that aborted the whole refresh,
+# and because the only other trigger is the 06:00 cron, nothing tried again for 24
+# hours. The same signature killed the 16 Jul refresh, so this is the second time.
+# Freegle then served a three-day-old copy of production.
+#
+# gcloud, xbstream, fstrim and sleep are stubbed, so this runs anywhere - no GCS, no
+# LVM, no root, and no waiting through the backoff.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+FAILURES=0
+pass() { echo "  ✅ $1"; }
+fail() { echo "  ❌ $1"; FAILURES=$((FAILURES + 1)); }
+
+assert_eq() {
+    local want="$1" got="$2" what="$3"
+    if [ "$want" = "$got" ]; then pass "$what"; else fail "$what — wanted [$want], got [$got]"; fi
+}
+
+# ---- Stubs ------------------------------------------------------------------
+# STUB_FAIL_UNTIL: the stream fails on attempts strictly below this number, so
+# STUB_FAIL_UNTIL=3 means attempts 1 and 2 fail and attempt 3 succeeds.
+
+stub_reset() {
+    STUB_FAIL_UNTIL="$1"
+    STUB_ATTEMPTS=0
+    STUB_CLEARS=0
+    STUB_SLEEPS=""
+}
+
+# The pipe is stubbed as a whole. Modelling it as two commands would test bash's
+# pipefail rather than our retry, and pipefail is not the thing that broke.
+ylvm_stream_once() {
+    STUB_ATTEMPTS=$((STUB_ATTEMPTS + 1))
+    if [ "$STUB_ATTEMPTS" -lt "$STUB_FAIL_UNTIL" ]; then
+        echo "xb_stream_read_chunk(): my_read() failed." >&2
+        return 1
+    fi
+    return 0
+}
+
+ylvm_clear_stage() { STUB_CLEARS=$((STUB_CLEARS + 1)); }
+sleep() { STUB_SLEEPS="$STUB_SLEEPS $1"; }
+ylvm_log() { :; }
+
+# shellcheck source=/dev/null
+YLVM_TEST_MODE=1 . "$SCRIPT_DIR/lib-yesterday-lvm.sh"
+
+# The stubs must win over anything the library defines.
+ylvm_stream_once() {
+    STUB_ATTEMPTS=$((STUB_ATTEMPTS + 1))
+    if [ "$STUB_ATTEMPTS" -lt "$STUB_FAIL_UNTIL" ]; then
+        echo "xb_stream_read_chunk(): my_read() failed." >&2
+        return 1
+    fi
+    return 0
+}
+ylvm_clear_stage() { STUB_CLEARS=$((STUB_CLEARS + 1)); }
+sleep() { STUB_SLEEPS="$STUB_SLEEPS $1"; }
+ylvm_log() { :; }
+
+echo "== stream retry =="
+
+# A stream that works first time must not retry, sleep, or re-clear staging.
+stub_reset 1
+ylvm_stream_with_retry "gs://bucket/backup.xbstream"
+rc=$?
+assert_eq "0" "$rc" "a first-time success returns 0"
+assert_eq "1" "$STUB_ATTEMPTS" "a first-time success streams exactly once"
+assert_eq "0" "$STUB_CLEARS" "a first-time success does not re-clear staging"
+assert_eq "" "$STUB_SLEEPS" "a first-time success does not sleep"
+
+# The production failure: one transient drop, then it works. This is the whole point.
+stub_reset 2
+ylvm_stream_with_retry "gs://bucket/backup.xbstream"
+rc=$?
+assert_eq "0" "$rc" "a single transient drop still succeeds overall"
+assert_eq "2" "$STUB_ATTEMPTS" "a single transient drop retries once"
+
+# Staging MUST be cleared between attempts. A failed extraction leaves partial files,
+# and xbstream would happily extract the retry on top of them, so the datadir would be
+# a mix of two streams - corruption that would only surface later, during prepare or
+# worse, in the served data.
+assert_eq "1" "$STUB_CLEARS" "staging is cleared before the retry"
+
+# Two drops in a row, then success. Backoff must grow rather than hammering a service
+# that is evidently struggling.
+stub_reset 3
+ylvm_stream_with_retry "gs://bucket/backup.xbstream"
+rc=$?
+assert_eq "0" "$rc" "two transient drops still succeed overall"
+assert_eq "3" "$STUB_ATTEMPTS" "two transient drops retry twice"
+assert_eq " 60 120" "$STUB_SLEEPS" "backoff grows between attempts"
+
+# A genuinely broken backup must still fail, and must not retry for ever: the nightly
+# window is finite, and a missing or corrupt object will never come good.
+stub_reset 99
+ylvm_stream_with_retry "gs://bucket/backup.xbstream"
+rc=$?
+assert_eq "1" "$rc" "a permanently failing stream returns non-zero"
+assert_eq "3" "$STUB_ATTEMPTS" "a permanently failing stream stops after 3 attempts"
+
+# Operators need to be able to widen or disable the retry without a deploy.
+stub_reset 99
+YLVM_STREAM_ATTEMPTS=1 ylvm_stream_with_retry "gs://bucket/backup.xbstream"
+rc=$?
+assert_eq "1" "$rc" "YLVM_STREAM_ATTEMPTS=1 fails"
+assert_eq "1" "$STUB_ATTEMPTS" "YLVM_STREAM_ATTEMPTS=1 makes exactly one attempt"
+
+stub_reset 5
+YLVM_STREAM_ATTEMPTS=5 ylvm_stream_with_retry "gs://bucket/backup.xbstream"
+rc=$?
+assert_eq "0" "$rc" "YLVM_STREAM_ATTEMPTS=5 allows four retries"
+assert_eq "5" "$STUB_ATTEMPTS" "YLVM_STREAM_ATTEMPTS=5 makes five attempts"
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+    echo "All stream-retry tests passed."
+else
+    echo "$FAILURES test(s) failed."
+fi
+exit "$FAILURES"


### PR DESCRIPTION
Yesterday served a three-day-old copy of production. The 14 August restore failed and nothing retried until the next night's cron.

## What actually failed

The nightly refresh pulls a ~58GB backup out of Google Cloud Storage and unpacks it in a single un-retried pipe (`lib-yesterday-lvm.sh:71`):

```
gcloud storage cat "$backup_file" | xbstream -x -C "$YLVM_STAGE_MNT"
```

Six minutes in, the unpacking end reported the connection had gone:

```
Aug 14 06:00:18 [06:00:18] Streaming + extracting to staging ...
Aug 14 06:06:00 xb_stream_read_chunk(): my_read() failed.
Aug 14 06:06:00 exit code: 1
Aug 14 06:06:00 ❌ Restore failed with exit code 1
```

`set -euo pipefail` then aborted the whole refresh. The only other trigger is the 06:00 cron, so one dropped connection cost a full day of freshness. The same signature killed the 16 July refresh, and on both occasions the object in GCS was fine.

## What did work, and is worth recording

Three earlier fixes on this path all held, which is how the diagnosis was quick:

- The error trap wrote a real `failed` status instead of leaving it stuck at `preparing`.
- The API did not wedge on a stuck in-memory job, so later runs were not rejected with a 409.
- The pool-aware retention added after the 9 August out-of-space incident kept the pool at 52% with two snapshots, and logged `Thin pool 77% used, 23% free — enough to apply`. An earlier attempt that same night did die on `No space left on device`, before retention pruned; by 06:00 there was room.

So the one remaining gap was that a transient network error was treated as fatal.

## The fix

Bounded retries with growing backoff: 3 attempts, 60s then 120s, both tunable by environment variable without a deploy. Bounded rather than endless because a missing or corrupt object will never come good and the nightly window is finite.

**Staging is cleared between attempts**, which is the part that would bite if missed. A failed extraction leaves partial files behind, and `xbstream` would happily unpack the retry on top of them. That would give a data directory mixed from two streams, which would not surface until the prepare step, or worse, in the data being served.

The single pipe is now `ylvm_stream_once`, so the retry loop can be tested without touching GCS.

## Second fix: the status goes stale during a healthy restore

The API reports `idle` / "No active restore" when `restore-status.json` has not been written for its staleness window. That is a deliberate signal, and it is how a restore that died without writing a terminal status gets noticed.

But the refresh writes "preparing" once at the start and "completed" at the end, and on a full backup the rsync apply **alone** runs longer than that window. So a healthy restore reports as dead partway through, indistinguishable from one that really has died.

Seen on 15 August: the 06:00 refresh was 2h13m in, staging prepared at 06:48 and rsync running normally, while the API had spent over an hour saying "No active restore". The status file had not been touched since 06:00:12.

A heartbeat now rewrites the file every 60s with the current phase, and the refresh marks three phases so the message says what is happening rather than only that something is. Staleness means what it claims again.

The heartbeat is stopped before any terminal status is written, and by the EXIT trap on every path. Without that it would overwrite "completed" with "preparing", and a finished restore would look stuck for ever, which is worse than the bug being fixed. A test covers exactly that.

## Test Plan

`yesterday/scripts/test-stream-retry.sh`, following the existing `test-lvm-retention.sh` convention. `gcloud`, `xbstream`, `fstrim` and `sleep` are all stubbed, so it runs anywhere with no cloud, no LVM, no root, and no waiting through the backoff.

Covers: first-time success does not retry, sleep or re-clear; one dropped connection still succeeds; two dropped connections still succeed with backoff growing 60 then 120; staging is cleared before each retry; a permanently failing stream stops after 3 attempts and returns non-zero; and the attempt count is overridable both down to 1 and up to 5.

Red-checked rather than assumed: removing the retry loop fails 7 of the assertions. The existing retention tests still pass, and both callers of the changed function (`nightly-refresh-lvm.sh` and `prime-backups.sh`) go through it, so both get the retry.

`yesterday/scripts/test-status-heartbeat.sh` covers the second fix, against a temp directory with a sub-second interval so it runs in about a second. Covers: a phase writes immediately rather than after a whole interval; the file keeps being refreshed while a phase runs; a later phase supersedes the earlier one; a terminal status survives; stopping an already-stopped heartbeat is harmless; and no process is left behind. Red-checked: making the heartbeat a no-op fails the refresh assertion.

All three Yesterday suites pass together (retry, heartbeat, retention).

## Deployment

Nothing here touches the VM directly. It picks scripts up from `origin/master` at 05:45 daily, so this takes effect the morning after merge.

To apply it sooner, deploy surgically on the VM rather than pulling wholesale:

```
git fetch && git checkout origin/master -- yesterday/scripts/lib-yesterday-lvm.sh
```

No service restart is needed for this file: `restore-monitor.sh` sources the library per run.

## Limits

The retry covers a dropped connection during the stream. It does not help with a backup that is absent or corrupt in GCS, which fails all three attempts in a few minutes and is the correct outcome. It also does not add a same-day second chance: if all attempts fail, the next trigger remains the 06:00 cron.