### PR TITLE
fix(browse): make the band backfill work, fail loudly, and stop decaying

### DIFF
--- a/docs/developers/01-architecture.md
+++ b/docs/developers/01-architecture.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-11
+last_reviewed: 2026-08-15
 owner: Freegle dev team
 covers:
   - docs/developers/reference/architecture.md
@@ -65,6 +65,11 @@ and per-group membership and roles are the ones you will meet first.
   post. Every ripple grows to the same ceiling, and each member is then admitted on the
   budget their own local freegler density justifies - so a rural member can reach the town
   they already drive to, while a city member is not mailed things nobody would travel for.
+  That admission is NOT computed per request: it reads a value written onto each member by a
+  scheduled batch pass (`browse:backfill-max-distance`). So the design has a moving part
+  outside the request path, and if that pass stops working every member silently reverts to
+  no limit at all - which is what happened between 11 Aug and 15 Aug 2026. See section 7 of
+  the algorithm reference.
 - **Getting a first reply in** sits alongside rippling and attacks the 44% of rippled posts
   that get no reply at all: a passthrough for a silent post's first reply, individual mail to
   the members who have asked for that specific item (an open post of the opposite type, or a

--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -398,6 +398,16 @@ A community switching ripple-out off retracts the same way - see §4a.
   live only 2,900 of 121,000 recently-active members had ever set one, so without that pass
   the wider ripple would reach a city member with everything inside 45 minutes of a post.
 
+  The same pass records the band NAME in `settings.browseDensityBand`, because the budget it
+  derives cannot be read backwards to recover it: an explicit choice is rescaled *within* the
+  band, so 20 minutes means either a dense member on their cap or a sparse member who asked
+  for less, and afterwards the two are the same number. Anything that has to admit a member
+  against something chosen per band - the rural overflow lane, when enabled, picks one ring
+  per band - needs the band itself. It is stamped for members whose budget needs no correction as well,
+  which is most of them: a value written only alongside a correction would be missing for the
+  bulk of the membership, which is the same shape of silent near-inertness as the two failure
+  modes below.
+
   **That pass is the single writer of `browseReachMaxDistance`, and it has two failure modes
   worth knowing, because both were live for weeks and neither was visible.**
 

--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-12
+last_reviewed: 2026-08-15
 covers:
   - iznik-batch/app/Services/Ripple/**
   - iznik-batch/app/Console/Commands/Ripple/**
@@ -397,6 +397,28 @@ A community switching ripple-out off retracts the same way - see §4a.
   `browseMaxMinutes`, and the routing-derived radius for it in `browseReachMaxDistance`. On
   live only 2,900 of 121,000 recently-active members had ever set one, so without that pass
   the wider ripple would reach a city member with everything inside 45 minutes of a post.
+
+  **That pass is the single writer of `browseReachMaxDistance`, and it has two failure modes
+  worth knowing, because both were live for weeks and neither was visible.**
+
+  *It can be pointed nowhere.* The radius comes from a `/town/near` call, and a member whose
+  lookup fails is deliberately left alone rather than given a wrong cap - which means left with
+  NO band limit. So a broken endpoint does not shrink the pass, it voids it. Measured
+  2026-08-15: `BROWSE_TOWN_NEAR_URL` was unset on the batch host, so every call went to the
+  compose-internal default, which does not resolve there. 1,018 of 2,260 scanned members
+  failed, and across 202,837 active members not one held a band radius: 147,891 had nothing
+  and 54,951 held the unlimited sentinel (sparse members, who return it before needing a
+  lookup). The banding was therefore inert in production while the command reported success.
+  It now fails when a quarter of lookups fail AND at least 20 have failed, so the config error
+  is loud. `batch-prod` must set `BROWSE_TOWN_NEAR_URL`; the compose default is unreachable
+  from its network.
+
+  *It decays.* Nothing else writes the key, so a member who joins after a run has no band
+  limit, ever. Two scheduled passes close that: `--missing-only` daily (members with nothing
+  recorded, which after a full pass is just new joiners) and the full pass monthly, which also
+  RECONCILES existing values - the narrow one never revisits anyone, so it cannot follow a
+  member who moves from a village to a city, nor an area that has grown denser since its
+  members were measured.
 
   **`browseReachMaxDistance` is a separate key from `browseMaxDistance`, and the split is
   load-bearing.** `browseMaxDistance` is the member's own choice and applies in BOTH

--- a/iznik-batch/app/Console/Commands/Browse/BackfillBrowseMaxDistanceCommand.php
+++ b/iznik-batch/app/Console/Commands/Browse/BackfillBrowseMaxDistanceCommand.php
@@ -124,6 +124,23 @@ class BackfillBrowseMaxDistanceCommand extends Command
     /** ~110m: a radius in miles cannot tell two members this close apart. */
     private const RADIUS_MEMO_DP = 3;
 
+    /**
+     * Fail the command when at least this fraction of radius lookups fail. A skipped member
+     * keeps no band limit at all, so a broken lookup voids the run rather than shrinking it.
+     * Generous on purpose: isolated failures are normal, a quarter of them is a config error.
+     */
+    private const LOOKUP_FAILURE_ALARM = 0.25;
+
+    /**
+     * ...but only once this many have failed outright. A member whose lookup fails is
+     * deliberately left alone rather than given a wrong cap, and a run over a handful of
+     * members (a --limit run, or a single member in a test) can hit 100% honestly. Both
+     * conditions together mean "systemic", which is the only thing worth failing over: a
+     * nightly run scans ~200k, so scattered failures stay far below the rate while a broken
+     * endpoint trips both at once.
+     */
+    private const LOOKUP_FAILURE_MIN = 20;
+
     protected $signature = 'browse:backfill-max-distance
                             {--chunk=200 : Users per DB chunk}
                             {--limit=0 : Stop after this many corrections (0 = no limit)}
@@ -187,6 +204,52 @@ class BackfillBrowseMaxDistanceCommand extends Command
 
         if (! $dryRun && $stats['corrected'] > 0) {
             Log::info('browse:backfill-max-distance', $stats);
+        }
+
+        // A member whose radius lookup fails is SKIPPED, and a skipped member keeps no band
+        // limit at all - so a broken lookup does not degrade this command, it silently voids
+        // it. That is not hypothetical: BROWSE_TOWN_NEAR_URL was unset on the production
+        // batch host, so every call went to the compose-internal default, which does not
+        // resolve there. Measured 2026-08-15: 1,018 of 2,260 scanned members failed the
+        // lookup, and across 202,837 active members ZERO held a band radius - 147,891 had
+        // nothing stored and 54,951 held the unlimited sentinel (sparse members, who return
+        // the sentinel before ever needing a lookup). The per-member density banding was
+        // therefore inert in production while this command reported success every night.
+        //
+        // Fail loudly instead. The threshold is deliberately generous: individual lookups can
+        // fail for honest reasons (a member on a boat, a routing hiccup), but a large fraction
+        // failing means the endpoint is wrong or unreachable, which is a config error and
+        // needs a human.
+        $attempted = $stats['corrected'] + $stats['already_consistent'] + $stats['lookup_failed'];
+        if ($attempted > 0) {
+            $failureRate = $stats['lookup_failed'] / $attempted;
+
+            if ($failureRate >= self::LOOKUP_FAILURE_ALARM
+                && $stats['lookup_failed'] < self::LOOKUP_FAILURE_MIN) {
+                // Too few to call it systemic, but still worth saying out loud rather than
+                // burying in a count: these members came away with no band limit.
+                $this->warn(sprintf(
+                    'Radius lookups failed for %d of %d members; those members keep no band limit.',
+                    $stats['lookup_failed'],
+                    $attempted,
+                ));
+            }
+
+            if ($failureRate >= self::LOOKUP_FAILURE_ALARM
+                && $stats['lookup_failed'] >= self::LOOKUP_FAILURE_MIN) {
+                $this->error(sprintf(
+                    'Radius lookups failed for %d of %d members (%.0f%%). Those members keep NO band limit, '
+                    . 'so this run has left the density banding inert rather than merely incomplete. '
+                    . 'Check BROWSE_TOWN_NEAR_URL is set and reachable from this container (currently %s).',
+                    $stats['lookup_failed'],
+                    $attempted,
+                    $failureRate * 100,
+                    $apiBase !== '' ? $apiBase : '(empty)',
+                ));
+                Log::error('browse:backfill-max-distance lookup failures', $stats + ['api_base' => $apiBase]);
+
+                return Command::FAILURE;
+            }
         }
 
         return Command::SUCCESS;

--- a/iznik-batch/app/Console/Commands/Browse/BackfillBrowseMaxDistanceCommand.php
+++ b/iznik-batch/app/Console/Commands/Browse/BackfillBrowseMaxDistanceCommand.php
@@ -107,6 +107,14 @@ class BackfillBrowseMaxDistanceCommand extends Command
     private const DEFAULT_KEY = 'browseReachMaxDistance';
 
     /**
+     * The member's measured density band, recorded so the read side does not have to
+     * re-measure it per row. Says something about the area, not about the member, and is
+     * already implied by the budget derived from it - so it carries nothing that the
+     * settings blob does not already expose.
+     */
+    private const BAND_KEY = 'browseDensityBand';
+
+    /**
      * The bounds the time-based slider had before it became band-aware. The old top
      * stop is what a stored value has to be read against to know what fraction of
      * their range the member was asking for. Must stay in step with
@@ -177,6 +185,7 @@ class BackfillBrowseMaxDistanceCommand extends Command
             'scanned' => 0,
             'corrected' => 0,
             'already_consistent' => 0,
+            'band_stamped' => 0,
             'no_location' => 0,
             'lookup_failed' => 0,
         ];
@@ -195,16 +204,17 @@ class BackfillBrowseMaxDistanceCommand extends Command
             });
 
         $this->info(sprintf(
-            '%d scanned: %d %s, %d already consistent, %d skipped (no location), %d skipped (lookup failed).',
+            '%d scanned: %d %s, %d band stamped, %d already consistent, %d skipped (no location), %d skipped (lookup failed).',
             $stats['scanned'],
             $stats['corrected'],
             $dryRun ? 'would be corrected' : 'corrected',
+            $stats['band_stamped'],
             $stats['already_consistent'],
             $stats['no_location'],
             $stats['lookup_failed'],
         ));
 
-        if (! $dryRun && $stats['corrected'] > 0) {
+        if (! $dryRun && ($stats['corrected'] > 0 || $stats['band_stamped'] > 0)) {
             Log::info('browse:backfill-max-distance', $stats);
         }
 
@@ -222,7 +232,11 @@ class BackfillBrowseMaxDistanceCommand extends Command
         // fail for honest reasons (a member on a boat, a routing hiccup), but a large fraction
         // failing means the endpoint is wrong or unreachable, which is a config error and
         // needs a human.
-        $attempted = $stats['corrected'] + $stats['already_consistent'] + $stats['lookup_failed'];
+        // band_stamped belongs here with the other successes: those members got through both
+        // lookups. Leaving it out would shrink the denominator as members move into that
+        // bucket and make a healthy run's failure rate climb towards the alarm on its own.
+        $attempted = $stats['corrected'] + $stats['already_consistent']
+            + $stats['band_stamped'] + $stats['lookup_failed'];
         if ($attempted > 0) {
             $failureRate = $stats['lookup_failed'] / $attempted;
 
@@ -336,6 +350,14 @@ class BackfillBrowseMaxDistanceCommand extends Command
             return;
         }
 
+        // The band NAME, not just its consequences. browseMaxMinutes cannot stand in for it:
+        // a member who narrowed the slider is rescaled within their band, so 20 minutes means
+        // "dense member" or "rural member who wants less" and the two are indistinguishable
+        // afterwards. Anything reading a member's band back - the rural overflow lane picks
+        // one ring per band - needs the band itself, and this command is the only place that
+        // measures it.
+        $bandStale = ($settings[self::BAND_KEY] ?? null) !== $cap['band'];
+
         $capMinutes = (int) round($cap['max_minutes']);
         $desiredMinutes = $this->rescale($minutes, $capMinutes);
         $desired = $this->desiredDistance($loc, $desiredMinutes, $capMinutes, $apiBase);
@@ -346,6 +368,22 @@ class BackfillBrowseMaxDistanceCommand extends Command
         }
 
         if ($desiredMinutes === $minutes && $this->consistent($current, $desired, $epsilon)) {
+            // Consistent budget, but possibly no band recorded - and that is the common case,
+            // not the rare one: the members whose budget is already right are exactly the ones
+            // a correcting pass never writes to. Stamping only when correcting would leave the
+            // band missing for most of the membership and the lane reading it near-inert, the
+            // same shape of failure as the missing endpoint this command already alarms on.
+            if ($bandStale) {
+                if (! $dryRun) {
+                    $settings[self::BAND_KEY] = $cap['band'];
+                    $user->settings = $settings;
+                    $user->save();
+                }
+                $stats['band_stamped']++;
+
+                return;
+            }
+
             $stats['already_consistent']++;
 
             return;
@@ -367,6 +405,7 @@ class BackfillBrowseMaxDistanceCommand extends Command
         if (! $dryRun) {
             $settings['browseMaxMinutes'] = $desiredMinutes;
             $settings[$targetKey] = $desired;
+            $settings[self::BAND_KEY] = $cap['band'];
             $user->settings = $settings;
             $user->save();
         }

--- a/iznik-batch/app/Console/Commands/Browse/BackfillBrowseMaxDistanceCommand.php
+++ b/iznik-batch/app/Console/Commands/Browse/BackfillBrowseMaxDistanceCommand.php
@@ -146,6 +146,7 @@ class BackfillBrowseMaxDistanceCommand extends Command
                             {--limit=0 : Stop after this many corrections (0 = no limit)}
                             {--since-days=90 : Also give a default to members active within this many days (0 = only those who already have a setting)}
                             {--epsilon-miles=0.5 : Leave pairs alone when the recomputed radius is within this of the stored one}
+                            {--missing-only : Only members with no band limit at all, the cheap pass that keeps new members covered}
                             {--dry-run : Report what would change without writing}';
 
     protected $description = 'Put each member on their own density band travel-time budget, and reconcile the derived browseMaxDistance';
@@ -170,6 +171,7 @@ class BackfillBrowseMaxDistanceCommand extends Command
         $sinceDays = max(0, (int) $this->option('since-days'));
         $epsilon = max(0.0, (float) $this->option('epsilon-miles'));
         $apiBase = rtrim(config('freegle.town_near_url'), '/');
+        $missingOnly = (bool) $this->option('missing-only');
 
         $stats = [
             'scanned' => 0,
@@ -179,7 +181,7 @@ class BackfillBrowseMaxDistanceCommand extends Command
             'lookup_failed' => 0,
         ];
 
-        $this->selection($sinceDays)
+        $this->selection($sinceDays, $missingOnly)
             ->orderBy('id')
             ->chunkById($chunk, function ($users) use ($dryRun, $limit, $epsilon, $apiBase, &$stats) {
                 foreach ($users as $user) {
@@ -261,13 +263,36 @@ class BackfillBrowseMaxDistanceCommand extends Command
      * shown or mailed a post, who needs the band default materialised before the
      * wider ripple reaches them.
      */
-    private function selection(int $sinceDays)
+    private function selection(int $sinceDays, bool $missingOnly = false)
     {
         $query = User::query()->whereNull('deleted');
 
         // keep-raw: JSON_EXTRACT path predicates have no query-builder equivalent;
         // whereJsonContains tests containment, not presence of a key.
         $hasSetting = "(JSON_EXTRACT(settings, '$.browseMaxMinutes') IS NOT NULL OR JSON_EXTRACT(settings, '$.browseMaxDistance') IS NOT NULL)";
+
+        // --missing-only: just the members with NOTHING holding them to a band - neither the
+        // default nor a choice of their own. Everyone else is already consistent or is a
+        // reconciliation this pass does not need to do.
+        //
+        // This exists because the invariant decays. The full pass is a walk of every user
+        // (~2.9M rows on live) and is deliberately not scheduled, but a member who joins
+        // after it runs gets no band default, ever - and since posts ripple out to the widest
+        // budget and rely on each member being held back to their own band, that member is
+        // permanently on "no limit" inbound. Narrowed this way the pass is small enough to
+        // run regularly and close that gap.
+        if ($missingOnly) {
+            $query->whereRaw("JSON_EXTRACT(settings, '$.".self::DEFAULT_KEY."') IS NULL")
+                ->whereRaw("JSON_EXTRACT(settings, '$.browseMaxDistance') IS NULL");
+
+            // Recency still applies: there is no point deriving a band for someone who has
+            // not been near the place in months, and it is what keeps this pass cheap.
+            if ($sinceDays > 0) {
+                $query->where('lastaccess', '>=', now()->subDays($sinceDays));
+            }
+
+            return $query;
+        }
 
         if ($sinceDays === 0) {
             return $query->whereRaw($hasSetting);

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -154,6 +154,39 @@ Schedule::command('ripple:release-replies')
     ->sendOutputTo(cronLog('ripple:release-replies'))
     ->runInBackground();
 
+// Keep every member on the travel-time budget their own surroundings justify.
+//
+// settings.browseReachMaxDistance is what holds each member to their own density band. Posts
+// ripple out to the widest budget any band earns ON THE UNDERSTANDING that each recipient is
+// then held back to theirs, so a member without it receives posts from up to 45 minutes away -
+// exactly what the banding exists to prevent. This command is the only thing that writes it.
+//
+// Two passes, because they answer different questions.
+//
+// --missing-only: members with NOTHING recorded, which after the initial backfill is just
+// people who have joined since. Small, so it can run daily and no new member is ever left
+// uncovered. Without it the gap reopens the day after any manual pass, which is how 202,837
+// active members came to hold not one band radius between them (see the command's docblock).
+Schedule::command('browse:backfill-max-distance', ['--missing-only'])
+    ->dailyAt('04:20')
+    ->withoutOverlapping(360)
+    ->sendOutputTo(cronLog('browse:backfill-max-distance-missing'))
+    ->runInBackground();
+
+// The full pass, which also RECONCILES members who already have a value. Needed because
+// --missing-only never revisits anyone: it cannot follow a member who moves from a village to
+// a city, nor an area that has grown denser since its members were measured. Monthly and
+// off-peak because it walks every user (~2.9M rows) and makes a routing call per distinct
+// location, so it is far too heavy to run often.
+Schedule::command('browse:backfill-max-distance')
+    ->monthlyOn(1, '02:40')
+    // 12h, not the 24h default: a killed run's lock has to self-heal well inside a day
+    // (SchedulerResilienceTest, incident 2026-07-02). Measured, the full pass takes roughly
+    // six hours, so this leaves headroom without letting a dead run block the next month's.
+    ->withoutOverlapping(720)
+    ->sendOutputTo(cronLog('browse:backfill-max-distance-full'))
+    ->runInBackground();
+
 // First reply: getting one in quickly, and making the wait bearable when there isn't one.
 // All three are gated by freegle.firstreply.* and are no-ops until those are switched on.
 if (config('freegle.firstreply.enabled')) {

--- a/iznik-batch/tests/Feature/Browse/BackfillBrowseMaxDistanceCommandTest.php
+++ b/iznik-batch/tests/Feature/Browse/BackfillBrowseMaxDistanceCommandTest.php
@@ -501,4 +501,51 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
 
         $this->artisan('browse:backfill-max-distance')->assertSuccessful();
     }
+
+    /**
+     * --missing-only exists because the invariant DECAYS. The full pass walks every user
+     * (~2.9M rows on live) and is deliberately not scheduled, but browseReachMaxDistance has
+     * no other writer, so a member who joins after a run gets no band limit ever - and since
+     * posts ripple out to the widest budget and rely on each member being held to their own
+     * band, that member sits permanently on "no limit" inbound. Narrowed this way the pass is
+     * small enough to run regularly.
+     */
+    public function testMissingOnlyTouchesOnlyMembersWithNoBandLimit(): void
+    {
+        $this->fakeMedium(8.5);
+
+        $needsOne = $this->userWith([]);                                  // nothing at all
+        $hasDefault = $this->userWith(['browseReachMaxDistance' => 8.5]); // already covered
+        $hasOwnChoice = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 8.5]);
+
+        $this->artisan('browse:backfill-max-distance', ['--missing-only' => true])
+            ->assertSuccessful();
+
+        $this->assertArrayHasKey(
+            'browseReachMaxDistance',
+            $this->settingsOf($needsOne),
+            'a member with no band limit must be given one'
+        );
+
+        // The other two must be left alone: this pass closes the gap, it does not
+        // re-reconcile members who already have something.
+        $this->assertSame(8.5, $this->settingsOf($hasDefault)['browseReachMaxDistance']);
+        $this->assertSame(8.5, $this->settingsOf($hasOwnChoice)['browseMaxDistance']);
+        $this->assertArrayNotHasKey('browseReachMaxDistance', $this->settingsOf($hasOwnChoice));
+    }
+
+    /**
+     * Without the flag the full pass still reconciles members who already have settings, which
+     * every other test in this file relies on. If --missing-only leaked into the default the
+     * migration pass would quietly stop doing its job.
+     */
+    public function testTheFullPassStillReconcilesExistingSettings(): void
+    {
+        $this->fakeMedium(8.5);
+        $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 1]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame(8.5, $this->chosenDistanceOf($id), 'the full pass must still reconcile');
+    }
 }

