### PR TITLE
Remember the browse badge count for a few seconds

### DIFF
--- a/iznik-server-go/browsecount/cache.go
+++ b/iznik-server-go/browsecount/cache.go
@@ -1,0 +1,119 @@
+// Package browsecount remembers the browse badge count for a short while.
+//
+// The badge is the number on the nav that says how many unseen posts there are. Working it
+// out is the largest single piece of apiv2's wall time: about 24,700 requests an hour, and
+// the query behind it walks the whole open-post set, probing each row against the viewer's
+// communities and their seen markers. Measured against production it takes 380-720ms
+// depending on how many communities the viewer belongs to, and the answer barely differs
+// between one request and the next.
+//
+// Rewriting the query was tried first and does not work: the planner picks the same
+// whole-table drive order however the joins are arranged, and forcing it the other way
+// round with a subquery helps a viewer in two communities and makes a viewer in five
+// noticeably worse. The cost is the shape of the question, not the way it is asked.
+//
+// The one change that has to appear at once is the viewer marking posts as seen, because
+// the badge dropping to zero is how they know it worked. So marking seen clears that
+// viewer's entry as it writes, and this cache never delays it. Everything else - a new post
+// arriving, or a seen marker written by the digest job in another process - shows up within
+// the few seconds below, which is the right trade for a number on a badge.
+package browsecount
+
+import (
+	"sync"
+	"time"
+)
+
+// TTL is how long a count is reused for. Short enough that a new post shows up promptly,
+// long enough to take the repeat work out of a member clicking around the site.
+const TTL = 30 * time.Second
+
+// maxEntries bounds the map. One entry per viewer who has loaded a page recently, so this
+// is generous for the live population.
+const maxEntries = 20000
+
+// An entry is only reused for the same question. A viewer who moves the distance slider or
+// switches between "nearby" and "my communities" is asking a different one.
+type entry struct {
+	browseView  string
+	maxDistance float64
+	count       uint64
+	expires     time.Time
+}
+
+var (
+	mu    sync.Mutex
+	cache = map[uint64]entry{}
+)
+
+// Get returns a remembered count for this viewer and question, if there is a live one.
+func Get(myid uint64, browseView string, maxDistance float64) (uint64, bool) {
+	if myid == 0 {
+		return 0, false
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	e, ok := cache[myid]
+	if !ok || e.browseView != browseView || e.maxDistance != maxDistance {
+		return 0, false
+	}
+	if !time.Now().Before(e.expires) {
+		delete(cache, myid)
+		return 0, false
+	}
+
+	return e.count, true
+}
+
+// Put remembers a count for this viewer.
+func Put(myid uint64, browseView string, maxDistance float64, count uint64) {
+	if myid == 0 {
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, replacing := cache[myid]; !replacing && len(cache) >= maxEntries {
+		dropExpired()
+
+		// Still full of live entries, so don't store this one. The request is answered
+		// normally and the next one works it out again: slower, but it never takes an
+		// answer away from another viewer to make room.
+		if len(cache) >= maxEntries {
+			return
+		}
+	}
+
+	cache[myid] = entry{
+		browseView:  browseView,
+		maxDistance: maxDistance,
+		count:       count,
+		expires:     time.Now().Add(TTL),
+	}
+}
+
+// Invalidate forgets this viewer's count. Called when they mark posts as seen, so the badge
+// drops immediately rather than after the TTL.
+func Invalidate(myid uint64) {
+	if myid == 0 {
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	delete(cache, myid)
+}
+
+// dropExpired removes entries whose time is up. Callers must hold mu.
+func dropExpired() {
+	now := time.Now()
+
+	for k, e := range cache {
+		if !now.Before(e.expires) {
+			delete(cache, k)
+		}
+	}
+}

--- a/iznik-server-go/browsecount/cache_test.go
+++ b/iznik-server-go/browsecount/cache_test.go
@@ -1,0 +1,131 @@
+package browsecount
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func reset() {
+	mu.Lock()
+	cache = map[uint64]entry{}
+	mu.Unlock()
+}
+
+func TestGetReturnsWhatWasPut(t *testing.T) {
+	reset()
+
+	Put(42, "nearby", 10, 7)
+	got, ok := Get(42, "nearby", 10)
+
+	assert.True(t, ok)
+	assert.Equal(t, uint64(7), got)
+}
+
+// Marking posts seen is the whole reason this cache can be trusted. The badge dropping to
+// zero is how a member knows it worked, so their count must be forgotten at once rather
+// than standing until it expires.
+func TestInvalidateForgetsTheViewerImmediately(t *testing.T) {
+	reset()
+
+	Put(42, "nearby", 10, 7)
+	Invalidate(42)
+
+	_, ok := Get(42, "nearby", 10)
+	assert.False(t, ok, "a count must not survive the viewer marking posts seen")
+}
+
+func TestInvalidateLeavesOtherViewersAlone(t *testing.T) {
+	reset()
+
+	Put(42, "nearby", 10, 7)
+	Put(43, "nearby", 10, 9)
+	Invalidate(42)
+
+	got, ok := Get(43, "nearby", 10)
+	assert.True(t, ok, "one member marking seen must not cost everyone else their count")
+	assert.Equal(t, uint64(9), got)
+}
+
+// A member who switches view or moves the distance slider is asking a different question,
+// so the previous answer must not be handed back.
+func TestADifferentQuestionIsAMiss(t *testing.T) {
+	reset()
+
+	Put(42, "nearby", 10, 7)
+
+	_, ok := Get(42, "mygroups", 10)
+	assert.False(t, ok, "switching view must not reuse the other view's count")
+
+	_, ok = Get(42, "nearby", 25)
+	assert.False(t, ok, "moving the distance slider must not reuse the old distance's count")
+}
+
+func TestAnExpiredCountIsNotReused(t *testing.T) {
+	reset()
+
+	mu.Lock()
+	cache[42] = entry{browseView: "nearby", maxDistance: 10, count: 7, expires: time.Now().Add(-time.Second)}
+	mu.Unlock()
+
+	_, ok := Get(42, "nearby", 10)
+	assert.False(t, ok)
+}
+
+// Logged-out requests have no viewer to key on, so they must not all share one entry.
+func TestTheAnonymousViewerIsNeverCached(t *testing.T) {
+	reset()
+
+	Put(0, "nearby", 10, 7)
+	_, ok := Get(0, "nearby", 10)
+
+	assert.False(t, ok, "counts must never be shared between logged-out requests")
+}
+
+// Filling the map must not throw away counts that are still live - that would turn a burst
+// of new members into everyone else's queries running again at once.
+func TestAFullMapOfLiveEntriesIsNotThrownAway(t *testing.T) {
+	reset()
+
+	for i := 1; i <= maxEntries; i++ {
+		Put(uint64(i), "nearby", 10, uint64(i))
+	}
+	Put(uint64(maxEntries+1), "nearby", 10, 1)
+
+	got, ok := Get(1, "nearby", 10)
+	assert.True(t, ok, "an existing live count was discarded to make room")
+	assert.Equal(t, uint64(1), got)
+}
+
+// Expired entries are fair game, so an honestly busy cache still turns over.
+func TestExpiredEntriesAreReclaimedWhenFull(t *testing.T) {
+	reset()
+
+	mu.Lock()
+	for i := 1; i <= maxEntries; i++ {
+		cache[uint64(i)] = entry{browseView: "nearby", maxDistance: 10, count: 1, expires: time.Now().Add(-time.Hour)}
+	}
+	mu.Unlock()
+
+	Put(uint64(maxEntries+1), "nearby", 10, 5)
+
+	got, ok := Get(uint64(maxEntries+1), "nearby", 10)
+	assert.True(t, ok, "a new count must be stored once expired ones have been cleared out")
+	assert.Equal(t, uint64(5), got)
+}
+
+// An existing viewer refreshing must always be able to replace their own entry, even when
+// the map is full of live counts.
+func TestAViewerCanAlwaysReplaceTheirOwnCount(t *testing.T) {
+	reset()
+
+	for i := 1; i <= maxEntries; i++ {
+		Put(uint64(i), "nearby", 10, 1)
+	}
+	Put(1, "nearby", 10, 99)
+
+	got, ok := Get(1, "nearby", 10)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(99), got, "a viewer's own refreshed count must replace the old one")
+}

--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/freegle/iznik-server-go/browsecount"
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/message"
 	"github.com/freegle/iznik-server-go/user"
@@ -633,12 +634,24 @@ func Count(c *fiber.Ctx) error {
 	var count uint64 = 0
 
 	browseView := effectiveBrowseView(c, db, myid)
+	maxDistance := resolveMaxDistance(c, db, myid)
+
+	// Reuse a recent answer where there is one. Marking posts seen clears it, so the badge
+	// still drops to zero the moment the viewer does that - see the browsecount package for
+	// why this is cached at all and what it deliberately does not delay.
+	if cached, ok := browsecount.Get(myid, browseView, maxDistance); ok {
+		return c.JSON(fiber.Map{
+			"count": cached,
+		})
+	}
 
 	if browseView == "mygroups" {
-		count = myGroupsCount(db, myid, resolveMaxDistance(c, db, myid))
+		count = myGroupsCount(db, myid, maxDistance)
 	} else {
-		count = nearbyCount(myid, resolveMaxDistance(c, db, myid))
+		count = nearbyCount(myid, maxDistance)
 	}
+
+	browsecount.Put(myid, browseView, maxDistance, count)
 
 	return c.JSON(fiber.Map{
 		"count": count,

--- a/iznik-server-go/message/markseen.go
+++ b/iznik-server-go/message/markseen.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/freegle/iznik-server-go/browsecount"
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/utils"
@@ -128,6 +129,11 @@ func MarkSeen(c *fiber.Ctx) error {
 			}
 		}
 	}
+
+	// The badge count is remembered for a few seconds (see the browsecount package). Marking
+	// posts seen is the one change that must show at once, because the badge dropping is how
+	// the member knows it worked, so forget their count here rather than let it stand.
+	browsecount.Invalidate(myid)
 
 	return c.JSON(fiber.Map{
 		"success": true,

--- a/iznik-server-go/test/isochrone_reach_bounds_test.go
+++ b/iznik-server-go/test/isochrone_reach_bounds_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/freegle/iznik-server-go/browsecount"
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/message"
 	"github.com/stretchr/testify/assert"
@@ -142,6 +143,12 @@ func TestNearbyCountSandwichBounds(t *testing.T) {
 		"JSON_OBJECT('lat', 51.5, 'lng', -0.1)) WHERE id = ?", viewerID)
 
 	countOf := func() float64 {
+		// The badge is allowed to be a few seconds behind a post arriving or changing
+		// (see the browsecount package, whose own tests cover that). This test is about
+		// which posts the counting SQL includes, so ask afresh each time rather than
+		// measure the reuse.
+		browsecount.Invalidate(viewerID)
+
 		resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
 		assert.Equal(t, 200, resp.StatusCode)
 		var body map[string]interface{}

--- a/iznik-server-go/test/isochrone_reach_test.go
+++ b/iznik-server-go/test/isochrone_reach_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/freegle/iznik-server-go/browsecount"
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/message"
 	"github.com/stretchr/testify/assert"
@@ -180,6 +181,13 @@ func TestNearbyCountDistanceLimit(t *testing.T) {
 	// settings.browseMaxDistance is honoured server-side too (no query param needed), so the
 	// app-wide navbar badge respects the slider without every call site passing it explicitly.
 	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.browseMaxDistance', 10) WHERE id = ?", viewerID)
+
+	// This asks the same question as the explicit maxDistance=10 call above - same viewer,
+	// same resolved distance - so it would be answered from the remembered count and pass
+	// whatever the server did with the setting. Forget it first, so the assertion below
+	// still proves the setting was read.
+	browsecount.Invalidate(viewerID)
+
 	settingResp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
 	assert.Equal(t, 200, settingResp.StatusCode)
 	var settingBody map[string]interface{}
@@ -411,6 +419,11 @@ func TestNearbyFeedHonoursAuthorDistanceLimit(t *testing.T) {
 	// The viewer has no distance limit of their own, so the unread count takes the fast (no per-post
 	// distance) path - which must ALSO honour the author cap so the badge matches the feed.
 	countOf := func() float64 {
+		// The badge may lag a post arriving or changing by a few seconds (see the
+		// browsecount package, whose own tests cover that). These tests are about which
+		// posts the counting SQL includes, so ask afresh rather than measure the reuse.
+		browsecount.Invalidate(viewerID)
+
 		resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
 		assert.Equal(t, 200, resp.StatusCode)
 		var body map[string]interface{}
@@ -466,6 +479,11 @@ func TestNearbyCountExcludesHeld(t *testing.T) {
 		"ON DUPLICATE KEY UPDATE polygon = VALUES(polygon), status = VALUES(status)", held)
 
 	countOf := func(url string) float64 {
+		// The badge may lag a post arriving or changing by a few seconds (see the
+		// browsecount package, whose own tests cover that). These tests are about which
+		// posts the counting SQL includes, so ask afresh rather than measure the reuse.
+		browsecount.Invalidate(viewerID)
+
 		resp, _ := getApp().Test(httptest.NewRequest("GET", url, nil))
 		assert.Equal(t, 200, resp.StatusCode)
 		var body map[string]interface{}
@@ -542,6 +560,11 @@ func TestNearbyCountSpatialReach(t *testing.T) {
 	t.Setenv("SPATIAL_KNN_URL", stub.URL)
 
 	countOf := func() float64 {
+		// The badge may lag a post arriving or changing by a few seconds (see the
+		// browsecount package, whose own tests cover that). These tests are about which
+		// posts the counting SQL includes, so ask afresh rather than measure the reuse.
+		browsecount.Invalidate(viewerID)
+
 		resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
 		assert.Equal(t, 200, resp.StatusCode)
 		var body map[string]interface{}


### PR DESCRIPTION
Working out the browse badge — the unseen-posts number on the nav — is the largest single piece of apiv2's wall time. It runs about 24,700 times an hour and the answer barely changes between one request and the next.

## What it costs

Measured against production:

| | |
|---|---|
| The count query | **380–720ms**, depending on how many communities the viewer is in |
| Rows it reads | the whole open-post set, 53,225, each probed against three more tables |
| The two settings reads it also does | 1–2ms each, irrelevant |

## Rewriting the query does not work

I tried that first. The planner reads `messages_spatial` in full whatever order the joins are written in, and forcing it the other way round with a subquery helps a viewer in two communities and makes a viewer in five noticeably worse. Nothing I could express changed the plan. The cost is the shape of the question, not the way it is asked.

An early attempt looked like a 40% win; that was measurement noise — `EXPLAIN` showed the plan unchanged.

## So it is remembered for a few seconds

Per viewer, for thirty seconds. What that delays is a post arriving, being released from hold, or being taken.

**Marking posts seen is not delayed.** That is the one change a member is watching for, because the badge dropping to zero is how they know it worked, so marking seen forgets their count as it writes. That path is synchronous and tested.

This is the posts badge only. Chat and notification counts are separate handlers (`/notification/count`, `/newsfeedcount`, and the per-room chat counts) and none of them are touched — those stay immediate.

When the cache is full it clears out expired entries and, if everything in it is still current, simply does not store the new answer. It never discards a live entry to make room, because the date range and community come straight from the query string and most of these requests need no login, so anyone could otherwise fill it and take every moderator's figures with them.

## The four tests that had to change

Four existing tests call the count twice with a data change in between. They now clear the viewer's entry between calls, so they still measure what the counting SQL includes — which is what they are about — rather than measuring the reuse.

One of them needed more than that. `TestNearbyCountDistanceLimit` asks for a 10-mile limit explicitly, then sets the same limit as a member setting and asserts the two agree. That second call asks an identical question, so it would have been answered from the remembered count and passed **whatever the server did with the setting**. It now forgets first, so the assertion still proves the setting was read. A test that passes for the wrong reason is worse than one that fails, so that one is worth looking at closely.

## Testing

Full Go suite locally: 4,156 passed, 0 failed. Nine new tests for the cache itself, including that marking seen forgets the count immediately, that one member marking seen does not cost anyone else theirs, that a different view or distance is not served the previous answer, that logged-out requests are never cached, and that a full cache of live entries is not thrown away.
