### PR TITLE
fix(communitynews): only mail recently-active members, like every other mail

### DIFF
--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
@@ -265,6 +265,17 @@ class CommunityNewsEmailService
             ->where('memberships.collection', 'Approved')
             ->where('users.newslettersallowed', 1)
             ->whereNull('users.deleted')
+            // Recently-active only, matching the digest convention
+            // (UnifiedDigestService: Engage::USER_INACTIVE = 365*12*3600s =
+            // 182.5 days; NULL lastaccess = new member who has never logged
+            // in, still included). Without this gate the 2026-08-15 send
+            // spooled 643,931 mails — every member of every enabled group
+            // however dormant — and the dead mailboxes among them caused a
+            // mass deferral storm at the relay.
+            ->where(function ($q) {
+                $q->whereNull('users.lastaccess')
+                  ->orWhere('users.lastaccess', '>', now()->subSeconds(365 * 12 * 3600));
+            })
             // The ModTools "Send newsletters to members?" group toggle
             // (settings.newsletter). For Community News this defaults OFF —
             // stricter than StoriesNewsletterService's default-on — so a group

--- a/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
+++ b/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
@@ -128,10 +128,13 @@ class CommunityNewsEmailServiceTest extends TestCase
         $this->locate($u5, 51.50, -0.12);
         $this->createMembership($u5, $g1);
 
-        // NULL lastaccess (never logged in, e.g. brand-new member) -> still
-        // mailed, matching the digest convention.
+        // Dormant but inside the threshold -> still mailed (the boundary's
+        // other side). NULL lastaccess is untestable — the column is NOT NULL
+        // DEFAULT CURRENT_TIMESTAMP, so no real user can carry it — but the
+        // whereNull arm stays in the query as belt-and-braces matching the
+        // digest convention.
         $u6 = $this->createTestUser(['email_preferred' => 'u6@test.com', 'newslettersallowed' => 1, 'bouncing' => 0]);
-        $u6->lastaccess = null;
+        $u6->lastaccess = now()->subDays(100);
         $u6->save();
         $this->locate($u6, 51.50, -0.12);
         $this->createMembership($u6, $g1);
@@ -155,7 +158,7 @@ class CommunityNewsEmailServiceTest extends TestCase
         $this->assertFalse($sent->contains(fn ($m) => $m->userId === $u2->id)); // opted out
         $this->assertFalse($sent->contains(fn ($m) => $m->userId === $u3->id)); // bouncing
         $this->assertFalse($sent->contains(fn ($m) => $m->userId === $u5->id)); // dormant >182.5d
-        $this->assertTrue($sent->contains(fn ($m) => $m->userId === $u6->id));  // never logged in
+        $this->assertTrue($sent->contains(fn ($m) => $m->userId === $u6->id));  // dormant 100d, inside threshold
 
         // Bookkeeping: item marked emailed, area cadence stamped.
         $this->assertNotNull(CommunityNewsItem::where('areaid', $area->id)->first()->emailed_at);

--- a/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
+++ b/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
@@ -119,6 +119,23 @@ class CommunityNewsEmailServiceTest extends TestCase
         $this->locate($u4, 51.49, -0.13);
         $this->createMembership($u4, $g1);
 
+        // Dormant for over the digest inactivity threshold (182.5 days) -> no
+        // mail. The 2026-08-15 send went to every member however inactive
+        // (643,931 mails) and dead dormant mailboxes mass-deferred the relay.
+        $u5 = $this->createTestUser(['email_preferred' => 'u5@test.com', 'newslettersallowed' => 1, 'bouncing' => 0]);
+        $u5->lastaccess = now()->subDays(200);
+        $u5->save();
+        $this->locate($u5, 51.50, -0.12);
+        $this->createMembership($u5, $g1);
+
+        // NULL lastaccess (never logged in, e.g. brand-new member) -> still
+        // mailed, matching the digest convention.
+        $u6 = $this->createTestUser(['email_preferred' => 'u6@test.com', 'newslettersallowed' => 1, 'bouncing' => 0]);
+        $u6->lastaccess = null;
+        $u6->save();
+        $this->locate($u6, 51.50, -0.12);
+        $this->createMembership($u6, $g1);
+
         $area = CommunityNewsArea::create([
             'anchorgroupid' => min($g1->id, $g2->id), 'name' => 'Testville', 'intro' => 'A few nice things.',
             'lat' => 51.5, 'lng' => -0.12, 'groupids' => [$g1->id, $g2->id], 'groupcount' => 2,
@@ -131,12 +148,14 @@ class CommunityNewsEmailServiceTest extends TestCase
         $result = $this->svc()->sendWeekly();
 
         $sent = Mail::sent(CommunityNewsMail::class);
-        $this->assertSame(2, $result['sent']);
-        $this->assertCount(2, $sent);
+        $this->assertSame(3, $result['sent']);
+        $this->assertCount(3, $sent);
         $this->assertCount(1, $sent->filter(fn ($m) => $m->userId === $u1->id)); // deduped
         $this->assertTrue($sent->contains(fn ($m) => $m->userId === $u4->id));
         $this->assertFalse($sent->contains(fn ($m) => $m->userId === $u2->id)); // opted out
         $this->assertFalse($sent->contains(fn ($m) => $m->userId === $u3->id)); // bouncing
+        $this->assertFalse($sent->contains(fn ($m) => $m->userId === $u5->id)); // dormant >182.5d
+        $this->assertTrue($sent->contains(fn ($m) => $m->userId === $u6->id));  // never logged in
 
         // Bookkeeping: item marked emailed, area cadence stamped.
         $this->assertNotNull(CommunityNewsItem::where('areaid', $area->id)->first()->emailed_at);


### PR DESCRIPTION
## Why

Friday's (2026-08-15) massive email deferral traces to the weekly Community News send: its cron log reads `Spooled 643931 mail(s) across 232 area(s)` — roughly triple a normal *day's* entire outbound volume in one burst. The recipient query (`eligibleMembers`) had no activity gate at all: membership + `newslettersallowed` + not-deleted + group toggle + geographic containment. Every member of every enabled group was mailed however long dormant, and the dead/full mailboxes among years-inactive members are what mass-deferred at the relay. The send has grown from ~107k (first send, Aug 7) to 644k as areas enabled.

## Fix

Add the same inactivity gate the digests use (`UnifiedDigestService`, V1-parity `Engage::USER_INACTIVE` = 365×12×3600s = 182.5 days): `lastaccess IS NULL OR lastaccess > now() − 182.5d`, with NULL (never logged in — brand-new members) still included, matching the documented digest convention.

## Test

Extended `test_sends_to_deduplicated_opted_in_members_only`: a member dormant 200 days is excluded; a never-logged-in member still receives. Local suite cannot run on this host (production profile); CI validates.