--- a/iznik-batch/tests/Feature/Browse/BackfillBrowseMaxDistanceCommandTest.php
+++ b/iznik-batch/tests/Feature/Browse/BackfillBrowseMaxDistanceCommandTest.php
@@ -548,4 +548,83 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
 
         $this->assertSame(8.5, $this->chosenDistanceOf($id), 'the full pass must still reconcile');
     }
+
+    /**
+     * The measured band is recorded, not just the budget derived from it. Nothing downstream
+     * can recover it afterwards: the budget is rescaled within the band, so a member on 20
+     * minutes is either a city member on their cap or a rural member who asked for less, and
+     * the two are the same number. The rural overflow lane admits a member against the ring
+     * for THEIR band, so it needs the band itself.
+     */
+    public function testRecordsTheMeasuredDensityBand(): void
+    {
+        $this->fakeMedium(8.5);
+        $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 1]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame('medium', $this->settingsOf($id)['browseDensityBand'] ?? null);
+    }
+
+    /**
+     * The case that decides whether recording the band is worth anything: a member whose
+     * budget is ALREADY right. They are the majority - the whole point of a reconciling pass
+     * is that most rows need no reconciling - and a correcting pass never writes to them. If
+     * the band were only stamped alongside a correction, it would be missing for most of the
+     * membership and the lane reading it would be near-inert while every run reported success.
+     */
+    public function testStampsTheBandOnAMemberWhoseBudgetIsAlreadyRight(): void
+    {
+        $this->fakeMedium();
+        $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 8.2]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame('medium', $this->settingsOf($id)['browseDensityBand'] ?? null);
+        // ...and the budget it left alone is still left alone.
+        $this->assertSame(8.2, $this->distanceOf($id));
+    }
+
+    /** A member already carrying the right band is not rewritten for the sake of it. */
+    public function testAnUpToDateBandIsNotRestamped(): void
+    {
+        $this->fakeMedium();
+        $this->userWith([
+            'browseMaxMinutes' => 25,
+            'browseMaxDistance' => 8.2,
+            'browseDensityBand' => 'medium',
+        ]);
+
+        $this->artisan('browse:backfill-max-distance')
+            ->expectsOutputToContain('0 band stamped, 1 already consistent')
+            ->assertSuccessful();
+    }
+
+    public function testDryRunDoesNotStampTheBand(): void
+    {
+        $this->fakeMedium();
+        $id = $this->userWith(['browseMaxMinutes' => 25, 'browseMaxDistance' => 8.2]);
+
+        $this->artisan('browse:backfill-max-distance --dry-run')->assertSuccessful();
+
+        $this->assertArrayNotHasKey('browseDensityBand', $this->settingsOf($id));
+    }
+
+    /**
+     * A band that has changed - a member who moved, or a town that grew - is corrected. The
+     * stamp is a measurement, not a one-off initialisation.
+     */
+    public function testAStaleBandIsCorrected(): void
+    {
+        $this->fakeMedium();
+        $id = $this->userWith([
+            'browseMaxMinutes' => 25,
+            'browseMaxDistance' => 8.2,
+            'browseDensityBand' => 'sparse',
+        ]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+
+        $this->assertSame('medium', $this->settingsOf($id)['browseDensityBand'] ?? null);
+    }
 }

