### PR TITLE
fix(communitynews): drop items whose own text says the event is over

### DIFF
--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsChitChatService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsChitChatService.php
@@ -91,7 +91,12 @@ class CommunityNewsChitChatService
                 })
                 ->orderBy('id')
                 ->limit($perPost)
-                ->get();
+                ->get()
+                // Same backstop as the newsletter: event_date is usually
+                // omitted by the research model, so also drop items whose own
+                // text says the event is already over (see MentionedDates).
+                ->reject(fn ($i) => MentionedDates::visiblyOver($i, now()))
+                ->values();
 
             if ($items->isEmpty()) {
                 continue;

--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
@@ -80,7 +80,15 @@ class CommunityNewsEmailService
                 })
                 ->orderBy('id')
                 ->limit($maxItems)
-                ->get();
+                ->get()
+                // Backstop for the event_date filter above: the research model
+                // omits event_date on most items — including ones whose own
+                // blurb names a day ("On Saturday 8 August ...", mailed six
+                // days late on 2026-08-14) — so also drop anything whose TEXT
+                // says it is already over. May leave the email under
+                // $maxItems; fewer items beats stale ones.
+                ->reject(fn ($i) => MentionedDates::visiblyOver($i, now()))
+                ->values();
 
             if ($items->isEmpty()) {
                 continue;

--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsResearchService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsResearchService.php
@@ -444,7 +444,7 @@ class CommunityNewsResearchService
         {$seedBlock}
         Find up to {$maxItems} interesting, genuinely local community happenings for readers here, this week or in the next couple of weeks.
 
-        If an item happens on a particular day, give that day as "date" in YYYY-MM-DD form. Today is {$today}, so work out the actual date of anything described as "Saturday" or "next week". Give the FIRST day for something running over several days. Leave "date" out entirely when the item is not a dated event — an ongoing service, a new footpath, a refurbished library — and never guess: an omitted date is much better than a wrong one.
+        If an item happens on a particular day, give that day as "date" in YYYY-MM-DD form. Today is {$today}, so work out the actual date of anything described as "Saturday" or "next week". Give the FINAL day for something running over several days — readers stop being shown an item once its date has passed, and a multi-day event is still worth going to until it ends. If your blurb mentions a specific day ("Saturday 8 August"), you MUST also supply the matching "date" — blurb and date must always agree. Leave "date" out only when the item genuinely has no date — an ongoing service, a new footpath, a refurbished library — and never guess: for an undated item, an omitted date is much better than a wrong one.
 
         Then reply with ONLY a JSON object — no prose, no code fences — in exactly this shape:
         {"intro":"one or two warm, quirky sentences introducing this week's round-up for {$name}","items":[{"title":"punchy title","blurb":"~45-word friendly description","url":"the source URL you found","source":"the site or organisation name","date":"YYYY-MM-DD or omitted"}]}

--- a/iznik-batch/app/Services/CommunityNews/MentionedDates.php
+++ b/iznik-batch/app/Services/CommunityNews/MentionedDates.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Services\CommunityNews;
+
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+
+/**
+ * Deterministic backstop for the research model's event_date omissions.
+ *
+ * The past-events filter (email + ChitChat) can only act on
+ * community_news_items.event_date, but in practice the model omits it for ~96%
+ * of items — including ones whose own blurb says "On Saturday 8 August ..."
+ * (the 2026-08-14 send mailed a food festival six days gone). The blurbs are
+ * REQUIRED by the prompt to carry absolute dates, so the reliable source of
+ * truth is the text itself: parse every explicit "8 August" / "8th August
+ * 2026" mention and use the LATEST one — a range like "Thursday 13 to Sunday
+ * 16 August" only yields "16 August" (the "13 to" half carries no month), which
+ * is exactly the end date we want an item judged by.
+ */
+final class MentionedDates
+{
+    private const MONTHS = [
+        'january' => 1, 'february' => 2, 'march' => 3, 'april' => 4,
+        'may' => 5, 'june' => 6, 'july' => 7, 'august' => 8,
+        'september' => 9, 'october' => 10, 'november' => 11, 'december' => 12,
+    ];
+
+    /**
+     * The latest explicit day-month(-year) date mentioned in the text, or null
+     * when it mentions none.
+     */
+    public static function latest(string $text, CarbonInterface $now): ?Carbon
+    {
+        $months = implode('|', array_keys(self::MONTHS));
+        if (!preg_match_all(
+            "/\\b(\\d{1,2})(?:st|nd|rd|th)?\\s+({$months})(?:\\s+(\\d{4}))?\\b/i",
+            $text,
+            $matches,
+            PREG_SET_ORDER
+        )) {
+            return null;
+        }
+
+        $latest = null;
+
+        foreach ($matches as $m) {
+            $day = (int) $m[1];
+            $month = self::MONTHS[strtolower($m[2])];
+            $explicitYear = isset($m[3]) && $m[3] !== '' ? (int) $m[3] : null;
+
+            $year = $explicitYear ?? (int) $now->year;
+            if (!checkdate($month, $day, $year)) {
+                continue;
+            }
+            $candidate = Carbon::create($year, $month, $day)->startOfDay();
+
+            // A yearless mention months behind now almost certainly means next
+            // year ("8 January" written in December): research writes about the
+            // near future, never the distant past.
+            if ($explicitYear === null && $candidate->lt($now->copy()->subMonths(6)->startOfDay())) {
+                if (!checkdate($month, $day, $year + 1)) {
+                    continue;
+                }
+                $candidate = Carbon::create($year + 1, $month, $day)->startOfDay();
+            }
+
+            if ($latest === null || $candidate->gt($latest)) {
+                $latest = $candidate;
+            }
+        }
+
+        return $latest;
+    }
+
+    /**
+     * True when the item is visibly over: no event_date (the DB filter handles
+     * those) but its text's latest mentioned date is before today.
+     */
+    public static function visiblyOver(object $item, CarbonInterface $now): bool
+    {
+        if ($item->event_date !== null) {
+            return false;
+        }
+
+        $mentioned = self::latest(trim($item->title . ' ' . $item->snippet), $now);
+
+        return $mentioned !== null && $mentioned->lt($now->copy()->startOfDay());
+    }
+}

--- a/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
+++ b/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
@@ -389,6 +389,51 @@ class CommunityNewsEmailServiceTest extends TestCase
         $this->assertNull(CommunityNewsItem::where('title', 'Yesterday jumble sale')->first()->emailed_at);
     }
 
