### PR TITLE
Community News: keep intros entirely in English, no token Welsh greetings

### DIFF
--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
@@ -111,7 +111,12 @@ class CommunityNewsEmailService
                 ];
             })->all();
 
-            $intro = $area->intro ?: "Here's a little round-up of what's going on around {$area->name}.";
+            // Intros are stored and reused for up to a week, so strip token
+            // Welsh/Gaelic greetings at send time too - an intro written before
+            // the parse-time backstop existed would otherwise keep going out
+            // until the area is next researched.
+            $intro = IntroLanguage::stripForeignGreeting((string) ($area->intro ?? ''))
+                ?: "Here's a little round-up of what's going on around {$area->name}.";
             $story = $this->pickStory($groupIds, $area);
 
             $sentForArea = 0;

--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsResearchService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsResearchService.php
@@ -303,6 +303,10 @@ class CommunityNewsResearchService
         }
 
         $intro = isset($json['intro']) && is_string($json['intro']) ? $this->replaceEmDashes(trim($json['intro'])) : '';
+        // Zero mixed language: a token "Shwmae, Caernarfon!" opening never
+        // reaches the stored intro, however the model phrases it. Items are
+        // exempt - a Welsh event NAME is a name, not a greeting.
+        $intro = IntroLanguage::stripForeignGreeting($intro);
 
         $items = [];
         foreach ((array) ($json['items'] ?? []) as $it) {
@@ -423,6 +427,7 @@ class CommunityNewsResearchService
         - Keep everything genuinely LOCAL to {$name} (or clearly within it). If you can't find enough real local material, return fewer items — quality over quantity.
         - Do NOT include repair cafés or Restart/Fixit-style repair events — Freegle already lists these separately (synced from the Restart Project and Repair Café Wales), so they would be duplicates.
         - UK English. Light, second-person, roughly 40-60 words per item: what it is and why someone might fancy it. No hashtags, no marketing-speak, at most the occasional emoji.
+        - Write ENTIRELY in English, the intro included, even for areas in Wales or Scotland. Never open with or sprinkle in greetings or phrases from Welsh, Gaelic or any other language ("Croeso", "Shwmae", "Bore da"): a half-and-half opening like "Croeso i mid August" reads as tokenism, not warmth. Welsh or Gaelic NAMES of places, events and organisations (the Eisteddfod, a Menter Iaith event) are fine when that is their real name.
         - Where it fits NATURALLY, end an item with a short, playful Freegle tie-in — one sentence linking the story to giving or asking for things on your local Freegle community ("Need dancing shoes? Ask on Freegle", "Got records gathering dust? Someone nearby would love them"). Skip it where it would feel forced; never salesy.
         - Give dates ABSOLUTELY ("Saturday 2 August", "until 14 September"), never relatively ("this Saturday", "tomorrow", "next week") — items may be published up to a couple of weeks after you write them, so relative dates go stale.
         - Don't plug Freegle itself unless a Freegle event genuinely comes up.
@@ -447,7 +452,7 @@ class CommunityNewsResearchService
         If an item happens on a particular day, give that day as "date" in YYYY-MM-DD form. Today is {$today}, so work out the actual date of anything described as "Saturday" or "next week". Give the FINAL day for something running over several days — readers stop being shown an item once its date has passed, and a multi-day event is still worth going to until it ends. If your blurb mentions a specific day ("Saturday 8 August"), you MUST also supply the matching "date" — blurb and date must always agree. Leave "date" out only when the item genuinely has no date — an ongoing service, a new footpath, a refurbished library — and never guess: for an undated item, an omitted date is much better than a wrong one.
 
         Then reply with ONLY a JSON object — no prose, no code fences — in exactly this shape:
-        {"intro":"one or two warm, quirky sentences introducing this week's round-up for {$name}","items":[{"title":"punchy title","blurb":"~45-word friendly description","url":"the source URL you found","source":"the site or organisation name","date":"YYYY-MM-DD or omitted"}]}
+        {"intro":"one or two warm, quirky sentences in UK English introducing this week's round-up for {$name}","items":[{"title":"punchy title","blurb":"~45-word friendly description","url":"the source URL you found","source":"the site or organisation name","date":"YYYY-MM-DD or omitted"}]}
         USER;
     }
 

