### PR TITLE
Ask the database which posts are due a chase-up, instead of 184k rows a run

### DIFF
--- a/iznik-batch/app/Services/ChaseUpService.php
+++ b/iznik-batch/app/Services/ChaseUpService.php
@@ -438,7 +438,7 @@ class ChaseUpService
     {
         $stats = ['chased' => 0, 'skipped' => 0];
 
-        $messages = $this->getCandidates($group->id, $mindate);
+        $messages = $this->getCandidates($group->id, $mindate, $reposts);
         $now = time();
 
         foreach ($messages as $msg) {
@@ -553,9 +553,21 @@ class ChaseUpService
      * Simplified here: exclude messages that have related messages.
      * Messages must have at least one chat reply (INNER JOIN chat_messages).
      */
-    protected function getCandidates(int $groupid, string $mindate)
+    protected function getCandidates(int $groupid, string $mindate, array $reposts = self::DEFAULT_REPOSTS)
     {
-        return DB::table('messages_groups')
+        // Three of the things that disqualify a post can be asked of the database
+        // directly, and they throw away almost everything. Measured against production
+        // over the ninety-day window this reads: 183,772 rows came back, of which only
+        // 5,423 survived these three tests in PHP. Everything else was fetched, held in
+        // memory and dropped.
+        //
+        // Much the largest of the three is the rippled-in test. A post that rippled into
+        // this community must not start its own chase-up - that would email the poster
+        // once per community it reached - and since rippling went live those copies are
+        // 85% of what this query returns.
+        $window = $this->chaseupWindowHours($reposts);
+
+        $query = DB::table('messages_groups')
             ->join('messages', 'messages.id', '=', 'messages_groups.msgid')
             ->join('memberships', function ($join) {
                 $join->on('memberships.userid', '=', 'messages.fromuser')
@@ -597,8 +609,59 @@ class ChaseUpService
                 'messages.fromaddr',
                 'messages.fromuser',
                 'messages_groups.arrival'
-            )
-            ->get();
+            );
+
+        // A copy that rippled in never starts its own chase-up (see processGroup).
+        $query->where('messages_groups.rippled_in', 0);
+
+        // Must have run out of reposts first. Rounded down, so if a community ever
+        // stored a fraction this asks for slightly more than PHP will accept rather
+        // than less - it can hand over a post PHP then discards, but it can never
+        // hold back one PHP would have chased.
+        if ($window['maxreposts'] > 0) {
+            $query->where('messages_groups.autoreposts', '>=', $window['maxreposts']);
+        }
+
+        // Either never chased up, or the last one is old enough. The interval differs by
+        // type, so ask per type rather than applying the shorter of the two to both.
+        $query->where(function ($q) use ($window) {
+            $q->whereNull('messages_groups.lastchaseup')
+                ->orWhere(function ($q2) use ($window) {
+                    $q2->where('messages.type', Message::TYPE_OFFER)
+                        ->where('messages_groups.lastchaseup', '<', $window['offer_before']);
+                })
+                ->orWhere(function ($q2) use ($window) {
+                    $q2->where('messages.type', Message::TYPE_WANTED)
+                        ->where('messages_groups.lastchaseup', '<', $window['wanted_before']);
+                });
+        });
+
+        return $query->get();
+    }
+
+    /**
+     * The database-side form of canChaseup's tests.
+     *
+     * Read from the same settings array canChaseup reads, so the two cannot drift apart,
+     * and timed off the same PHP clock canChaseup compares against.
+     *
+     * A day is deducted from each interval deliberately. This decides which rows to
+     * fetch; canChaseup still decides what actually gets chased. Being a day generous
+     * means the two can only disagree in one direction - handing over a post that PHP
+     * then declines, which costs one wasted row - rather than withholding one PHP would
+     * have chased, which would silently lose a chase-up.
+     */
+    protected function chaseupWindowHours(array $reposts): array
+    {
+        $chaseupDays = $reposts['chaseups'] ?? 2;
+        $offerDays = (int) max($reposts['offer'] ?? 3, $chaseupDays);
+        $wantedDays = (int) max($reposts['wanted'] ?? 7, $chaseupDays);
+
+        return [
+            'maxreposts' => (int) ($reposts['max'] ?? 5),
+            'offer_before' => now()->subHours(max(0, $offerDays * 24 - 24))->toDateTimeString(),
+            'wanted_before' => now()->subHours(max(0, $wantedDays * 24 - 24))->toDateTimeString(),
+        ];
     }
 
     /**

--- a/iznik-batch/tests/Unit/Services/ChaseUpServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChaseUpServiceTest.php
@@ -186,6 +186,43 @@ class ChaseUpServiceTest extends TestCase
         $this->assertEquals(0, $stats['chased']);
     }
 
+    public function test_a_post_just_past_the_chaseup_interval_is_still_fetched(): void
+    {
+        // The database is now asked to leave out posts whose last chase-up is too recent,
+        // instead of fetching every one and discarding it. The danger in doing that is
+        // asking for too little: a post left out of the fetch is never considered again,
+        // so its chase-up is lost silently. The window therefore reaches back a day
+        // further than the rule it stands in for.
+        //
+        // Defaults give an offer an interval of five days, so a chase-up sent five days
+        // and an hour ago is due. It must survive the fetch.
+        $data = $this->createChaseCandidate();
+        DB::table('messages_groups')
+            ->where('msgid', $data['message']->id)
+            ->where('groupid', $data['group']->id)
+            ->update(['lastchaseup' => now()->subHours(5 * 24 + 1)]);
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(1, $stats['chased'], 'a due chase-up must not be filtered out of the fetch');
+    }
+
+    public function test_a_recently_chased_post_is_not_chased_again(): void
+    {
+        // The other side of the same window. This one is fetched - the window is
+        // deliberately a day wider than the rule - and then declined in PHP, which is
+        // the safe way round for the two to disagree.
+        $data = $this->createChaseCandidate();
+        DB::table('messages_groups')
+            ->where('msgid', $data['message']->id)
+            ->where('groupid', $data['group']->id)
+            ->update(['lastchaseup' => now()->subHours(4 * 24)]);
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(0, $stats['chased'], 'a post chased up four days ago is not due again yet');
+    }
+
     public function test_skips_message_with_outcome(): void
     {
         $data = $this->createChaseCandidate();


### PR DESCRIPTION
The chase-up run fetches about 184,000 rows from the database and sends chase-ups about 5,400 of them. The rest are read, held in memory and thrown away one at a time in PHP.

## What it does now

`ChaseUpService::getCandidates` asks for every approved post in the last ninety days that has a chat reply and no outcome, per community. Three of the things that then disqualify a post are decided afterwards in PHP, and all three can be asked of the database instead.

Measured against production over that ninety-day window:

| Filter applied | Rows still in play |
|---|---|
| What the query returns today | 183,772 |
| ...that are not a rippled-in copy | 27,697 |
| ...that have also run out of reposts | 6,003 |
| ...whose last chase-up is also old enough | 5,423 |

So 97% of what comes back was never going to be chased up.

Much the largest single cut is the first one. A post that rippled into a community must not start its own chase-up, because that would email the poster once for every community the post reached — the home posting drives it. Since rippling went live those copies are 85% of what this query returns.

## What changes

Those three tests are now part of the query. The PHP checks stay exactly as they were: the query decides which rows to fetch, the existing code still decides what actually gets chased.

## The one risk, and how it is handled

Fetching less is only safe if the query never asks for too little. A post left out of the fetch is not deferred, it is never looked at again, so its chase-up would be lost silently and nobody would notice.

Two of the three tests are exact — whether a copy rippled in, and whether the repost count has been reached — so there is nothing to get wrong. The repost figure is rounded down, which if a community ever stored a fraction means the query hands over slightly more than PHP accepts rather than less.

The timing test needs more care, so the window deliberately reaches back a day further than the rule it stands in for. A post whose chase-up interval has just elapsed is comfortably inside it. That means the two can only disagree in one direction: the query hands over a post PHP then declines, costing one wasted row, rather than withholding one PHP would have chased.

Both directions have tests: a post one hour past its interval is still fetched and chased, and a post four days into a five-day interval is fetched and then correctly left alone.

## Testing

Full Laravel suite locally: 5,681 passed, 0 failed. Two new tests as described above. The existing tests for the two behaviours now enforced in the query — a post short of its repost count, and a rippled-only posting — still pass, and now pin the same outcome at the query level.