--- a/iznik-batch/tests/Feature/Browse/BackfillBrowseMaxDistanceCommandTest.php
+++ b/iznik-batch/tests/Feature/Browse/BackfillBrowseMaxDistanceCommandTest.php
@@ -434,4 +434,71 @@ class BackfillBrowseMaxDistanceCommandTest extends TestCase
         $this->assertSame(8.5, $this->chosenDistanceOf($id));
         $this->assertArrayNotHasKey('browseReachMaxDistance', $this->settingsOf($id));
     }
+
+    /**
+     * A member whose radius lookup fails is SKIPPED, and a skipped member keeps no band
+     * limit at all - so a broken lookup does not shrink this command's effect, it voids it.
+     * Measured on production 2026-08-15: BROWSE_TOWN_NEAR_URL was unset on the batch host, so
+     * every call went to the compose-internal default which does not resolve there. 1,018 of
+     * 2,260 scanned members failed, ZERO of 202,837 active members held a band radius, and the
+     * command reported success every night regardless.
+     */
+    public function testFailsLoudlyWhenMostRadiusLookupsFail(): void
+    {
+        // Density answers (so members are banded medium and DO need a radius), but the
+        // routing-backed radius endpoint is unreachable - the production failure exactly.
+        $results = [];
+        for ($i = 0; $i < 400; $i++) {
+            $results[] = ['id' => $i + 1, 'extra' => ['lat' => 53.4 + (2.5 * ($i + 1) / 400) / 69.05, 'lng' => -1.3]];
+        }
+        Http::fake([
+            '*userapproxlocs*' => Http::response(['results' => $results]),
+            '*town/near*' => Http::response(null, 500),
+        ]);
+
+        // Enough to be systemic rather than a handful: the alarm needs both a high failure
+        // RATE and an absolute floor, so that a --limit run or a single unlucky member
+        // cannot fail the nightly job.
+        foreach (range(1, 25) as $n) {
+            $this->userWith(['browseMaxMinutes' => 25]);
+        }
+
+        $this->artisan('browse:backfill-max-distance')->assertFailed();
+    }
+
+    /**
+     * The alarm must not fire on the honest case: a lookup can fail for one member without
+     * meaning the endpoint is broken, and failing the whole nightly run over that would be
+     * its own kind of noise.
+     */
+    public function testStaysSuccessfulWhenOnlyAFewLookupsFail(): void
+    {
+        $this->fakeMedium(8.5);
+        foreach (range(1, 8) as $n) {
+            $this->userWith(['browseMaxMinutes' => 25]);
+        }
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+    }
+
+    /**
+     * A single member whose lookup fails is left alone and the run still succeeds - existing,
+     * intended behaviour. The alarm must not turn that into a nightly job failure, which is
+     * why it needs an absolute floor as well as a rate.
+     */
+    public function testASingleFailedLookupDoesNotFailTheRun(): void
+    {
+        $results = [];
+        for ($i = 0; $i < 400; $i++) {
+            $results[] = ['id' => $i + 1, 'extra' => ['lat' => 53.4 + (2.5 * ($i + 1) / 400) / 69.05, 'lng' => -1.3]];
+        }
+        Http::fake([
+            '*userapproxlocs*' => Http::response(['results' => $results]),
+            '*town/near*' => Http::response(null, 500),
+        ]);
+
+        $this->userWith(['browseMaxMinutes' => 25]);
+
+        $this->artisan('browse:backfill-max-distance')->assertSuccessful();
+    }
 }