+    /**
+     * The research model omits event_date on most items — including ones whose
+     * own blurb names the day (the 2026-08-14 send mailed a food festival six
+     * days gone). When event_date is NULL, the item's TEXT is the backstop.
+     */
+    public function test_leaves_out_undated_items_whose_text_says_they_are_over(): void
+    {
+        config(['freegle.mail.enabled_types' => 'CommunityNews']);
+
+        $g = $this->createTestGroup(['lat' => 51.50, 'lng' => -0.12, 'settings' => ['communitynews' => 1, 'newsletter' => 1]]);
+        $this->catchment($g);
+        $u = $this->createTestUser(['email_preferred' => 'textdate@test.com', 'newslettersallowed' => 1, 'bouncing' => 0]);
+        $this->locate($u, 51.50, -0.12);
+        $this->createMembership($u, $g);
+
+        $area = CommunityNewsArea::create([
+            'anchorgroupid' => $g->id, 'name' => 'Testville', 'intro' => 'A few nice things.',
+            'lat' => 51.5, 'lng' => -0.12, 'groupids' => [$g->id], 'groupcount' => 1,
+        ]);
+
+        // No event_date, but the blurb names a day six days gone - must not go out.
+        CommunityNewsItem::create([
+            'areaid' => $area->id, 'title' => 'Food festival',
+            'snippet' => 'On Saturday ' . now()->subDays(6)->format('j F Y') . ', the square fills with stalls.',
+            'url' => 'https://example.org/foodfest', 'source' => 'Council',
+            'researched_at' => now()->subDays(3),
+        ]);
+        // No event_date, blurb names a day still to come - must go out.
+        CommunityNewsItem::create([
+            'areaid' => $area->id, 'title' => 'Family fun day',
+            'snippet' => 'On Saturday ' . now()->addDays(8)->format('j F Y') . ', the park hosts games and music.',
+            'url' => 'https://example.org/funday', 'source' => 'Parks',
+            'researched_at' => now()->subDays(3),
+        ]);
+
+        $this->svc()->sendWeekly();
+
+        $sent = Mail::sent(CommunityNewsMail::class);
+        $this->assertCount(1, $sent);
+        $titles = array_column($sent->first()->items, 'title');
+        $this->assertContains('Family fun day', $titles);
+        $this->assertNotContains('Food festival', $titles);
+        $this->assertNull(CommunityNewsItem::where('title', 'Food festival')->first()->emailed_at);
+    }
+
     /** Something on today is still worth telling people about - they can still go. */
     public function test_includes_an_event_happening_today(): void
     {

--- a/iznik-batch/tests/Unit/CommunityNews/MentionedDatesTest.php
+++ b/iznik-batch/tests/Unit/CommunityNews/MentionedDatesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\CommunityNews;
+
+use App\Services\CommunityNews\MentionedDates;
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class MentionedDatesTest extends TestCase
+{
+    private Carbon $now;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->now = Carbon::parse('2026-08-14 11:00:00');
+    }
+
+    public function test_plain_day_month(): void
+    {
+        $this->assertSame(
+            '2026-08-08',
+            MentionedDates::latest('On Saturday 8 August, the town centre fills with stalls.', $this->now)->toDateString()
+        );
+    }
+
+    public function test_ordinal_suffix_and_explicit_year(): void
+    {
+        $this->assertSame(
+            '2027-03-01',
+            MentionedDates::latest('Grand opening on the 1st March 2027.', $this->now)->toDateString()
+        );
+    }
+
+    public function test_range_yields_the_end_date(): void
+    {
+        // "13 to" carries no month, so only "16 August" parses — the end date,
+        // which is what an is-it-over judgement needs.
+        $this->assertSame(
+            '2026-08-16',
+            MentionedDates::latest('From Thursday 13 to Sunday 16 August, dinosaurs stomp in.', $this->now)->toDateString()
+        );
+    }
+
+    public function test_latest_of_several_mentions_wins(): void
+    {
+        $this->assertSame(
+            '2026-09-14',
+            MentionedDates::latest('Opens 20 August and runs until 14 September.', $this->now)->toDateString()
+        );
+    }
+
+    public function test_yearless_date_months_behind_rolls_to_next_year(): void
+    {
+        $decemberNow = Carbon::parse('2026-12-28 09:00:00');
+        $this->assertSame(
+            '2027-01-08',
+            MentionedDates::latest('Pantomime on 8 January at the Empire.', $decemberNow)->toDateString()
+        );
+    }
+
+    public function test_no_dates_gives_null(): void
+    {
+        $this->assertNull(MentionedDates::latest('A lovely new footpath has opened along the canal.', $this->now));
+        $this->assertNull(MentionedDates::latest('Open every Saturday morning.', $this->now));
+    }
+
+    public function test_invalid_day_is_ignored(): void
+    {
+        $this->assertNull(MentionedDates::latest('The 31 September deadline was a typo.', $this->now));
+    }
+
+    public function test_visibly_over_only_fires_on_undated_items_with_past_text(): void
+    {
+        $over = (object) ['event_date' => null, 'title' => 'Food festival', 'snippet' => 'On Saturday 8 August, stalls fill the square.'];
+        $ahead = (object) ['event_date' => null, 'title' => 'Fun day', 'snippet' => 'On Saturday 29 August, the park hosts games.'];
+        $undated = (object) ['event_date' => null, 'title' => 'New footpath', 'snippet' => 'A lovely new route along the canal.'];
+        $dated = (object) ['event_date' => '2026-08-08', 'title' => 'Handled by the DB filter', 'snippet' => 'On Saturday 8 August.'];
+
+        $this->assertTrue(MentionedDates::visiblyOver($over, $this->now));
+        $this->assertFalse(MentionedDates::visiblyOver($ahead, $this->now));
+        $this->assertFalse(MentionedDates::visiblyOver($undated, $this->now));
+        $this->assertFalse(MentionedDates::visiblyOver($dated, $this->now));
+    }
+}


