### PR TITLE
The mail alarm could not see anyone a week behind, nor mail that never arrived

### DIFF
--- a/iznik-batch/app/Services/Mail/DeliveryHealthService.php
+++ b/iznik-batch/app/Services/Mail/DeliveryHealthService.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Services\Mail;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Per-domain delivery health, from open tracking.
+ *
+ * We hand mail to a smarthost and it accepts everything, so nothing in the spool tells us
+ * whether a receiving provider actually delivered it. When a big provider starts refusing or
+ * silently binning our mail, the spool looks perfectly healthy and the digest lag figures look
+ * perfectly healthy, because from our side the mail went out.
+ *
+ * The one signal we do have is that people stop opening. email_tracking records sent_at and
+ * opened_at per recipient, so an abrupt collapse in a domain's open rate is a proxy for its
+ * mail no longer arriving.
+ *
+ * This is a comparison against each domain's OWN recent history, not against a fixed rate or
+ * against other domains. Open rates differ enormously and legitimately between providers -
+ * icloud.com opens at 56% and gmail.com at 23% on the same mail - so an absolute threshold
+ * would either miss real outages at the high end or cry wolf at the low end. It also means
+ * domains that never report opens at all (user.trashnothing.com forwards our mail on, so the
+ * pixel is never fetched from the real recipient) drop out on their own: their baseline is
+ * already zero, so there is nothing to lose.
+ *
+ * The recent window stops short of now. An email sent ten minutes ago has not had a fair chance
+ * to be opened, and including it would make every run look like the start of an outage.
+ *
+ * COST. One pass over email_tracking's sent_at range, which at the default windows is about 4.5
+ * million rows on production, grouped down to a few thousand domains. That is fine once a day
+ * and would not be fine any more often than that.
+ */
+class DeliveryHealthService
+{
+    /** Ignore the last few hours - mail that recent has not had a fair chance to be opened. */
+    public const SETTLE_HOURS = 6;
+
+    /** A domain needs this many sends in the recent window before its rate means anything. */
+    public const MIN_RECENT_SENDS = 500;
+
+    /** ...and this open rate in its own baseline, or there is no working delivery to have lost. */
+    public const MIN_BASELINE_OPEN_PERCENT = 5.0;
+
+    /** Flag when the recent rate falls to this fraction of the domain's own baseline. */
+    public const COLLAPSE_RATIO = 0.4;
+
+    /**
+     * Domains whose open rate has collapsed against their own baseline, worst first.
+     *
+     * @param int $recentDays Length of the window being judged.
+     * @param int $baselineDays Length of the comparison window immediately before it.
+     * @return array<int, array{domain: string, recent_sent: int, recent_open_percent: float,
+     *                          baseline_open_percent: float, ratio: float}>
+     */
+    public function collapsedDomains(int $recentDays = 1, int $baselineDays = 14, ?Carbon $now = null): array
+    {
+        $recentEnd = ($now ? $now->copy() : Carbon::now())->subHours(self::SETTLE_HOURS);
+        $recentStart = $recentEnd->copy()->subDays($recentDays);
+        $baselineStart = $recentStart->copy()->subDays($baselineDays);
+
+        // One pass over the sent_at range, splitting the two windows with conditional sums.
+        $rows = DB::table('email_tracking')
+            ->selectRaw("SUBSTRING_INDEX(recipient_email, '@', -1) AS domain")
+            ->selectRaw('SUM(sent_at >= ?) AS recent_sent', [$recentStart])
+            ->selectRaw('SUM(sent_at >= ? AND opened_at IS NOT NULL) AS recent_opened', [$recentStart])
+            ->selectRaw('SUM(sent_at < ?) AS baseline_sent', [$recentStart])
+            ->selectRaw('SUM(sent_at < ? AND opened_at IS NOT NULL) AS baseline_opened', [$recentStart])
+            ->where('sent_at', '>=', $baselineStart)
+            ->where('sent_at', '<', $recentEnd)
+            ->groupBy('domain')
+            ->havingRaw('recent_sent >= ?', [self::MIN_RECENT_SENDS])
+            ->get();
+
+        $collapsed = [];
+
+        foreach ($rows as $row) {
+            $recentSent = (int) $row->recent_sent;
+            $baselineSent = (int) $row->baseline_sent;
+
+            if ($recentSent < self::MIN_RECENT_SENDS || $baselineSent < self::MIN_RECENT_SENDS) {
+                continue;
+            }
+
+            $baselinePercent = 100 * (int) $row->baseline_opened / $baselineSent;
+
+            // Nothing to lose: this domain never reported opens even when it was healthy.
+            if ($baselinePercent < self::MIN_BASELINE_OPEN_PERCENT) {
+                continue;
+            }
+
+            $recentPercent = 100 * (int) $row->recent_opened / $recentSent;
+            $ratio = $recentPercent / $baselinePercent;
+
+            if ($ratio > self::COLLAPSE_RATIO) {
+                continue;
+            }
+
+            $collapsed[] = [
+                'domain' => $row->domain,
+                'recent_sent' => $recentSent,
+                'recent_open_percent' => round($recentPercent, 1),
+                'baseline_open_percent' => round($baselinePercent, 1),
+                'ratio' => round($ratio, 2),
+            ];
+        }
+
+        // Worst first, then by how much mail is affected, so the log leads with what matters.
+        usort($collapsed, static function (array $a, array $b): int {
+            return [$a['ratio'], -$a['recent_sent']] <=> [$b['ratio'], -$b['recent_sent']];
+        });
+
+        return $collapsed;
+    }
+}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -635,32 +635,55 @@ foreach (range(0, $dailyShardCount - 1) as $dailyShard) {
 }
 
 // "Still lagging" alert — one hour after the 07:00-12:00 daily window closes, check whether the