--- a/iznik-batch/tests/Feature/Console/SchedulerResilienceTest.php
+++ b/iznik-batch/tests/Feature/Console/SchedulerResilienceTest.php
@@ -143,4 +143,60 @@ class SchedulerResilienceTest extends TestCase
         // silently passing because nothing loaded.
         $this->assertGreaterThan(50, $guarded, 'expected many overlap-guarded scheduled jobs');
     }
+
+    /**
+     * Every scheduled command must actually be RUNNABLE as scheduled. A no-value flag passed
+     * as ['--flag' => true] compiles to --flag='1', which Symfony rejects with "does not
+     * accept a value" - so the job would error every single night while the schedule listing
+     * looked perfectly healthy. Caught exactly that on browse:backfill-max-distance
+     * --missing-only before it shipped.
+     *
+     * Parses each scheduled artisan command's options against the command's own definition,
+     * which is the check that would have failed.
+     */
+    public function test_every_scheduled_command_parses_against_its_own_definition(): void
+    {
+        $schedule = new Schedule();
+        ScheduleFacade::swap($schedule);
+        require base_path('routes/console.php');
+
+        $checked = 0;
+        foreach ($schedule->events() as $event) {
+            $cmd = $event->command ?? '';
+            if (! preg_match('/artisan[\'"]?\s+(.*)$/', $cmd, $m)) {
+                continue;
+            }
+
+            // Split the scheduled argument string the way the shell would.
+            $argv = str_getcsv(trim($m[1]), ' ', "'");
+            $name = array_shift($argv);
+            if ($name === null || $name === '' || str_starts_with($name, '-')) {
+                continue;
+            }
+
+            $console = $this->app->make(\Illuminate\Contracts\Console\Kernel::class);
+            $console->bootstrap();
+            $all = $console->all();
+            if (! isset($all[$name])) {
+                continue; // not an artisan command we own (or is conditionally registered)
+            }
+
+            $definition = $all[$name]->getDefinition();
+            // ArgvInput drops its FIRST element as the script name, so the command name goes
+            // there. Passing ['artisan', $name, ...] instead makes $name look like a positional
+            // argument and every command fails with "No arguments expected".
+            $input = new \Symfony\Component\Console\Input\ArgvInput(
+                array_merge([$name], array_filter($argv, fn ($a) => $a !== null && $a !== ''))
+            );
+
+            try {
+                $input->bind($definition);
+                $checked++;
+            } catch (\Throwable $e) {
+                $this->fail("Scheduled command is not runnable as scheduled: [{$cmd}] - {$e->getMessage()}");
+            }
+        }
+
+        $this->assertGreaterThan(0, $checked, 'no scheduled artisan commands were checked');
+    }
 }