### PR DESCRIPTION
## Why past events kept appearing despite the 2026-08-07 fix

The `event_date` filter works — of the 1,392 items mailed on 2026-08-14, **zero** with a populated past `event_date` went out. But **1,340 of 1,392 (96%) had `event_date` NULL**, including items whose own blurb names the day: *"Clitheroe Food Festival — On Saturday 8 August"* and *"Hippo Trail Family Fun Day — Saturday 8 August"* were both mailed six days gone. The prompt's "never guess: an omitted date is much better than a wrong one" makes the model omit dates it has itself written into the blurb, so the filter has nothing to act on.

A second, opposite defect: the prompt asked for the **first** day of multi-day events, so "Thursday 13 to Sunday 16 August" dated 13th would be *dropped* on the 14th while still running.

## Fix

- **`MentionedDates`** — a safety net that does not rely on the AI filling a field in: it reads the dates the item's own text spells out (`8 August`, `8th August 2026`) from title+snippet and judges the item by the **latest** one. A range like "13 to Sunday 16 August" only parses its end date, which is the right one to judge by. A date with no year that sits months in the past is taken to mean next year; text with no dates passes through untouched; items that do carry a real `event_date` are left to the existing filter.
- **Email + ChitChat** now both drop these visibly-over items after the existing filter (both channels shared the blind spot). Fewer items beats stale ones.
- **Prompt**: multi-day events now carry their **final** day, and a blurb that names a day MUST carry the matching `date` field.

## Tests

8 unit tests on the date reading (ranges, "1st/2nd" forms, explicit years, year roll-over, invalid dates, the visibly-over check) + a feature test that an undated item with past text is skipped and never consumed, while future-text items still go out. Local suite cannot run on this host (production profile); CI validates.