### PR TITLE
fix(monitoring): drop the package list from the reboot warning entirely

### DIFF
--- a/iznik-batch/app/Monitoring/Checks/HostHealthCheck.php
+++ b/iznik-batch/app/Monitoring/Checks/HostHealthCheck.php
@@ -33,7 +33,6 @@ class HostHealthCheck extends AbstractOutcomeCheck
      */
     public const PROBE = <<<'SH'
 echo "REBOOT:$([ -f /var/run/reboot-required ] && echo yes || echo no)"
-echo "REBOOT_PKGS:$(sort -u /var/run/reboot-required.pkgs 2>/dev/null | head -3 | tr '\n' ' ')"
 echo "SECURITY:$(apt-get upgrade -s 2>/dev/null | grep -c '^Inst.*[Ss]ecurit')"
 if command -v monit >/dev/null 2>&1; then echo "MONIT_BEGIN"; monit summary -B 2>&1; echo "MONIT_END"; else echo "MONIT_ABSENT"; fi
 SH;
@@ -114,19 +113,11 @@ SH;
         $warnings = [];
 
         if (preg_match('/^REBOOT:yes$/m', $output)) {
-            $pkgs = '';
-            if (preg_match('/^REBOOT_PKGS:(.+)$/m', $output, $m) && trim($m[1]) !== '') {
-                // Versioned kernel package names (linux-image-5.15.0-186-generic) say
-                // nothing a mod acts on and change every kernel: strip the version
-                // segments so the modal reads "linux-image-generic", and dedupe in
-                // case two kernel versions are pending at once.
-                $names = array_unique(array_map(
-                    fn (string $pkg): string => preg_replace('/-\d+(?:\.\d+)*(?:-\d+)?/', '', $pkg),
-                    preg_split('/\s+/', trim($m[1]))
-                ));
-                $pkgs = ' (' . implode(' ', $names) . ')';
-            }
-            $warnings[] = "reboot required{$pkgs}";
+            // Just the fact. The package list (even version-stripped) tells a
+            // mod nothing they act on — the action is identical whatever
+            // triggered the flag, and the operator who reboots can read
+            // /var/run/reboot-required.pkgs on the host.
+            $warnings[] = 'reboot required';
         }
 
         if (preg_match('/^SECURITY:(\d+)$/m', $output, $m) && (int) $m[1] > 0) {

--- a/iznik-batch/tests/Feature/Monitor/HostHealthCheckTest.php
+++ b/iznik-batch/tests/Feature/Monitor/HostHealthCheckTest.php
@@ -42,12 +42,10 @@ class HostHealthCheckTest extends TestCase
      */
     private function probeOutput(
         string $reboot = 'no',
-        string $rebootPkgs = '',
         int $security = 0,
         ?array $monitLines = ['freegle-host                     OK                          System'],
     ): string {
         $out = "REBOOT:{$reboot}\n";
-        $out .= "REBOOT_PKGS:{$rebootPkgs}\n";
         $out .= "SECURITY:{$security}\n";
 
         if ($monitLines === null) {
@@ -88,26 +86,16 @@ class HostHealthCheckTest extends TestCase
         $this->assertTrue($result->isOk(), $result->message);
     }
 
-    public function test_reboot_required_is_a_warning_naming_the_packages(): void
+    public function test_reboot_required_is_a_plain_warning_without_packages(): void
     {
-        $result = $this->evaluate($this->probeOutput(reboot: 'yes', rebootPkgs: 'linux-base libc6'));
+        $result = $this->evaluate($this->probeOutput(reboot: 'yes'));
 
         $this->assertTrue($result->isBreach());
         $this->assertSame('warning', $result->severity);
         $this->assertStringContainsString('reboot required', $result->message);
-        $this->assertStringContainsString('linux-base libc6', $result->message);
-    }
-
-    public function test_reboot_package_names_lose_their_version_and_dedupe(): void
-    {
-        $result = $this->evaluate($this->probeOutput(
-            reboot: 'yes',
-            rebootPkgs: 'linux-image-5.15.0-186-generic linux-base libc6 linux-image-5.15.0-181-generic',
-        ));
-
-        $this->assertTrue($result->isBreach());
-        $this->assertStringContainsString('(linux-image-generic linux-base libc6)', $result->message);
-        $this->assertStringNotContainsString('5.15', $result->message);
+        // No package list: it names nothing a mod acts on, and it made the
+        // modal read like a changelog.
+        $this->assertStringNotContainsString('(', $result->message);
     }
 
     public function test_pending_security_updates_are_a_warning_with_the_count(): void
@@ -156,7 +144,7 @@ class HostHealthCheckTest extends TestCase
 
     public function test_a_dead_monit_daemon_is_an_error(): void
     {
-        $output = "REBOOT:no\nREBOOT_PKGS:\nSECURITY:0\nMONIT_BEGIN\n"
+        $output = "REBOOT:no\nSECURITY:0\nMONIT_BEGIN\n"
             . "Status not available -- the monit daemon is not running\nMONIT_END\n";
 
         $result = $this->evaluate($output);


### PR DESCRIPTION
Follow-up to #1348: stripping the kernel versions was not enough — even trimmed, the bracketed package list names nothing a moderator acts on. The action is the same whatever set the flag, and whoever performs the reboot can read `/var/run/reboot-required.pkgs` on the host itself.

The status modal now reads just `reboot required`. The probe no longer collects the package list, and the tests assert the plain message.

Verified live on batch-prod: all four current reboot warnings (db1, db2, db3, docker) now render bare. Local suite cannot run on this host (production profile); CI validates.