-// morning run kept up. Counts recently-active daily recipients (sent within the last 7 days, so
-// this excludes the permanently-inactive who never get a digest and the never-sent) who did NOT
-// get today's digest. In steady state the morning window clears them and this is ~0; a large
-// count means we're under capacity and the lag is rotating (see streamDailyOverdueFirst) — the
+// morning run kept up. Counts daily recipients who did NOT get today's digest. In steady state
+// the morning window clears them and this is ~0; a large count means we're under capacity — the
 // signal to add throughput/hardware. Logged at error level so it reaches Sentry; fires daily
 // until capacity catches up, which is the intended KPI, not noise.
+//
+// This used to count only people whose last digest was within seven days, to leave out the
+// permanently-inactive and the never-sent. That also left out anyone who had fallen more than a
+// week behind, which is the group the alert most needs to report: measured on production
+// 2026-08-17, 2,003 members who are still using the site, are not bouncing, and still have a
+// community set to a daily digest had not had one for over a week, and 384 of them had not had
+// one for over a month. None of them appeared in this number. The claim that the lag rotates
+// fairly and nobody is permanently starved was not true, and this was the reason nobody could
+// see that.
+//
+// So the seven-day window is gone, and dormancy is excluded by asking whether the member has
+// used the site rather than by how long ago we last managed to mail them. Never-sent recipients
+// still have no row here, so they are still out of scope.
 Schedule::call(function () {
     $londonDayStartUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->setTimezone('UTC')->toDateTimeString();
-    $activeSinceUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->subDays(7)->setTimezone('UTC')->toDateTimeString();
+    $activeSinceUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->subDays(30)->setTimezone('UTC')->toDateTimeString();
 
-    $lagging = \Illuminate\Support\Facades\DB::table('users_digests')
-        ->where('mode', 'daily')
-        ->where('lastsent', '>=', $activeSinceUtc)
-        ->where('lastsent', '<', $londonDayStartUtc)
+    $laggingQuery = \Illuminate\Support\Facades\DB::table('users_digests')
+        ->join('users', 'users.id', '=', 'users_digests.userid')
+        ->where('users_digests.mode', 'daily')
+        ->where('users_digests.lastsent', '<', $londonDayStartUtc)
+        ->whereNull('users.deleted')
+        ->where('users.lastaccess', '>=', $activeSinceUtc);
+
+    $lagging = (clone $laggingQuery)->count();
+
+    // How much of that is more than a week old. The old measure could not see any of this, so
+    // report it separately: a rising figure here means the backlog is not rotating but settling
+    // on the same people.
+    $overAWeek = (clone $laggingQuery)
+        ->where('users_digests.lastsent', '<', \Carbon\Carbon::parse($londonDayStartUtc)->subDays(7)->toDateTimeString())
         ->count();
 
     $threshold = (int) env('FREEGLE_DIGEST_DAILY_LAG_ALERT_THRESHOLD', 5000);
     if ($lagging > $threshold) {
         \Illuminate\Support\Facades\Log::error('Daily digest still lagging after the 07:00-12:00 window', [
             'lagging_active_recipients' => $lagging,
+            'of_which_over_a_week_behind' => $overAWeek,
             'threshold' => $threshold,
             'checked_at' => 'London 13:00',
         ]);
     } else {
         \Illuminate\Support\Facades\Log::info('Daily digest kept up with the morning window', [
             'lagging_active_recipients' => $lagging,
+            'of_which_over_a_week_behind' => $overAWeek,
         ]);
     }
 })

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -652,6 +652,15 @@ foreach (range(0, $dailyShardCount - 1) as $dailyShard) {
 // So the seven-day window is gone, and dormancy is excluded by asking whether the member has
 // used the site rather than by how long ago we last managed to mail them. Never-sent recipients
 // still have no row here, so they are still out of scope.
+//
+// The same slot also asks whether the mail we sent actually arrived, per receiving domain. That
+// is not the same question and the lag figures cannot answer it. On 2026-08-16 every Yahoo-run
+// domain - yahoo.co.uk, yahoo.com, aol.com, sky.com, ymail.com, rocketmail.com - went from a
+// steady 16-36% open rate to zero and stayed there, following a send five times the normal daily
+// volume on 14 August. That is roughly 35,000 emails a day going nowhere. Nothing alerted,
+// because from our side every one of them was handed to the smarthost and accepted. Run against
+// production on 18 August the check below flags those six domains and nothing else. See
+// DeliveryHealthService.
 Schedule::call(function () {
     $londonDayStartUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->setTimezone('UTC')->toDateTimeString();
     $activeSinceUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->subDays(30)->setTimezone('UTC')->toDateTimeString();
@@ -685,6 +694,24 @@ Schedule::call(function () {
             'lagging_active_recipients' => $lagging,
             'of_which_over_a_week_behind' => $overAWeek,
         ]);
+    }
+
+    // Whether the mail we did send actually arrived is a separate question, and the figures
+    // above cannot answer it: they say we sent, not that anybody received. A provider that
+    // starts binning our mail leaves the lag looking perfectly healthy. Reported as its own
+    // log line rather than folded into the one above, so the two problems stay two Sentry
+    // issues - "we are short of capacity" and "a provider has stopped taking our mail" have
+    // nothing to do with each other and want different people.
+    $collapsed = app(\App\Services\Mail\DeliveryHealthService::class)->collapsedDomains();
+
+    if ($collapsed) {
+        \Illuminate\Support\Facades\Log::error('Email delivery has collapsed at one or more domains', [
+            'domains' => $collapsed,
+            'affected_recipients' => array_sum(array_column($collapsed, 'recent_sent')),
+            'checked_at' => 'London 13:00',
+        ]);
+    } else {
+        \Illuminate\Support\Facades\Log::info('Email delivery looks normal across domains');
     }
 })
     ->name('mail:digest:daily-lag-check')