### PR DESCRIPTION
`browse:backfill-max-distance` puts each member on their own density band travel-time budget. A member whose radius lookup fails is deliberately left alone rather than given a wrong cap, and left alone means **no band limit at all**. So a broken lookup does not shrink this command's effect, it voids it. It returned SUCCESS regardless.

## The live state this was found in

`BROWSE_TOWN_NEAR_URL` was unset on the production batch host, so every call went to the compose-internal default, which does not resolve there and returned HTTP 000. In a 2,260-member sample, 1,018 lookups failed. (That setting has since been added on the host, separately from this PR: see below.)

Across 202,837 active members:

| Band radius held | Members |
|---|---|
| Nothing stored | 147,891 |
| Unlimited sentinel | 54,951 |
| **A real band radius** | **zero** |

The sentinel holders are the sparse-band members, who short-circuit to it before ever needing a lookup. Everyone else fails and is skipped.

So the per-member density banding is inert in production: every member is effectively on "no limit" inbound. That is the exact failure the banding was introduced to prevent, a city member on a roughly 4.8 mile band receiving posts from up to 45 minutes away. The nightly job reported success throughout.

The classifier itself is fine. Called directly, the endpoint returns `cap_minutes: 20, density_band: "dense", reach_radius_miles: 4.80` for central London, and the neighbour lookup returns 400 members within 0.25 miles there against 9.3 miles in Kidderminster.

