### PR TITLE
fix(ripple): fetch the due batch by name, not select *, one schedule at a time

### DIFF
--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -1279,11 +1279,22 @@ class ExpandService
 
     private function advanceDue(bool $dryRun, int $limit, array &$stats, ?int $onlyMsgid = null, ?string $withinPolyWkt = null): void
     {
+        // Named columns, NOT select * : this table's rows average ~600KB
+        // (polygon) with schedule JSON, max_polygon and the sandwich bounds on
+        // top, so an unqualified fetch of a 500-row due batch materialises
+        // gigabytes in one fetchAll. That was the 21-28 memory-exhaustion
+        // fatals a day from 2026-08-12 (argv-attributed to ripple:expand):
+        // the density resize + re-init churn made due batches big enough to
+        // blow the 1GB limit. schedule - the one big column each advance
+        // genuinely needs - is fetched per row inside the loop, so at most one
+        // row's schedule is in memory at a time.
         $rows = DB::table('rippling_reach')
+            ->select(['msgid', 'lat', 'lng', 'tick', 'min_tick', 'total_ticks', 'arrival'])
             ->where('status', 'expanding')
             ->whereNotNull('next_expansion_at')
             ->where('next_expansion_at', '<=', now())
             ->when($onlyMsgid !== null, fn ($q) => $q->where('msgid', $onlyMsgid))
+            // keep-raw: ST_Contains/ST_GeomFromText are spatial functions the builder cannot render
             ->when($withinPolyWkt !== null, fn ($q) => $q->whereRaw(
                 'ST_Contains(ST_GeomFromText(?, ' . self::SRID . '), ST_SRID(POINT(lng, lat), ' . self::SRID . '))',
                 [$withinPolyWkt]
@@ -1293,7 +1304,8 @@ class ExpandService
 
         foreach ($rows as $row) {
             try {
-                $ticks = json_decode($row->schedule, true);
+                $schedule = DB::table('rippling_reach')->where('msgid', $row->msgid)->value('schedule');
+                $ticks = json_decode($schedule, true);
                 if (!is_array($ticks) || empty($ticks)) {
                     $stats['skipped']++;
                     continue;

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -1287,9 +1287,12 @@ class ExpandService
         // the density resize + re-init churn made due batches big enough to
         // blow the 1GB limit. schedule - the one big column each advance
         // genuinely needs - is fetched per row inside the loop, so at most one
-        // row's schedule is in memory at a time.
+        // row's schedule is in memory at a time. This list must cover every
+        // $row-> use to the END of this function - rejected_groups is read
+        // ~60 lines down for the secondary-reject clip, and leaving it out
+        // silently skipped the clip (caught by the two clip tests in CI).
         $rows = DB::table('rippling_reach')
-            ->select(['msgid', 'lat', 'lng', 'tick', 'min_tick', 'total_ticks', 'arrival'])
+            ->select(['msgid', 'lat', 'lng', 'tick', 'min_tick', 'total_ticks', 'arrival', 'rejected_groups'])
             ->where('status', 'expanding')
             ->whereNotNull('next_expansion_at')
             ->where('next_expansion_at', '<=', now())


### PR DESCRIPTION
## The 21–28 memory-exhaustion fatals a day, named at last

Since 2026-08-12 batch has died at the 1GB PHP limit 21–28 times a day inside `Connection.php` `fetchAll`, with no way to tell which command. With #1358's argv stamping live, today's crashes name it: **`ripple:expand --limit=500`**.

`advanceDue` fetched its due batch with **no column list**. A `rippling_reach` row averages ~600KB of `polygon`, plus multi-MB `schedule` JSON, `max_polygon` and both sandwich bounds (and now `overflow_bounds`) — so a due batch of up to 500 rows materialises gigabytes in one fetch. The Aug-12 density resize + re-init churn made due batches large enough to cross 1GB, which is why the fatals started that day.

The advance loop uses exactly eight small fields plus `schedule`. This names them in the select, and fetches `schedule` per row inside the loop — at most one row's schedule in memory at a time. No behaviour change; the per-row PK lookup is noise against the ~185 advances/tick.

Verified live on batch-prod via the bind mount before committing. Local suite cannot run on this host (production profile); CI validates.