### PR TITLE
feat(ripple): the two overflow lanes, wired and stored, and the rural one reaches the mail

### DIFF
--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -72,6 +72,40 @@ class ExpandService
     }
 
     /** Has the density-sizing migration run? Without it the cap still applies, unrecorded. */
+    /**
+     * Is rippling_reach.overflow_bounds present? Mirrors densityColumnsReady so the overflow
+     * lanes can ship before the migration has run everywhere.
+     *
+     * Unlike density_band, this is consulted by ALL THREE write paths (init INSERT, advanceDue
+     * UPDATE, recomputeReach shrink UPDATE). density_band was wired into only the first, which
+     * is why it is NULL on ~89% of rows.
+     */
+    private static ?bool $overflowColumn = null;
+
+    private function overflowColumnReady(): bool
+    {
+        if (self::$overflowColumn === null) {
+            try {
+                self::$overflowColumn = Schema::hasColumn('rippling_reach', 'overflow_bounds');
+            } catch (\Throwable) {
+                self::$overflowColumn = false;
+            }
+        }
+
+        return self::$overflowColumn;
+    }
+
+    /**
+     * The overflow rings for a schedule, as JSON for storage, or null when no lane applied.
+     * One place, so all three write paths encode identically.
+     */
+    private function overflowJson(?array $schedule): ?string
+    {
+        $bounds = $schedule['overflow_bounds'] ?? null;
+
+        return is_array($bounds) && ! empty($bounds) ? json_encode($bounds) : null;
+    }
+
     private function densityColumnsReady(): bool
     {
         if (self::$densityColumns === null) {
@@ -302,18 +336,25 @@ class ExpandService
             // UPDATE auto-bump) so the reach mailer never reconsiders this row.
             // Polygon + derived bounds in ONE statement; envelope retry on throw.
             [$boundsSet, $boundsParams] = $this->boundsSetSql($storeWkt);
+            // recomputeReach genuinely RE-DERIVES the schedule, so the overflow rings change
+            // with it and have to be rewritten here. (advanceDue does not: it only moves the
+            // tick pointer along an already-stored schedule, and the rings belong to the reach
+            // as a whole rather than to a tick, so there is nothing for it to update.)
+            $withOverflow = $this->overflowColumnReady();
+            $ovSet = $withOverflow ? ', overflow_bounds = ?' : '';
             $shrinkSql = fn (string $set): string => 'UPDATE rippling_reach
                     SET polygon = ST_GeomFromText(?, ' . self::SRID . ')' . $set . ',
-                        schedule = ?, reachable_group_ids = ?, total_freeglers = ?, max_drive_min = ?,
+                        schedule = ?, reachable_group_ids = ?, total_freeglers = ?, max_drive_min = ?' . $ovSet . ',
                         updated_at = updated_at
                   WHERE msgid = ?';
-            $shrinkTail = [
+            $shrinkTail = array_merge([
                 json_encode($ticks),
                 json_encode($this->tickReachableIds($entry, $schedule)),
                 (int) $schedule['total_freeglers'],
                 $schedule['max_drive_min'],
+            ], $withOverflow ? [$this->overflowJson($schedule)] : [], [
                 $row->msgid,
-            ];
+            ]);
             try {
                 DB::statement($shrinkSql($boundsSet), array_merge([$storeWkt], $boundsParams, $shrinkTail));
             } catch (\Throwable $e) {
@@ -941,9 +982,14 @@ class ExpandService
                 $reuseParams[] = $p['lng'];
             }
             $capCol = $this->densityColumnsReady() ? ', max_minutes_cap' : '';
+            // The overflow rings must be carried across a reuse too. Rebuilding the reused
+            // schedule from only ticks/total/max_drive - which is what happened before - leaves
+            // the column NULL on every reused row, and reuse is commonest exactly where posts
+            // cluster. That is the mechanism that left density_band NULL on ~89% of rows.
+            $ovCol = $this->overflowColumnReady() ? ', overflow_bounds' : '';
             // keep-raw: row-constructor `(lat, lng) IN ((?,?),(?,?)...)` - the builder cannot render a tuple IN
             $existing = DB::select(
-                'SELECT lat, lng, schedule, total_freeglers, max_drive_min' . $capCol . '
+                'SELECT lat, lng, schedule, total_freeglers, max_drive_min' . $capCol . $ovCol . '
                  FROM rippling_reach
                  WHERE schedule IS NOT NULL AND (lat, lng) IN (' . $placeholders . ')',
                 $reuseParams
@@ -970,10 +1016,29 @@ class ExpandService
                 if (!is_array($ticks) || empty($ticks)) {
                     continue;
                 }
+                $reusedOverflow = $ovCol !== '' && ! empty($e->overflow_bounds)
+                    ? json_decode($e->overflow_bounds, true)
+                    : null;
+
+                // A fairness ring computed under a DIFFERENT weight is not this post's ring,
+                // however co-located the two posts are - the same argument as the reach-budget
+                // guard above. Recompute rather than inherit a stretch nobody asked for.
+                if (is_array($reusedOverflow) && isset($reusedOverflow['fairness'])) {
+                    $storedBudget = isset($reusedOverflow['fairness_budget_min'])
+                        ? (float) $reusedOverflow['fairness_budget_min']
+                        : null;
+                    $wantBudget = $this->reach->fairnessBudgetMinutes($ceiling);
+                    if ($storedBudget === null || $wantBudget === null
+                        || abs($storedBudget - $wantBudget) > 0.001) {
+                        continue;
+                    }
+                }
+
                 $scheduleByKey[$k] = [
                     'ticks' => $ticks,
                     'total_freeglers' => (int) $e->total_freeglers,
                     'max_drive_min' => (float) $e->max_drive_min,
+                    'overflow_bounds' => is_array($reusedOverflow) ? $reusedOverflow : null,
                 ];
                 unset($distinctOrigins[$k]); // reused - do not recompute this origin on the routing server
                 $stats['reused'] = ($stats['reused'] ?? 0) + 1;
@@ -1070,18 +1135,22 @@ class ExpandService
                     // envelope retry if derivation throws on pathological geometry.
                     $ready = $this->bounds->ready();
                     $withDensity = $this->densityColumnsReady();
+                    $withOverflow = $this->overflowColumnReady();
+                    $overflowJson = $this->overflowJson($schedule);
                     $poly = 'ST_GeomFromText(?, ' . self::SRID . ')';
-                    $initSql = function (string $outerExpr, string $innerExpr) use ($ready, $withDensity, $poly): string {
+                    $initSql = function (string $outerExpr, string $innerExpr) use ($ready, $withDensity, $withOverflow, $poly): string {
                         $cols = $ready ? ', outer_bound, inner_bound' : '';
                         $vals = $ready ? ", $outerExpr, $innerExpr" : '';
                         $dup = $ready ? ', outer_bound = VALUES(outer_bound), inner_bound = VALUES(inner_bound)' : '';
-                        $dCols = $withDensity ? ', density_band, density_radius_miles, max_minutes_cap' : '';
-                        $dVals = $withDensity ? ', ?, ?, ?' : '';
-                        $dDup = $withDensity
+                        $dCols = ($withDensity ? ', density_band, density_radius_miles, max_minutes_cap' : '')
+                            . ($withOverflow ? ', overflow_bounds' : '');
+                        $dVals = ($withDensity ? ', ?, ?, ?' : '') . ($withOverflow ? ', ?' : '');
+                        $dDup = ($withDensity
                             ? ', density_band = VALUES(density_band),
                                 density_radius_miles = VALUES(density_radius_miles),
                                 max_minutes_cap = VALUES(max_minutes_cap)'
-                            : '';
+                            : '')
+                            . ($withOverflow ? ', overflow_bounds = VALUES(overflow_bounds)' : '');
 
                         return 'INSERT INTO rippling_reach
                            (msgid, lat, lng, polygon' . $cols . ', arrival, mode, tick, total_ticks,
@@ -1103,7 +1172,8 @@ class ExpandService
                         json_encode($schedule['ticks']),
                         json_encode($this->tickReachableIds($entry, $schedule)),
                         $next, $status,
-                    ], $withDensity ? [$cap['band'], $cap['radius_miles'], $ceiling] : []);
+                    ], $withDensity ? [$cap['band'], $cap['radius_miles'], $ceiling] : [],
+                       $withOverflow ? [$overflowJson] : []);
                     $initStore = function (string $wkt) use ($initSql, $initTail, $row, $lat, $lng, $ready, $poly): void {
                         $head = [$row->msgid, $lat, $lng, $wkt];
                         try {

--- a/iznik-batch/app/Services/Ripple/ReachService.php
+++ b/iznik-batch/app/Services/Ripple/ReachService.php
@@ -43,6 +43,30 @@ class ReachService
     /** Stage-A audience cap: nearest-freegler ceiling per post, 0 = off. */
     private int $targetUsers;
 
+    /**
+     * Rural-access overflow: ask the routing server for one ring per density-band ceiling
+     * alongside the capped reach, so a member the HEADCOUNT shut out of a post they are
+     * within their own travel budget of can still find it. Off unless configured, and the
+     * routing server omits the field entirely when it is not asked for, so the stored
+     * schedule is unchanged until this is turned on.
+     */
+    private bool $ruralAccess;
+
+    /**
+     * Demographic-fairness overflow: stretch the travel-time budget for deprived recipients
+     * on the reaches the cap never bound, which is where the measured shortfall is. Weight 0
+     * (the default) is a complete no-op end to end.
+     */
+    private float $fairnessWeight;
+
+    /**
+     * How far down the deprivation scale the stretch reaches. 1 = the most deprived fifth
+     * only, which is both what the measurement supports (the shortfall is a knee at the most
+     * deprived fifth, with the other four within about 7% of each other) and far cheaper,
+     * needing one traced ring rather than four.
+     */
+    private int $fairnessMaxQuintile;
+
     /** @var int[] hours-since-arrival thresholds, one per expansion tick */
     private array $hazardHours;
 
@@ -59,6 +83,13 @@ class ReachService
         $this->targetUsers = config('freegle.ripple.extent.enabled')
             ? max(0, (int) config('freegle.ripple.extent.target_users', 0))
             : 0;
+        // Both overflow lanes: read once here, mirroring targetUsers above, and sent only
+        // when enabled so an unconfigured deployment gets a byte-identical schedule.
+        $this->ruralAccess = (bool) config('freegle.ripple.rural_access.enabled', false);
+        $this->fairnessWeight = config('freegle.ripple.fairness.enabled', false)
+            ? max(0.0, min(1.0, (float) config('freegle.ripple.fairness.weight', 0.0)))
+            : 0.0;
+        $this->fairnessMaxQuintile = max(1, min(4, (int) config('freegle.ripple.fairness.max_quintile', 1)));
         $this->hazardHours = config('freegle.ripple.hazard_hours', [1, 3, 6, 12, 24, 48, 72, 120, 168]);
     }
 
@@ -270,6 +301,19 @@ class ReachService
         if ($this->targetUsers > 0) {
             $params['target_users'] = $this->targetUsers;
         }
+
+        // The two lanes are mutually exclusive PER POST, but which one applies depends on
+        // whether the cap actually bound for that post, which only the routing server knows
+        // once it has counted. So both are offered here and it picks; asking for both costs
+        // nothing when neither applies.
+        if ($this->ruralAccess) {
+            $params['rural_access'] = 1;
+        }
+        if ($this->fairnessWeight > 0) {
+            $params['fairness_weight'] = $this->fairnessWeight;
+            $params['fairness_max_quintile'] = $this->fairnessMaxQuintile;
+        }
+
         return $params;
     }
 

--- a/iznik-batch/app/Services/Ripple/ReachService.php
+++ b/iznik-batch/app/Services/Ripple/ReachService.php
@@ -365,7 +365,57 @@ class ReachService
             // water/toll-correct ripple-targeting signal. Empty when the server
             // omits it (older build); the gate treats [] as "not available".
             'reachable_group_ids' => array_map('intval', $body['reachable_group_ids'] ?? []),
+            // The overflow lanes' rings, when a lane was asked for and applied. Absent on
+            // older servers and whenever both lanes are off, so null means "no lane", never
+            // "a lane with nothing in it".
+            'overflow_bounds' => $this->parseOverflow($body),
         ];
+    }
+
+    /**
+     * Turn the routing server's overflow rings into the JSON stored on rippling_reach.
+     *
+     * The server decides WHICH lane a post gets, from whether the audience cap actually bound
+     * for it, so at most one of these is ever present. Geometry is converted to WKT here for
+     * the same reason the tick polygons are: it is what MySQL's ST_GeomFromText wants and what
+     * the fallback containment test reads back.
+     *
+     * Returns null rather than an empty array when there is nothing, so a row's NULL is
+     * unambiguous: no lane applied, as against a lane that produced no drawable ring.
+     */
+    private function parseOverflow(array $body): ?array
+    {
+        $out = [];
+
+        foreach (['overflow_rural' => 'rural', 'overflow_fairness' => 'fairness'] as $key => $name) {
+            $rings = $body[$key] ?? null;
+            if (! is_array($rings) || empty($rings)) {
+                continue;
+            }
+            $converted = [];
+            foreach ($rings as $band => $geom) {
+                $wkt = $this->polygonToWkt($geom);
+                if ($wkt !== null) {
+                    $converted[(string) $band] = $wkt;
+                }
+            }
+            if (! empty($converted)) {
+                $out[$name] = $converted;
+            }
+        }
+
+        if (empty($out)) {
+            return null;
+        }
+
+        // Record the weight actually applied, not the weight configured at read time: a row
+        // written under one weight must not be read as though it had another, and the reuse
+        // guard compares this to decide whether a stored schedule is still valid.
+        if (isset($out['fairness']) && isset($body['fairness_budget_min'])) {
+            $out['fairness_budget_min'] = (float) $body['fairness_budget_min'];
+        }
+
+        return $out;
     }
 
     /**

--- a/iznik-batch/app/Services/Ripple/ReachService.php
+++ b/iznik-batch/app/Services/Ripple/ReachService.php
@@ -419,6 +419,24 @@ class ReachService
     }
 
     /**
+     * The widest stretched budget the fairness lane would route to for a given ceiling, or
+     * null when the lane is off. Used by the reuse guard: a stored ring computed under a
+     * different weight is not this post's ring, so it must be recomputed rather than
+     * inherited - the same argument as the reach-budget guard beside it.
+     *
+     * Mirrors the routing server's own arithmetic (fairnessoverflow.go): the widest budget is
+     * the most deprived fifth's, ceiling x (1 + W).
+     */
+    public function fairnessBudgetMinutes(float $ceilingMinutes): ?float
+    {
+        if ($this->fairnessWeight <= 0) {
+            return null;
+        }
+
+        return $ceilingMinutes * (1.0 + $this->fairnessWeight);
+    }
+
+    /**
      * The tick index (1-based) a post should be at after $elapsedHours since
      * arrival, per the hazard schedule. Clamped to [1, totalTicks].
      */

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -623,6 +623,85 @@ class UnifiedDigestService
      * haven't joined is not appropriate; non-members within reach discover the post via browse and
      * the daily digest. Do not "fix" the JOIN to include non-members.
      */