--- a/iznik-batch/app/Services/CommunityNews/IntroLanguage.php
+++ b/iznik-batch/app/Services/CommunityNews/IntroLanguage.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Services\CommunityNews;
+
+/**
+ * Deterministic backstop against mixed-language intros.
+ *
+ * Welsh-named areas (Caerdydd, Wrecsam, Pen-y-Bont ar Ogwr...) coax the
+ * research model into opening an otherwise-English intro with a token Welsh
+ * greeting - "Croeso i mid August", "Shwmae, Caernarfon!" - which reads as
+ * tokenism, not warmth (12 of 239 live areas on 2026-08-17). The prompt now
+ * forbids it, but like the em-dash rule this is enforced in code too so it
+ * holds however the model phrases things.
+ *
+ * Scope is deliberately tight: only sentence-INITIAL greetings are stripped,
+ * and only from intros. A greeting word mid-sentence ("we say croeso to the
+ * new library") and Welsh NAMES of places or events in items ("Croeso i
+ * Gaerdydd festival") are legitimate and untouched.
+ */
+final class IntroLanguage
+{
+    /**
+     * Greetings the model bolts onto intros, sentence-initially, in Welsh,
+     * Scottish Gaelic, Irish, Cornish and Manx. Lower-case; matched
+     * case-insensitively on a word boundary.
+     */
+    private const GREETINGS = [
+        // Welsh
+        'croeso', 'shwmae', 'shw mae', "s'mae", "su'mae", 'sut mae', 'bore da',
+        'prynhawn da', 'noswaith dda', 'helo bawb', 'henffych', 'hwyl fawr',
+        'hwyl', 'diolch yn fawr', 'diolch', 'haia',
+        // Scottish Gaelic
+        'fàilte', 'failte', 'madainn mhath', 'feasgar math',
+        // Irish
+        'fáilte', 'céad míle fáilte', 'dia dhuit', 'dia daoibh',
+        // Cornish and Manx
+        'dydh da', 'myttin da', 'moghrey mie', 'fastyr mie',
+    ];
+
+    /**
+     * The intro with any leading non-English greeting sentence(s) removed.
+     * An intro that was nothing but a greeting comes back as ''.
+     */
+    public static function stripForeignGreeting(string $intro): string
+    {
+        $alternation = implode('|', array_map(
+            fn ($g) => preg_quote($g, '/'),
+            self::GREETINGS
+        ));
+        // From the start (quotes allowed), a greeting on a word boundary, then
+        // the rest of that sentence up to and including its end punctuation.
+        $pattern = '/^["\'\x{201C}\x{201D}\x{2018}\x{2019}]*\s*(?:' . $alternation . ')\b[^.!?]*[.!?\x{2026}]*\s*/iu';
+
+        $text = trim($intro);
+        // Loop: the model sometimes stacks greetings ("Shwmae! Croeso i...").
+        for ($i = 0; $i < 5; $i++) {
+            $stripped = preg_replace($pattern, '', $text, 1);
+            if ($stripped === null || $stripped === $text) {
+                break;
+            }
+            $text = $stripped;
+        }
+
+        return trim($text);
+    }
+}

--- a/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
+++ b/iznik-batch/tests/Feature/CommunityNews/CommunityNewsEmailServiceTest.php
@@ -514,4 +514,65 @@ class CommunityNewsEmailServiceTest extends TestCase
         $this->assertCount(1, $sent);
         $this->assertContains('New cycle path opens', array_column($sent->first()->items, 'title'));
     }