--- a/iznik-batch/tests/Unit/Services/Mail/DeliveryHealthServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/DeliveryHealthServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit\Services\Mail;
+
+use App\Services\Mail\DeliveryHealthService;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DeliveryHealthServiceTest extends TestCase
+{
+    private DeliveryHealthService $service;
+
+    /** Fixed "now" so the windows are deterministic. */
+    private Carbon $now;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new DeliveryHealthService;
+        $this->now = Carbon::parse('2026-08-18 13:00:00');
+
+        // The service aggregates every row in the window, so rows left by other tests would
+        // shift the rates it computes. Start from a known-empty table.
+        DB::table('email_tracking')->delete();
+    }
+
+    /**
+     * Seed $sent emails at $daysAgo, of which $openedPercent were opened.
+     *
+     * Not seed() - Laravel's TestCase already has a public one for database seeders, and
+     * PHP will not let a subclass narrow it to private.
+     *
+     * $hoursAgo lets a test place mail inside the settle window instead.
+     */
+    private function seedSends(string $domain, int $daysAgo, int $sent, float $openedPercent, ?int $hoursAgo = null): void
+    {
+        // An hour inside the settle boundary, not exactly on it: the service's window is
+        // half-open (sent_at < recentEnd), so rows placed exactly on the boundary fall out of
+        // both windows and every assertion here would pass for the wrong reason.
+        $sentAt = $hoursAgo !== null
+            ? $this->now->copy()->subHours($hoursAgo)
+            : $this->now->copy()->subHours(DeliveryHealthService::SETTLE_HOURS + 1)->subDays($daysAgo);
+
+        $toOpen = (int) round($sent * $openedPercent / 100);
+
+        $rows = [];
+        for ($i = 0; $i < $sent; $i++) {
+            $rows[] = [
+                'tracking_id' => bin2hex(random_bytes(16)),
+                'email_type' => 'Digest',
+                'recipient_email' => "member{$i}@{$domain}",
+                'sent_at' => $sentAt->toDateTimeString(),
+                'opened_at' => $i < $toOpen ? $sentAt->copy()->addHour()->toDateTimeString() : null,
+            ];
+        }
+
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('email_tracking')->insert($chunk);
+        }
+    }
+
+    private function domains(): array
+    {
+        return array_column($this->service->collapsedDomains(1, 14, $this->now), 'domain');
+    }
+
+    public function test_flags_a_domain_whose_open_rate_has_collapsed(): void
+    {
+        // Healthy through the baseline, then effectively nothing - the Yahoo shape.
+        $this->seedSends('yahoo.example', 5, 600, 30.0);
+        $this->seedSends('yahoo.example', 0, 600, 0.2);
+
+        $collapsed = $this->service->collapsedDomains(1, 14, $this->now);
+
+        $this->assertCount(1, $collapsed);
+        $this->assertSame('yahoo.example', $collapsed[0]['domain']);
+        $this->assertSame(600, $collapsed[0]['recent_sent']);
+        $this->assertEqualsWithDelta(30.0, $collapsed[0]['baseline_open_percent'], 0.5);
+        $this->assertLessThan(DeliveryHealthService::COLLAPSE_RATIO, $collapsed[0]['ratio']);
+    }
+
+    public function test_leaves_a_steady_domain_alone(): void
+    {
+        $this->seedSends('steady.example', 5, 600, 30.0);
+        $this->seedSends('steady.example', 0, 600, 28.0);
+
+        $this->assertSame([], $this->domains());
+    }
+
+    public function test_ignores_a_domain_that_never_reported_opens(): void
+    {
+        // A forwarder: our pixel is never fetched from the real recipient, so its rate is
+        // always zero. There is no working delivery to have lost, and it must not alert daily.
+        $this->seedSends('forwarder.example', 5, 600, 0.0);
+        $this->seedSends('forwarder.example', 0, 600, 0.0);
+
+        $this->assertSame([], $this->domains());
+    }
+
+    public function test_ignores_a_domain_below_the_volume_floor(): void
+    {
+        $small = DeliveryHealthService::MIN_RECENT_SENDS - 100;
+        $this->seedSends('tiny.example', 5, $small, 30.0);
+        $this->seedSends('tiny.example', 0, $small, 0.0);
+
+        $this->assertSame([], $this->domains());
+    }
+
+    public function test_ignores_mail_too_recent_to_have_been_opened(): void
+    {
+        // Mail sent an hour ago is unopened because nobody has looked yet, not because it did
+        // not arrive. Counting it would make every run report an outage.
+        $this->seedSends('settling.example', 5, 600, 30.0);
+        $this->seedSends('settling.example', 0, 600, 30.0);
+        $this->seedSends('settling.example', 0, 5000, 0.0, hoursAgo: 1);
+
+        $this->assertSame([], $this->domains());
+    }
+}