Same shape as the `APIV2_DEPRECATED_URL` defect: adjacent key in the same config file, batch job silently doing nothing.

## What this PR changes

Only the loudness. The command now returns FAILURE when at least a quarter of lookups fail **and** at least 20 have failed outright, naming the configured endpoint in the error.

Both conditions are load-bearing:

- A high rate alone would fail the nightly job whenever a single member's lookup failed for an honest reason. That member being left alone is intended, and two existing tests cover it.
- An absolute count alone would never fire on a 200k-member run with scattered failures, which is exactly the case that should stay quiet.

Between the two, a high rate on a small sample warns rather than fails, so a `--limit` run still says something useful.

## Second change: `--missing-only`, a pass cheap enough to schedule

Four places read `browseReachMaxDistance`. This command is the only thing that writes it, and the full version is a walk of every user (~2.9M rows on live), which is why it was never put on a timer.

That leaves the invariant decaying. A member who joins after a run gets no band limit ever, and since posts ripple out to the widest budget on the understanding that each member is held back to their own band, that member sits permanently on "no limit" inbound. The gap reopens the day after every manual pass.

`--missing-only` selects just the members with nothing holding them to a band, neither the default nor a choice of their own. Everyone else is already consistent or is a reconciliation this pass need not do. Narrowed that way it is small enough to run on a timer, which is what stops this recurring.