+
+    /**
+     * Intros are stored on the area and reused for a week, so a mixed-language
+     * greeting written before the parse-time backstop existed (12 live Welsh
+     * areas as of 2026-08-17) would keep going out until re-research. The send
+     * path strips it too, so a stored "Shwmae, Wrecsam!" never reaches members.
+     */
+    public function test_strips_a_stored_welsh_greeting_intro_at_send_time(): void
+    {
+        config(['freegle.mail.enabled_types' => 'CommunityNews']);
+
+        $g = $this->createTestGroup(['lat' => 51.50, 'lng' => -0.12, 'settings' => ['communitynews' => 1, 'newsletter' => 1]]);
+        $this->catchment($g);
+        $u = $this->createTestUser(['email_preferred' => 'welsh@test.com', 'newslettersallowed' => 1, 'bouncing' => 0]);
+        $this->locate($u, 51.50, -0.12);
+        $this->createMembership($u, $g);
+
+        $area = CommunityNewsArea::create([
+            'anchorgroupid' => $g->id, 'name' => 'Testville',
+            'intro' => 'Shwmae, Testville! The balloons are inflating.',
+            'lat' => 51.5, 'lng' => -0.12, 'groupids' => [$g->id], 'groupcount' => 1,
+        ]);
+        CommunityNewsItem::create([
+            'areaid' => $area->id, 'title' => 'T', 'snippet' => 'B',
+            'url' => 'https://example.org/x', 'source' => 'S', 'researched_at' => now(),
+        ]);
+
+        $this->svc()->sendWeekly();
+
+        $sent = Mail::sent(CommunityNewsMail::class);
+        $this->assertCount(1, $sent);
+        $this->assertSame('The balloons are inflating.', $sent->first()->intro);
+    }
+
+    /** A stored intro that is ONLY a greeting falls back to the stock line. */
+    public function test_greeting_only_stored_intro_falls_back_to_default(): void
+    {
+        config(['freegle.mail.enabled_types' => 'CommunityNews']);
+
+        $g = $this->createTestGroup(['lat' => 51.50, 'lng' => -0.12, 'settings' => ['communitynews' => 1, 'newsletter' => 1]]);
+        $this->catchment($g);
+        $u = $this->createTestUser(['email_preferred' => 'croeso@test.com', 'newslettersallowed' => 1, 'bouncing' => 0]);
+        $this->locate($u, 51.50, -0.12);
+        $this->createMembership($u, $g);
+
+        $area = CommunityNewsArea::create([
+            'anchorgroupid' => $g->id, 'name' => 'Testville',
+            'intro' => 'Croeso i mid August',
+            'lat' => 51.5, 'lng' => -0.12, 'groupids' => [$g->id], 'groupcount' => 1,
+        ]);
+        CommunityNewsItem::create([
+            'areaid' => $area->id, 'title' => 'T', 'snippet' => 'B',
+            'url' => 'https://example.org/x', 'source' => 'S', 'researched_at' => now(),
+        ]);
+
+        $this->svc()->sendWeekly();
+
+        $sent = Mail::sent(CommunityNewsMail::class);
+        $this->assertCount(1, $sent);
+        $this->assertSame("Here's a little round-up of what's going on around Testville.", $sent->first()->intro);
+    }
 }

--- a/iznik-batch/tests/Feature/CommunityNews/CommunityNewsResearchServiceTest.php
+++ b/iznik-batch/tests/Feature/CommunityNews/CommunityNewsResearchServiceTest.php
@@ -296,4 +296,62 @@ class CommunityNewsResearchServiceTest extends TestCase
             $this->assertNull($items[0]['date'], "expected '{$raw}' to be rejected as an event date");
         }
     }
