### PR TITLE
fix(newsfeed): an empty body is an invalid preview, not a crash a minute

### DIFF
--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -3858,6 +3858,12 @@ class IncomingMailService
             }
 
             $html = $response->body();
+            if (trim($html) === '') {
+                // loadHTML('') throws ValueError on PHP 8 - the @ silences
+                // warnings, not thrown Errors (same trap as the link-preview
+                // cron, fixed together 2026-08-17).
+                return [];
+            }
             $doc = new \DOMDocument;
             @$doc->loadHTML($html);
 

--- a/iznik-batch/app/Services/NewsfeedLinkPreviewService.php
+++ b/iznik-batch/app/Services/NewsfeedLinkPreviewService.php
@@ -144,6 +144,15 @@ class NewsfeedLinkPreviewService
                 return $this->upsertInvalid($url);
             }
 
+            // A 200 with an empty body is a real thing (tracker pixels, broken
+            // CDNs). DOMDocument::loadHTML('') throws ValueError on PHP 8 - an
+            // \Error, so the \Exception catch below never saw it, the row was
+            // never marked invalid, and the same URL crashed the cron every
+            // minute (2026-08-17, 08:45 onwards).
+            if (trim($response->body()) === '') {
+                return $this->upsertInvalid($url);
+            }
+
             $data = $this->parseHtml($response->body());
 
             DB::statement(
@@ -161,7 +170,10 @@ class NewsfeedLinkPreviewService
             );
 
             return (int) DB::getPdo()->lastInsertId();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // \Throwable, not \Exception: the parser throws \Error subclasses
+            // (ValueError above being the proven case) and an unmarked row
+            // retries forever.
             return $this->upsertInvalid($url);
         }
     }


### PR DESCRIPTION
Caught live by the new batch error monitor at 09:12 today: `DOMDocument::loadHTML(): Argument #1 ($source) must not be empty`, repeating every minute since 08:45 (31 occurrences).

A newsfeed post links a URL that answers 200 with an empty body. `loadHTML('')` throws `ValueError` on PHP 8 — an `\Error`, so the cron's `catch (\Exception)` never saw it, the `link_previews` row was never written, and the same URL re-crashed the cron every minute forever.

Fix: treat an empty body as an invalid preview (same as a non-2xx response, recorded against the URL so it is not retried), and widen the catch to `\Throwable` so any future parser `\Error` marks the row instead of looping. The TrashNothing image scraper in `IncomingMailService` had the identical latent trap behind an `@` (which silences warnings, not thrown Errors) — guarded the same way.

Verified live on batch-prod via the bind mount: the every-minute error stream stops once the row is marked. Local suite cannot run on this host (production profile); CI validates.