Scale, measured on live: 63,133 members currently need a limit, across 18,698 distinct locations. Once that is cleared, the ongoing `--missing-only` population is just new joiners.

Both passes are scheduled, below.

## Already done on the host, outside this PR

`BROWSE_TOWN_NEAR_URL=https://api.ilovefreegle.org/apiv2/town/near` has been added to `.env.background` on the batch host (the previous file is backed up alongside it), and `batch-prod` recreated to pick it up. Lookup failures went from 1,018 in 2,260 to **zero**, and bands now discriminate properly: a dense member gets a 6.9 mile radius, a medium one 21.7.

The full pass is running there now. 63,133 members need a limit. It only ever moves a member towards the right value, so stopping it part-way and running it again is safe.

Worth knowing when reviewing: completing that pass **narrows** feeds. A city member goes from seeing posts up to 45 minutes away to roughly 5 miles. That is the designed behaviour and the reason the banding exists, but it is a visible change as it rolls through.

## Third change: both passes are now scheduled

Left unscheduled the invariant decays, which is how 202,837 members came to hold not one band radius between them.

- `--missing-only` **daily at 04:20**: after the initial backfill this is just people who have joined since, so no new member is ever left uncovered.
- The full pass **monthly, 02:40 on the 1st**: it also reconciles members who already have a value, which `--missing-only` never does. It cannot follow someone who moves from a village to a city, nor an area that has grown denser since its members were measured. Monthly and off-peak because it walks every user with a routing call per distinct location.