+
+    /**
+     * Welsh-named areas coax the model into token Welsh greetings ("Croeso i
+     * mid August", "Shwmae, Caernarfon!") on an otherwise-English intro. The
+     * deterministic backstop strips the greeting sentence at parse time so a
+     * mixed-language intro can never be stored, however the model phrases it.
+     */
+    public function test_parse_strips_a_token_welsh_greeting_from_the_intro(): void
+    {
+        $text = json_encode([
+            'intro' => 'Croeso i mid August, Wrecsam! The balloons are inflating and the parks are humming.',
+            'items' => [
+                ['title' => 'T', 'blurb' => 'b', 'url' => 'https://ok.org', 'source' => 'S'],
+            ],
+        ]);
+
+        [$intro] = $this->svc()->parse($text, 6);
+
+        $this->assertSame('The balloons are inflating and the parks are humming.', $intro);
+    }
+
+    /** Item titles are exempt: a Welsh EVENT name is a name, not a greeting. */
+    public function test_parse_leaves_welsh_named_items_alone(): void
+    {
+        $text = json_encode([
+            'intro' => 'x',
+            'items' => [
+                ['title' => 'Croeso i Gaerdydd festival', 'blurb' => 'A weekend of Welsh music.', 'url' => 'https://ok.org', 'source' => 'S'],
+            ],
+        ]);
+
+        [, $items] = $this->svc()->parse($text, 6);
+
+        $this->assertSame('Croeso i Gaerdydd festival', $items[0]['title']);
+    }
+
+    /** The prompts must pin the output language, intro included. */
+    public function test_research_prompts_demand_english_only(): void
+    {
+        config(['freegle.communitynews.anthropic_api_key' => 'test-key']);
+
+        $json = json_encode(['intro' => 'x', 'items' => [
+            ['title' => 'T', 'blurb' => 'b', 'url' => 'https://ok.org', 'source' => 'S'],
+        ]]);
+        Http::fake(['api.anthropic.com/*' => Http::response([
+            'stop_reason' => 'end_turn',
+            'content' => [['type' => 'text', 'text' => $json]],
+        ], 200)]);
+
+        $this->svc()->researchArea($this->area());
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            return str_contains($body['system'] ?? '', 'ENTIRELY in English')
+                && str_contains($body['messages'][0]['content'] ?? '', 'in UK English');
+        });
+    }
 }

--- a/iznik-batch/tests/Unit/CommunityNews/IntroLanguageTest.php
+++ b/iznik-batch/tests/Unit/CommunityNews/IntroLanguageTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Unit\CommunityNews;
+
+use App\Services\CommunityNews\IntroLanguage;
+use PHPUnit\Framework\TestCase;
+
+class IntroLanguageTest extends TestCase
+{
+    /**
+     * The observed production failure mode: a token Welsh greeting bolted onto
+     * an otherwise-English intro. The greeting sentence goes; the English part
+     * stays.
+     */
+    public function test_strips_a_leading_welsh_greeting_sentence(): void
+    {
+        $cases = [
+            'Shwmae, Caernarfon! The castle is busier than ever this fortnight.'
+                => 'The castle is busier than ever this fortnight.',
+            'Bore da, Cwmbran! The schools are still off and the farm is full of falconry.'
+                => 'The schools are still off and the farm is full of falconry.',
+            'Croeso to your Port Talbot round-up! The seafront is still in full summer swing.'
+                => 'The seafront is still in full summer swing.',
+            'Croeso i mid August, Wrecsam! The balloons are inflating.'
+                => 'The balloons are inflating.',
+            'Prynhawn da, Merthyr! Plenty to tempt you out this week.'
+                => 'Plenty to tempt you out this week.',
+        ];
+
+        foreach ($cases as $in => $want) {
+            $this->assertSame($want, IntroLanguage::stripForeignGreeting($in), "for: {$in}");
+        }
+    }
+
+    public function test_strips_consecutive_greeting_sentences(): void
+    {
+        $this->assertSame(
+            'Here is what your neighbours are up to.',
+            IntroLanguage::stripForeignGreeting('Shwmae! Croeso i Wrecsam! Here is what your neighbours are up to.')
+        );
+    }
+
+    public function test_is_case_insensitive(): void
+    {
+        $this->assertSame(
+            'The market is back.',
+            IntroLanguage::stripForeignGreeting('SHWMAE, LLANGEFNI! The market is back.')
+        );
+    }
+
+    public function test_strips_gaelic_greetings_too(): void
+    {
+        $this->assertSame(
+            'The festival returns to the glen.',
+            IntroLanguage::stripForeignGreeting('Fàilte! The festival returns to the glen.')
+        );
+    }
+
+    /** A greeting with no closing punctuation swallows to the end of the text. */
+    public function test_an_intro_that_is_only_a_greeting_comes_back_empty(): void
+    {
+        $this->assertSame('', IntroLanguage::stripForeignGreeting('Croeso i mid August'));
+        $this->assertSame('', IntroLanguage::stripForeignGreeting('Shwmae, Caernarfon!'));
+    }
+
+    public function test_plain_english_intros_pass_through_untouched(): void
+    {
+        $cases = [
+            'A gentle armful of free days out and fresh-veg markets to see you through.',
+            // A Welsh proper noun mid-sentence is a name, not a greeting.
+            'There is a warm welcome waiting at the Eisteddfod this week.',
+            // A greeting word that is not sentence-initial stays: only the
+            // bolted-on opening is the failure mode this guards against.
+            'We say croeso to the newly reopened library.',
+            // "Croesofield" contains "croeso" but is not the word itself.
+            'Croesofield Church holds its summer fete on Saturday.',
+        ];
+
+        foreach ($cases as $intro) {
+            $this->assertSame($intro, IntroLanguage::stripForeignGreeting($intro), "for: {$intro}");
+        }
+    }
+
+    public function test_empty_input_stays_empty(): void
+    {
+        $this->assertSame('', IntroLanguage::stripForeignGreeting(''));
+        $this->assertSame('', IntroLanguage::stripForeignGreeting('   '));
+    }
+}