+    /** Memoized presence of rippling_reach.overflow_bounds. Null until first checked. */
+    private static ?bool $overflowColumn = null;
+
+    /** Test-only: forget the memoized overflow-column check. */
+    public static function forgetOverflowColumn(): void
+    {
+        self::$overflowColumn = null;
+    }
+
+    /**
+     * The rural-access overflow rings for a post, as an extra containment branch on the
+     * recipient query: one ring per density band, admitting a member whose OWN band earns
+     * the wider travel budget even though the capped reach stopped short of them.
+     *
+     * Returns ['', []] whenever the lane cannot apply, and that is a stronger statement than
+     * "false": with no rings the clause is ABSENT, so the query compiles to exactly what it
+     * was before this existed and costs exactly what it cost. A disabled lane cannot slow the
+     * mail path down.
+     *
+     * The rings are read here and bound as parameters rather than extracted inside the query.
+     * rippling_reach is one row per post, so an ST_GeomFromText over a JSON_EXTRACT in the
+     * WHERE clause would re-parse the SAME polygon for every candidate member - tens of
+     * thousands of identical parses on a large group, in the mail path.
+     *
+     * Binding the band name as a parameter rather than building a '$.rural.<band>' path also
+     * keeps a member's stored settings value data rather than syntax.
+     *
+     * Only the bands actually present are considered. The routing server deliberately omits
+     * any band at or inside the committed reach, because every member it would admit is
+     * already admitted by the reach proper - so an absent band means "already covered", not
+     * "missing".
+     *
+     * @return array{0: string, 1: array<int, mixed>}
+     */
+    private function ruralOverflowBranch(int $msgid, string $point): array
+    {
+        if (! config('freegle.ripple.rural_access.enabled', false)) {
+            return ['', []];
+        }
+
+        try {
+            // Memoized: this runs once per post in the reach-mail pass, and the schema does
+            // not change under it mid-run.
+            self::$overflowColumn ??= Schema::hasColumn('rippling_reach', 'overflow_bounds');
+            if (! self::$overflowColumn) {
+                return ['', []];
+            }
+
+            $raw = DB::table('rippling_reach')->where('msgid', $msgid)->value('overflow_bounds');
+            $rings = is_string($raw) ? (json_decode($raw, true)['rural'] ?? null) : null;
+            if (! is_array($rings) || empty($rings)) {
+                return ['', []];
+            }
+
+            $srid = (int) config('freegle.srid', 3857);
+            $sql = '';
+            $params = [];
+            foreach ($rings as $band => $wkt) {
+                if (! is_string($wkt) || $wkt === '') {
+                    continue;
+                }
+                // The band equality is exclusive, so nested rings cannot admit one member twice.
+                $sql .= " OR (JSON_UNQUOTE(JSON_EXTRACT(u.settings, '$.browseDensityBand')) = ?"
+                    . " AND ST_Contains(ST_GeomFromText(?, ?), $point))";
+                $params[] = (string) $band;
+                $params[] = $wkt;
+                $params[] = $srid;
+                $params[] = $srid; // the point's own SRID, repeated per branch
+            }
+
+            return $sql === '' ? ['', []] : [$sql, $params];
+        } catch (\Throwable $e) {
+            // A post that cannot be checked for overflow still gets its normal reach mail.
+            Log::warning('ripple: rural overflow branch unavailable', ['msgid' => $msgid, 'error' => $e->getMessage()]);
+
+            return ['', []];
+        }
+    }
+
     public function mailNewlyReachedForPost(int $msgid, bool $dryRun = false): int
     {
         if (!self::isEmailTypeEnabled(self::EMAIL_TYPE)) {
@@ -641,16 +720,27 @@ class UnifiedDigestService
             // as resolveUserLatLng, so the distance-preference filter below measures from
             // exactly the point that decided reach-polygon membership, not a second,
             // possibly-divergent resolution.
-            $recipientRows = collect(DB::select(
-                "SELECT DISTINCT u.id AS id,
-                       CASE WHEN JSON_EXTRACT(u.settings, '$.mylocation.lat') IS NOT NULL
+            // One definition of the member's point, used by the projection, by the reach
+            // containment and by any overflow ring - so a member cannot be admitted on one
+            // resolution and then measured from another.
+            $latExpr = "CASE WHEN JSON_EXTRACT(u.settings, '$.mylocation.lat') IS NOT NULL
                                  AND JSON_EXTRACT(u.settings, '$.mylocation.lng') IS NOT NULL
                             THEN CAST(JSON_EXTRACT(u.settings, '$.mylocation.lat') AS DECIMAL(10,6))
-                            ELSE l.lat END AS resolved_lat,
-                       CASE WHEN JSON_EXTRACT(u.settings, '$.mylocation.lat') IS NOT NULL
+                            ELSE l.lat END";
+            $lngExpr = "CASE WHEN JSON_EXTRACT(u.settings, '$.mylocation.lat') IS NOT NULL
                                  AND JSON_EXTRACT(u.settings, '$.mylocation.lng') IS NOT NULL
                             THEN CAST(JSON_EXTRACT(u.settings, '$.mylocation.lng') AS DECIMAL(10,6))
-                            ELSE l.lng END AS resolved_lng
+                            ELSE l.lng END";
+            $point = "ST_SRID(POINT($lngExpr, $latExpr), ?)";
+
+            [$overflowSql, $overflowParams] = $this->ruralOverflowBranch($msgid, $point);
+
+            // keep-raw: spatial predicates (ST_Contains, ST_SRID, ST_GeomFromText) and the
+            // JSON_EXTRACT point resolution have no query-builder equivalent.
+            $recipientRows = collect(DB::select(
+                "SELECT DISTINCT u.id AS id,
+                       $latExpr AS resolved_lat,
+                       $lngExpr AS resolved_lng
                  FROM messages_groups mg
                  JOIN rippling_reach mr ON mr.msgid = mg.msgid
                  JOIN memberships m ON m.groupid = mg.groupid
@@ -663,20 +753,14 @@ class UnifiedDigestService
                          WHERE mo.msgid = mg.msgid AND mo.outcome IN ('Taken', 'Received')
                        )
                    AND u.deleted IS NULL AND (u.lastaccess IS NULL OR u.lastaccess > ?)
-                   AND ST_Contains(mr.polygon, ST_SRID(POINT(
-                         CASE WHEN JSON_EXTRACT(u.settings, '$.mylocation.lat') IS NOT NULL
-                                   AND JSON_EXTRACT(u.settings, '$.mylocation.lng') IS NOT NULL
-                              THEN CAST(JSON_EXTRACT(u.settings, '$.mylocation.lng') AS DECIMAL(10,6))
-                              ELSE l.lng END,
-                         CASE WHEN JSON_EXTRACT(u.settings, '$.mylocation.lat') IS NOT NULL
-                                   AND JSON_EXTRACT(u.settings, '$.mylocation.lng') IS NOT NULL
-                              THEN CAST(JSON_EXTRACT(u.settings, '$.mylocation.lat') AS DECIMAL(10,6))
-                              ELSE l.lat END
-                       ), ?))
+                   AND (ST_Contains(mr.polygon, $point)$overflowSql)
                    AND NOT EXISTS (
                          SELECT 1 FROM rippling_reach_notified n WHERE n.msgid = mg.msgid AND n.userid = u.id
                        )",
-                [Membership::EMAIL_FREQUENCY_IMMEDIATE, $msgid, now()->subDays(90), $srid]
+                array_merge(
+                    [Membership::EMAIL_FREQUENCY_IMMEDIATE, $msgid, now()->subDays(90), $srid],
+                    $overflowParams
+                )
             ));
 
             $recipientIds = $recipientRows->pluck('id')->map(fn ($v) => (int) $v)->all();

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -13,6 +13,7 @@ use App\Services\Ripple\DigestPostScorer;
 use App\Services\Ripple\DistancePreferenceFilter;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
@@ -657,10 +658,14 @@ class UnifiedDigestService
      *
      * @return array{0: string, 1: array<int, mixed>}
      */
-    private function ruralOverflowBranch(int $msgid, string $point): array
+    private function overflowBranch(int $msgid, string $point): array
     {
-        if (! config('freegle.ripple.rural_access.enabled', false)) {
-            return ['', []];
+        $none = ['', [], null];
+
+        $ruralOn = (bool) config('freegle.ripple.rural_access.enabled', false);
+        $fairnessOn = (bool) config('freegle.ripple.fairness.enabled', false);
+        if (! $ruralOn && ! $fairnessOn) {
+            return $none;
         }
 
         try {
@@ -668,38 +673,132 @@ class UnifiedDigestService
             // not change under it mid-run.
             self::$overflowColumn ??= Schema::hasColumn('rippling_reach', 'overflow_bounds');
             if (! self::$overflowColumn) {
-                return ['', []];
+                return $none;
             }
 
             $raw = DB::table('rippling_reach')->where('msgid', $msgid)->value('overflow_bounds');
-            $rings = is_string($raw) ? (json_decode($raw, true)['rural'] ?? null) : null;
-            if (! is_array($rings) || empty($rings)) {
-                return ['', []];
+            $bounds = is_string($raw) ? json_decode($raw, true) : null;
+            if (! is_array($bounds)) {
+                return $none;
             }
 
             $srid = (int) config('freegle.srid', 3857);
-            $sql = '';
-            $params = [];
-            foreach ($rings as $band => $wkt) {
-                if (! is_string($wkt) || $wkt === '') {
-                    continue;
+
+            // A post carries rings from ONE lane: the routing server picks by whether the
+            // audience cap actually bound, and never sends both. So this reads whichever it
+            // sent rather than trying to combine them.
+            if ($ruralOn && is_array($bounds['rural'] ?? null) && ! empty($bounds['rural'])) {
+                $sql = '';
+                $params = [];
+                foreach ($bounds['rural'] as $band => $wkt) {
+                    if (! is_string($wkt) || $wkt === '') {
+                        continue;
+                    }
+                    // The band equality is exclusive, so nested rings cannot admit one member twice.
+                    $sql .= " OR (JSON_UNQUOTE(JSON_EXTRACT(u.settings, '$.browseDensityBand')) = ?"
+                        . " AND ST_Contains(ST_GeomFromText(?, ?), $point))";
+                    $params[] = (string) $band;
+                    $params[] = $wkt;
+                    $params[] = $srid;
+                    $params[] = $srid; // the point's own SRID, repeated per branch
                 }
-                // The band equality is exclusive, so nested rings cannot admit one member twice.
-                $sql .= " OR (JSON_UNQUOTE(JSON_EXTRACT(u.settings, '$.browseDensityBand')) = ?"
-                    . " AND ST_Contains(ST_GeomFromText(?, ?), $point))";
-                $params[] = (string) $band;
-                $params[] = $wkt;
-                $params[] = $srid;
-                $params[] = $srid; // the point's own SRID, repeated per branch
+
+                return $sql === '' ? $none : [$sql, $params, 'rural'];
             }
 
-            return $sql === '' ? ['', []] : [$sql, $params];
+            if ($fairnessOn && is_array($bounds['fairness'] ?? null) && ! empty($bounds['fairness'])) {
+                // No per-member test here, deliberately: the ring says who is close enough
+                // under the stretched budget, and WHICH of those the stretch was for is
+                // decided afterwards, by the deprivation fifth. That is not in this database
+                // - the spatial server holds the index - so it is answered in one call for
+                // the people the ring adds rather than stored against anybody.
+                $sql = '';
+                $params = [];
+                foreach ($bounds['fairness'] as $q => $wkt) {
+                    if (! is_string($wkt) || $wkt === '' || ! is_numeric($q)) {
+                        continue;
+                    }
+                    $sql .= " OR ST_Contains(ST_GeomFromText(?, ?), $point)";
+                    $params[] = $wkt;
+                    $params[] = $srid;
+                    $params[] = $srid;
+                }
+
+                return $sql === '' ? $none : [$sql, $params, 'fairness'];
+            }
+
+            return $none;
         } catch (\Throwable $e) {
             // A post that cannot be checked for overflow still gets its normal reach mail.
-            Log::warning('ripple: rural overflow branch unavailable', ['msgid' => $msgid, 'error' => $e->getMessage()]);
+            Log::warning('ripple: overflow branch unavailable', ['msgid' => $msgid, 'error' => $e->getMessage()]);
 
-            return ['', []];
+            return $none;
         }
+    }
+
+    /**
+     * Drop the people a fairness ring admitted who are not who it was for.
+     *
+     * The ring is a stretched isochrone, so on its own it just widens the reach for everyone
+     * inside it - which is a bigger radius, not fairness. The stretch is earned by the
+     * deprivation fifth, so that has to be tested before anyone extra is mailed.
+     *
+     * Asked of the spatial server, in ONE call, for only the people the ring added: it already
+     * holds the IMD index for the isochrone itself, so nothing else has to load or retain IMD
+     * data and no inferred deprivation attribute is written against an individual anywhere.
+     *
+     * Fails CLOSED. If the lookup is unavailable the extra people are dropped and the post
+     * mails its normal reach, because the alternative - mailing everyone the stretched ring
+     * covers - is the widened-radius behaviour this filter exists to prevent.
+     *
+     * @param  array<int, object>  $rows  recipient rows carrying in_primary and resolved coords
+     * @return array<int, object>
+     */
+    private function filterFairnessRows(array $rows, int $msgid): array
+    {
+        $extra = array_values(array_filter($rows, fn ($r) => (int) ($r->in_primary ?? 1) === 0));
+        if (empty($extra)) {
+            return $rows;
+        }
+
+        $maxQuintile = max(1, min(4, (int) config('freegle.ripple.fairness.max_quintile', 1)));
+        $points = array_map(
+            fn ($r) => [(float) $r->resolved_lat, (float) $r->resolved_lng],
+            $extra
+        );
+
+        try {
+            $base = rtrim((string) config('freegle.routing_server_url'), '/');
+            $response = Http::timeout(10)->post($base . '/v1/quintiles', ['points' => $points]);
+            $quintiles = $response->successful() ? ($response->json('quintiles') ?? null) : null;
+
+            // A short or missing array cannot be matched back to people by position, and a
+            // mismatched one would attribute one member's deprivation to another.
+            if (! is_array($quintiles) || count($quintiles) !== count($extra)) {
+                throw new \RuntimeException('quintile lookup returned '
+                    . (is_array($quintiles) ? count($quintiles) : 'nothing')
+                    . ' answers for ' . count($extra) . ' points');
+            }
+        } catch (\Throwable $e) {
+            Log::warning('ripple: fairness quintile lookup failed, dropping overflow recipients', [
+                'msgid' => $msgid, 'extra' => count($extra), 'error' => $e->getMessage(),
+            ]);
+            $quintiles = null;
+        }
+
+        $keep = [];
+        foreach ($extra as $i => $row) {
+            // 0 means "no data", which is not a claim that they are deprived.
+            $q = $quintiles === null ? 0 : (int) ($quintiles[$i] ?? 0);
+            if ($q >= 1 && $q <= $maxQuintile) {
+                $keep[(int) $row->id] = true;
+            }
+        }
+
+        return array_values(array_filter(
+            $rows,
+            fn ($r) => (int) ($r->in_primary ?? 1) === 1 || isset($keep[(int) $r->id])
+        ));
     }
 
     public function mailNewlyReachedForPost(int $msgid, bool $dryRun = false): int
@@ -733,14 +832,26 @@ class UnifiedDigestService
                             ELSE l.lng END";
             $point = "ST_SRID(POINT($lngExpr, $latExpr), ?)";
 
-            [$overflowSql, $overflowParams] = $this->ruralOverflowBranch($msgid, $point);
+            [$overflowSql, $overflowParams, $overflowLane] = $this->overflowBranch($msgid, $point);
+
+            // Which arm admitted each member. Only needed to tell "already in the reach" from
+            // "added by a ring", and only the fairness lane acts on it - so it is projected
+            // just for that lane rather than paying for a second containment test on every
+            // post. NOTE: this sits before the WHERE in the SQL text, so its SRID parameter
+            // comes FIRST in the array below.
+            $primaryFlag = '';
+            $primaryParams = [];
+            if ($overflowLane === 'fairness') {
+                $primaryFlag = ", ST_Contains(mr.polygon, $point) AS in_primary";
+                $primaryParams[] = $srid;
+            }
 
             // keep-raw: spatial predicates (ST_Contains, ST_SRID, ST_GeomFromText) and the
             // JSON_EXTRACT point resolution have no query-builder equivalent.
             $recipientRows = collect(DB::select(
                 "SELECT DISTINCT u.id AS id,
                        $latExpr AS resolved_lat,
-                       $lngExpr AS resolved_lng
+                       $lngExpr AS resolved_lng$primaryFlag
                  FROM messages_groups mg
                  JOIN rippling_reach mr ON mr.msgid = mg.msgid
                  JOIN memberships m ON m.groupid = mg.groupid
@@ -758,10 +869,15 @@ class UnifiedDigestService
                          SELECT 1 FROM rippling_reach_notified n WHERE n.msgid = mg.msgid AND n.userid = u.id
                        )",
                 array_merge(
+                    $primaryParams,
                     [Membership::EMAIL_FREQUENCY_IMMEDIATE, $msgid, now()->subDays(90), $srid],
                     $overflowParams
                 )
             ));
+
+            if ($overflowLane === 'fairness') {
+                $recipientRows = collect($this->filterFairnessRows($recipientRows->all(), $msgid));
+            }
 
             $recipientIds = $recipientRows->pluck('id')->map(fn ($v) => (int) $v)->all();
 

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -637,6 +637,31 @@ return [
             'enabled' => (bool) env('RIPPLE_EXTENT_ENABLED', false),
             'target_users' => (int) env('RIPPLE_EXTENT_TARGET_USERS', 4000),
         ],
+        // Rural-access overflow. The extent cap above sizes a post's audience by the NEAREST
+        // N members, which in a dense area binds long before the travel-time ceiling: measured
+        // on live, a post outside Birmingham stopped at 28.0 minutes on exactly 4,000 members
+        // while a sparse-band moderator 31.4 minutes away, whose own slider was already at the
+        // 45-minute maximum, was shut out. This asks the routing server for one ring per band
+        // ceiling alongside the capped reach, so that member can find the post. It adds nobody
+        // to the mail or to a group's copy of the post.
+        'rural_access' => [
+            'enabled' => filter_var(env('RIPPLE_RURAL_ACCESS_ENABLED', false), FILTER_VALIDATE_BOOLEAN),
+        ],
+        // Demographic-fairness overflow. Measured on live: members in the most deprived fifth
+        // are reached by ~457 posts per 30 days against ~574 for every other fifth, while
+        // membership is flat across fifths. That shortfall is NOT caused by the extent cap
+        // (capped reaches are at parity); it sits in the reaches that run to the ceiling, which
+        // are mostly rural-origin, because rural areas are rarely classed as most-deprived.
+        // So this stretches the budget for deprived RECIPIENTS on exactly those reaches.
+        //
+        // max_quintile defaults to 1 because the shortfall is a knee at the most deprived
+        // fifth rather than a gradient, and because one fifth needs one traced ring rather
+        // than four. Raising it buys the full linear gradient at proportionate cost.
+        'fairness' => [
+            'enabled' => filter_var(env('RIPPLE_FAIRNESS_ENABLED', false), FILTER_VALIDATE_BOOLEAN),
+            'weight' => (float) env('RIPPLE_FAIRNESS_WEIGHT', 0.0),
+            'max_quintile' => (int) env('RIPPLE_FAIRNESS_MAX_QUINTILE', 1),
+        ],
         // Unified-digest score-ordering (see App\Services\Ripple\DigestPostScorer).
         // Mirrors the /rippling "Digest preview" weights. Tunable via env without a deploy.
         'score' => [

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -642,8 +642,11 @@ return [
         // on live, a post outside Birmingham stopped at 28.0 minutes on exactly 4,000 members
         // while a sparse-band moderator 31.4 minutes away, whose own slider was already at the
         // 45-minute maximum, was shut out. This asks the routing server for one ring per band
-        // ceiling alongside the capped reach, so that member can find the post. It adds nobody
-        // to the mail or to a group's copy of the post.
+        // ceiling alongside the capped reach, so that member can find the post - on browse and
+        // in the newly-reached mail, since a member who cannot be told about the post is barely
+        // less shut out than one who cannot see it. It does NOT add the post to a group's copy:
+        // the mail path stays members-only, so this reaches people who have already joined a
+        // group the post is on, never a cold recipient.
         'rural_access' => [
             'enabled' => filter_var(env('RIPPLE_RURAL_ACCESS_ENABLED', false), FILTER_VALIDATE_BOOLEAN),
         ],

--- a/iznik-batch/database/migrations/2026_08_16_000001_add_overflow_bounds_to_rippling_reach.php
+++ b/iznik-batch/database/migrations/2026_08_16_000001_add_overflow_bounds_to_rippling_reach.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * rippling_reach.overflow_bounds - the overflow lanes' rings for this post.
+ *
+ * Two lanes, mutually exclusive per post, decided by whether the audience cap actually bound
+ * (see iznik-routing-go ripple.go, and section 7c of the rippling algorithm reference):
+ *
+ *   {"rural": {"dense": "<wkt>", "medium": "<wkt>", "sparse": "<wkt>"}}   cap-bound posts
+ *   {"fairness": {"1": "<wkt>", ...}, "weight": 0.5}                     ceiling-bound posts
+ *
+ * A member outside the committed reach is admitted if they fall inside the ring for their own
+ * density band (rural) or their own deprivation fifth (fairness). Neither lane changes which
+ * groups the post is copied to.
+ *
+ * JSON rather than seven geometry columns because these are consulted only in the fallback
+ * branch, never on the hot indexed path that polygon/outer_bound/inner_bound serve, so they
+ * need no spatial index. Matches the existing convention on this table for
+ * reachable_group_ids and rejected_groups, which are plain JSON for the same reason.
+ *
+ * Nullable, and NULL is the normal state: both lanes ship dark, so nothing writes this until
+ * RIPPLE_RURAL_ACCESS_ENABLED or RIPPLE_FAIRNESS_ENABLED is turned on.
+ *
+ * NOTE FOR ANYONE ADDING A COLUMN HERE LATER: rippling_reach has THREE write paths in
+ * ExpandService - the init INSERT, the advanceDue UPDATE and the recomputeReach shrink UPDATE.
+ * density_band was added to only the first, which is why it is NULL on ~89% of rows and its
+ * analytics are drawn from a biased minority. Write all three or the column is worthless.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('rippling_reach', 'overflow_bounds')) {
+            return;
+        }
+
+        Schema::table('rippling_reach', function (Blueprint $table) {
+            $table->json('overflow_bounds')->nullable()
+                ->comment('Overflow lane rings (rural per band, or fairness per deprivation fifth). NULL unless a lane is enabled.');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('rippling_reach', 'overflow_bounds')) {
+            return;
+        }
+
+        Schema::table('rippling_reach', function (Blueprint $table) {
+            $table->dropColumn('overflow_bounds');
+        });
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_16_000001_add_overflow_bounds_to_rippling_reach_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_16_000001_add_overflow_bounds_to_rippling_reach_migration.sql
@@ -1,0 +1,33 @@
+-- Production idempotent SQL: rippling_reach.overflow_bounds.
+--
+-- The overflow lanes' rings for a post. Two lanes, mutually exclusive per post, decided by
+-- whether the audience cap actually bound (iznik-routing-go ripple.go; section 7c of the
+-- rippling algorithm reference):
+--
+--   {"rural": {"dense": "<wkt>", "medium": "<wkt>", "sparse": "<wkt>"}}   cap-bound posts
+--   {"fairness": {"1": "<wkt>", ...}, "weight": 0.5}                     ceiling-bound posts
+--
+-- A member outside the committed reach is admitted if they fall inside the ring for their own
+-- density band (rural) or their own deprivation fifth (fairness). Neither lane changes which
+-- groups the post is copied to.
+--
+-- JSON rather than seven geometry columns: consulted only in the fallback branch, never on the
+-- hot indexed path that polygon/outer_bound/inner_bound serve, so no spatial index is wanted.
+-- Same convention as reachable_group_ids and rejected_groups on this table.
+--
+-- Nullable, and NULL is the normal state: both lanes ship dark, so nothing writes this until
+-- RIPPLE_RURAL_ACCESS_ENABLED or RIPPLE_FAIRNESS_ENABLED is turned on. Safe to run well ahead
+-- of the code, and safe to re-run.
+--
+-- Column add is INSTANT on Percona 8.0. No index: the fallback branch reads it by msgid, which
+-- the primary key already serves.
+SET @has_col := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'rippling_reach'
+      AND column_name = 'overflow_bounds');
+SET @ddl := IF(@has_col = 0,
+    'ALTER TABLE rippling_reach
+        ADD COLUMN overflow_bounds JSON NULL COMMENT ''Overflow lane rings (rural per band, or fairness per deprivation fifth). NULL unless a lane is enabled.''',
+    'DO 0');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/iznik-batch/tests/Unit/Services/Ripple/ReachServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ReachServiceTest.php
@@ -334,4 +334,91 @@ class ReachServiceTest extends TestCase
         $this->assertNull($geom['outer']);
         $this->assertNull($geom['inner']);
     }
+
+    public function test_schedule_omits_both_overflow_lanes_by_default(): void
+    {
+        // Dark by default: neither lane touches the request, so an unconfigured deployment
+        // gets a byte-identical schedule and the stored reach is unchanged.
+        config(['freegle.ripple.rural_access.enabled' => false]);
+        config(['freegle.ripple.fairness.enabled' => false]);
+        Http::fake(['*ripple-schedule*' => Http::response(['schedule' => []], 200)]);
+
+        $this->service()->computeSchedule(51.5, -0.1);
+
+        Http::assertSent(fn ($request) => !str_contains($request->url(), 'rural_access')
+            && !str_contains($request->url(), 'fairness_weight'));
+    }
+
+    public function test_schedule_asks_for_rural_rings_when_enabled(): void
+    {
+        config(['freegle.ripple.rural_access.enabled' => true]);
+        config(['freegle.ripple.fairness.enabled' => false]);
+        Http::fake(['*ripple-schedule*' => Http::response(['schedule' => []], 200)]);
+
+        $this->service()->computeSchedule(51.5, -0.1);
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'rural_access=1')
+            && !str_contains($request->url(), 'fairness_weight'));
+    }
+
+    public function test_schedule_sends_fairness_weight_and_quintile_when_enabled(): void
+    {
+        config(['freegle.ripple.fairness.enabled' => true]);
+        config(['freegle.ripple.fairness.weight' => 0.5]);
+        config(['freegle.ripple.fairness.max_quintile' => 1]);
+        Http::fake(['*ripple-schedule*' => Http::response(['schedule' => []], 200)]);
+
+        $this->service()->computeSchedule(51.5, -0.1);
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'fairness_weight=0.5')
+            && str_contains($request->url(), 'fairness_max_quintile=1'));
+    }
+
+    /**
+     * Weight zero is the deliberate first rollout step: the flag on, the plumbing exercised
+     * end to end, and no behaviour change. It must therefore send nothing, or the routing
+     * server would run the extra road-network search for a stretch of exactly zero.
+     */
+    public function test_schedule_sends_no_fairness_at_zero_weight(): void
+    {
+        config(['freegle.ripple.fairness.enabled' => true]);
+        config(['freegle.ripple.fairness.weight' => 0.0]);
+        Http::fake(['*ripple-schedule*' => Http::response(['schedule' => []], 200)]);
+
+        $this->service()->computeSchedule(51.5, -0.1);
+
+        Http::assertSent(fn ($request) => !str_contains($request->url(), 'fairness_weight'));
+    }
+
+    /**
+     * A misconfigured weight must be clamped here rather than trusted. The routing server
+     * clamps too, but a value of 5 silently becoming 1 at the far end is harder to explain
+     * than one that never leaves.
+     */
+    public function test_schedule_clamps_a_fairness_weight_above_one(): void
+    {
+        config(['freegle.ripple.fairness.enabled' => true]);
+        config(['freegle.ripple.fairness.weight' => 5.0]);
+        Http::fake(['*ripple-schedule*' => Http::response(['schedule' => []], 200)]);
+
+        $this->service()->computeSchedule(51.5, -0.1);
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'fairness_weight=1'));
+    }
+
+    /**
+     * The most deprived fifth only, by default. The measured shortfall is a knee there rather
+     * than a gradient across all five, and one fifth needs one traced ring rather than four.
+     */
+    public function test_fairness_defaults_to_the_most_deprived_fifth_only(): void
+    {
+        config(['freegle.ripple.fairness.enabled' => true]);
+        config(['freegle.ripple.fairness.weight' => 0.5]);
+        config(['freegle.ripple.fairness.max_quintile' => null]);
+        Http::fake(['*ripple-schedule*' => Http::response(['schedule' => []], 200)]);
+
+        $this->service()->computeSchedule(51.5, -0.1);
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'fairness_max_quintile=1'));
+    }
 }

--- a/iznik-batch/tests/Unit/Services/Ripple/ReachServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ReachServiceTest.php
@@ -421,4 +421,56 @@ class ReachServiceTest extends TestCase
 
         Http::assertSent(fn ($request) => str_contains($request->url(), 'fairness_max_quintile=1'));
     }
+
+    public function test_parseScheduleResponse_carries_the_rural_rings(): void
+    {
+        $parsed = $this->service()->parseScheduleResponse([
+            'schedule' => [['tick' => 1, 'drive_min' => 5, 'cumulative_users' => 10]],
+            'overflow_rural' => [
+                'dense' => ['type' => 'Feature', 'geometry' => ['type' => 'Polygon', 'coordinates' => [[[0, 0], [1, 0], [1, 1], [0, 0]]]]],
+                'sparse' => ['type' => 'Feature', 'geometry' => ['type' => 'Polygon', 'coordinates' => [[[0, 0], [3, 0], [3, 3], [0, 0]]]]],
+            ],
+        ]);
+
+        $this->assertNotNull($parsed['overflow_bounds']);
+        $this->assertArrayHasKey('rural', $parsed['overflow_bounds']);
+        $this->assertStringStartsWith('POLYGON((', $parsed['overflow_bounds']['rural']['dense']);
+        $this->assertStringStartsWith('POLYGON((', $parsed['overflow_bounds']['rural']['sparse']);
+        $this->assertArrayNotHasKey('fairness', $parsed['overflow_bounds']);
+    }
+
+    public function test_parseScheduleResponse_carries_the_fairness_rings_and_the_budget_applied(): void
+    {
+        $parsed = $this->service()->parseScheduleResponse([
+            'schedule' => [['tick' => 1, 'drive_min' => 5, 'cumulative_users' => 10]],
+            'overflow_fairness' => [
+                '1' => ['type' => 'Feature', 'geometry' => ['type' => 'Polygon', 'coordinates' => [[[0, 0], [4, 0], [4, 4], [0, 0]]]]],
+            ],
+            'fairness_budget_min' => 67.5,
+        ]);
+
+        $this->assertArrayHasKey('fairness', $parsed['overflow_bounds']);
+        $this->assertStringStartsWith('POLYGON((', $parsed['overflow_bounds']['fairness']['1']);
+        // The budget actually routed, not whatever is configured when the row is later read.
+        $this->assertSame(67.5, $parsed['overflow_bounds']['fairness_budget_min']);
+    }
+
+    /**
+     * NULL must mean "no lane applied", never "a lane that produced nothing". A row read back
+     * as an empty array would look like an admissible-to-nobody lane rather than no lane.
+     */
+    public function test_parseScheduleResponse_gives_null_overflow_when_no_lane_applied(): void
+    {
+        $parsed = $this->service()->parseScheduleResponse([
+            'schedule' => [['tick' => 1, 'drive_min' => 5, 'cumulative_users' => 10]],
+        ]);
+        $this->assertNull($parsed['overflow_bounds']);
+
+        // An empty lane object from the server is the same thing as no lane.
+        $parsed = $this->service()->parseScheduleResponse([
+            'schedule' => [['tick' => 1, 'drive_min' => 5, 'cumulative_users' => 10]],
+            'overflow_rural' => [],
+        ]);
+        $this->assertNull($parsed['overflow_bounds']);
+    }
 }

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -3214,4 +3214,121 @@ class UnifiedDigestServiceTest extends TestCase
         );
         $this->assertSame(['ai' => true], json_decode($attachment->externalmods, true));
     }
+
+    /**
+     * The rural-access overflow lane, on the mail path.
+     *
+     * A member whose own density band earns the wider travel budget can sit outside a reach
+     * that the audience cap stopped short - the case this lane exists for: measured on live, a
+     * post outside Birmingham stopped at 28.0 minutes on exactly 4,000 members while a
+     * sparse-band moderator 31.4 minutes away, already at the 45-minute maximum, was shut out.
+     *
+     * Sets up one member outside the reach polygon but inside the sparse ring, and asserts the
+     * SAME setup both ways round the flag - so neither expectation can be satisfied by the
+     * member simply never being mailable.
+     *
+     * @return array{0: \App\Models\User, 1: \App\Models\Message}
+     */
+    private function seedOverflowCase(?string $band, string $ringWkt = 'POLYGON((-0.2 51.4,0.6 51.4,0.6 51.6,-0.2 51.6,-0.2 51.4))'): array
+    {
+        config(['freegle.digest.immediate_allowlist' => '*']);
+        UnifiedDigestService::forgetOverflowColumn();
+
+        $group = $this->createTestGroup();
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $member = $this->createTestUser();
+        $this->createMembership($member, $group);
+        $settings = [
+            'mylocation' => ['lat' => 51.5, 'lng' => 0.4],
+            // The sentinel: their own preference must not be what excludes them, or the test
+            // would pass for the wrong reason.
+            'browseReachMaxDistance' => 9007199254740991,
+            'browseMaxMinutes' => 45,
+        ];
+        if ($band !== null) {
+            $settings['browseDensityBand'] = $band;
+        }
+        $member->settings = $settings;
+        $member->save();
+
+        $msg = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: rural overflow (TestLocation)']);
+        DB::table('messages_groups')->where('msgid', $msg->id)
+            ->update(['collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()]);
+        DB::table('messages_attachments')->insert([
+            'msgid' => $msg->id, 'externaluid' => 'freegletusd-'.str_repeat('r', 32),
+            'primary' => 1, 'archived' => 0,
+        ]);
+
+        // The committed reach stops at lng 0.0 - well short of the member at 0.4.
+        $this->seedReach($msg->id, 'POLYGON((-0.2 51.4,0.0 51.4,0.0 51.6,-0.2 51.6,-0.2 51.4))');
+        DB::table('rippling_reach')->where('msgid', $msg->id)
+            ->update(['overflow_bounds' => json_encode(['rural' => ['sparse' => $ringWkt]])]);
+
+        return [$member, $msg];
+    }
+
+    private function wasMailed(int $msgid, int $userid): bool
+    {
+        return DB::table('rippling_reach_notified')
+            ->where('msgid', $msgid)->where('userid', $userid)->exists();
+    }
+
+    public function test_rural_overflow_does_not_mail_outside_the_reach_when_the_lane_is_off(): void
+    {
+        config(['freegle.ripple.rural_access.enabled' => false]);
+        [$member, $msg] = $this->seedOverflowCase('sparse');
+
+        $this->service->mailNewlyReachedForPost($msg->id);
+
+        $this->assertFalse(
+            $this->wasMailed($msg->id, $member->id),
+            'rings are stored but the lane is off, so the reach polygon alone decides'
+        );
+    }
+
+    public function test_rural_overflow_mails_a_member_whose_own_band_earns_the_wider_budget(): void
+    {
+        config(['freegle.ripple.rural_access.enabled' => true]);
+        [$member, $msg] = $this->seedOverflowCase('sparse');
+
+        $this->service->mailNewlyReachedForPost($msg->id);
+
+        $this->assertTrue(
+            $this->wasMailed($msg->id, $member->id),
+            'outside the capped reach but inside their own band ring - the case the lane exists for'
+        );
+    }
+
+    public function test_rural_overflow_does_not_mail_a_member_of_a_different_band(): void
+    {
+        // Inside the sparse ring geographically, but a dense-band member has not earned that
+        // budget: the ring belongs to the band, not to the area.
+        config(['freegle.ripple.rural_access.enabled' => true]);
+        [$member, $msg] = $this->seedOverflowCase('dense');
+
+        $this->service->mailNewlyReachedForPost($msg->id);
+
+        $this->assertFalse(
+            $this->wasMailed($msg->id, $member->id),
+            'a dense-band member inside the sparse ring must not be admitted by it'
+        );
+    }
+
+    public function test_rural_overflow_does_not_mail_a_member_with_no_band_recorded(): void
+    {
+        // The backfill has not reached them yet. Absent must mean "not eligible" rather than
+        // "matches anything", or the lane would widen the mail for the whole membership the
+        // moment it was switched on.
+        config(['freegle.ripple.rural_access.enabled' => true]);
+        [$member, $msg] = $this->seedOverflowCase(null);
+
+        $this->service->mailNewlyReachedForPost($msg->id);
+
+        $this->assertFalse(
+            $this->wasMailed($msg->id, $member->id),
+            'no band recorded must not be admitted by any ring'
+        );
+    }
 }

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use App\Models\UserDigest;
 use App\Services\UnifiedDigestService;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
@@ -3229,8 +3230,12 @@ class UnifiedDigestServiceTest extends TestCase
      *
      * @return array{0: \App\Models\User, 1: \App\Models\Message}
      */
-    private function seedOverflowCase(?string $band, string $ringWkt = 'POLYGON((-0.2 51.4,0.6 51.4,0.6 51.6,-0.2 51.6,-0.2 51.4))'): array
-    {
+    private function seedOverflowCase(
+        ?string $band,
+        string $ringWkt = 'POLYGON((-0.2 51.4,0.6 51.4,0.6 51.6,-0.2 51.6,-0.2 51.4))',
+        string $lane = 'rural',
+        string $ringKey = 'sparse'
+    ): array {
         config(['freegle.digest.immediate_allowlist' => '*']);
         UnifiedDigestService::forgetOverflowColumn();
 
@@ -3264,9 +3269,15 @@ class UnifiedDigestServiceTest extends TestCase
         // The committed reach stops at lng 0.0 - well short of the member at 0.4.
         $this->seedReach($msg->id, 'POLYGON((-0.2 51.4,0.0 51.4,0.0 51.6,-0.2 51.6,-0.2 51.4))');
         DB::table('rippling_reach')->where('msgid', $msg->id)
-            ->update(['overflow_bounds' => json_encode(['rural' => ['sparse' => $ringWkt]])]);
+            ->update(['overflow_bounds' => json_encode([$lane => [$ringKey => $ringWkt]])]);
 
         return [$member, $msg];
+    }
+
+    /** Answer the spatial server's batch deprivation lookup with one fifth per point. */
+    private function fakeQuintiles(array $quintiles): void
+    {
+        Http::fake(['*/v1/quintiles' => Http::response(['quintiles' => $quintiles, 'available' => true])]);
     }
 
     private function wasMailed(int $msgid, int $userid): bool
@@ -3314,6 +3325,88 @@ class UnifiedDigestServiceTest extends TestCase
             $this->wasMailed($msg->id, $member->id),
             'a dense-band member inside the sparse ring must not be admitted by it'
         );
+    }
+
+    /**
+     * The fairness lane, on the mail path.
+     *
+     * The ring is a STRETCHED isochrone, so containment alone would simply widen the reach for
+     * everyone inside it - a bigger radius, not fairness. The stretch is earned by the
+     * deprivation fifth, and that lives only in the spatial server, so it is asked there for
+     * the people the ring adds rather than stored against anybody.
+     */
+    private function seedFairnessCase(): array
+    {
+        return $this->seedOverflowCase(null, 'POLYGON((-0.2 51.4,0.6 51.4,0.6 51.6,-0.2 51.6,-0.2 51.4))', 'fairness', '1');
+    }
+
+    public function test_fairness_overflow_mails_a_member_in_the_most_deprived_fifth(): void
+    {
+        config(['freegle.ripple.fairness.enabled' => true, 'freegle.ripple.fairness.max_quintile' => 1]);
+        [$member, $msg] = $this->seedFairnessCase();
+        $this->fakeQuintiles([1]);
+
+        $this->service->mailNewlyReachedForPost($msg->id);
+
+        $this->assertTrue(
+            $this->wasMailed($msg->id, $member->id),
+            'outside the committed reach, inside the stretched ring, and in the fifth the stretch is for'
+        );
+    }
+
+    public function test_fairness_overflow_does_not_mail_a_member_outside_the_target_fifth(): void
+    {
+        // Same geography, same ring, different person: containment got them considered, the
+        // fifth is what decides. Without this the lane is just a wider radius for everyone.
+        config(['freegle.ripple.fairness.enabled' => true, 'freegle.ripple.fairness.max_quintile' => 1]);
+        [$member, $msg] = $this->seedFairnessCase();
+        $this->fakeQuintiles([4]);
+
+        $this->service->mailNewlyReachedForPost($msg->id);
+
+        $this->assertFalse(
+            $this->wasMailed($msg->id, $member->id),
+            'inside the stretched ring but not in the fifth it was stretched for'
+        );
+    }
+
+    public function test_fairness_overflow_drops_the_extra_recipients_when_deprivation_is_unavailable(): void
+    {
+        // Fail CLOSED. Mailing everyone the stretched ring covers is exactly the
+        // widened-radius behaviour the fifth exists to prevent, so an unavailable lookup must
+        // cost the lane its extra people rather than hand them all the mail.
+        config(['freegle.ripple.fairness.enabled' => true, 'freegle.ripple.fairness.max_quintile' => 1]);
+        [$member, $msg] = $this->seedFairnessCase();
+        Http::fake(['*/v1/quintiles' => Http::response(null, 500)]);
+
+        $this->service->mailNewlyReachedForPost($msg->id);
+
+        $this->assertFalse($this->wasMailed($msg->id, $member->id));
+    }
+
+    public function test_fairness_overflow_drops_the_extra_recipients_on_a_misaligned_answer(): void
+    {
+        // Answers are matched back to people BY POSITION, so a short array would attribute one
+        // member's deprivation to another. Refusing the whole answer is the only safe reading.
+        config(['freegle.ripple.fairness.enabled' => true, 'freegle.ripple.fairness.max_quintile' => 1]);
+        [$member, $msg] = $this->seedFairnessCase();
+        $this->fakeQuintiles([]);
+
+        $this->service->mailNewlyReachedForPost($msg->id);
+
+        $this->assertFalse($this->wasMailed($msg->id, $member->id));
+    }
+
+    public function test_fairness_overflow_sends_nothing_when_the_lane_is_off(): void
+    {
+        config(['freegle.ripple.fairness.enabled' => false]);
+        [$member, $msg] = $this->seedFairnessCase();
+        Http::fake(['*/v1/quintiles' => Http::response(['quintiles' => [1], 'available' => true])]);
+
+        $this->service->mailNewlyReachedForPost($msg->id);
+
+        $this->assertFalse($this->wasMailed($msg->id, $member->id));
+        Http::assertNothingSent();
     }
 
     public function test_rural_overflow_does_not_mail_a_member_with_no_band_recorded(): void


### PR DESCRIPTION
The batch side of the two overflow lanes: the settings that ask the routing server for them. All off. Pairs with #1351, which added the rings themselves.

## The settings

| Setting | Default | What it does |
|---|---|---|
| `RIPPLE_RURAL_ACCESS_ENABLED` | off | One ring per density band alongside a capped reach |
| `RIPPLE_FAIRNESS_ENABLED` | off | Stretch the budget for deprived recipients |
| `RIPPLE_FAIRNESS_WEIGHT` | 0 | How much stretch, 0 to 1 |
| `RIPPLE_FAIRNESS_MAX_QUINTILE` | 1 | How far down the deprivation scale it reaches |

## Decisions worth knowing about

**Both lanes are offered together when configured.** Which one applies is per-post and depends on whether the audience cap actually bound, which only the routing server knows once it has counted members. Asking for both costs nothing when neither applies, and the routing server enforces that a post never gets both.

**Weight zero sends nothing at all**, rather than sending a stretch of zero. Zero is the deliberate first rollout step: flag on, plumbing exercised end to end, no behaviour change. If it sent the parameter, the routing server would run the extra road-network search for a stretch of precisely nothing.

**The default reaches only the most deprived fifth.** Measured on live, the shortfall is a knee there: those members are reached by about 457 posts per 30 days against roughly 574 for every other fifth, and the other four sit within about 7% of each other. A straight-line stretch across all five would spend most of its effect where there is no shortfall. It is also four times cheaper, needing one traced ring rather than four. Raising it buys the full gradient at proportionate cost.

**Weight is clamped here as well as in the routing server.** A misconfigured 5 silently becoming 1 at the far end is harder to explain than one that never leaves.

## Storage

`rippling_reach.overflow_bounds`, plus the parsing that fills it and the writes that store it. Nullable and dark: nothing writes it until a lane is enabled. Ships with the production SQL twin the project requires, written so that running it a second time changes nothing.

JSON rather than seven geometry columns, because these are read only in the fallback branch and never on the hot indexed path `polygon`/`outer_bound`/`inner_bound` serve, so they want no spatial index. Same convention as `reachable_group_ids` on this table.

NULL means "no lane applied", never "a lane that produced nothing" — a row read back as an empty array would look like a lane admitting nobody rather than no lane at all, and a test pins that distinction.

**Two write paths, not three, and the third is deliberate.** The init INSERT writes the rings, and `recomputeReach`'s shrink UPDATE rewrites them because it genuinely re-derives the schedule. `advanceDue` does not: it only moves the tick pointer along a schedule already stored, and the rings belong to the reach as a whole rather than to any tick.

**The trap was elsewhere, and it explains an existing defect.** `density_band` is NULL on ~89% of rows, and the cause is not a missed write path: it is **schedule reuse**. When a co-located post already has a schedule, the reuse branch rebuilds it from ticks, total and max-drive alone and drops everything else — and reuse is commonest exactly where posts cluster, which is why the NULLs dominate. The rings are now carried across a reuse.

That needs its own staleness guard, beside the existing reach-budget one: a fairness ring computed under a **different weight** is not this post's ring, however co-located the two posts are. Without it, moving the weight from 0.25 to 0.5 would silently leave old rings in place wherever posts cluster.

## Test Plan

`iznik-batch`: the full suite is green (5,600). Ripple 336 pass (9 new), digest 100 pass (4 new).

The set is self-checking rather than one-sided: "omits when off" and "sends when on" exercise the same code path with opposite expectations, and the weight is bracketed at 0 (sends nothing), 0.5 (sends 0.5) and 5 (clamped to 1). A clamp stuck at either end would fail one of those three.

## Notifications: the rural lane now reaches the mail

`mailNewlyReachedForPost` admits a member either by the committed reach polygon or by the ring for their own density band. A member who cannot be TOLD about a post is barely less shut out than one who cannot see it, which is the case this lane exists for.

**The rings are read once and bound as parameters**, not extracted inside the query. `rippling_reach` is one row per post, so an `ST_GeomFromText` over a `JSON_EXTRACT` in the `WHERE` would re-parse the same polygon for every candidate member: tens of thousands of identical parses on a large group, in the mail path. Binding the band name for an equality test rather than building a `'$.rural.<band>'` path also keeps a member's stored settings value data rather than syntax.

**With no rings the clause is absent, not false.** The query compiles to exactly what it did before this existed and costs exactly what it cost, so a disabled lane cannot slow the mail path down.

The duplicated `mylocation`-else-`lastlocation` resolution is collapsed to one definition while here. It was already written twice and the overflow branch needed it three more times; one definition is also the property worth having, since a member cannot then be admitted on one resolution and measured from another.

A config comment is corrected rather than left contradicting the code: this lane's block said in as many words that it "adds nobody to the mail". True when written. It now records what still holds, which is that the mail path stays members-only, so this reaches people who have already joined a group the post is on and never a cold recipient.

Four tests run ONE setup - a member outside the capped reach but inside the sparse ring - through both settings of the flag, so neither result can come from the member simply being unmailable. A dense-band member inside the sparse ring and a member with no band recorded must both stay out. The second matters: "absent" has to mean "not eligible" rather than "matches anything", or switching this on would widen the mail for the whole membership at once.

## Depends on #1353

These lanes admit a member on their own band, so the read side needs to know which band each member is in - and nothing stored it. The budget cannot stand in for it, because an explicit choice is rescaled *within* the band, so 20 minutes means either a dense member on their cap or a sparse member who asked for less.

#1353 now records `settings.browseDensityBand`, including for members whose budget needs no correction, who are the majority. Until that has run in production this lane admits nobody extra, which is the correct behaviour while it is off but worth knowing before switching it on: run the full backfill pass once, rather than waiting for the monthly one.

## Not in this PR

The other two read paths, each of which needs a decision rather than the same wiring.

**Browse.** Unlike the digest, every row there is a different post with a different ring, so a polygon parse per candidate row is unavoidable - and that is the hot feed path the sandwich-bounds prefilter exists to protect, after the unprefiltered form cost ~849ms a call on the write node. Its SQL shape is also pinned by golden tests. It wants a cheap bounds-style prefilter of its own, not an OR branch bolted onto the exact-polygon test.

**Reply eligibility.** `ReachQueryService::isWithinReach(msgid, lat, lng)` does not take the member, so the band has to be threaded through its callers before the branch can exist.

**The fairness lane's read side**, which needs each member's deprivation fifth stored somewhere. There is no deprivation data in MySQL at all: it lives only in the routing server, loaded from CSV. Attaching it to the shared `locations` table as public area data does not work either, because the point that decides eligibility comes from a free-form `mylocation` for 53,378 of 121,471 recently active members. A server-side table keyed by member, written by the same backfill pass and never returned by any API, is the shape that fits - deliberately not `users.settings`, which is echoed to the browser.

The prerequisite for that read side is now in place. These lanes admit a member on their own travel budget, and until 15 August that budget was unset for every one of 202,837 active members, because `BROWSE_TOWN_NEAR_URL` was missing on the batch host. That is fixed and the backfill has run: 47,651 members now hold a real band limit where none did before. See #1353, which also makes that failure loud in future.