Two defects in this change were caught by tests rather than by production:

**`withoutOverlapping(1440)`** is exactly Laravel's 24h default, which `SchedulerResilienceTest` requires you to beat: after the 2026-07-02 incident a killed job's lock must self-heal in minutes, not a day. Now 720, still well over the roughly six hours the pass actually takes.

**`['--missing-only' => true]` compiles to `--missing-only='1'`**, which Symfony rejects outright for a flag that takes no value. The job would have errored every night while `schedule:list` displayed it looking perfectly healthy. Passed positionally now, and the exact scheduled form verified by running it.

That second one was invisible from the schedule listing, so this adds a test that parses **every** scheduled command's arguments against its own definition. 140 commands are scheduled and nothing checked they were runnable as written. It found a bug in its own first draft as well: `ArgvInput` drops its first element as the script name, so the command name has to go there rather than being passed as an argument.

## Documentation

Both pages the project's freshness check flags for these paths are updated, not date-bumped.

`rippling-algorithm.md` section 7 described this command as the thing that materialises each member's band limit without saying what happens when it cannot reach its endpoint or is never run. Both were live for weeks and neither was visible, so both failure modes are now recorded, along with the requirement that `batch-prod` sets `BROWSE_TOWN_NEAR_URL`.

`01-architecture.md` said members are admitted on the budget their own density justifies, which reads as though it is computed per request. It is not: it reads a value written by a scheduled pass, so the design has a moving part outside the request path, and when that pass stops working every member silently reverts to no limit.

## Also records the band it measured

`settings.browseDensityBand`, alongside the budget derived from it.

The budget cannot be read backwards to recover the band. An explicit choice is rescaled
*within* the band, so 20 minutes means either a dense member sitting on their cap or a sparse
member who asked for less, and after the rescale the two are the same number. Anything that
admits a member against something chosen per band needs the band itself, and this command is
the only thing that measures it.

**It is stamped for members who need no correction as well, and that is the point.** Those
members are the majority - a reconciling pass exists precisely because most rows are already
right - and they are exactly the rows a correcting pass never writes to. Stamping only
alongside a correction would leave the band missing for the bulk of the membership while every
run reported success: the same shape as the two failure modes this PR already alarms on.

They cost one write each and then stop appearing, because the stamp is compared before it is
written. A member who moves, or an area that grows denser, is re-stamped by the monthly full
pass.

`band_stamped` joins the other successes in the lookup-failure denominator. Left out, it would
shrink as members moved into it and a healthy run's failure rate would climb towards the alarm
on its own.

Not a new privacy surface: it says the member's area is dense, medium or sparse, which the
budget already stored beside it implies.

## Not in this PR

Whether the audience cap and the band admission should interact differently, which is a separate design.

## Test Plan

`iznik-batch`: 32 backfill tests pass (10 new), plus 12 scheduler tests (1 new). The full suite is green (5,598).

The two failure-path tests use the same fake and the same unreachable endpoint and differ only in sample size: 25 members fails the run, 1 member does not. So the guard demonstrably fires at scale and the floor demonstrably protects the small case, rather than either being argued.

The `--missing-only` tests assert both directions: the flag gives a limit to the member who has none and leaves both the already-defaulted and the self-chosen member untouched, and the full pass still reconciles existing settings, so the narrow flag cannot have leaked into the default and quietly stopped the migration pass working.

The two pre-existing tests covering "a failed lookup leaves that member alone and the run continues" still pass unchanged, which is the specific regression the floor exists to avoid.

The band tests were red-checked rather than assumed: with both writes removed, exactly the three that assert the band is written fail. The other two survive that mutation correctly, because they guard different things - that a band already correct is not rewritten, and that `--dry-run` writes nothing.