### PR DESCRIPTION
## Summary

- Community News intros for Welsh-named areas came out mixed-language: the research model bolted a token Welsh greeting onto an otherwise-English intro ("Croeso i mid August", "Shwmae, Caernarfon!", "Bore da, Cwmbran!"). 12 of 239 live areas were affected as of 2026-08-17. Item titles and blurbs were clean, and the intro is the only AI-written text that gets stored and reused (on `community_news_areas.intro`, re-sent by the weekly email until the area is next researched).
- The research prompts now say explicitly: write entirely in UK English, intro included, and never sprinkle greetings from Welsh, Gaelic or any other language. Welsh NAMES of places, events and organisations (the Eisteddfod) remain fine.
- A new helper, `IntroLanguage::stripForeignGreeting()`, is the safety net for when the model ignores the prompt. It removes a Welsh, Scottish Gaelic, Irish, Cornish or Manx greeting from the start of an intro (repeating if greetings are stacked), and an intro that was nothing but a greeting comes back empty. This is plain string handling in code, not another model call, so it works however the model phrases things - the same approach the service already uses to keep em dashes out.
- It is applied in two places: when parsing a research result (a mixed intro can never be stored) and when sending the weekly email (the 12 greetings already stored on live never reach members while waiting for the next research pass). A stored intro that was only a greeting falls back to the stock "Here's a little round-up..." line.
- Item titles and blurbs are deliberately left alone by the helper: a Welsh event name ("Croeso i Gaerdydd festival") is a name, not a greeting.

## Rollout

Nothing to do: research runs hourly and revisits each area roughly every 3 days, so all stored intros regenerate under the new prompt within days, and the send-time strip protects any Friday 11:00 email before that. A manual `php artisan community-news:research --force` regenerates them immediately if wanted.

## Code Quality Review

- Scope is tight: only greetings at the start of a sentence, and only in intros. Mid-sentence words ("we say croeso to the new library") and names that contain a greeting word ("Croesofield Church") pass through, covered by tests.
- The greeting list is a constant and each entry is escaped before building the pattern; no user input reaches it. A failed regex replace is handled.
- Follows the existing `MentionedDates` pattern for this kind of helper (final class, static method, same namespace, so no imports needed).
- Nothing else reads `area->intro` beyond the two places now covered (checked by grep).

## Future Improvements

- Proper Welsh-language support (a fully-translated intro or bilingual newsletter for strongly Welsh-speaking areas) would be a deliberate product feature with its own quality checks, not half-and-half greetings. Out of scope here by decision: zero Welsh.

## Test Plan

- Tests were written first and confirmed failing (all 7 new unit tests errored, class not found), then made to pass.
- `IntroLanguageTest` (Unit, 7 tests): the greeting shapes seen in production get stripped, stacked greetings, case-insensitivity, Gaelic, greeting-only becomes empty, plain-English and proper-noun cases untouched, empty input.
- `CommunityNewsResearchServiceTest`: parsing strips a token greeting from the intro; Welsh-named items untouched; the English-only instruction is asserted to actually be in the prompts sent.
- `CommunityNewsEmailServiceTest`: a stored "Shwmae, Testville!" intro goes out stripped; a greeting-only stored intro falls back to the stock line.
- Filtered run: 33 of 33 tests across the three classes. Full Laravel suite: 5,640 of 5,640 pass via the status API. Docs freshness check: OK (no docs page covers these paths).