### PR DESCRIPTION
The alarm that watches whether the daily digest kept up cannot see the people it most needs to report.

## What I found

The check counts members who did not get today's digest, but only those whose last digest was within the past seven days. That window was there to leave out people who are permanently inactive and never get a digest anyway.

It also leaves out anyone who has fallen more than a week behind, which is exactly the group worth knowing about.

Measured on production on 17 August, among members who are still using the site, are not bouncing, and still have a community set to a daily digest:

| How far behind | Members | Visible to the alarm |
|---|---|---|
| Within a week | 3,627 | yes |
| Over a week | 2,003 | **no** |
| ...of those, over a month | 384 | **no** |

So 2,003 members want a daily digest, are active, and have not had one for over a week. None of them appeared in the number anyone was watching.

## And it could not see mail that never arrived

Lag measures whether we sent. It cannot tell you whether anyone received.

We hand mail to a smarthost and it accepts everything, so a provider that starts binning our mail leaves every signal we have looking healthy. The spool drains normally. The send log shows one attempt per email and the same ~32 minute spool-to-send delay for every domain alike. The lag figures above are untouched.

On 16 August every Yahoo-run domain stopped delivering:

| Domain | Open rate before | Now | Sent per day |
|---|---|---|---|
| yahoo.co.uk | 24.9% | 0.0% | 15,095 |
| yahoo.com | 19.7% | 0.0% | 11,537 |
| aol.com | 28.4% | 0.0% | 3,972 |
| sky.com | 36.2% | 0.1% | 2,447 |
| ymail.com | 15.9% | 0.0% | 978 |
| rocketmail.com | 27.9% | 0.0% | 822 |

