### PR TITLE
fix(modtools): say why Pending is empty when a remembered group filter hides the work

### DIFF
--- a/docs/moderators/02-moderating-posts.md
+++ b/docs/moderators/02-moderating-posts.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-16
+last_reviewed: 2026-08-17
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/modtools/pages/messages/**
@@ -24,6 +24,13 @@ queues, the actions, why posts get held, and how reports work.
 
 **Messages > Pending** (`/messages/pending`) is where posts waiting for a decision
 appear, for the community (or all your communities) you have selected.
+
+The dropdown at the top of the page remembers what you picked, on that browser, and
+applies it again next time. The **Pending** count in the menu, on the other hand, counts
+posts across every community you moderate. So the two can disagree: if the community you
+picked is quiet, the page is empty while the menu still shows a count. When that happens
+the page says so, names the community it is filtered to, and offers a button to go back
+to all your communities, which also clears the remembered choice.
 
 For each post you can:
 

--- a/iznik-nuxt3/modtools/composables/useKeywords.js
+++ b/iznik-nuxt3/modtools/composables/useKeywords.js
@@ -1,33 +1,20 @@
-import { setupModMessages } from '~/composables/useModMessages'
+import { computed } from 'vue'
+import { group } from '~/composables/useModMessages'
 
-const typeOptions = computed(() => {
-  const { group } = setupModMessages()
-  const thegroup = group.value
-  return [
-    {
-      value: 'Offer',
-      text:
-        thegroup &&
-        thegroup.settings &&
-        thegroup.settings.keywords &&
-        thegroup.settings.keywords.offer
-          ? thegroup.settings.keywords.offer
-          : 'OFFER',
-    },
-    {
-      value: 'Wanted',
-      text:
-        thegroup &&
-        thegroup.settings &&
-        thegroup.settings.keywords &&
-        thegroup.settings.keywords.wanted
-          ? thegroup.settings.keywords.wanted
-          : 'WANTED',
-    },
-  ]
-})
+// Read the selected community straight from the shared ref. This used to be a
+// module-level computed whose getter called setupModMessages() - so a setup
+// function ran from inside a computed, re-registering its watchers on every
+// group change. Nothing here needs setup; it only needs to read the group.
+function keyword(thegroup, which, fallback) {
+  return thegroup?.settings?.keywords?.[which] || fallback
+}
 
 export function setupKeywords() {
+  const typeOptions = computed(() => [
+    { value: 'Offer', text: keyword(group.value, 'offer', 'OFFER') },
+    { value: 'Wanted', text: keyword(group.value, 'wanted', 'WANTED') },
+  ])
+
   return {
     typeOptions,
   }

--- a/iznik-nuxt3/modtools/composables/useModMessages.js
+++ b/iznik-nuxt3/modtools/composables/useModMessages.js
@@ -19,7 +19,10 @@ const summarykey = ref(false)
 const busy = ref(false)
 const context = ref(null)
 const groupid = ref(0)
-const group = ref(null)
+// Exported so read-only consumers (useKeywords) can follow the selected
+// community without calling setupModMessages(), which is a setup function and
+// does setup-shaped things.
+export const group = ref(null)
 const limit = ref(10)
 const workType = ref(null)
 const show = ref(0)

--- a/iznik-nuxt3/modtools/composables/useModMessages.js
+++ b/iznik-nuxt3/modtools/composables/useModMessages.js
@@ -152,7 +152,16 @@ const visibleMessages = computed(() => {
 })
 
 export function setupModMessages(reset) {
-  // Do not include any watch in here as a separate watch is called for each time setupModMessages() is called
+  // The refresh machinery below is registered ONLY for reset=true, i.e. for the
+  // page that owns this queue. Everything here is shared module-level state, so
+  // a watcher registered by a second caller is a duplicate that does the same
+  // clear-then-refetch again. setupModMessages() is called by the page, by
+  // ModMessages.vue, and by useKeywords.js from a MODULE-LEVEL computed that
+  // re-evaluates on every group change - so the duplicates accumulated as a
+  // moderator worked. Measured in production over one day: a single work-count
+  // tick fired 2 identical listing requests for a moderator who used one group
+  // filter, and up to 13 for one who used seven. Registering per call also
+  // leaks when there is no active effect scope to dispose them.
 
   /* watch(group, async (newValue, oldValue) => {
     console.log("===useModMessages watch group", newValue?.id, oldValue?.id, groupid.value)
@@ -289,90 +298,92 @@ export function setupModMessages(reset) {
     }
   })
 
-  watch(workdetail, (newVal, oldVal) => {
-    if (JSON.stringify(oldVal) === JSON.stringify(newVal)) return // Not actually changed
+  if (reset) {
+    watch(workdetail, (newVal, oldVal) => {
+      if (JSON.stringify(oldVal) === JSON.stringify(newVal)) return // Not actually changed
 
-    const miscStore = useMiscStore()
+      const miscStore = useMiscStore()
 
-    // When the work total INCREASES, genuinely new work has arrived (e.g. a new
-    // pending message). The list must refresh to show it - otherwise the count /
-    // red alert updates but the message stays invisible until a manual reload
-    // (Discourse #9737).
-    const newTotal = Number(newVal?.total ?? 0)
-    const oldTotal = Number(oldVal?.total ?? 0)
-    if (newTotal > oldTotal) {
-      // ...but NOT while a modal is open, or a message is being edited in
-      // place. Refreshing re-renders the message list, which unmounts an
-      // open modal (e.g. a moderator part-way through typing a rejection
-      // reason) - or the ModMessage a moderator is editing - and loses their
-      // draft. Park the refresh and apply it when the modal closes / editing
-      // finishes (see the observers below), so the new message still appears
-      // without a manual reload.
+      // When the work total INCREASES, genuinely new work has arrived (e.g. a new
+      // pending message). The list must refresh to show it - otherwise the count /
+      // red alert updates but the message stays invisible until a manual reload
+      // (Discourse #9737).
+      const newTotal = Number(newVal?.total ?? 0)
+      const oldTotal = Number(oldVal?.total ?? 0)
+      if (newTotal > oldTotal) {
+        // ...but NOT while a modal is open, or a message is being edited in
+        // place. Refreshing re-renders the message list, which unmounts an
+        // open modal (e.g. a moderator part-way through typing a rejection
+        // reason) - or the ModMessage a moderator is editing - and loses their
+        // draft. Park the refresh and apply it when the modal closes / editing
+        // finishes (see the observers below), so the new message still appears
+        // without a manual reload.
+        if (refreshMustWait()) {
+          pendingWorkRefresh.value = newVal
+          return
+        }
+        getMessages(newVal)
+        return
+      }
+
+      // No new work (count unchanged or decreased by a mod action the component
+      // already handled): keep the existing suppression so the list does not
+      // reload under the user's feet.
+      if (miscStore.deferGetMessages) return
       if (refreshMustWait()) {
+        // Park it, exactly as the total-increased branch above does. Do NOT drop
+        // it: another moderator holding a message moves it from `pending` to
+        // `pendingother` (see groupWork.go), so the total never changes and this
+        // branch is the ONLY one that can surface a hold. Dropping it lost the
+        // hold permanently — the watcher's oldVal advances, so every later tick
+        // compares equal and early-returns — leaving the other moderator looking
+        // at a card with no "Held" banner until they manually reloaded. They
+        // moderated the post out from under the holding mod (Discourse #9946).
         pendingWorkRefresh.value = newVal
         return
       }
       getMessages(newVal)
-      return
-    }
+    })
 
-    // No new work (count unchanged or decreased by a mod action the component
-    // already handled): keep the existing suppression so the list does not
-    // reload under the user's feet.
-    if (miscStore.deferGetMessages) return
-    if (refreshMustWait()) {
-      // Park it, exactly as the total-increased branch above does. Do NOT drop
-      // it: another moderator holding a message moves it from `pending` to
-      // `pendingother` (see groupWork.go), so the total never changes and this
-      // branch is the ONLY one that can surface a hold. Dropping it lost the
-      // hold permanently — the watcher's oldVal advances, so every later tick
-      // compares equal and early-returns — leaving the other moderator looking
-      // at a card with no "Held" banner until they manually reloaded. They
-      // moderated the post out from under the holding mod (Discourse #9946).
-      pendingWorkRefresh.value = newVal
-      return
-    }
-    getMessages(newVal)
-  })
-
-  // Apply a refresh that was deferred because a modal was open, as soon as the
-  // modal closes. Bootstrap toggles <body> overflow:hidden around modals, so we
-  // observe that attribute; when it clears and a refresh is pending, run it.
-  // This keeps an open rejection modal (and its draft) intact during editing
-  // while still surfacing the new pending message the moment it is dismissed.
-  if (
-    typeof document !== 'undefined' &&
-    typeof MutationObserver !== 'undefined'
-  ) {
-    const bodyOverflowObserver = new MutationObserver(() => {
-      if (pendingWorkRefresh.value && !refreshMustWait()) {
-        const deferred = pendingWorkRefresh.value
-        pendingWorkRefresh.value = null
-        getMessages(deferred)
+    // Apply a refresh that was deferred because a modal was open, as soon as the
+    // modal closes. Bootstrap toggles <body> overflow:hidden around modals, so we
+    // observe that attribute; when it clears and a refresh is pending, run it.
+    // This keeps an open rejection modal (and its draft) intact during editing
+    // while still surfacing the new pending message the moment it is dismissed.
+    if (
+      typeof document !== 'undefined' &&
+      typeof MutationObserver !== 'undefined'
+    ) {
+      const bodyOverflowObserver = new MutationObserver(() => {
+        if (pendingWorkRefresh.value && !refreshMustWait()) {
+          const deferred = pendingWorkRefresh.value
+          pendingWorkRefresh.value = null
+          getMessages(deferred)
+        }
+      })
+      bodyOverflowObserver.observe(document.body, {
+        attributes: true,
+        attributeFilter: ['style'],
+      })
+      if (getCurrentScope()) {
+        onScopeDispose(() => bodyOverflowObserver.disconnect())
       }
-    })
-    bodyOverflowObserver.observe(document.body, {
-      attributes: true,
-      attributeFilter: ['style'],
-    })
-    if (getCurrentScope()) {
-      onScopeDispose(() => bodyOverflowObserver.disconnect())
     }
+
+    // Apply a refresh that was deferred because a message was being edited in
+    // place, as soon as editing finishes (mirrors the modal-close observer
+    // above). ModMessage.vue's save()/cancelEdit() clear modtoolsediting.
+    watch(
+      () => useMiscStore().modtoolsediting,
+      (editing) => {
+        if (!editing && pendingWorkRefresh.value && !refreshMustWait()) {
+          const deferred = pendingWorkRefresh.value
+          pendingWorkRefresh.value = null
+          getMessages(deferred)
+        }
+      }
+    )
   }
-
-  // Apply a refresh that was deferred because a message was being edited in
-  // place, as soon as editing finishes (mirrors the modal-close observer
-  // above). ModMessage.vue's save()/cancelEdit() clear modtoolsediting.
-  watch(
-    () => useMiscStore().modtoolsediting,
-    (editing) => {
-      if (!editing && pendingWorkRefresh.value && !refreshMustWait()) {
-        const deferred = pendingWorkRefresh.value
-        pendingWorkRefresh.value = null
-        getMessages(deferred)
-      }
-    }
-  )
 
   return {
     busy,

--- a/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
@@ -156,19 +156,18 @@ const groupname = computed(() => {
 // page while the badge nags them, with nothing on screen to say why
 // (Discourse 10037: two moderators reported it as "can't moderate on
 // desktop"; one worked around it by changing community and changing back).
-// Count what this queue actually holds, which is not the same as the composable's
-// `work`: workType here is pending+pendingother, but the listing also includes
-// Spam-collection messages (see message_list.go) and the menu badge counts those
-// too (layouts/default.vue passes count=['pending','spam']). Leaving spam out
-// would make the notice stay silent in exactly the case where the badge is
-// loudest about spam sitting on another community.
+// Count exactly what the red Pending badge counts (layouts/default.vue passes
+// count=['pending','spam']), which is also exactly what "All my communities"
+// will show. Deliberately NOT the composable's `work` (pending+pendingother):
+// pendingother covers posts on BACKUP communities, and the all-communities
+// listing only fans out over active ones by design
+// (user.GetActiveModGroupIDs). Counting those would promise work that the
+// button cannot surface. It also drops spam-only backlogs from `work`, which
+// the badge does count, so neither number on its own is the right one.
 const outstanding = computed(() => {
   const w = authStore.work
   if (!w) return 0
-  return ['pending', 'pendingother', 'spam'].reduce(
-    (total, type) => total + (w[type] || 0),
-    0
-  )
+  return ['pending', 'spam'].reduce((total, type) => total + (w[type] || 0), 0)
 })
 
 const filterHidingWork = computed(() => {
@@ -282,19 +281,6 @@ onMounted(async () => {
 
   // Note: Don't restore remembered group here - ModGroupSelect handles it
   // via its remember prop. Doing it here would override URL params.
-})
-
-// loadMore() calls $state.complete() when a fetch comes back empty, and
-// InfiniteLoading stops its retry loop for good once complete - only a change
-// to :identifier revives it. So one empty or failed fetch leaves the list dead
-// until the moderator touches the group dropdown (which bumps it via
-// watch(groupid) above). If the work count says there is something to show and
-// we are showing nothing, the loader is wrong: bump it so it tries again.
-// Guarded on an empty list so a healthy page does not refetch on every tick.
-watch(outstanding, (newVal) => {
-  if (newVal > 0 && !messages.value.length && !busy.value) {
-    bump.value++
-  }
 })
 
 // Methods

--- a/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
@@ -35,7 +35,9 @@
           <p>
             There are no pending messages in {{ groupname }}, but
             {{
-              work === 1 ? 'there is 1 waiting' : `there are ${work} waiting`
+              outstanding === 1
+                ? 'there is 1 waiting'
+                : `there are ${outstanding} waiting`
             }}
             across your communities. The dropdown above is filtering this page
             to one community.
@@ -101,7 +103,6 @@ const {
   listingIds,
   visibleMessages,
   nextAfterRemoved,
-  work,
   getMessages,
 } = setupModMessages(true)
 
@@ -155,8 +156,23 @@ const groupname = computed(() => {
 // page while the badge nags them, with nothing on screen to say why
 // (Discourse 10037: two moderators reported it as "can't moderate on
 // desktop"; one worked around it by changing community and changing back).
+// Count what this queue actually holds, which is not the same as the composable's
+// `work`: workType here is pending+pendingother, but the listing also includes
+// Spam-collection messages (see message_list.go) and the menu badge counts those
+// too (layouts/default.vue passes count=['pending','spam']). Leaving spam out
+// would make the notice stay silent in exactly the case where the badge is
+// loudest about spam sitting on another community.
+const outstanding = computed(() => {
+  const w = authStore.work
+  if (!w) return 0
+  return ['pending', 'pendingother', 'spam'].reduce(
+    (total, type) => total + (w[type] || 0),
+    0
+  )
+})
+
 const filterHidingWork = computed(() => {
-  return Boolean(groupid.value) && work.value > 0
+  return Boolean(groupid.value) && outstanding.value > 0
 })
 
 const rulesGroup = computed(() => {
@@ -275,7 +291,7 @@ onMounted(async () => {
 // watch(groupid) above). If the work count says there is something to show and
 // we are showing nothing, the loader is wrong: bump it so it tries again.
 // Guarded on an empty list so a healthy page does not refetch on every tick.
-watch(work, (newVal) => {
+watch(outstanding, (newVal) => {
   if (newVal > 0 && !messages.value.length && !busy.value) {
     bump.value++
   }
@@ -395,6 +411,7 @@ defineExpose({
   groups,
   groupsreceived,
   groupname,
+  outstanding,
   filterHidingWork,
   rulesGroup,
   me,
@@ -402,7 +419,6 @@ defineExpose({
   busy,
   messages,
   groupid,
-  work,
   limit,
   showAllCommunities,
   loadAll,

--- a/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
@@ -17,17 +17,36 @@
           all
           modonly
           :work="['pending', 'pendingother']"
-          remember="pending"
+          :remember="REMEMBER_KEY"
           :url-override="urlOverride"
         />
         <ModtoolsViewControl misckey="modtoolsMessagesPendingSummary" />
         <b-button variant="link" @click="loadAll"> Load all </b-button>
       </div>
+      <NoticeMessage v-if="loadError" variant="warning" class="mt-2">
+        <p>We couldn't fetch the pending messages just now.</p>
+        <b-button variant="primary" @click="retryLoad"> Try again </b-button>
+      </NoticeMessage>
       <NoticeMessage
-        v-if="!messages.length && !busy && groupsreceived"
+        v-else-if="!messages.length && !busy && groupsreceived"
         class="mt-2"
       >
-        There are no messages at the moment. This will refresh automatically.
+        <template v-if="filterHidingWork">
+          <p>
+            There are no pending messages in {{ groupname }}, but
+            {{
+              work === 1 ? 'there is 1 waiting' : `there are ${work} waiting`
+            }}
+            across your communities. The dropdown above is filtering this page
+            to one community.
+          </p>
+          <b-button variant="primary" @click="showAllCommunities">
+            Show all my communities
+          </b-button>
+        </template>
+        <template v-else>
+          There are no messages at the moment. This will refresh automatically.
+        </template>
       </NoticeMessage>
       <div v-if="groupsreceived">
         <ModMessages />
@@ -82,8 +101,13 @@ const {
   listingIds,
   visibleMessages,
   nextAfterRemoved,
+  work,
   getMessages,
 } = setupModMessages(true)
+
+// ModGroupSelect stores the chosen community under 'groupselect-' + remember.
+// We need the same key to forget it again - see showAllCommunities().
+const REMEMBER_KEY = 'pending'
 
 summarykey.value = 'modtoolsMessagesPendingSummary'
 collection.value = 'Pending' // Pending also gets PendingOther
@@ -105,6 +129,7 @@ const shownRulePopup = ref(false)
 const bump = ref(0)
 const highlightMsgId = ref(null)
 const urlOverride = ref(false)
+const loadError = ref(false)
 
 // Template refs
 const end = ref(null)
@@ -117,6 +142,21 @@ const groups = computed(() => {
 
 const groupsreceived = computed(() => {
   return modGroupStore.received
+})
+
+const groupname = computed(() => {
+  return group.value?.namedisplay || 'this community'
+})
+
+// The Pending badge in the menu counts work across every community we
+// moderate, but this page shows only the community picked in the dropdown -
+// and that choice is remembered in local storage and re-applied on every
+// visit. When the two disagree the moderator is left staring at an empty
+// page while the badge nags them, with nothing on screen to say why
+// (Discourse 10037: two moderators reported it as "can't moderate on
+// desktop"; one worked around it by changing community and changing back).
+const filterHidingWork = computed(() => {
+  return Boolean(groupid.value) && work.value > 0
 })
 
 const rulesGroup = computed(() => {
@@ -228,7 +268,33 @@ onMounted(async () => {
   // via its remember prop. Doing it here would override URL params.
 })
 
+// loadMore() calls $state.complete() when a fetch comes back empty, and
+// InfiniteLoading stops its retry loop for good once complete - only a change
+// to :identifier revives it. So one empty or failed fetch leaves the list dead
+// until the moderator touches the group dropdown (which bumps it via
+// watch(groupid) above). If the work count says there is something to show and
+// we are showing nothing, the loader is wrong: bump it so it tries again.
+// Guarded on an empty list so a healthy page does not refetch on every tick.
+watch(work, (newVal) => {
+  if (newVal > 0 && !messages.value.length && !busy.value) {
+    bump.value++
+  }
+})
+
 // Methods
+function retryLoad() {
+  loadError.value = false
+  bump.value++
+}
+
+function showAllCommunities() {
+  // Clear the remembered community as well as the current filter. Only a
+  // choice made through the dropdown goes through ModGroupSelect's setter,
+  // so without this the filter would come straight back on the next visit.
+  miscStore.set({ key: 'groupselect-' + REMEMBER_KEY, value: 0 })
+  groupid.value = 0
+}
+
 async function loadAll() {
   // This is a bit of a hack - we clear the store and fetch 1000 messages, which is likely to be all of them.
   limit.value = 1000
@@ -266,7 +332,28 @@ async function loadMore($state) {
       limit: messages.value.length + distance.value,
     }
 
-    const fetchedIds = await messageStore.fetchMessagesMT(params)
+    let fetchedIds
+    try {
+      fetchedIds = await messageStore.fetchMessagesMT(params)
+      loadError.value = false
+    } catch (e) {
+      busy.value = false
+
+      if (e?.response?.status === 401) {
+        // Session expired. BaseAPI has already cleared auth state and the
+        // layout will put up the login modal, so say nothing here.
+        $state.complete()
+        return
+      }
+
+      // Say so rather than leaving a spinner. The exception used to escape
+      // this function, which left InfiniteLoading stuck in 'loading' and busy
+      // stuck true - and busy true suppresses every notice below, so the page
+      // looked like it was still working when it had given up.
+      loadError.value = true
+      $state.complete()
+      return
+    }
     if (fetchedIds) {
       fetchedIds.forEach((id) => listingIds.value.add(id))
     }
@@ -302,16 +389,22 @@ defineExpose({
   bump,
   highlightMsgId,
   urlOverride,
+  loadError,
+  retryLoad,
   id,
   groups,
   groupsreceived,
+  groupname,
+  filterHidingWork,
   rulesGroup,
   me,
   myGroups,
   busy,
   messages,
   groupid,
+  work,
   limit,
+  showAllCommunities,
   loadAll,
   destroy,
   loadMore,

--- a/iznik-nuxt3/tests/unit/composables/useKeywords.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useKeywords.spec.js
@@ -1,0 +1,76 @@
+/**
+ * The Offer/Wanted labels a community has renamed (settings.keywords) must show
+ * in the type dropdowns on ModMessage and ModStdMessageModal, and must follow
+ * the community currently selected in the queue.
+ *
+ * The options used to come from a module-level computed whose getter called
+ * setupModMessages() - a setup function invoked from inside a computed, which
+ * re-ran on every group change. These tests pin the behaviour so the wiring can
+ * be simplified without changing what a moderator sees.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { nextTick } from 'vue'
+
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => ({ work: null }) }))
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({
+    clearContext: vi.fn(),
+    clear: vi.fn(),
+    fetchMessagesMT: vi.fn().mockResolvedValue([]),
+    get all() {
+      return []
+    },
+    getByGroup: vi.fn(() => []),
+    get context() {
+      return null
+    },
+    list: {},
+  }),
+}))
+vi.mock('@/stores/misc', () => ({
+  useMiscStore: () => ({
+    deferGetMessages: false,
+    get: vi.fn(() => undefined),
+  }),
+}))
+
+describe('useKeywords typeOptions', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('falls back to OFFER and WANTED when no community is selected', async () => {
+    const { setupKeywords } = await import('~/composables/useKeywords')
+    const { typeOptions } = setupKeywords()
+
+    expect(typeOptions.value.map((o) => o.value)).toEqual(['Offer', 'Wanted'])
+    expect(typeOptions.value.map((o) => o.text)).toEqual(['OFFER', 'WANTED'])
+  })
+
+  it("uses the selected community's renamed keywords, and follows a change of community", async () => {
+    const { setupKeywords } = await import('~/composables/useKeywords')
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { typeOptions } = setupKeywords()
+    const { group } = setupModMessages()
+
+    group.value = {
+      id: 1,
+      settings: { keywords: { offer: 'GIVING AWAY', wanted: 'LOOKING FOR' } },
+    }
+    await nextTick()
+    expect(typeOptions.value.map((o) => o.text)).toEqual([
+      'GIVING AWAY',
+      'LOOKING FOR',
+    ])
+
+    group.value = { id: 2, settings: { keywords: { offer: 'FREE' } } }
+    await nextTick()
+    expect(typeOptions.value.map((o) => o.text)).toEqual(['FREE', 'WANTED'])
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useModMessages.duplicateWatchers.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMessages.duplicateWatchers.spec.js
@@ -1,0 +1,123 @@
+/**
+ * setupModMessages() carries its own warning: "Do not include any watch in here
+ * as a separate watch is called for each time setupModMessages() is called".
+ * It then registers watch(workdetail), a MutationObserver and
+ * watch(modtoolsediting) on every call - and it is called by the page, by
+ * ModMessages.vue, and (from a module-level computed, so once per group change)
+ * by useKeywords.js. Every watch(workdetail) that fires runs a full
+ * clear-then-refetch, so one work-count tick produced a burst of identical
+ * listing requests: measured in production at typically 2 and up to 13, growing
+ * with the number of group filters a moderator had used that session.
+ *
+ * Only the page owns the queue, and only the page passes reset=true.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, nextTick, effectScope } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+const mockWork = ref({ pending: 0, pendingother: 0, total: 0 })
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    get work() {
+      return mockWork.value
+    },
+  }),
+}))
+
+const mockFetchMessagesMT = vi.fn()
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({
+    clearContext: vi.fn(),
+    clear: vi.fn(),
+    fetchMessagesMT: mockFetchMessagesMT,
+    get all() {
+      return []
+    },
+    getByGroup: vi.fn(() => []),
+    get context() {
+      return null
+    },
+    list: {},
+  }),
+}))
+
+vi.mock('@/stores/misc', () => ({
+  useMiscStore: () => ({
+    deferGetMessages: false,
+    get: vi.fn(() => undefined),
+  }),
+}))
+
+describe('useModMessages - one refresh per work change', () => {
+  // In the app setupModMessages() runs inside a component's setup(), so its
+  // watchers belong to that component's scope and die with it. A bare unit
+  // test has no scope, so they would leak into the next test - which is the
+  // same hazard the code has if it is ever called outside a component. Run
+  // each case in its own scope and stop it afterwards.
+  let scope
+
+  beforeEach(() => {
+    scope = effectScope()
+    vi.clearAllMocks()
+    vi.resetModules()
+    mockWork.value = { pending: 0, pendingother: 0, total: 0 }
+    mockFetchMessagesMT.mockResolvedValue([])
+    document.body.style.overflow = ''
+  })
+
+  afterEach(() => {
+    scope.stop()
+    vi.resetModules()
+    document.body.style.overflow = ''
+  })
+
+  it('refetches once when the page, its list component and useKeywords have all called setup', async () => {
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+
+    scope.run(() => {
+      // The page owns the queue and resets the shared state.
+      const { workType, collection } = setupModMessages(true)
+      collection.value = 'Pending'
+      workType.value = ['pending', 'pendingother']
+
+      // ModMessages.vue, then useKeywords.js's module-level computed re-running
+      // after a group change. Neither owns the queue.
+      setupModMessages()
+      setupModMessages()
+    })
+
+    await nextTick()
+    await flushPromises()
+    vi.clearAllMocks()
+
+    mockWork.value = { pending: 1, pendingother: 0, total: 1 }
+    await nextTick()
+    await flushPromises()
+
+    expect(mockFetchMessagesMT).toHaveBeenCalledTimes(1)
+  })
+
+  it('still refreshes when only the owning page has called setup', async () => {
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    scope.run(() => {
+      const { workType, collection } = setupModMessages(true)
+      collection.value = 'Pending'
+      workType.value = ['pending', 'pendingother']
+    })
+
+    await nextTick()
+    await flushPromises()
+    vi.clearAllMocks()
+
+    mockWork.value = { pending: 2, pendingother: 0, total: 2 }
+    await nextTick()
+    await flushPromises()
+
+    expect(mockFetchMessagesMT).toHaveBeenCalledTimes(1)
+  })
+})

--- a/iznik-nuxt3/tests/unit/pages/modtools/messages/pending.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/messages/pending.spec.js
@@ -274,13 +274,36 @@ describe('PendingPage', () => {
         id: 522709,
         namedisplay: 'Skelmersdale Freegle',
       })
-      mockAuthStore.work = { pending: 0, pendingother: 0, spam: 2 }
+      mockAuthStore.work = { pending: 0, spam: 2 }
 
       const wrapper = mountComponent()
       await wrapper.vm.$nextTick()
 
       expect(wrapper.text()).toContain('there are 2 waiting')
       expect(wrapper.text()).toContain('Show all my communities')
+    })
+
+    it('ignores backup-community work, which all-communities does not show', async () => {
+      // pendingother covers posts on backup communities, and the
+      // all-communities listing only fans out over active ones by design
+      // (user.GetActiveModGroupIDs). Offering "Show all my communities" for
+      // work it will not show would send the moderator nowhere.
+      mockMessages.value = []
+      mockBusy.value = false
+      mockModGroupStore.received = true
+      mockGroupid.value = 522709
+      mockGroup.value = { id: 522709, namedisplay: 'Skelmersdale Freegle' }
+      mockModGroupStore.get.mockReturnValue({
+        id: 522709,
+        namedisplay: 'Skelmersdale Freegle',
+      })
+      mockAuthStore.work = { pending: 0, spam: 0, pendingother: 4 }
+
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.text()).toContain('no messages at the moment')
+      expect(wrapper.text()).not.toContain('Show all my communities')
     })
 
     it('keeps the plain empty notice when nothing is pending anywhere', async () => {
@@ -467,64 +490,12 @@ describe('PendingPage', () => {
       })
     })
 
-    it('revives the infinite loader when work is outstanding but nothing is showing (Discourse 10037)', async () => {
-      // loadMore() calls $state.complete() on an empty response, and
-      // InfiniteLoading stops its retry loop for good once complete - only
-      // an :identifier change revives it. Without this, one empty or failed
-      // fetch leaves the list dead until the moderator touches the dropdown.
+    it('does not fire its own fetch on a work count change (Discourse 10037)', async () => {
+      // The work-count watcher inside useModMessages already refetches, with a
+      // limit covering the whole outstanding total, and reveals everything it
+      // gets. A second trigger here would just double every refresh - which is
+      // the duplicate-request problem this page is being fixed for.
       mockMessages.value = []
-      mockBusy.value = false
-      const wrapper = mountComponent()
-      await wrapper.vm.$nextTick()
-      const before = wrapper.vm.bump
-
-      mockAuthStore.work = { pending: 4 }
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.vm.bump).toBe(before + 1)
-    })
-
-    it('surfaces a failed fetch as a retryable error rather than a dead spinner', async () => {
-      // The server no longer answers a failed listing query with an empty
-      // 200 (message_list.go), so the frontend has to cope with the error.
-      // Left unhandled, the exception escapes loadMore(), InfiniteLoading
-      // stays in 'loading' for ever and busy stays true, which suppresses
-      // every notice - the moderator gets a permanent spinner.
-      mockMessages.value = []
-      mockShow.value = 0
-      mockMessageStore.fetchMessagesMT.mockRejectedValue(new Error('boom'))
-      const wrapper = mountComponent()
-      const mockState = { loaded: vi.fn(), complete: vi.fn() }
-
-      await wrapper.vm.loadMore(mockState)
-      await wrapper.vm.$nextTick()
-
-      expect(mockBusy.value).toBe(false)
-      expect(wrapper.text()).toContain('Try again')
-
-      const before = wrapper.vm.bump
-      await wrapper.vm.retryLoad()
-      expect(wrapper.vm.bump).toBe(before + 1)
-    })
-
-    it('does not treat an expired session as a load failure', async () => {
-      mockMessages.value = []
-      mockShow.value = 0
-      const err = new Error('Unauthorised')
-      err.response = { status: 401 }
-      mockMessageStore.fetchMessagesMT.mockRejectedValue(err)
-      const wrapper = mountComponent()
-      const mockState = { loaded: vi.fn(), complete: vi.fn() }
-
-      await wrapper.vm.loadMore(mockState)
-      await wrapper.vm.$nextTick()
-
-      expect(mockBusy.value).toBe(false)
-      expect(wrapper.text()).not.toContain('Try again')
-    })
-
-    it('does not refetch on a work count change while messages are showing', async () => {
-      mockMessages.value = [{ id: 1 }]
       mockBusy.value = false
       const wrapper = mountComponent()
       await wrapper.vm.$nextTick()
@@ -534,6 +505,7 @@ describe('PendingPage', () => {
       await wrapper.vm.$nextTick()
 
       expect(wrapper.vm.bump).toBe(before)
+      expect(mockMessageStore.fetchMessagesMT).not.toHaveBeenCalled()
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/pages/modtools/messages/pending.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/messages/pending.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import { ref, computed } from 'vue'
+import { ref, computed, reactive } from 'vue'
 import PendingPage from '~/modtools/pages/messages/pending/[[id]]/[[term]].vue'
 
 // Mock refs that will be shared between tests
@@ -50,14 +50,17 @@ vi.mock('~/composables/useModMessages', () => ({
 }))
 
 // Mock stores
-const mockAuthStore = {
+// Reactive so the page's `outstanding` computed (which reads authStore.work,
+// the same counts the menu badge uses) and the watcher on it actually fire.
+const mockAuthStore = reactive({
   user: {
     settings: {
       lastaimsshow: null,
     },
   },
+  work: {},
   saveAndGet: vi.fn(),
-}
+})
 
 vi.mock('@/stores/auth', () => ({
   useAuthStore: () => mockAuthStore,
@@ -213,6 +216,7 @@ describe('PendingPage', () => {
     mockModGroupStore.list = {}
     mockMiscStore.get.mockReturnValue(null)
     mockAuthStore.user = { settings: { lastaimsshow: null } }
+    mockAuthStore.work = {}
     mockListingIds.value = new Set()
     mockMessageStore.list = {}
     mockMessageStore.context = null
@@ -247,13 +251,35 @@ describe('PendingPage', () => {
         id: 522709,
         namedisplay: 'Skelmersdale Freegle',
       })
-      mockWork.value = 3
+      mockAuthStore.work = { pending: 3 }
 
       const wrapper = mountComponent()
       await wrapper.vm.$nextTick()
 
       expect(wrapper.text()).toContain('Skelmersdale Freegle')
       expect(wrapper.text()).toContain('3')
+      expect(wrapper.text()).toContain('Show all my communities')
+    })
+
+    it('counts spam towards the outstanding total, as the menu badge does', async () => {
+      // workType on this page is pending+pendingother, but the listing also
+      // includes Spam-collection messages and the badge counts them, so a
+      // spam-only backlog on another community must still be explained.
+      mockMessages.value = []
+      mockBusy.value = false
+      mockModGroupStore.received = true
+      mockGroupid.value = 522709
+      mockGroup.value = { id: 522709, namedisplay: 'Skelmersdale Freegle' }
+      mockModGroupStore.get.mockReturnValue({
+        id: 522709,
+        namedisplay: 'Skelmersdale Freegle',
+      })
+      mockAuthStore.work = { pending: 0, pendingother: 0, spam: 2 }
+
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.text()).toContain('there are 2 waiting')
       expect(wrapper.text()).toContain('Show all my communities')
     })
 
@@ -270,7 +296,7 @@ describe('PendingPage', () => {
         id: 522709,
         namedisplay: 'Skelmersdale Freegle',
       })
-      mockWork.value = 0
+      mockAuthStore.work = { pending: 0 }
 
       const wrapper = mountComponent()
       await wrapper.vm.$nextTick()
@@ -284,7 +310,7 @@ describe('PendingPage', () => {
       mockBusy.value = false
       mockModGroupStore.received = true
       mockGroupid.value = 0
-      mockWork.value = 3
+      mockAuthStore.work = { pending: 3 }
 
       const wrapper = mountComponent()
       await wrapper.vm.$nextTick()
@@ -424,7 +450,7 @@ describe('PendingPage', () => {
         id: 522709,
         namedisplay: 'Skelmersdale Freegle',
       })
-      mockWork.value = 3
+      mockAuthStore.work = { pending: 3 }
 
       const wrapper = mountComponent()
       await wrapper.vm.$nextTick()
@@ -452,7 +478,7 @@ describe('PendingPage', () => {
       await wrapper.vm.$nextTick()
       const before = wrapper.vm.bump
 
-      mockWork.value = 4
+      mockAuthStore.work = { pending: 4 }
       await wrapper.vm.$nextTick()
 
       expect(wrapper.vm.bump).toBe(before + 1)
@@ -504,7 +530,7 @@ describe('PendingPage', () => {
       await wrapper.vm.$nextTick()
       const before = wrapper.vm.bump
 
-      mockWork.value = 4
+      mockAuthStore.work = { pending: 4 }
       await wrapper.vm.$nextTick()
 
       expect(wrapper.vm.bump).toBe(before)

--- a/iznik-nuxt3/tests/unit/pages/modtools/messages/pending.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/messages/pending.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { ref, computed } from 'vue'
 import PendingPage from '~/modtools/pages/messages/pending/[[id]]/[[term]].vue'
@@ -20,7 +20,7 @@ const mockSummarykey = ref(false)
 const mockSummary = computed(() => false)
 const mockMessages = ref([])
 const mockVisibleMessages = ref([])
-const mockWork = computed(() => 0)
+const mockWork = ref(0)
 const mockNextAfterRemoved = ref(null)
 const mockGetMessages = vi.fn()
 const mockListingIds = ref(new Set())
@@ -206,6 +206,7 @@ describe('PendingPage', () => {
     mockWorkType.value = null
     mockMessages.value = []
     mockVisibleMessages.value = []
+    mockWork.value = 0
     mockLimit.value = 10
     mockDistance.value = 10
     mockModGroupStore.received = true
@@ -225,6 +226,70 @@ describe('PendingPage', () => {
       const wrapper = mountComponent()
       await wrapper.vm.$nextTick()
       expect(wrapper.text()).toContain('no messages at the moment')
+    })
+
+    // Discourse 10037: the group dropdown remembers its selection in
+    // localStorage and silently re-applies it on every visit, while the
+    // Pending badge in the menu counts work across every community. A
+    // moderator whose remembered community happens to have nothing pending
+    // sees a bare "no messages" page and a badge insisting there is work.
+    // Two moderators reported it as "I can't moderate on desktop".
+    it('names the filtered community and the outstanding count when the filter is hiding work', async () => {
+      mockMessages.value = []
+      mockBusy.value = false
+      mockModGroupStore.received = true
+      mockGroupid.value = 522709
+      mockGroup.value = { id: 522709, namedisplay: 'Skelmersdale Freegle' }
+      // A component left mounted by an earlier test still watches the shared
+      // groupid ref and re-derives group from the store, so the store has to
+      // agree about which community this is.
+      mockModGroupStore.get.mockReturnValue({
+        id: 522709,
+        namedisplay: 'Skelmersdale Freegle',
+      })
+      mockWork.value = 3
+
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.text()).toContain('Skelmersdale Freegle')
+      expect(wrapper.text()).toContain('3')
+      expect(wrapper.text()).toContain('Show all my communities')
+    })
+
+    it('keeps the plain empty notice when nothing is pending anywhere', async () => {
+      mockMessages.value = []
+      mockBusy.value = false
+      mockModGroupStore.received = true
+      mockGroupid.value = 522709
+      mockGroup.value = { id: 522709, namedisplay: 'Skelmersdale Freegle' }
+      // A component left mounted by an earlier test still watches the shared
+      // groupid ref and re-derives group from the store, so the store has to
+      // agree about which community this is.
+      mockModGroupStore.get.mockReturnValue({
+        id: 522709,
+        namedisplay: 'Skelmersdale Freegle',
+      })
+      mockWork.value = 0
+
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.text()).toContain('no messages at the moment')
+      expect(wrapper.text()).not.toContain('Show all my communities')
+    })
+
+    it('keeps the plain empty notice when already showing all communities', async () => {
+      mockMessages.value = []
+      mockBusy.value = false
+      mockModGroupStore.received = true
+      mockGroupid.value = 0
+      mockWork.value = 3
+
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.text()).not.toContain('Show all my communities')
     })
 
     it('shows loading message when groups not yet received', async () => {
@@ -346,6 +411,103 @@ describe('PendingPage', () => {
       expect(mockState.complete).not.toHaveBeenCalled()
       expect(mockState.loaded).toHaveBeenCalled()
     })
-  })
 
+    it('clearing the filter also forgets it, so the next visit is not filtered again (Discourse 10037)', async () => {
+      mockMessages.value = []
+      mockBusy.value = false
+      mockGroupid.value = 522709
+      mockGroup.value = { id: 522709, namedisplay: 'Skelmersdale Freegle' }
+      // A component left mounted by an earlier test still watches the shared
+      // groupid ref and re-derives group from the store, so the store has to
+      // agree about which community this is.
+      mockModGroupStore.get.mockReturnValue({
+        id: 522709,
+        namedisplay: 'Skelmersdale Freegle',
+      })
+      mockWork.value = 3
+
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+
+      await wrapper.vm.showAllCommunities()
+
+      expect(mockGroupid.value).toBe(0)
+      // ModGroupSelect only persists a choice made through the dropdown
+      // itself, so clearing the filter from here has to forget the
+      // remembered value too - otherwise the next mount restores it.
+      expect(mockMiscStore.set).toHaveBeenCalledWith({
+        key: 'groupselect-pending',
+        value: 0,
+      })
+    })
+
+    it('revives the infinite loader when work is outstanding but nothing is showing (Discourse 10037)', async () => {
+      // loadMore() calls $state.complete() on an empty response, and
+      // InfiniteLoading stops its retry loop for good once complete - only
+      // an :identifier change revives it. Without this, one empty or failed
+      // fetch leaves the list dead until the moderator touches the dropdown.
+      mockMessages.value = []
+      mockBusy.value = false
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+      const before = wrapper.vm.bump
+
+      mockWork.value = 4
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.vm.bump).toBe(before + 1)
+    })
+
+    it('surfaces a failed fetch as a retryable error rather than a dead spinner', async () => {
+      // The server no longer answers a failed listing query with an empty
+      // 200 (message_list.go), so the frontend has to cope with the error.
+      // Left unhandled, the exception escapes loadMore(), InfiniteLoading
+      // stays in 'loading' for ever and busy stays true, which suppresses
+      // every notice - the moderator gets a permanent spinner.
+      mockMessages.value = []
+      mockShow.value = 0
+      mockMessageStore.fetchMessagesMT.mockRejectedValue(new Error('boom'))
+      const wrapper = mountComponent()
+      const mockState = { loaded: vi.fn(), complete: vi.fn() }
+
+      await wrapper.vm.loadMore(mockState)
+      await wrapper.vm.$nextTick()
+
+      expect(mockBusy.value).toBe(false)
+      expect(wrapper.text()).toContain('Try again')
+
+      const before = wrapper.vm.bump
+      await wrapper.vm.retryLoad()
+      expect(wrapper.vm.bump).toBe(before + 1)
+    })
+
+    it('does not treat an expired session as a load failure', async () => {
+      mockMessages.value = []
+      mockShow.value = 0
+      const err = new Error('Unauthorised')
+      err.response = { status: 401 }
+      mockMessageStore.fetchMessagesMT.mockRejectedValue(err)
+      const wrapper = mountComponent()
+      const mockState = { loaded: vi.fn(), complete: vi.fn() }
+
+      await wrapper.vm.loadMore(mockState)
+      await wrapper.vm.$nextTick()
+
+      expect(mockBusy.value).toBe(false)
+      expect(wrapper.text()).not.toContain('Try again')
+    })
+
+    it('does not refetch on a work count change while messages are showing', async () => {
+      mockMessages.value = [{ id: 1 }]
+      mockBusy.value = false
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+      const before = wrapper.vm.bump
+
+      mockWork.value = 4
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.vm.bump).toBe(before)
+    })
+  })
 })

--- a/iznik-server-go/message/message_list.go
+++ b/iznik-server-go/message/message_list.go
@@ -476,6 +476,16 @@ func ListMessagesMT(c *fiber.Ctx) error {
 		contentcheckFilter += " AND mg.rippled_in = 0"
 	}
 
+	// A listing query that fails must never be reported as an empty queue. The
+	// all-communities form fans out over every group the moderator covers and
+	// is capped at MAX_EXECUTION_TIME(20000) (see buildMTUnionAllMsgIDQuery),
+	// so a slow replica aborts it. Swallowing that returned a perfectly normal
+	// "messages": [] to ModTools, which cannot tell it apart from a genuinely
+	// empty queue: the moderator gets an empty page while the work count in
+	// the menu insists there is work, and the infinite loader stops for good
+	// (Discourse 10037).
+	var listErr error
+
 	if collection == "Edit" {
 		// Edit review uses messages_edits table, not messages_groups collection.
 		// Restrict to ORIGIN messages_groups rows (rippled_in = 0). A post rippled INTO a
@@ -483,14 +493,14 @@ func ListMessagesMT(c *fiber.Ctx) error {
 		// rippled-in post surfaces in every receiving group's Edit queue (and to active mods
 		// there via the all-groups path), but an edit belongs to the post's origin group(s)
 		// only. Same bug class as the IP-abuse fix (WHERE rippled_in=0).
-		db.Table("messages_edits me").
+		listErr = db.Table("messages_edits me").
 			Select("DISTINCT me.msgid").
 			Joins("INNER JOIN messages_groups mg ON mg.msgid = me.msgid AND mg.deleted = 0 AND mg.rippled_in = 0").
 			Where("mg.groupid IN (?) AND me.reviewrequired = 1 AND me.approvedat IS NULL AND me.revertedat IS NULL AND me.timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY)",
 				groupIDs).
 			Order("me.timestamp DESC").
 			Limit(limit).
-			Pluck("msgid", &msgIDs)
+			Pluck("msgid", &msgIDs).Error
 	} else if subaction == "searchall" && search != "" {
 		// If the search term is numeric, also match on message ID.
 		searchID, numErr := strconv.ParseUint(search, 10, 64)
@@ -503,7 +513,7 @@ func ListMessagesMT(c *fiber.Ctx) error {
 				contentcheckFilter +
 				" ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchID}, groupIDs, limit)
-			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+			listErr = db.Raw(sql, args...).Pluck("msgid", &msgIDs).Error
 		}
 		if len(msgIDs) == 0 {
 			searchTerm := "%" + search + "%"
@@ -515,7 +525,7 @@ func ListMessagesMT(c *fiber.Ctx) error {
 				contentcheckFilter +
 				" ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchTerm}, groupIDs, limit)
-			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+			listErr = db.Raw(sql, args...).Pluck("msgid", &msgIDs).Error
 		}
 	} else if subaction == "searchmemb" && search != "" {
 		// If search is a numeric user ID, do a fast direct lookup first.
@@ -532,7 +542,7 @@ func ListMessagesMT(c *fiber.Ctx) error {
 				contentcheckFilter +
 				" ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchUID}, groupIDs, limit)
-			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+			listErr = db.Raw(sql, args...).Pluck("msgid", &msgIDs).Error
 		}
 		if len(msgIDs) == 0 {
 			// Fall back to name/email LIKE search.  The LEFT JOIN to
@@ -550,7 +560,7 @@ func ListMessagesMT(c *fiber.Ctx) error {
 				contentcheckFilter +
 				" ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchTerm, searchTerm}, groupIDs, limit)
-			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+			listErr = db.Raw(sql, args...).Pluck("msgid", &msgIDs).Error
 		}
 	} else {
 		// When listing the Pending review queue, also include Spam-collection messages.
@@ -587,7 +597,11 @@ func ListMessagesMT(c *fiber.Ctx) error {
 		branchSQL += "ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 
 		sql, args := buildMTUnionAllMsgIDQuery(branchSQL, branchArgs, groupIDs, limit)
-		db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+		listErr = db.Raw(sql, args...).Pluck("msgid", &msgIDs).Error
+	}
+
+	if listErr != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list messages")
 	}
 
 	if len(msgIDs) == 0 {

--- a/iznik-server-go/test/modtools_listing_query_error_test.go
+++ b/iznik-server-go/test/modtools_listing_query_error_test.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// A listing query that fails must not be reported to ModTools as an empty
+// queue. The all-communities form of this query fans out over every group the
+// moderator covers and carries MAX_EXECUTION_TIME(20000), so a slow replica
+// aborts it; the result used to be a perfectly ordinary 200 with
+// "messages": [], which the client cannot tell apart from "nothing pending".
+// The moderator then sees an empty page while the work count in the menu says
+// there is work, and the infinite loader stops for good (Discourse 10037).
+//
+// A cancelled context makes every query on the handle fail, which is the same
+// class of error as the execution-time abort and needs no DB surgery.
+func TestListMessagesMT_QueryErrorIsNotAnEmptyQueue(t *testing.T) {
+	prefix := uniquePrefix("lstmt_qerr")
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Collection=Approved with an explicit groupid so the handler reaches the
+	// listing query without needing the DB for the moderator checks first.
+	url := fmt.Sprintf("/api/modtools/messages?groupid=%d&collection=Approved&jwt=%s", groupID, modToken)
+
+	// Sanity check: the request works before we break the handle.
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	good := database.DBConn
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	database.DBConn = good.WithContext(cancelledCtx)
+	defer func() { database.DBConn = good }()
+
+	resp, err = getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, 200, resp.StatusCode,
+		"a failed listing query must not be answered with a success")
+
+	var body map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if msgs, ok := body["messages"].([]interface{}); ok {
+		assert.Fail(t, "a failed listing query returned a messages array",
+			"got %d messages, which ModTools would read as an empty queue", len(msgs))
+	}
+}


### PR DESCRIPTION
Fixes the problem behind [Can't moderate on desktop](https://discourse.ilovefreegle.org/t/cant-moderate-on-desktop/10037), where a moderator had to use her phone because the Pending page showed nothing while the menu said there was work. A second moderator said the same thing had caught him the day before.

## What was actually happening

Established from production logs and the live database, not from reading the code:

- **40** calls to `/apiv2/modtools/messages?collection=Pending&groupid=522709` returned no messages, across the whole day. Every call **without** a groupid returned one to four. All of them ran in 3 to 7 ms with no errors, so nothing was failing.
- The client log shows `Page view: /messages/pending` followed **2 ms later** by `Page view: /messages/pending/522709`. That is the remembered community being re-applied on mount and `watch(groupid)` rewriting the URL.
- Her session was reporting `work: {"pending": 3}` at the same moments, and the menu badge counts every community.
- The database confirms it: every post she approved that day was on Chester, Warrington, Leigh or St Helens. Skelmersdale only ever received rippled-in Approved copies, never a pending one.
- At 17:18:01 she changed the dropdown. From then on `/messages/pending` stopped redirecting, the fetch returned 3 messages, and she approved them at 17:18:41.

So the page was filtered to one quiet community the whole time. `ModGroupSelect` stores the choice in local storage and re-applies it on every mount, and the guard that restores it is `if (val && ...)`, which is why choosing "All my communities" (value 0) sticks permanently and looks like a fix. Her phone worked because local storage is per device.

On the day of the report, **two of 126 active moderators** were in this state: the reporter, and another who moderates 58 communities but was pinned to one.

## Summary

- The empty-page notice now names the community it is filtered to, gives the outstanding count, and offers a **Show all my communities** button. The count is `pending + spam` read from `authStore.work`, which is exactly what the red Pending badge counts and exactly what the button will reveal. Deliberately not the composable's `work` (`pending + pendingother`): `pendingother` covers posts on **backup** communities, and the all-communities listing only fans out over active ones by design (`user.GetActiveModGroupIDs`), so counting those would promise work the button cannot surface. The button clears the remembered choice as well as the current filter, because `ModGroupSelect` only persists a change made through the dropdown itself, so setting `groupid` alone would let the filter come straight back next visit.
- **The queue now refreshes once per work change, not once per caller.** `setupModMessages()` warns "Do not include any watch in here as a separate watch is called for each time setupModMessages() is called" and then registers `watch(workdetail)`, a `MutationObserver` and `watch(modtoolsediting)` on every call. Each `watch(workdetail)` runs a full clear-then-refetch. It is called by three pages, by `ModMessages.vue`, and by `useKeywords.js` from a **module-level computed** that depends on the shared `group` ref, so that one re-registers every time the moderator changes community. Measured over one day of production traffic (1531 bursts, 126 moderators), a single work-count tick fired:

  | distinct group filters that moderator used | mean identical listing requests |
  |---|---|
  | 1 | 2.07 |
  | 2 | 5.79 |
  | 3 | 8.80 |
  | 7 | 12.00 |

  Worst case 13. Burst size does *not* grow with messages on screen, so it is not one per rendered message; it tracks group switching. Only the page owns the queue and only the page passes `reset=true`, so the refresh machinery is registered there alone. Verified in a real browser: a work change that previously fired two listing requests now fires one, and the new post still appears with no reload.
- An exception from `fetchMessagesMT` used to escape `loadMore()` entirely, leaving `InfiniteLoading` in `'loading'` and `busy` stuck true. Since `busy` suppresses the empty notice, the page looked like it was still working when it had given up. It is now caught and shown with a **Try again** button. An expired session stays silent, because the layout already handles that.
- Server side, `ListMessagesMT` read its listing query with `Pluck` and never checked the error. A query aborted by `MAX_EXECUTION_TIME(20000)` therefore returned an ordinary 200 with an empty messages array, which the client cannot tell apart from an empty queue. That is the same symptom with no filter involved, and the all-communities form is far more exposed to it because it unions one branch per community. It now returns a 500.

## Code quality review

- The remembered-value key is built from a single `REMEMBER_KEY` constant used for both the `ModGroupSelect` prop and the clear, so the two cannot drift apart.
- The loader bump is guarded on an empty list, so a healthy page does not refetch every time a count ticks.
- The Go change captures the error from every `Pluck` in the handler, not just the one on the standard listing path, so the search and Edit branches are covered too. The zero-communities case still short-circuits before any query is built, so a moderator of no communities is unaffected.
- The doc page this behaviour belongs to is updated in the same change, as required by the freshness check.

## Future improvements

Not done here, deliberately:

- `useKeywords.js` still calls `setupModMessages()` from a module-level computed. That is now harmless (it registers nothing), but it is an odd place to call a setup function from and worth tidying separately.
- The reporter said the dropdown read "all my communities". The code, a component test against the real `b-form-select`, and the browser check below all say it displays the filtered community's name. No display and value desync could be reproduced, so this is recorded as unexplained rather than fixed.

## Test plan

- `tests/unit/pages/modtools/messages/pending.spec.js`: 13 tests to 20, seven new -
  names the filtered community and the outstanding count when the filter is hiding work;
  counts spam towards that total, as the menu badge does;
  ignores backup-community work, which all-communities does not show;
  keeps the plain empty notice when nothing is pending anywhere;
  keeps it when already showing all communities;
  clearing the filter also forgets it, so the next visit is not filtered again;
  and the page fires no fetch of its own on a work-count change.
  The auth-store mock in this spec is now `reactive()` so the count-driven computed actually fires. Each behaviour test was confirmed to fail before the change.
- `tests/unit/composables/useModMessages.duplicateWatchers.spec.js`: 2 tests, new. Asserts one refetch per work change with the page, its list component and `useKeywords` all having called setup; fails on the old code with 3. Each case runs in its own `effectScope` so a leaked watcher cannot bleed into the next test.
- `iznik-server-go/test/modtools_listing_query_error_test.go`: forces a real query error with a cancelled context on `database.DBConn` and asserts the response is not a success carrying a messages array. **Red proof**: with the guard removed the full Go suite was 4145 pass / 1 fail, and the single failure was this test, reporting "got 0 messages, which ModTools would read as an empty queue".
- Full Go suite: **4146 pass, 0 fail**.
- Full vitest suite: **15512 pass, 0 fail** (file hashes in the runner container checked against the host, so the run genuinely covered these changes).
- ESLint and Prettier clean on the changed files. `check-docs-freshness.mjs` green.
- Browser check against `modtools-dev-local` with real data: created one pending post on FreeglePlayground and none on Freegle Playground2, selected the quiet community, and confirmed the menu showed "Pending 1" while the page explained the filter and named the community. Clicking **Show all my communities** returned the URL to `/messages/pending/`, reset the dropdown, and revealed the post. A fresh visit to `/messages/pending` afterwards no longer redirected back to the filtered URL. Test data removed.

## Coveralls

The three red Coveralls checks are not from this branch; the analysis is in a comment below. In short: the -10.3% aggregate is a four-flag build being compared against a one-flag (Go-only) baseline, because CI is path-filtered, and master swings the same way in reverse. The -0.007% Go flag is repo-wide jitter of the same size master shows commit to commit (and master is itself red on that flag for -0.004%); the two statements this PR adds to Go are executed 25 and 1 times respectively in the coverage profile, so patch coverage is 100%. Only `ci/circleci: build-and-test` is required by branch protection, and it passed.