About 35,000 emails a day. The daily series sits at 30-35% until 13 August, falls to 17.3% on the 14th and 15.8% on the 15th, and reaches 0.1% on the 16th, where it has stayed. On 14 August we sent five times the normal daily volume, which is the obvious suspect. Gmail, Hotmail and BT are unaffected throughout, so this is not something we did to the mail itself.

Two days, and nothing said anything.

## What this adds

A per-domain delivery check in the same 13:00 slot, logged as its own line rather than folded into the lag one, so the two stay two Sentry issues. "We are short of capacity" and "a provider has stopped taking our mail" have nothing to do with each other and want different people.

The only signal we have that mail arrived is that somebody opened it. So the check compares each domain's recent open rate against that domain's own earlier baseline. Not against a fixed rate, and not against other domains: genuine rates run from 19% at yahoo.com to 56% at icloud.com on the same mail, so any absolute threshold would either miss real outages at the top of that range or cry wolf at the bottom.

Comparing a domain with itself also disposes of forwarders without naming them. `user.trashnothing.com` passes our mail on, so our pixel is never fetched from the real recipient and its rate is permanently zero - but so is its baseline, so it never registers as having lost anything.

The recent window stops six hours short of now, because mail sent ten minutes ago is unopened for reasons that have nothing to do with delivery.

Run against production today, it flags those six domains and nothing else.

The comment on this check says the backlog rotates fairly and nobody is permanently starved. Looking at how far behind people are, that is not what is happening: the backlog piles up at five and six days and then falls off the edge of what gets counted. Some people have been waiting over a month.

## What this changes

The seven-day window is gone. Dormant members are excluded by asking whether they have used the site in the last month, rather than by how long ago we last managed to mail them — so the alarm no longer loses sight of someone precisely because the problem got worse.

It also now reports how much of the backlog is more than a week old, separately. That is the number that tells you whether the lag is rotating or settling on the same people.

Run against production today, the corrected check reports 6,758 lagging, of which 3,099 are over a week behind. The old form reported 6,653 and could not break it down.

## What this does not do

Nothing here makes the digest faster or reaches anybody sooner. It only stops the measurement hiding the problem. The underlying capacity shortfall is what the night-precompute plan's item C was written for, and these figures suggest it is worth more than the headline number implied.

Nor does it get us unblocked at Yahoo. That is a deliverability conversation, and the volume spike on 14 August is where I would start it. This only means we find out next time within a day instead of never.

## Testing

Full Laravel suite locally.

The delivery check is a service with unit tests: a collapsed domain is flagged, a steady one is not, a permanently-zero forwarder is not, a domain under the volume floor is not, and a pile of too-recent mail does not drag a healthy domain under.

The lag check is a closure registered on the scheduler and had no test before this; the change there is to which rows are counted, and the figures above are the before-and-after run against production data.

