### PR TITLE
Detect provider deferrals and stop generating mail into them

### DIFF
--- a/.env.background.example
+++ b/.env.background.example
@@ -71,6 +71,37 @@ FREEGLE_MONITORING_HOSTS=root@10.x.x.x,root@10.x.x.y
 MONITORING_SSH_KEY_HOST_PATH=/path/to/ssh/private/key
 
 # =============================================================================
+# Deferral-aware mail suppression (mail:deferrals:scan)
+# =============================================================================
+# Our relay 250-accepts a message and only afterwards discovers the receiving
+# provider will not take it, so nothing in the sending path can see a deferral.
+# On 2026-08-15 Yahoo began 421-ing everything from the relay's IP; three days
+# later 85,537 messages were queued and ~9,400 people had received nothing.
+# This reads the relay's own Postfix queue and stops us generating into it.
+#
+# Off by default. The schedule entry is wrapped in this check, so a false here
+# means the job is not even registered.
+FREEGLE_MAIL_DEFERRALS_ENABLED=false
+# ssh target for the outbound relay. As with FREEGLE_MONITORING_HOSTS above,
+# the estate's topology lives ONLY here. Empty = disabled.
+FREEGLE_MAIL_DEFERRALS_HOST=deferrals@10.x.x.x
+# Private key for that probe, as a path on the HOST. Mounted read-only into
+# the container at /etc/mail-deferrals-ssh-key (see docker-compose.yml).
+#
+# Deliberately NOT the monitoring key. That one is a root shell across the
+# whole estate; this only ever needs to read a mail queue. Restrict it on the
+# relay with a forced command in authorized_keys, e.g.
+#   command="/usr/local/sbin/freegle-deferral-probe",no-port-forwarding,#   no-agent-forwarding,no-X11-forwarding,no-pty ssh-ed25519 AAAA...
+# where that script runs the probe and, for --purge, postsuper -d reading ids
+# from stdin. Without the forced command this key is a shell on the relay.
+MAIL_DEFERRALS_SSH_KEY_HOST_PATH=/path/to/deferrals/ssh/private/key
+# Thresholds are all optional; see iznik-batch/config/freegle.php for what
+# each was set against and why.
+#FREEGLE_MAIL_DEFERRALS_MXGROUP_MIN=500
+#FREEGLE_MAIL_DEFERRALS_MXGROUP_MAX_DELIVERED=10
+#FREEGLE_MAIL_DEFERRALS_RELEASE_MAX=100
+
+# =============================================================================
 # Git Summary (Weekly Code Changes Report)
 # =============================================================================
 # Google Gemini API key for AI summarization

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1699,6 +1699,10 @@ services:
       # /etc/monitoring-ssh-key. Defaults to /dev/null (dev/CI: checks are
       # disabled anyway when FREEGLE_MONITORING_HOSTS is empty).
       - ${MONITORING_SSH_KEY_HOST_PATH:-/dev/null}:/etc/monitoring-ssh-key:ro
+      # Read-only probe key for mail:deferrals:scan. Separate from the
+      # monitoring key above on purpose: that one is a root shell across the
+      # estate, this one only reads the outbound relay's mail queue.
+      - ${MAIL_DEFERRALS_SSH_KEY_HOST_PATH:-/dev/null}:/etc/mail-deferrals-ssh-key:ro
     extra_hosts:
       - "db-host:${DB_HOST_IP:-127.0.0.1}"
       # Read replica for the DB read/write split. Falls back to the write host

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -38,6 +38,7 @@ Read these directly; the pages above link into them rather than copy them:
 | Rippling out algorithm | [./reference/rippling-algorithm.md](./reference/rippling-algorithm.md) |
 | Getting a first reply in | [./reference/first-reply.md](./reference/first-reply.md) |
 | Unsubscribing from email (List-Unsubscribe) | [./reference/unsubscribe.md](./reference/unsubscribe.md) |
+| Mail deferrals and suppression | [./reference/mail-deferrals.md](./reference/mail-deferrals.md) |
 | Donation asks in email (Stripe, wallets) | [./reference/donation-asks-in-email.md](./reference/donation-asks-in-email.md) |
 | Browser testing with Chrome DevTools | [./reference/browser-testing.md](./reference/browser-testing.md) |
 | Worktrees / parallel instances | [./reference/worktrees.md](./reference/worktrees.md) |

--- a/docs/developers/reference/mail-deferrals.md
+++ b/docs/developers/reference/mail-deferrals.md
@@ -11,7 +11,10 @@ covers:
   - iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
   - iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
   - iznik-batch/tests/Feature/Mail/DeferralCatchUpServiceTest.php
+  - iznik-batch/tests/Feature/Mail/ScanDeferralsCommandTest.php
+  - iznik-server-go/emailtracking/deferrals.go
   - iznik-nuxt3/modtools/components/ModMailDelayed.vue
+  - iznik-nuxt3/modtools/components/ModSupportMailDeferrals.vue
 ---
 
 # Mail deferrals and suppression
@@ -270,5 +273,11 @@ generate, plus the `suppressionid` that was in force at the time. Claimed by
 - `tests/Feature/Mail/MailSuppressionServiceTest.php` - the gate itself.
 - `tests/Feature/Mail/DeferralCatchUpServiceTest.php` - one catch-up, not a
   replay.
+- `tests/Feature/Mail/ScanDeferralsCommandTest.php` - the acceptance test:
+  replaying the incident queue, one scan suppresses Yahoo and every domain
+  behind it while Gmail keeps getting mail, and purge refuses to run without
+  `--force`.
 - `tests/Unit/Services/Mail/Incoming/BounceServiceTest.php` - the deferral
   ignore patterns.
+- `iznik-server-go/test/membership_test.go` - the delayed fields on the
+  memberships payload, including that they clear after catch-up.

--- a/docs/developers/reference/mail-deferrals.md
+++ b/docs/developers/reference/mail-deferrals.md
@@ -190,6 +190,23 @@ point - so the backlog policy is per type:
 generate. That is what lets the catch-up say something true about the size of
 the gap, and it is what ModTools shows moderators.
 
+Release is evaluated per tier, because the two tiers are different scales. A
+relay family always has a tail of stragglers, so it clears when the backlog is
+back to a normal level and the provider is visibly taking our mail again. One
+mailbox holds single figures, so applying the relay-sized threshold to it would
+call a still-full mailbox clear on the very next scan; an address clears only
+when the queue holds nothing for it at all.
+
+Any scan that is not clear resets the counter, so the two clear scans have to
+be consecutive. Targets the same scan has just re-confirmed as deferring are
+kept out of the release pass entirely, since it reads a snapshot taken before
+those confirmations were written.
+
+One known gap: a domain served by two suppressed relay families gets a single
+child row, under whichever family claimed it first. Releasing that family
+releases the row even though the other is still blocking. The next scan
+re-creates it under the remaining family, so the exposure is one scan interval.
+
 ## Queue hygiene
 
 `mail:deferrals:scan --purge` deletes the queued backlog for a suppressed

--- a/docs/developers/reference/mail-deferrals.md
+++ b/docs/developers/reference/mail-deferrals.md
@@ -1,0 +1,253 @@
+---
+last_reviewed: 2026-08-18
+owner: Freegle dev team
+covers:
+  - iznik-batch/app/Services/Mail/Deferrals/*.php
+  - iznik-batch/app/Services/Mail/MailSuppressionService.php
+  - iznik-batch/app/Console/Commands/Mail/ScanDeferralsCommand.php
+  - iznik-batch/app/Mail/Deferrals/UnreadChatCatchUpMail.php
+  - iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables.php
+  - iznik-batch/tests/Unit/Services/Mail/Deferrals/*.php
+  - iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
+  - iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
+  - iznik-batch/tests/Feature/Mail/DeferralCatchUpServiceTest.php
+  - iznik-nuxt3/modtools/components/ModMailDelayed.vue
+---
+
+# Mail deferrals and suppression
+
+## The problem this solves
+
+We hand our outbound mail to a relay over SMTP. The relay accepts each message
+with a `250` and takes responsibility for delivering it onward. Everything
+after that - the actual conversation with Gmail, Yahoo, Microsoft - happens on
+the relay, out of sight of any code in this repo.
+
+That is fine until a provider stops accepting us. Then the relay keeps taking
+our mail, keeps answering `250`, and quietly stacks it up in a queue that
+cannot drain. Nothing in `EmailSpoolerService`, nothing in
+`SmtpFailureClassifier`, nothing in `monitor:email-health` can see it: they all
+measure whether we successfully handed mail over, which we did.
+
+On 2026-08-15 at 16:38 UTC Yahoo began returning
+`421 4.7.0 [TSS04] ... temporarily deferred due to unexpected volume or user
+complaints` to every message from the relay's IP, triggered by a Community
+News send that tripled the relay's normal volume for two days running. Three
+days later nobody had noticed. The deferred queue held 85,537 messages and was
+growing by around 1,300 an hour. About 9,400 people had received nothing.
+
+Two things were broken, and this feature fixes both.
+
+**We could not see it.** Nothing in our code was capable of observing a
+deferral, so no alert could ever have fired.
+
+**We kept generating into it.** Roughly 67,000 digests a day plus per-post
+immediate mail continued to render - the expensive MJML and AMP compile - for
+addresses that provably could not receive any of it. The 85k backlog was 61%
+`[Group] OFFER:` immediate mail, 25% digests, and the rest chat notifications,
+WeMissYou and Community News.
+
+## How detection works
+
+`mail:deferrals:scan` runs every fifteen minutes and reads the relay's own
+Postfix queue.
+
+It reaches the relay with `App\Monitoring\HostCommandRunner`, the same
+ssh-and-parse-stdout mechanism the host health probes already use. The probe is
+read-only and runs in one round trip. It uses `postqueue -j` rather than
+`mailq`, because `mailq` takes minutes over a queue this size and `postqueue -j`
+emits one JSON object per line, which we can cap and stream.
+
+The relay's topology is not in this repo and must not be: the ssh target lives
+only in the environment. See "Configuration" below.
+
+### Two tiers, and the first is the one that matters
+
+**MX group (primary).** Deferrals are grouped by the *relay host* Postfix
+blamed, not by the recipient's domain. This matters more than it looks.
+Providers block per sending-IP-to-receiving-infrastructure pair. When Yahoo
+blocked us, that single block took out `yahoo.co.uk`, `yahoo.com`, `ymail.com`,
+`rocketmail.com`, `aol.com`, `aol.co.uk`, `aim.com` **and `sky.com`** - Sky's
+mail is Yahoo-hosted, which nothing about the domain name would tell you. All
+of them relay through `*.am0.yahoodns.net`. Group by relay and you catch all
+eight; group by domain and you are playing whack-a-mole with a list you will
+never finish.
+
+A relay family is suppressed when its deferred backlog is over threshold *and*
+deliveries to it have all but stopped. Both halves are needed: a big backlog
+alone can be a slow evening, and a quiet hour alone can be a quiet hour. During
+the incident the ratio was roughly one delivery an hour against tens of
+thousands of deferral events, so in practice this is not a close call.
+
+**Per address (secondary).** An individual mailbox with enough deferrals over
+enough hours. This catches `452 4.2.2 Recipient mailbox quota exceeded`, which
+is present in the queue independently of any incident. It is deliberately
+slower and more forgiving than the MX-group tier, because a mailbox that is
+full today is often fine tomorrow.
+
+### Where the domain list comes from
+
+When a relay family is suppressed we also write a child `domain` row for every
+recipient domain we actually saw deferring behind it. That is what keeps the
+sending-loop check to a plain indexed lookup with no DNS in the hot path - and
+it is better evidence than an MX lookup would be, because it is a record of
+what actually happened to our mail rather than what DNS says should have.
+
+### Alerting
+
+Any new MX-group suppression raises a Sentry alert, as does a relay we cannot
+reach at all. The entire reason this ran for three days is that nothing
+shouted.
+
+## How suppression works
+
+`App\Services\Mail\MailSuppressionService::isSuppressed()` is the gate. It is
+called from inside each sending job's per-recipient loop, **before the render**
+rather than at spool or send time, because the render is where the cost is.
+
+Gated paths, all of which skip before a `Mailable` is constructed:
+
+| Mail | Where the gate sits |
+|------|---------------------|
+| Immediate `[Group] OFFER:` / `WANTED:` | `UnifiedDigestService::processGroupImmediate()`, after the `email_preferred` guard |
+| Reach and match mail | `UnifiedDigestService::spoolPostToRecipients()`, same place |
+| Daily digest | `UnifiedDigestService::sendDigestToUser()`, before the digest tracker is read |
+| Chat notifications | `ChatNotificationService::processMessage()`, after the `email_preferred` guard |
+| WeMissYou / engagement | `EngageEmailService::sendToUsers()` |
+| Community News | `CommunityNewsEmailService::sendWeekly()` |
+
+There is a final backstop inside `EmailSpoolerService::spool()` itself, above
+the render call. It catches anything that does not gate earlier, including any
+new send path somebody adds later without knowing this exists. It returns `''`
+rather than throwing, matching the existing permanent-failure contract, because
+callers key off the truthiness of the returned id.
+
+### Why not `users.bouncing`
+
+Because it means something else. `bouncing` means *this address is bad*. It is
+shown to moderators as such, they act on it, and historically it was never
+reset. A deferral is our sending reputation with a provider; the member's
+address is fine and there is nothing they can do. Conflating the two would get
+members chased for our problem.
+
+## Release, and what happens to the backlog
+
+A suppression is released when deliveries to the relay have resumed *and* its
+deferred count has stayed below threshold for two consecutive scans. Release is
+deliberately harder than suppression, so a single quiet moment inside a
+provider's own backoff window cannot reopen the floodgates.
+
+There is also a fail-open: if the probe has not been able to confirm a
+suppression for `stale_after_hours`, it is released and alerted on. Quietly not
+mailing an entire provider for ever, because our own probe broke, would be
+worse than the problem this feature was written to solve.
+
+We never store the mail we declined to render - storing it would defeat the
+point - so the backlog policy is per type:
+
+| Type | On release |
+|------|------------|
+| `[Group] OFFER:` / `WANTED:` | Dropped. A three-day-old post is taken or gone. The immediate-mail cursor is per group rather than per member, so it has moved on regardless. |
+| Community News, WeMissYou, volunteering | Dropped. All periodic; the next one along is a better email than a stale one. |
+| Daily digest | One catch-up covering the whole window. This needs no code: the gate returns *before* the digest tracker is advanced, so the next daily run naturally spans the gap and sends exactly one. |
+| Chat notifications | One "you have unread messages" summary. Never replayed individually - a stack of days-old notifications arriving at once is its own harm, and is the behaviour that gets a sender deferred in the first place. |
+
+`mail_suppressed_counts` records, per member and per type, what we declined to
+generate. That is what lets the catch-up say something true about the size of
+the gap, and it is what ModTools shows moderators.
+
+## Queue hygiene
+
+`mail:deferrals:scan --purge` deletes the queued backlog for a suppressed
+relay. It is dry-run unless `--force` is also given.
+
+This is not tidying. Postfix retries a deferred message until
+`maximal_queue_lifetime` and then emits **one bounce per message**, each
+carrying the provider's original 4xx text, each landing back in our own bounce
+processing. With around nine queued messages per affected member, that would
+push essentially every one of them past the five-soft-bounces-in-fourteen-days
+threshold in `BounceService::checkAndSuspendUser()` and suspend them for a
+problem that was ours.
+
+`postsuper -d` removes messages silently with no DSN at all, which is the only
+thing that stops that cascade.
+
+As a second line of defence, `BounceService::IGNORE_PATTERNS` now matches
+`temporarily deferred`, `[TSS04]` and `delivery time expired`, so a queue-expiry
+DSN that does reach us never counts toward suspension. Note that VERP does not
+save us here: bulk mail carries a plain `noreply@` envelope sender, but
+`processBounce()` falls back to the DSN's `Original-Recipient` header, so
+attribution still lands on the member.
+
+Only ever purge after a dry run against a verified id list. Ids are filtered
+against a queue-id shape before they reach the relay's shell.
+
+## What moderators see
+
+`ModMailDelayed.vue` renders next to the existing bouncing treatment in
+`ModMember.vue`:
+
+> **Email delayed since 15 August** - Yahoo is not currently accepting our mail.
+
+It is deliberately `info` rather than `danger`, and deliberately worded so it
+cannot be mistaken for bouncing. The only correct action is to wait.
+
+The apiv2 `/memberships` payload carries `maildelayedsince`,
+`maildelayedprovider` and `maildelayedcount`. These are correlated subqueries
+rather than joins, because a member can have more than one email row and a
+suppression can match both by domain and by address, either of which would
+multiply member rows. They are pointers in Go so a query branch that does not
+select them reads as *unknown* rather than as a confident "not delayed".
+
+## Configuration
+
+Everything lives under `freegle.mail.deferrals` in `iznik-batch/config/freegle.php`.
+
+The feature is **off by default** (`FREEGLE_MAIL_DEFERRALS_ENABLED`) and the
+schedule entry is wrapped in that config check, so it is not even registered in
+dev or CI.
+
+The relay's ssh target (`FREEGLE_MAIL_DEFERRALS_HOST`) and its key
+(`MAIL_DEFERRALS_SSH_KEY_HOST_PATH`, bind-mounted read-only into the container)
+live only in the uncommitted environment on the batch host, following the same
+rule as `FREEGLE_MONITORING_HOSTS`. The topology never enters committed code.
+
+The key is deliberately separate from the monitoring key. That one is a root
+shell across the whole estate; this one only ever needs to read a mail queue,
+and should be restricted with a forced command in `authorized_keys` on the
+relay. That restriction is an ops action outside this repo.
+
+Thresholds (backlog size, delivery rate, release window, staleness) are all
+env-overridable - see the comments in `config/freegle.php`, which explain what
+each was set against.
+
+## Schema
+
+Two tables, created by
+`2026_08_18_000001_create_mail_suppressions_tables.php` with the paired
+idempotent production SQL alongside it.
+
+`mail_suppressions` - one row per suppression, scoped `mxgroup`, `domain` or
+`address`. Domain rows hang off their mxgroup row via `parentid`, so releasing
+a provider cascades. Rows are kept after release; the active set is
+`released_at IS NULL`.
+
+`mail_suppressed_counts` - per member and per type, what we declined to
+generate, claimed by `caughtup_at` before the catch-up sends so a crash cannot
+send it twice.
+
+## Tests
+
+- `tests/Unit/Services/Mail/Deferrals/MxGrouperTest.php` - relay grouping,
+  including the public-suffix and shared-platform cases that would otherwise
+  suppress far too much.
+- `tests/Unit/Services/Mail/Deferrals/DeferralProbeTest.php` - parsing real
+  `postqueue -j` shapes, truncation, unattributable deferrals, and the purge
+  input filter.
+- `tests/Feature/Mail/DeferralScanServiceTest.php` - the suppress/release
+  decisions, including "busy is not blocked" and the two-clear-scan rule.
+- `tests/Feature/Mail/MailSuppressionServiceTest.php` - the gate itself.
+- `tests/Feature/Mail/DeferralCatchUpServiceTest.php` - one catch-up, not a
+  replay.
+- `tests/Unit/Services/Mail/Incoming/BounceServiceTest.php` - the deferral
+  ignore patterns.

--- a/docs/developers/reference/mail-deferrals.md
+++ b/docs/developers/reference/mail-deferrals.md
@@ -193,11 +193,32 @@ It is deliberately `info` rather than `danger`, and deliberately worded so it
 cannot be mistaken for bouncing. The only correct action is to wait.
 
 The apiv2 `/memberships` payload carries `maildelayedsince`,
-`maildelayedprovider` and `maildelayedcount`. These are correlated subqueries
-rather than joins, because a member can have more than one email row and a
-suppression can match both by domain and by address, either of which would
-multiply member rows. They are pointers in Go so a query branch that does not
-select them reads as *unknown* rather than as a confident "not delayed".
+`maildelayedprovider` and `maildelayedcount`.
+
+All three read from `mail_suppressed_counts`, which the batch side writes -
+including which suppression was in force - at the moment it declines to
+generate each email. That is deliberate. Working out later which provider is
+refusing a given member would mean resolving their send address the way the
+mailer does (a ranking over `users_emails`, not a flag) and then matching it
+by domain: not something a reporting query should be reimplementing, not
+indexable, and wrong by the time the suppression has been released anyway.
+
+The consequence worth knowing is that a member shows as delayed once we have
+actually held something back for them, rather than from the instant their
+provider is suppressed. In practice that is the next digest or post
+notification they were due. "Delayed since" therefore means "since we started
+holding your mail", which is also the date the count belongs to.
+
+They are correlated subqueries rather than joins, because a member has one row
+per type of mail held and a join would multiply member rows; each is keyed on
+`msc.userid`, the leading column of that table's unique index. They are
+pointers in Go so a query branch that does not select them reads as *unknown*
+rather than as a confident "not delayed".
+
+**Support view**: sysadmin > Mail > Delayed
+(`GET /modtools/email/deferrals`) lists every active suppression and every
+member whose mail is being held, capped at 1,000 rows with the cap stated
+rather than silently applied.
 
 ## Configuration
 
@@ -233,8 +254,8 @@ a provider cascades. Rows are kept after release; the active set is
 `released_at IS NULL`.
 
 `mail_suppressed_counts` - per member and per type, what we declined to
-generate, claimed by `caughtup_at` before the catch-up sends so a crash cannot
-send it twice.
+generate, plus the `suppressionid` that was in force at the time. Claimed by
+`caughtup_at` before the catch-up sends, so a crash cannot send it twice.
 
 ## Tests
 

--- a/docs/developers/reference/mail-deferrals.md
+++ b/docs/developers/reference/mail-deferrals.md
@@ -125,6 +125,26 @@ new send path somebody adds later without knowing this exists. It returns `''`
 rather than throwing, matching the existing permanent-failure contract, because
 callers key off the truthiness of the returned id.
 
+### Two deliberate asymmetries
+
+The `EmailSpoolerService::spool()` backstop **logs but does not count**. The
+per-recipient gates do the counting, because they are the only ones that know
+whose mail it is; a `Mailable` at spool time may not carry a member id at all.
+Anything the backstop catches is therefore something no gate covered, which is
+a gap to close in the gate rather than a number to record - and it shows up in
+the log so that it can be.
+
+Freegle's own addresses are **never** suppressed, at any scope. The volume is
+trivial - alerts, reports, mod notifications to team addresses - so nothing is
+saved by holding them, and the failure mode is absurd: the alert saying a
+provider has stopped accepting our mail is exactly the message that would be
+dropped.
+
+And the `BounceService` ignore patterns are unconditional rather than scoped
+to a live suppression, on purpose. A queue-expiry DSN turns up as much as five
+days after the deferral that caused it, by which time the suppression has
+usually been released. Scoping the patterns to active suppressions would miss
+exactly the DSNs they exist to catch.
 ### What the gate does not catch
 
 Mail already sitting in the file spool when a suppression starts still goes

--- a/docs/developers/reference/mail-deferrals.md
+++ b/docs/developers/reference/mail-deferrals.md
@@ -125,6 +125,16 @@ new send path somebody adds later without knowing this exists. It returns `''`
 rather than throwing, matching the existing permanent-failure contract, because
 callers key off the truthiness of the returned id.
 
+### What the gate does not catch
+
+Mail already sitting in the file spool when a suppression starts still goes
+out, and will be deferred like the rest. That is deliberate. Holding it at
+send time instead would need a per-message backoff that the spool format does
+not have today, and `ProcessSpoolCommand --daemon` retries transient
+failures on its next tick about a second later - so a send-time hold would hot
+loop against a provider that is already unhappy with our volume. The spool
+drains in minutes, so the tail is minutes of mail against days of it.
+
 ### Why not `users.bouncing`
 
 Because it means something else. `bouncing` means *this address is bad*. It is

--- a/docs/developers/reference/mail-deferrals.md
+++ b/docs/developers/reference/mail-deferrals.md
@@ -4,6 +4,8 @@ owner: Freegle dev team
 covers:
   - iznik-batch/app/Services/Mail/Deferrals/*.php
   - iznik-batch/app/Services/Mail/MailSuppressionService.php
+  - iznik-batch/app/Services/Mail/DeliveryHealthService.php
+  - iznik-batch/tests/Unit/Services/Mail/DeliveryHealthServiceTest.php
   - iznik-batch/app/Console/Commands/Mail/ScanDeferralsCommand.php
   - iznik-batch/app/Mail/Deferrals/UnreadChatCatchUpMail.php
   - iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables.php
@@ -102,6 +104,30 @@ what actually happened to our mail rather than what DNS says should have.
 Any new MX-group suppression raises a Sentry alert, as does a relay we cannot
 reach at all. The entire reason this ran for three days is that nothing
 shouted.
+
+### The other half: mail that is accepted and then binned
+
+Everything above catches a provider that *refuses* us. The refusal leaves the message in the
+relay's queue, where it can be counted.
+
+A provider can fail us the opposite way: accept every message and then quietly do nothing with
+it. That leaves no queue entry at all, so the scan cannot see it, and from our side everything
+looks perfect. On 2026-08-16 every Yahoo-run domain - `yahoo.co.uk`, `yahoo.com`, `aol.com`,
+`sky.com`, `ymail.com`, `rocketmail.com` - went from a steady 16-36% open rate to zero and
+stayed there, following a send five times the normal daily volume two days earlier. That is
+about 35,000 emails a day going nowhere, and nothing alerted.
+
+`DeliveryHealthService` watches for that shape by comparing each domain's open rate against its
+own recent history, once a day. It compares a domain against itself rather than against a fixed
+figure or against other domains, because open rates differ hugely and legitimately between
+providers - `icloud.com` opens at 56% where `gmail.com` opens at 23% on the same mail - so any
+absolute threshold would either miss real outages at the top or cry wolf at the bottom.
+Domains that never report opens drop out by themselves, because their baseline is already zero.
+
+The two are reported as separate alerts on purpose. "A provider has stopped taking our mail"
+and "we are short of capacity" are different problems for different people. When the scan
+suppresses a provider, expect the open-rate check to name the same domains a day or so later:
+that is the two agreeing, not a duplicate.
 
 ## How suppression works
 

--- a/docs/developers/reference/mail-deferrals.md
+++ b/docs/developers/reference/mail-deferrals.md
@@ -15,6 +15,7 @@ covers:
   - iznik-server-go/emailtracking/deferrals.go
   - iznik-nuxt3/modtools/components/ModMailDelayed.vue
   - iznik-nuxt3/modtools/components/ModSupportMailDeferrals.vue
+  - iznik-nuxt3/tests/unit/components/modtools/ModMailDelayed.spec.js
 ---
 
 # Mail deferrals and suppression
@@ -311,3 +312,5 @@ generate, plus the `suppressionid` that was in force at the time. Claimed by
   ignore patterns.
 - `iznik-server-go/test/membership_test.go` - the delayed fields on the
   memberships payload, including that they clear after catch-up.
+- `iznik-nuxt3/tests/unit/components/modtools/ModMailDelayed.spec.js` - the
+  moderator wording, and that it reads as information rather than as a fault.

--- a/docs/moderators/03-managing-members.md
+++ b/docs/moderators/03-managing-members.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-09
+last_reviewed: 2026-08-18
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/modtools/pages/members/**
@@ -32,6 +32,28 @@ From here you can:
   survives).
 - **Export** the members list.
 - Change a member's **role** (Member, Moderator, Owner).
+
+## "Email delayed" is not the same as "bouncing"
+
+You may see a blue notice on a member saying **Email delayed since <date> - <provider> is
+not currently accepting our mail**.
+
+This is not a problem with that member's email address, and it is nothing they or you can
+fix. It means the company that runs their email - Yahoo, Microsoft, whoever - has
+temporarily stopped accepting mail from Freegle's sending servers. It affects everyone at
+that provider at once, so if you see it on one member you will usually see it on many.
+
+While that is going on we deliberately stop generating their emails rather than pile up
+mail that cannot be delivered, and the notice tells you roughly how many we have held
+back. When the provider starts accepting us again, they get a catch-up digest and a
+summary of any unread chats. Stale post notifications are not resent, because by then the
+item has usually gone.
+
+So: nothing to do. Do not chase the member, and do not remove them.
+
+Contrast this with the red **bouncing** notice, which really does mean their address is
+rejecting mail - a closed account, a typo, a full mailbox - and where reactivating after
+they have fixed it is the right move.
 
 ## Member review
 

--- a/iznik-batch/.env.example
+++ b/iznik-batch/.env.example
@@ -116,6 +116,16 @@ FREEGLE_MONITORING_BG_TASKS_MAX_AGE_MIN=10
 FREEGLE_MONITORING_BG_TASKS_BACKLOG=0
 # spam:refresh-mobile-cidrs — alert if no UK-mobile CIDR refresh within N days.
 FREEGLE_MONITORING_MOBILE_CIDRS_MAX_AGE_DAYS=40
+
+# Deferral-aware mail suppression (mail:deferrals:scan).
+# Reads the outbound relay's Postfix queue over ssh and stops us generating
+# mail for providers that have stopped accepting us. See
+# docs/developers/reference/mail-deferrals.md. Off unless a relay is
+# configured; the relay's address lives only in .env.background on the batch
+# host, never here.
+FREEGLE_MAIL_DEFERRALS_ENABLED=false
+FREEGLE_MAIL_DEFERRALS_HOST=
+FREEGLE_MAIL_DEFERRALS_SSH_KEY=/etc/mail-deferrals-ssh-key
 # Per-minute processing queues (contentcheck, chat process-incoming, memberships):
 # a row unprocessed longer than this (minutes) = stuck worker.
 FREEGLE_MONITORING_PROCESSING_BACKLOG_MAX_AGE_MIN=15

--- a/iznik-batch/app/Console/Commands/Mail/ScanDeferralsCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/ScanDeferralsCommand.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace App\Console\Commands\Mail;
+
+use App\Services\Mail\Deferrals\DeferralCatchUpService;
+use App\Services\Mail\Deferrals\DeferralProbe;
+use App\Services\Mail\Deferrals\DeferralScanService;
+use App\Services\Mail\Deferrals\RelayQueueSnapshot;
+use App\Services\Mail\MailSuppressionService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Find out whether a provider has stopped accepting our mail, and stop
+ * generating into the hole if so.
+ *
+ * The gap this fills: our relay 250-accepts every message and only discovers
+ * afterwards that the receiving provider will not take it. Nothing in the
+ * sending path can see that. On 2026-08-15 Yahoo began deferring everything
+ * from the relay's IP; three days later nobody had noticed, 85,537 messages
+ * were queued and growing by about 1,300 an hour, and roughly 9,400 people
+ * had received none of it.
+ *
+ * So this command goes and looks - reading the relay's own queue over ssh -
+ * and then does the two things that were missing: it says so loudly, and it
+ * stops the sending jobs generating mail that cannot be delivered.
+ */
+class ScanDeferralsCommand extends Command
+{
+    protected $signature = 'mail:deferrals:scan
+        {--dry-run : Report what would change without writing anything}
+        {--purge : Delete the queued backlog for suppressed relays (dry-run unless --force)}
+        {--force : Actually delete when used with --purge}
+        {--no-catchup : Skip the post-release catch-up pass}';
+
+    protected $description = 'Read the outbound relay queue, suppress mail to providers deferring us, and release when they recover';
+
+    public function handle(
+        DeferralProbe $probe,
+        DeferralScanService $scan,
+        DeferralCatchUpService $catchUp,
+    ): int {
+        $cfg = (array) config('freegle.mail.deferrals', []);
+
+        if (! ($cfg['enabled'] ?? false)) {
+            $this->info('Deferral scanning is disabled (FREEGLE_MAIL_DEFERRALS_ENABLED).');
+
+            return self::SUCCESS;
+        }
+
+        $target = trim((string) ($cfg['host'] ?? ''));
+        if ($target === '') {
+            // Empty in dev and CI by design - the estate's topology lives only
+            // in the environment - so this is information, not an error.
+            $this->info('No relay host configured (FREEGLE_MAIL_DEFERRALS_HOST); nothing to scan.');
+
+            return self::SUCCESS;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+
+        $snapshot = $probe->probe($target, (int) ($cfg['max_queue_bytes'] ?? 64 * 1024 * 1024));
+
+        if ($snapshot === null) {
+            // Being unable to see the relay is itself worth knowing: this
+            // command running green while blind is how the original incident
+            // stayed invisible for three days.
+            $this->error('Could not read the relay queue.');
+            $this->alertSentry('Mail deferral scan could not read the relay queue', [
+                'target' => $target,
+            ]);
+
+            return self::FAILURE;
+        }
+
+        $this->reportSnapshot($snapshot);
+
+        $result = $scan->apply($snapshot, $dryRun);
+
+        foreach ($result['suppressed'] as $s) {
+            $line = sprintf(
+                '%s SUPPRESSED %s %s (%d deferred, %d delivered/hr%s)',
+                $dryRun ? '[dry-run]' : '',
+                $s['scope'],
+                $s['value'],
+                $s['deferred'],
+                $s['delivered'] ?? 0,
+                ! empty($s['blind']) ? ', no delivery data' : ''
+            );
+            $this->warn(trim($line));
+
+            if (($s['scope'] ?? '') === 'mxgroup') {
+                // The whole reason this went unnoticed for three days is that
+                // nothing shouted. Shout.
+                $this->alertSentry(
+                    sprintf(
+                        'Mail suppressed: %s is not accepting our mail (%d messages deferred since %s)',
+                        $s['provider'] ?? $s['value'],
+                        $s['deferred'],
+                        $s['deferred_since'] ?? 'unknown'
+                    ),
+                    [
+                        'mxgroup' => $s['value'],
+                        'provider' => $s['provider'],
+                        'deferred' => $s['deferred'],
+                        'delivered_last_hour' => $s['delivered'] ?? 0,
+                        'domains' => $s['domains'] ?? [],
+                        'reason' => $s['reason'] ?? '',
+                    ]
+                );
+            }
+        }
+
+        foreach ($result['released'] as $r) {
+            $this->info(sprintf(
+                '%s RELEASED %s %s%s',
+                $dryRun ? '[dry-run]' : '',
+                $r['scope'],
+                $r['value'],
+                $r['stale'] ? ' (stale - probe had not confirmed it, failing open)' : ''
+            ));
+
+            if ($r['stale']) {
+                $this->alertSentry(
+                    sprintf('Mail suppression released as stale: %s %s', $r['scope'], $r['value']),
+                    ['scope' => $r['scope'], 'value' => $r['value']]
+                );
+            }
+        }
+
+        if ($this->option('purge')) {
+            $this->purge($probe, $snapshot, $target);
+        }
+
+        if (! $this->option('no-catchup')) {
+            $catch = $catchUp->run($dryRun);
+            $this->info(sprintf(
+                'Catch-up: %d sent, %d dropped by policy, %d still waiting.',
+                $catch['sent'],
+                $catch['dropped'],
+                $catch['skipped']
+            ));
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function reportSnapshot(RelayQueueSnapshot $snapshot): void
+    {
+        $total = array_sum(array_column($snapshot->groups, 'count'));
+        $this->line(sprintf(
+            'Relay queue: %d deferred recipients across %d relay families, %d distinct addresses.',
+            $total,
+            count($snapshot->groups),
+            count($snapshot->addresses)
+        ));
+
+        if ($snapshot->unattributed > 0) {
+            $this->line(sprintf('%d deferrals blamed no provider (local failures).', $snapshot->unattributed));
+        }
+
+        if (! $snapshot->hasDeliveryData()) {
+            // Say it out loud rather than let a suppression decision quietly
+            // rest on half the evidence.
+            $this->warn('No delivery data from the relay: suppression will run on queue depth alone.');
+        }
+
+        if ($snapshot->truncated) {
+            $this->warn('Relay queue listing was truncated at the byte cap; counts are a lower bound.');
+        }
+
+        foreach ($snapshot->groups as $group => $stats) {
+            $this->line(sprintf(
+                '  %-40s %6d deferred  %5d delivered/hr',
+                $group,
+                $stats['count'],
+                $snapshot->deliveriesFor($group)
+            ));
+        }
+    }
+
+    /**
+     * Delete the queued backlog for relays we have suppressed.
+     *
+     * Silent and irreversible, so it is dry-run unless --force, and it only
+     * ever names ids we just read from the queue for a relay that is actually
+     * suppressed right now.
+     */
+    private function purge(DeferralProbe $probe, RelayQueueSnapshot $snapshot, string $target): void
+    {
+        $suppressed = DB::table('mail_suppressions')
+            ->where('scope', MailSuppressionService::SCOPE_MXGROUP)
+            ->whereNull('released_at')
+            ->pluck('value')
+            ->all();
+
+        if ($suppressed === []) {
+            $this->info('Purge: nothing is suppressed, so nothing to purge.');
+
+            return;
+        }
+
+        $ids = [];
+        foreach ($suppressed as $group) {
+            $ids = array_merge($ids, $snapshot->queueIdsFor($group));
+        }
+        $ids = array_values(array_unique($ids));
+
+        if ($ids === []) {
+            $this->info('Purge: no queued messages found for the suppressed relays.');
+
+            return;
+        }
+
+        if (! $this->option('force')) {
+            $this->warn(sprintf(
+                'Purge: %d queued message(s) for %s would be deleted. Re-run with --force to do it.',
+                count($ids),
+                implode(', ', $suppressed)
+            ));
+            $this->line('First 10 ids: '.implode(' ', array_slice($ids, 0, 10)));
+
+            return;
+        }
+
+        $deleted = $probe->purge($target, $ids);
+        $this->info(sprintf('Purge: asked the relay to delete %d message(s).', $deleted));
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function alertSentry(string $message, array $context = []): void
+    {
+        Log::warning($message, $context);
+
+        // Guarded because Sentry's helpers are not loaded in every
+        // environment (e.g. tests).
+        if (function_exists('\Sentry\captureMessage')) {
+            \Sentry\withScope(function ($scope) use ($message, $context) {
+                foreach ($context as $key => $value) {
+                    $scope->setExtra($key, $value);
+                }
+                \Sentry\captureMessage($message);
+            });
+        }
+    }
+}

--- a/iznik-batch/app/Console/Commands/Mail/ScanDeferralsCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/ScanDeferralsCommand.php
@@ -71,6 +71,24 @@ class ScanDeferralsCommand extends Command
                 'target' => $target,
             ]);
 
+            // A broken probe is exactly when a suppression is most likely to
+            // get stuck on for ever, so the staleness fail-open still has to
+            // run. Deliberately only the staleness rule: an empty snapshot is
+            // not evidence that anything has recovered, so it must not count
+            // as a clear scan.
+            foreach ($scan->releaseStale($dryRun) as $r) {
+                $this->warn(sprintf(
+                    '%s RELEASED %s %s as stale - the probe has not confirmed it for too long',
+                    $dryRun ? '[dry-run]' : '',
+                    $r['scope'],
+                    $r['value']
+                ));
+                $this->alertSentry(
+                    sprintf('Mail suppression released as stale while the relay was unreachable: %s %s', $r['scope'], $r['value']),
+                    ['scope' => $r['scope'], 'value' => $r['value']]
+                );
+            }
+
             return self::FAILURE;
         }
 
@@ -130,7 +148,14 @@ class ScanDeferralsCommand extends Command
         }
 
         if ($this->option('purge')) {
-            $this->purge($probe, $snapshot, $target);
+            // --dry-run outranks --force. Someone reaching for --dry-run is
+            // asking what would happen, and answering that by deleting mail
+            // off a production relay would be the worst possible reply.
+            if ($dryRun) {
+                $this->warn('[dry-run] --purge ignored: --dry-run means change nothing.');
+            } else {
+                $this->purge($probe, $snapshot, $target);
+            }
         }
 
         if (! $this->option('no-catchup')) {

--- a/iznik-batch/app/Mail/Deferrals/UnreadChatCatchUpMail.php
+++ b/iznik-batch/app/Mail/Deferrals/UnreadChatCatchUpMail.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Mail\Deferrals;
+
+use App\Mail\MjmlMailable;
+use App\Mail\Traits\LoggableEmail;
+use App\Mail\Traits\TrackableEmail;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * "You have unread messages", sent once after a deferral is released.
+ *
+ * While a provider is refusing our mail we stop generating chat
+ * notifications entirely rather than pile them into a queue that cannot
+ * drain. When the provider starts accepting us again the member may have
+ * missed days of replies, and replaying every one of them would land a stack
+ * of stale notifications in a mailbox all at once - which is exactly the
+ * behaviour that gets a sender deferred in the first place.
+ *
+ * So: one email, saying there are messages waiting and where to read them.
+ */
+class UnreadChatCatchUpMail extends MjmlMailable
+{
+    use LoggableEmail;
+    use TrackableEmail;
+
+    public function __construct(
+        public readonly int $recipientUserId,
+        public readonly string $recipientEmail,
+        public readonly string $recipientName,
+        public readonly int $chatCount,
+        public readonly int $messageCount,
+        public readonly string $delayedSince,
+        public readonly ?string $provider,
+    ) {
+        parent::__construct();
+    }
+
+    protected function getSubject(): string
+    {
+        if ($this->chatCount === 1) {
+            return 'You have unread messages on '.config('freegle.branding.name');
+        }
+
+        return "You have unread messages in {$this->chatCount} chats on ".config('freegle.branding.name');
+    }
+
+    /**
+     * Chat mail, so it carries the chat unsubscribe like any other chat
+     * notification would have done.
+     */
+    protected function unsubscribeType(): ?string
+    {
+        return 'chat';
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->recipientUserId;
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            to: [new Address($this->recipientEmail, $this->recipientName)],
+            subject: $this->getSubject(),
+        );
+    }
+
+    public function build(): static
+    {
+        $userSite = rtrim((string) config('freegle.sites.user'), '/');
+        $chatsUrl = $this->trackedUrl($userSite . '/chats', 'catchup_chats', 'chats');
+        $settingsUrl = $this->trackedUrl($userSite . '/settings', 'footer_settings', 'settings');
+
+        return $this->mjmlView('emails.mjml.deferrals.unread-chat-catchup', array_merge([
+            'recipientName' => $this->recipientName,
+            'email' => $this->recipientEmail,
+            'chatCount' => $this->chatCount,
+            'messageCount' => $this->messageCount,
+            'delayedSince' => $this->delayedSince,
+            'provider' => $this->provider,
+            'chatsUrl' => $chatsUrl,
+            'settingsUrl' => $settingsUrl,
+            'userSite' => $userSite,
+        ], $this->getTrackingData()), 'emails.text.deferrals.unread-chat-catchup')
+            ->applyLogging('UnreadChatCatchUp');
+    }
+}

--- a/iznik-batch/app/Mail/Deferrals/UnreadChatCatchUpMail.php
+++ b/iznik-batch/app/Mail/Deferrals/UnreadChatCatchUpMail.php
@@ -5,6 +5,7 @@ namespace App\Mail\Deferrals;
 use App\Mail\MjmlMailable;
 use App\Mail\Traits\LoggableEmail;
 use App\Mail\Traits\TrackableEmail;
+use App\Services\UnsubscribeService;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Envelope;
 
@@ -52,7 +53,7 @@ class UnreadChatCatchUpMail extends MjmlMailable
      */
     protected function unsubscribeType(): ?string
     {
-        return 'chat';
+        return UnsubscribeService::TYPE_CHAT;
     }
 
     protected function getRecipientUserId(): ?int

--- a/iznik-batch/app/Models/User.php
+++ b/iznik-batch/app/Models/User.php
@@ -1797,6 +1797,17 @@ class User extends Model implements Auditable
                 $group = Group::find($groupId);
                 $preferredEmail = $this->email_preferred;
 
+                // The one send path left that reaches a member's own mailbox
+                // without going through EmailSpoolerService, so it needs the
+                // deferral gate applied by hand. Not counted for catch-up:
+                // there is nothing to catch up on, since by the time a
+                // provider recovers they have already left the group.
+                if ($group && $preferredEmail
+                    && app(\App\Services\Mail\MailSuppressionService::class)->isSuppressed($preferredEmail)) {
+                    Logger::info("Skipping farewell email for user {$this->id} on group {$groupId}: their provider is deferring our mail");
+                    $group = NULL;
+                }
+
                 if ($group && $preferredEmail) {
                     try {
                         \Illuminate\Support\Facades\Mail::raw('Parting is such sweet sorrow.', function ($message) use ($group, $preferredEmail) {

--- a/iznik-batch/app/Providers/AppServiceProvider.php
+++ b/iznik-batch/app/Providers/AppServiceProvider.php
@@ -55,6 +55,26 @@ class AppServiceProvider extends ServiceProvider
             );
         });
 
+        // How mail:deferrals:scan reaches the outbound relay. Deliberately a
+        // separate key and a longer timeout from the monitoring probe above:
+        // that key is a root shell across the whole estate, whereas this one
+        // only ever needs to read a mail queue, and ops restricts it with a
+        // forced command. Contextual so the DeferralProbe gets this runner
+        // while HostHealthCheck keeps the monitoring one.
+        $this->app->when(\App\Services\Mail\Deferrals\DeferralProbe::class)
+            ->needs(\App\Monitoring\HostCommandRunner::class)
+            ->give(function () {
+                return new \App\Monitoring\SshHostCommandRunner(
+                    (string) config('freegle.mail.deferrals.ssh_key', '/etc/mail-deferrals-ssh-key'),
+                    (int) config('freegle.mail.deferrals.ssh_timeout_seconds', 120),
+                );
+            });
+
+        // The suppression gate is consulted inside every per-recipient sending
+        // loop, and it caches the active set in-process. A singleton means one
+        // cache per batch job rather than one per call site.
+        $this->app->singleton(\App\Services\Mail\MailSuppressionService::class);
+
         // Scheduler overlap mutex backend. Default (LOCK_STORE=flock) binds
         // FlockEventMutex — OS-level flock that auto-releases on process death.
         // Setting LOCK_STORE=redis (or another cache store) binds a TTL-based cache

--- a/iznik-batch/app/Services/ChatChaseupExpectedService.php
+++ b/iznik-batch/app/Services/ChatChaseupExpectedService.php
@@ -108,6 +108,14 @@ class ChatChaseupExpectedService
                 : $chatRoom->user1;
             $sender = User::find($otherUserId);
 
+            // Their provider is refusing our mail, so this chase-up cannot
+            // arrive. Skipped BEFORE $chased is incremented: counting a
+            // reminder we never sent would record the member as chased and
+            // stop us ever chasing them for real.
+            if ($this->chatNotificationService->chaseupSuppressed($recipient)) {
+                continue;
+            }
+
             if (! $dryRun) {
                 $this->chatNotificationService->sendChaseupExpected($recipient, $sender, $chatRoom, $message);
             }

--- a/iznik-batch/app/Services/ChatNotificationService.php
+++ b/iznik-batch/app/Services/ChatNotificationService.php
@@ -226,20 +226,24 @@ class ChatNotificationService
                     continue;
                 }
 
-                // The member's provider is refusing our mail. Skip without
-                // touching chat_roster.lastmsgemailed, so the watermark stays
-                // where it is and the release catch-up can still see that
-                // they have unread messages. We do NOT replay these
-                // individually on release - a stack of days-old chat
-                // notifications arriving at once is its own harm - they turn
-                // into one "you have unread messages" summary instead.
-                if (app(\App\Services\Mail\MailSuppressionService::class)
-                    ->shouldSkip($sendingTo->email_preferred, (int) $sendingTo->id, 'chat')) {
+                // Check if we should notify this user about this message.
+                if (! $this->shouldNotifyUser($sendingTo, $message, $chatRoom, $chatType, $roster->isModerator ?? false)) {
                     continue;
                 }
 
-                // Check if we should notify this user about this message.
-                if (! $this->shouldNotifyUser($sendingTo, $message, $chatRoom, $chatType, $roster->isModerator ?? false)) {
+                // The member's provider is refusing our mail. Deliberately
+                // AFTER the preference check: someone who has chat
+                // notifications turned off was never going to get this email,
+                // so recording it as owed would earn them a "you have unread
+                // messages" catch-up they never asked for.
+                //
+                // Skips without touching chat_roster.lastmsgemailed, so the
+                // watermark stays where it is and the catch-up can still see
+                // there are unread messages. These are never replayed
+                // individually - a stack of days-old notifications arriving
+                // at once is its own harm - they become one summary instead.
+                if (app(\App\Services\Mail\MailSuppressionService::class)
+                    ->shouldSkip($sendingTo->email_preferred, (int) $sendingTo->id, 'chat')) {
                     continue;
                 }
 
@@ -565,6 +569,21 @@ class ChatNotificationService
 
         $spooler = $this->spooler ?? app(EmailSpoolerService::class);
         $spooler->spool($mailable, $sendingTo->email_preferred, 'chat');
+    }
+
+    /**
+     * Whether a chase-up should be held back because the recipient's provider
+     * is refusing our mail.
+     *
+     * Asked by the caller rather than swallowed here, because
+     * ChatChaseupExpectedService marks the expectation as chased once this
+     * returns - and a chase-up we never sent must not count as one we did, or
+     * the member is recorded as having been reminded when they were not.
+     */
+    public function chaseupSuppressed(User $sendingTo): bool
+    {
+        return app(\App\Services\Mail\MailSuppressionService::class)
+            ->shouldSkip($sendingTo->email_preferred, (int) $sendingTo->id, 'chat');
     }
 
     /**

--- a/iznik-batch/app/Services/ChatNotificationService.php
+++ b/iznik-batch/app/Services/ChatNotificationService.php
@@ -226,6 +226,18 @@ class ChatNotificationService
                     continue;
                 }
 
+                // The member's provider is refusing our mail. Skip without
+                // touching chat_roster.lastmsgemailed, so the watermark stays
+                // where it is and the release catch-up can still see that
+                // they have unread messages. We do NOT replay these
+                // individually on release - a stack of days-old chat
+                // notifications arriving at once is its own harm - they turn
+                // into one "you have unread messages" summary instead.
+                if (app(\App\Services\Mail\MailSuppressionService::class)
+                    ->shouldSkip($sendingTo->email_preferred, (int) $sendingTo->id, 'chat')) {
+                    continue;
+                }
+
                 // Check if we should notify this user about this message.
                 if (! $this->shouldNotifyUser($sendingTo, $message, $chatRoom, $chatType, $roster->isModerator ?? false)) {
                     continue;

--- a/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
+++ b/iznik-batch/app/Services/CommunityNews/CommunityNewsEmailService.php
@@ -131,6 +131,15 @@ class CommunityNewsEmailService
                     continue;
                 }
 
+                // Provider is refusing our mail. Community News is weekly and
+                // dropped rather than caught up on release: next week's issue
+                // is a better email than a stale one. Counted anyway so the
+                // scale of what a member missed is visible in ModTools.
+                if (app(\App\Services\Mail\MailSuppressionService::class)
+                    ->shouldSkip($email, (int) $member->id, 'communitynews')) {
+                    continue;
+                }
+
                 $name = $user->fullname
                     ?? trim(($user->firstname ?? '') . ' ' . ($user->lastname ?? ''))
                     ?: 'Freegle Member';

--- a/iznik-batch/app/Services/EmailSpoolerService.php
+++ b/iznik-batch/app/Services/EmailSpoolerService.php
@@ -83,6 +83,21 @@ class EmailSpoolerService
             $mailable->to($to);
         }
 
+        // Last line of defence against generating into a queue that cannot
+        // drain. The per-recipient loops in the sending jobs already gate
+        // before they build a Mailable, which is where the real saving is;
+        // this catches the paths that do not, and any new one somebody adds
+        // later without knowing about deferrals. It sits above
+        // captureBuiltMessage() so the MJML render is still skipped.
+        //
+        // Returns '' rather than throwing, matching the existing
+        // permanent-failure contract below - callers key off the truthiness
+        // of the returned id, so throwing here would change the shape of
+        // every caller's error handling.
+        if ($this->isSuppressedForDeferral($normalizedTo, $emailType)) {
+            return '';
+        }
+
         // Build the complete message using a capturing transport.
         // This runs all withSymfonyMessage callbacks and captures the final message.
         //
@@ -960,5 +975,36 @@ class EmailSpoolerService
         foreach ($data['headers'] as $name => $value) {
             $headers->addTextHeader($name, $value);
         }
+    }
+    /**
+     * Whether every recipient of this message is behind a provider that is
+     * currently refusing our mail.
+     *
+     * All of them, not any: a message addressed to a member and cc'd to a
+     * mod should still go if the mod can receive it. In practice batch mail
+     * is single-recipient, so this is nearly always one address.
+     */
+    private function isSuppressedForDeferral(array $normalizedTo, ?string $emailType): bool
+    {
+        if ($normalizedTo === []) {
+            return FALSE;
+        }
+
+        $suppressions = app(\App\Services\Mail\MailSuppressionService::class);
+
+        foreach ($normalizedTo as $addr) {
+            $address = is_array($addr) ? ($addr['address'] ?? '') : (string) $addr;
+
+            if (!$suppressions->isSuppressed($address)) {
+                return FALSE;
+            }
+        }
+
+        Log::info('EmailSpoolerService: not spooling, recipient provider is deferring our mail', [
+            'email_type' => $emailType,
+            'recipients' => count($normalizedTo),
+        ]);
+
+        return TRUE;
     }
 }

--- a/iznik-batch/app/Services/EngageEmailService.php
+++ b/iznik-batch/app/Services/EngageEmailService.php
@@ -65,6 +65,15 @@ class EngageEmailService
                 continue;
             }
 
+            // Provider is refusing our mail. Skipped without writing to the
+            // `engage` table, so the RESEND_INTERVAL_DAYS clock does not
+            // start: when they recover, this member is a fresh candidate
+            // rather than one we have to wait months to try again.
+            if (app(\App\Services\Mail\MailSuppressionService::class)
+                ->shouldSkip($user->email_preferred, (int) $user->id, 'engage')) {
+                continue;
+            }
+
             if (!$force && !$user->relevantallowed) {
                 continue;
             }

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralCatchUpService.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralCatchUpService.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace App\Services\Mail\Deferrals;
+
+use App\Mail\Deferrals\UnreadChatCatchUpMail;
+use App\Models\User;
+use App\Services\EmailSpoolerService;
+use App\Services\Mail\MailSuppressionService;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * What we send once a provider starts accepting our mail again.
+ *
+ * The rule is that we do not replay the backlog. We never stored the mail we
+ * declined to render - storing it would have defeated the point - and even if
+ * we had, most of it would be worse than useless by now. So the policy is per
+ * type, and it is deliberately asymmetric:
+ *
+ *   OFFER/WANTED posts   dropped. A three-day-old post is taken or gone, and
+ *                        the immediate-mail cursor is per group rather than
+ *                        per member, so it has already moved on regardless.
+ *   Community News,      dropped. All of them are periodic; the next one
+ *   WeMissYou,           along is a better email than a stale one.
+ *   volunteering
+ *   Daily digest         one catch-up covering the whole window. This needs
+ *                        no code here: the suppression skip returns before
+ *                        the digest tracker is advanced, so the next daily
+ *                        run naturally spans the gap and sends exactly one.
+ *   Chat notifications   one "you have unread messages" summary. Chat is the
+ *                        only one where the member is waiting on a person
+ *                        rather than on us, so silence is the costly outcome.
+ *
+ * Which leaves this class with one real job: the chat summary.
+ */
+class DeferralCatchUpService
+{
+    public function __construct(
+        private readonly MailSuppressionService $suppressions,
+    ) {}
+
+    /**
+     * Send catch-ups to everyone whose suppression has lifted.
+     *
+     * @return array{sent: int, dropped: int, skipped: int}
+     */
+    public function run(bool $dryRun = false, int $limit = 5000): array
+    {
+        $sent = 0;
+        $dropped = 0;
+        $skipped = 0;
+
+        $owed = DB::table('mail_suppressed_counts')
+            ->whereNull('caughtup_at')
+            ->orderBy('userid')
+            ->limit($limit)
+            ->get();
+
+        // Group by member so someone who missed digests AND chat gets one
+        // decision, not one per row.
+        $byUser = [];
+        foreach ($owed as $row) {
+            $byUser[$row->userid][$row->emailtype] = $row;
+        }
+
+        foreach ($byUser as $userId => $rows) {
+            $user = User::find($userId);
+            $email = $user?->email_preferred;
+
+            if ($user === null || ! $email) {
+                // Nothing we can do for them; clear the debt so it does not
+                // sit in the table for ever.
+                $dropped += count($rows);
+                if (! $dryRun) {
+                    $this->markCaughtUp((int) $userId, array_keys($rows));
+                }
+
+                continue;
+            }
+
+            if ($this->suppressions->isSuppressed($email)) {
+                // Still blocked - either the release has not reached this
+                // member's provider or a second episode started. Leave the
+                // counters alone; they are still accruing.
+                $skipped += count($rows);
+
+                continue;
+            }
+
+            foreach ($rows as $type => $row) {
+                if ($type !== 'chat') {
+                    // Everything except chat is dropped by policy. Recorded
+                    // rather than silently forgotten, so the numbers in the
+                    // log add up.
+                    $dropped++;
+
+                    continue;
+                }
+
+                $summary = $this->unreadChatSummary((int) $userId);
+
+                if ($summary['chats'] === 0) {
+                    // They have read everything in the meantime, or the other
+                    // side gave up. No email is the right email.
+                    $dropped++;
+
+                    continue;
+                }
+
+                if ($dryRun) {
+                    $sent++;
+
+                    continue;
+                }
+
+                try {
+                    app(EmailSpoolerService::class)->spool(
+                        new UnreadChatCatchUpMail(
+                            recipientUserId: (int) $userId,
+                            recipientEmail: $email,
+                            recipientName: $user->displayname ?: 'there',
+                            chatCount: $summary['chats'],
+                            messageCount: $summary['messages'],
+                            delayedSince: $this->formatSince($row->firstat),
+                            provider: $this->providerFor($email),
+                        ),
+                        $email,
+                        emailType: 'chat_catchup'
+                    );
+                    $sent++;
+                } catch (\Throwable $e) {
+                    Log::error('Mail deferrals: catch-up send failed', [
+                        'userid' => $userId,
+                        'error' => $e->getMessage(),
+                    ]);
+
+                    // Leave the row unclaimed so the next pass retries it.
+                    $skipped++;
+
+                    continue 2;
+                }
+            }
+
+            if (! $dryRun) {
+                $this->markCaughtUp((int) $userId, array_keys($rows));
+            }
+        }
+
+        Log::info('Mail deferrals: catch-up pass complete', [
+            'sent' => $sent,
+            'dropped' => $dropped,
+            'skipped' => $skipped,
+            'dry_run' => $dryRun,
+        ]);
+
+        return ['sent' => $sent, 'dropped' => $dropped, 'skipped' => $skipped];
+    }
+
+    /**
+     * How many chats have messages this member has not been emailed about.
+     *
+     * chat_roster.lastmsgemailed is a genuine per-(chat, member) watermark, so
+     * skipping a member during suppression leaves exactly the state we need
+     * here - no side table required. The normal notification sweep would have
+     * missed these because it also time-windows on message date, which is why
+     * this asks the question chat-wide instead.
+     *
+     * @return array{chats:int, messages:int}
+     */
+    private function unreadChatSummary(int $userId): array
+    {
+        $row = DB::table('chat_roster')
+            ->join('chat_messages', 'chat_messages.chatid', '=', 'chat_roster.chatid')
+            ->where('chat_roster.userid', $userId)
+            // Their own messages are not something to catch up on.
+            ->where('chat_messages.userid', '!=', $userId)
+            ->whereNull('chat_messages.reviewrejected')
+            ->where(function ($q) {
+                $q->whereNull('chat_roster.lastmsgemailed')
+                    ->orWhereColumn('chat_messages.id', '>', 'chat_roster.lastmsgemailed');
+            })
+            ->selectRaw('COUNT(DISTINCT chat_roster.chatid) AS chats, COUNT(*) AS messages')
+            ->first();
+
+        return [
+            'chats' => (int) ($row->chats ?? 0),
+            'messages' => (int) ($row->messages ?? 0),
+        ];
+    }
+
+    /**
+     * @param  string[]  $types
+     */
+    private function markCaughtUp(int $userId, array $types): void
+    {
+        DB::table('mail_suppressed_counts')
+            ->where('userid', $userId)
+            ->whereIn('emailtype', $types)
+            ->whereNull('caughtup_at')
+            ->update(['caughtup_at' => now()]);
+    }
+
+    /**
+     * The most recent suppression that covered this address, released or not,
+     * so the email can name the provider that was refusing us.
+     */
+    private function providerFor(string $email): ?string
+    {
+        $at = strrpos($email, '@');
+        if ($at === false) {
+            return null;
+        }
+
+        $domain = strtolower(substr($email, $at + 1));
+
+        $row = DB::table('mail_suppressions')
+            ->where('scope', MailSuppressionService::SCOPE_DOMAIN)
+            ->where('value', $domain)
+            ->orderByDesc('id')
+            ->first();
+
+        return $row?->provider;
+    }
+
+    private function formatSince(?string $when): string
+    {
+        if ($when === null) {
+            return 'recently';
+        }
+
+        try {
+            return Carbon::parse($when)->format('j F');
+        } catch (\Throwable) {
+            return 'recently';
+        }
+    }
+}

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralCatchUpService.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralCatchUpService.php
@@ -188,7 +188,7 @@ class DeferralCatchUpService
             ->where('chat_roster.userid', $userId)
             // Their own messages are not something to catch up on.
             ->where('chat_messages.userid', '!=', $userId)
-            ->whereNull('chat_messages.reviewrejected')
+            ->where('chat_messages.reviewrejected', 0)
             ->where(function ($q) {
                 $q->whereNull('chat_roster.lastmsgemailed')
                     ->orWhereColumn('chat_messages.id', '>', 'chat_roster.lastmsgemailed');

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralCatchUpService.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralCatchUpService.php
@@ -115,7 +115,12 @@ class DeferralCatchUpService
                 }
 
                 try {
-                    app(EmailSpoolerService::class)->spool(
+                    // spool() returns the empty string rather than throwing
+                    // when it declines a message - a permanently bad address,
+                    // or the deferral backstop if a fresh episode started
+                    // since we checked. Counting that as sent is how a member
+                    // ends up permanently owed a catch-up nobody knows about.
+                    $spoolId = app(EmailSpoolerService::class)->spool(
                         new UnreadChatCatchUpMail(
                             recipientUserId: (int) $userId,
                             recipientEmail: $email,
@@ -128,7 +133,15 @@ class DeferralCatchUpService
                         $email,
                         emailType: 'chat_catchup'
                     );
-                    $sent++;
+
+                    if ($spoolId === '') {
+                        Log::warning('Mail deferrals: the spooler declined the catch-up', [
+                            'userid' => $userId,
+                        ]);
+                        $dropped++;
+                    } else {
+                        $sent++;
+                    }
                 } catch (\Throwable $e) {
                     Log::error('Mail deferrals: catch-up send failed', [
                         'userid' => $userId,

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralCatchUpService.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralCatchUpService.php
@@ -123,7 +123,7 @@ class DeferralCatchUpService
                             chatCount: $summary['chats'],
                             messageCount: $summary['messages'],
                             delayedSince: $this->formatSince($row->firstat),
-                            provider: $this->providerFor($email),
+                            provider: $this->providerFor($row->suppressionid ?? null),
                         ),
                         $email,
                         emailType: 'chat_catchup'
@@ -202,25 +202,21 @@ class DeferralCatchUpService
     }
 
     /**
-     * The most recent suppression that covered this address, released or not,
-     * so the email can name the provider that was refusing us.
+     * The provider that was refusing us, from the suppression we recorded at
+     * the time we declined to send.
+     *
+     * Recorded rather than re-derived: by the time the catch-up runs the
+     * suppression has been released, and working backwards from the member's
+     * address would mean reimplementing the mailer's own address-ranking
+     * rules against history that has already moved on.
      */
-    private function providerFor(string $email): ?string
+    private function providerFor(?int $suppressionId): ?string
     {
-        $at = strrpos($email, '@');
-        if ($at === false) {
+        if ($suppressionId === null || $suppressionId <= 0) {
             return null;
         }
 
-        $domain = strtolower(substr($email, $at + 1));
-
-        $row = DB::table('mail_suppressions')
-            ->where('scope', MailSuppressionService::SCOPE_DOMAIN)
-            ->where('value', $domain)
-            ->orderByDesc('id')
-            ->first();
-
-        return $row?->provider;
+        return DB::table('mail_suppressions')->where('id', $suppressionId)->value('provider');
     }
 
     private function formatSince(?string $when): string

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralProbe.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralProbe.php
@@ -14,6 +14,11 @@ use Illuminate\Support\Facades\Log;
  * is on the relay itself, in its queue and its maillog. This class is the
  * one-way window onto that.
  *
+ * This only sees a provider that REFUSES us - a 4xx in the SMTP conversation, which leaves the
+ * message sitting in the queue where we can count it. A provider that accepts everything and
+ * then bins it silently leaves no queue entry at all, and is invisible here;
+ * App\Services\Mail\DeliveryHealthService watches open rates for that shape instead.
+ *
  * It reuses App\Monitoring\HostCommandRunner - the same ssh-and-parse-stdout
  * shape the host health probes already use - rather than inventing a second
  * way to reach a production host. The runner is injected, so tests feed it

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralProbe.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralProbe.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace App\Services\Mail\Deferrals;
+
+use App\Monitoring\HostCommandRunner;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Reads the outbound relay's Postfix queue and recent delivery log.
+ *
+ * The relay is a separate machine: batch hands mail to it over SMTP and gets
+ * a 250 back, so by the time a receiving provider refuses the mail we have
+ * long since stopped watching. The only place that refusal is written down
+ * is on the relay itself, in its queue and its maillog. This class is the
+ * one-way window onto that.
+ *
+ * It reuses App\Monitoring\HostCommandRunner - the same ssh-and-parse-stdout
+ * shape the host health probes already use - rather than inventing a second
+ * way to reach a production host. The runner is injected, so tests feed it
+ * canned relay output and never go near ssh.
+ */
+class DeferralProbe
+{
+    // Section markers. The probe prints them unconditionally, so their absence
+    // means the script did not run rather than "the queue happens to be empty".
+    public const MARK_QUEUE = '===FREEGLE-DEFERRALS-QUEUE===';
+
+    public const MARK_DELIVERED = '===FREEGLE-DEFERRALS-DELIVERED===';
+
+    public const MARK_END = '===FREEGLE-DEFERRALS-END===';
+
+    public const MARK_TRUNCATED = '===FREEGLE-DEFERRALS-TRUNCATED===';
+
+    public function __construct(
+        private readonly HostCommandRunner $runner,
+    ) {}
+
+    /**
+     * Run the probe against the relay.
+     *
+     * @param  string  $target  ssh target, e.g. "deferrals@10.0.0.1"
+     * @param  int  $maxQueueBytes  cap on the queue listing we will accept back
+     * @return RelayQueueSnapshot|null null if the relay was unreachable
+     */
+    public function probe(string $target, int $maxQueueBytes): ?RelayQueueSnapshot
+    {
+        $output = $this->runner->run($target, $this->script($maxQueueBytes));
+
+        if ($output === null) {
+            Log::warning('Mail deferral probe: relay unreachable', ['target' => $target]);
+
+            return null;
+        }
+
+        if (! str_contains($output, self::MARK_END)) {
+            // Output without the closing marker means the script died partway
+            // or the transport cut it off. Half a queue listing would silently
+            // understate every count, so refuse it rather than act on it.
+            Log::error('Mail deferral probe: incomplete output from relay', [
+                'target' => $target,
+                'bytes' => strlen($output),
+            ]);
+
+            return null;
+        }
+
+        return $this->parse($output);
+    }
+
+    /**
+     * The script we run on the relay.
+     *
+     * Deliberately one round trip and deliberately read-only. `postqueue -j`
+     * emits one JSON object per line (not an array), which is what lets us
+     * cap the transfer with head and still hand back parseable records.
+     *
+     * The delivered-count section is best-effort: relays differ in whether
+     * they log to journald or a flat maillog, and we would rather have the
+     * queue half of the picture than nothing at all. Missing delivery data
+     * degrades the release check rather than breaking the scan - see
+     * DeferralScanService.
+     */
+    private function script(int $maxQueueBytes): string
+    {
+        $bytes = max(1024, $maxQueueBytes);
+
+        return <<<SH
+            set -u
+            echo '{$this->markQueue()}'
+            if command -v postqueue >/dev/null 2>&1; then
+                OUT=\$(postqueue -j 2>/dev/null | head -c {$bytes})
+                echo "\$OUT"
+                # head -c cuts mid-line, so say so rather than let the scan
+                # treat a truncated tail as a complete picture.
+                if [ "\$(printf '%s' "\$OUT" | wc -c)" -ge {$bytes} ]; then
+                    echo '{$this->markTruncated()}'
+                fi
+            fi
+            echo '{$this->markDelivered()}'
+            # status=sent lines in the last hour, bucketed by the relay host
+            # Postfix recorded for the delivery. Try journald first, then the
+            # traditional flat log; emit nothing if neither is readable.
+            if command -v journalctl >/dev/null 2>&1 && journalctl -u postfix --since '1 hour ago' -q >/dev/null 2>&1; then
+                journalctl -u postfix --since '1 hour ago' -q 2>/dev/null | grep 'status=sent' || true
+            elif [ -r /var/log/mail.log ]; then
+                # No time filter available without parsing syslog timestamps,
+                # so take the tail as an approximation of "recent".
+                tail -n 200000 /var/log/mail.log 2>/dev/null | grep 'status=sent' || true
+            fi
+            echo '{$this->markEnd()}'
+            SH;
+    }
+
+    /**
+     * Ask the relay to delete specific queued messages.
+     *
+     * This is not tidying. Postfix retries a deferred message until
+     * maximal_queue_lifetime and then emits one bounce per message - tens of
+     * thousands of them, each carrying the provider's original 4xx text, each
+     * landing back in our own bounce processing. `postsuper -d` removes them
+     * silently with no DSN at all, which is the only thing that stops that
+     * cascade.
+     *
+     * Callers must have established that the relay family is suppressed;
+     * this method only does what it is told.
+     *
+     * @param  string[]  $queueIds
+     * @return int number of ids we asked the relay to delete
+     */
+    public function purge(string $target, array $queueIds): int
+    {
+        // The ids come from the relay's own listing, but they are still being
+        // pasted into a shell on a production host, so anything that does not
+        // look like a queue id is dropped rather than trusted.
+        $safe = array_values(array_filter(
+            $queueIds,
+            fn ($id) => is_string($id) && preg_match('/^[A-Za-z0-9]{6,32}$/', $id) === 1
+        ));
+
+        if ($safe === []) {
+            return 0;
+        }
+
+        $deleted = 0;
+
+        foreach (array_chunk($safe, 500) as $chunk) {
+            // postsuper reads ids from stdin when given "-".
+            $script = 'printf "%s\n" '.implode(' ', $chunk).' | postsuper -d - 2>&1';
+
+            $out = $this->runner->run($target, $script);
+
+            if ($out === null) {
+                Log::error('Mail deferral purge: relay became unreachable partway', [
+                    'target' => $target,
+                    'deleted_before_failure' => $deleted,
+                ]);
+                break;
+            }
+
+            $deleted += count($chunk);
+        }
+
+        Log::warning('Mail deferral purge: asked relay to delete queued messages', [
+            'target' => $target,
+            'requested' => count($safe),
+            'deleted' => $deleted,
+        ]);
+
+        return $deleted;
+    }
+
+    private function markQueue(): string
+    {
+        return self::MARK_QUEUE;
+    }
+
+    private function markDelivered(): string
+    {
+        return self::MARK_DELIVERED;
+    }
+
+    private function markEnd(): string
+    {
+        return self::MARK_END;
+    }
+
+    private function markTruncated(): string
+    {
+        return self::MARK_TRUNCATED;
+    }
+
+    /**
+     * Turn the probe's stdout into a snapshot.
+     */
+    private function parse(string $output): RelayQueueSnapshot
+    {
+        $snapshot = new RelayQueueSnapshot;
+
+        $section = null;
+        $truncated = false;
+
+        foreach (explode("\n", $output) as $line) {
+            $line = rtrim($line, "\r");
+
+            if ($line === self::MARK_QUEUE) {
+                $section = 'queue';
+
+                continue;
+            }
+            if ($line === self::MARK_DELIVERED) {
+                $section = 'delivered';
+
+                continue;
+            }
+            if ($line === self::MARK_END) {
+                break;
+            }
+            if ($line === self::MARK_TRUNCATED) {
+                $truncated = true;
+
+                continue;
+            }
+            if ($line === '') {
+                continue;
+            }
+
+            if ($section === 'queue') {
+                $this->parseQueueLine($line, $snapshot);
+            } elseif ($section === 'delivered') {
+                $this->parseDeliveredLine($line, $snapshot);
+            }
+        }
+
+        $snapshot->truncated = $truncated;
+
+        return $snapshot;
+    }
+
+    /**
+     * One queue file, as emitted by `postqueue -j`.
+     *
+     * A message that delivers leaves the queue altogether, so everything here
+     * is work still owed. We only care about mail that has actually been
+     * attempted and pushed back: `incoming` and `hold` have not been tried,
+     * and `corrupt` is a different problem entirely.
+     */
+    private function parseQueueLine(string $line, RelayQueueSnapshot $snapshot): void
+    {
+        $entry = json_decode($line, true);
+
+        if (! is_array($entry) || ! isset($entry['recipients']) || ! is_array($entry['recipients'])) {
+            // A truncated final line is expected when we capped the transfer;
+            // anything else is worth knowing about but not worth aborting for.
+            $snapshot->unparseableLines++;
+
+            return;
+        }
+
+        $queue = $entry['queue_name'] ?? '';
+        if ($queue !== 'deferred' && $queue !== 'active') {
+            return;
+        }
+
+        $arrival = isset($entry['arrival_time']) ? (int) $entry['arrival_time'] : null;
+        $queueId = isset($entry['queue_id']) ? (string) $entry['queue_id'] : null;
+
+        foreach ($entry['recipients'] as $recipient) {
+            if (! is_array($recipient) || empty($recipient['address'])) {
+                continue;
+            }
+
+            // Absent for a recipient that has not been attempted yet. Those
+            // are not evidence of a deferral, so they do not count.
+            $reason = $recipient['delay_reason'] ?? null;
+            if (! is_string($reason) || $reason === '') {
+                continue;
+            }
+
+            $snapshot->addDeferral(
+                address: (string) $recipient['address'],
+                reason: $reason,
+                arrivalTime: $arrival,
+                queueId: $queueId,
+            );
+        }
+    }
+
+    /**
+     * One `status=sent` maillog line, e.g.
+     *   ... postfix/smtp[123]: ABC123: to=<a@b.com>, relay=mx.b.com[1.2.3.4]:25,
+     *   delay=1.2, ..., status=sent (250 ok)
+     *
+     * We only need the relay host, to know which providers are still taking
+     * our mail.
+     */
+    private function parseDeliveredLine(string $line, RelayQueueSnapshot $snapshot): void
+    {
+        if (! preg_match('/relay=([^\[\s,:]+)/', $line, $m)) {
+            return;
+        }
+
+        $host = strtolower(rtrim($m[1], '.'));
+
+        // Local deliveries and pipe transports are not a provider taking our
+        // mail, so they must not count as evidence that one has recovered.
+        if ($host === '' || $host === 'none' || $host === 'local') {
+            return;
+        }
+
+        $snapshot->addDelivery(MxGrouper::group($host));
+    }
+}

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralScanService.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralScanService.php
@@ -238,7 +238,15 @@ class DeferralScanService
             // suppression for this long, we are more likely to be broken than
             // the provider is, and quietly not mailing a whole provider for
             // ever is the worse failure.
-            $stale = $staleHours > 0
+            //
+            // $stats being non-null means THIS scan saw the target still
+            // deferring, so it is confirmed no matter how long the gap before
+            // it was. Without that check, a probe that had been down for a
+            // day would come back, see the provider still solidly blocked,
+            // and release the suppression on the strength of the stale
+            // last_seen it was about to overwrite.
+            $stale = $stats === null
+                && $staleHours > 0
                 && $row->last_seen !== null
                 && Carbon::parse($row->last_seen)->lt(now()->subHours($staleHours));
 

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralScanService.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralScanService.php
@@ -72,6 +72,58 @@ class DeferralScanService
     }
 
     /**
+     * Release suppressions the probe has been unable to confirm for too long.
+     *
+     * Called when the relay could not be read at all - which is exactly when
+     * a suppression is most likely to get stuck on for ever, because the
+     * normal release path needs a snapshot it never gets.
+     *
+     * Only the staleness rule applies here. An absent snapshot is not
+     * evidence that a provider has recovered, so it must never count as a
+     * clear scan - otherwise two failed probes in a row would release every
+     * suppression we have.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function releaseStale(bool $dryRun = false): array
+    {
+        $staleHours = (int) config('freegle.mail.deferrals.stale_after_hours', 24);
+        if ($staleHours <= 0) {
+            return [];
+        }
+
+        $released = [];
+
+        foreach ($this->activeByKey() as $key => $row) {
+            [$scope, $value] = explode("\0", $key, 2);
+
+            // Domain rows are children; releasing the parent cascades.
+            if ($scope === MailSuppressionService::SCOPE_DOMAIN) {
+                continue;
+            }
+
+            if ($row->last_seen === null
+                || Carbon::parse($row->last_seen)->gte(now()->subHours($staleHours))) {
+                continue;
+            }
+
+            $released[] = ['id' => $row->id, 'scope' => $scope, 'value' => $value, 'stale' => true];
+
+            if (! $dryRun) {
+                DB::table('mail_suppressions')
+                    ->where('id', $row->id)
+                    ->orWhere('parentid', $row->id)
+                    ->update(['released_at' => now(), 'clear_scans' => 0]);
+            }
+        }
+
+        if (! $dryRun && $released !== []) {
+            $this->suppressions->flushCache();
+        }
+
+        return $released;
+    }
+    /**
      * @param  array<string, object>  $active
      * @return array<int, array<string, mixed>>
      */
@@ -110,6 +162,11 @@ class DeferralScanService
                 // clear-scan counter, because this scan is not clear.
                 if (! $dryRun) {
                     $this->refresh($existing->id, $stats, clearScans: 0);
+                    // An episode lasting days keeps turning up domains we
+                    // had not seen behind this relay when it started -
+                    // sky.com only shows up once somebody at Sky is due an
+                    // email. Without this they keep being generated for.
+                    $this->addDomainRows((int) $existing->id, $stats, $existing->provider, $existing->reason);
                 }
 
                 continue;
@@ -320,36 +377,49 @@ class DeferralScanService
                 'message_count' => $stats['count'],
             ]);
 
-            $rows = [];
-            foreach (array_keys($stats['domains']) as $domain) {
-                $rows[] = [
-                    'scope' => MailSuppressionService::SCOPE_DOMAIN,
-                    'value' => $domain,
-                    'parentid' => $id,
-                    'provider' => $provider,
-                    'reason' => $reason,
-                    'deferred_since' => $since,
-                    'first_seen' => now(),
-                    'last_seen' => now(),
-                    'message_count' => $stats['domains'][$domain],
-                ];
-            }
-
-            foreach (array_chunk($rows, 200) as $chunk) {
-                DB::table('mail_suppressions')->insert($chunk);
-            }
+            $this->addDomainRows($id, $stats, $provider, $reason);
 
             Log::warning('Mail deferrals: suppressing relay family', [
                 'mxgroup' => $group,
                 'provider' => $provider,
                 'deferred' => $stats['count'],
                 'delivered_last_hour' => $delivered,
-                'domains' => count($rows),
+                'domains' => count($stats['domains']),
                 'deferred_since' => $since,
             ]);
 
             return $id;
         });
+    }
+
+    /**
+     * Write a child domain row for each recipient domain seen behind a relay.
+     *
+     * insertOrIgnore because the schema permits only one ACTIVE row per
+     * (scope, value): a domain served by two relay families, or one already
+     * suppressed on its own, is covered either way, and a second row would
+     * buy nothing but a failed transaction.
+     */
+    private function addDomainRows(int $parentId, array $stats, ?string $provider, ?string $reason): void
+    {
+        $rows = [];
+        foreach ($stats['domains'] as $domain => $count) {
+            $rows[] = [
+                'scope' => MailSuppressionService::SCOPE_DOMAIN,
+                'value' => $domain,
+                'parentid' => $parentId,
+                'provider' => $provider,
+                'reason' => $reason,
+                'deferred_since' => $this->toDate($stats['oldest']),
+                'first_seen' => now(),
+                'last_seen' => now(),
+                'message_count' => $count,
+            ];
+        }
+
+        foreach (array_chunk($rows, 200) as $chunk) {
+            DB::table('mail_suppressions')->insertOrIgnore($chunk);
+        }
     }
 
     private function refresh(int $id, array $stats, int $clearScans): void

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralScanService.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralScanService.php
@@ -48,17 +48,24 @@ class DeferralScanService
 
         $active = $this->activeByKey();
 
+        // Ids this scan re-confirmed as still deferring. They are kept out
+        // of the release pass below, which reads $active - a snapshot taken
+        // before those confirmations were written. Without this the release
+        // pass evaluates state the same run has already superseded, and
+        // writes its own clear-scan count straight over the reset.
+        $reconfirmed = [];
+
         $suppressed = array_merge(
             $suppressed,
-            $this->applyMxGroups($snapshot, $active, $cfg, $dryRun)
+            $this->applyMxGroups($snapshot, $active, $cfg, $dryRun, $reconfirmed)
         );
 
         $suppressed = array_merge(
             $suppressed,
-            $this->applyAddresses($snapshot, $active, $cfg, $dryRun)
+            $this->applyAddresses($snapshot, $active, $cfg, $dryRun, $reconfirmed)
         );
 
-        $released = $this->applyReleases($snapshot, $active, $cfg, $dryRun);
+        $released = $this->applyReleases($snapshot, $active, $cfg, $dryRun, $reconfirmed);
 
         if (! $dryRun && ($suppressed !== [] || $released !== [])) {
             $this->suppressions->flushCache();
@@ -127,7 +134,7 @@ class DeferralScanService
      * @param  array<string, object>  $active
      * @return array<int, array<string, mixed>>
      */
-    private function applyMxGroups(RelayQueueSnapshot $snapshot, array $active, array $cfg, bool $dryRun): array
+    private function applyMxGroups(RelayQueueSnapshot $snapshot, array $active, array $cfg, bool $dryRun, array &$reconfirmed): array
     {
         $minDeferred = (int) ($cfg['mxgroup_min_deferred'] ?? 500);
         $maxDelivered = (int) ($cfg['mxgroup_max_delivered_per_hour'] ?? 10);
@@ -160,6 +167,8 @@ class DeferralScanService
             if ($existing !== null) {
                 // Already suppressed. Refresh the evidence and reset the
                 // clear-scan counter, because this scan is not clear.
+                $reconfirmed[(int) $existing->id] = true;
+
                 if (! $dryRun) {
                     $this->refresh($existing->id, $stats, clearScans: 0);
                     // An episode lasting days keeps turning up domains we
@@ -198,7 +207,7 @@ class DeferralScanService
      * @param  array<string, object>  $active
      * @return array<int, array<string, mixed>>
      */
-    private function applyAddresses(RelayQueueSnapshot $snapshot, array $active, array $cfg, bool $dryRun): array
+    private function applyAddresses(RelayQueueSnapshot $snapshot, array $active, array $cfg, bool $dryRun, array &$reconfirmed): array
     {
         $minDeferred = (int) ($cfg['address_min_deferred'] ?? 5);
         $minHours = (int) ($cfg['address_min_hours'] ?? 24);
@@ -225,6 +234,8 @@ class DeferralScanService
 
             $key = MailSuppressionService::SCOPE_ADDRESS."\0".$address;
             if (isset($active[$key])) {
+                $reconfirmed[(int) $active[$key]->id] = true;
+
                 if (! $dryRun) {
                     $this->refresh($active[$key]->id, $stats, clearScans: 0);
                 }
@@ -262,7 +273,7 @@ class DeferralScanService
      * @param  array<string, object>  $active
      * @return array<int, array<string, mixed>>
      */
-    private function applyReleases(RelayQueueSnapshot $snapshot, array $active, array $cfg, bool $dryRun): array
+    private function applyReleases(RelayQueueSnapshot $snapshot, array $active, array $cfg, bool $dryRun, array $reconfirmed = []): array
     {
         $releaseMax = (int) ($cfg['release_max_deferred'] ?? 100);
         $needClear = max(1, (int) ($cfg['release_clear_scans'] ?? 2));
@@ -279,17 +290,37 @@ class DeferralScanService
                 continue;
             }
 
+            // This scan already re-confirmed the target is still deferring
+            // and reset its clear-scan counter. $row is from before that,
+            // so anything decided from it here would be decided on state we
+            // have already superseded.
+            if (isset($reconfirmed[(int) $row->id])) {
+                continue;
+            }
+
             $stats = $scope === MailSuppressionService::SCOPE_MXGROUP
                 ? ($snapshot->groups[$value] ?? null)
                 : ($snapshot->addresses[$value] ?? null);
 
             $stillDeferred = $stats['count'] ?? 0;
 
-            $deliveriesResumed = $scope !== MailSuppressionService::SCOPE_MXGROUP
-                || ! $snapshot->hasDeliveryData()
-                || $snapshot->deliveriesFor($value) > 0;
+            if ($scope === MailSuppressionService::SCOPE_MXGROUP) {
+                // A relay family always has a tail of stragglers, so
+                // "clear" means the backlog has drained to a normal level
+                // AND the provider is visibly taking our mail again.
+                $deliveriesResumed = ! $snapshot->hasDeliveryData()
+                    || $snapshot->deliveriesFor($value) > 0;
 
-            $clear = $stillDeferred <= $releaseMax && $deliveriesResumed;
+                $clear = $stillDeferred <= $releaseMax && $deliveriesResumed;
+            } else {
+                // One mailbox is a different scale entirely. A member holds
+                // single figures of queued mail, so the relay-sized
+                // threshold would call a still-full mailbox clear on the
+                // very next scan and release it while it was still
+                // bouncing us. Here clear means exactly what it says: the
+                // queue holds nothing for this address any more.
+                $clear = $stillDeferred === 0;
+            }
 
             // Fail open. If the probe has been unable to confirm a
             // suppression for this long, we are more likely to be broken than
@@ -308,6 +339,19 @@ class DeferralScanService
                 && Carbon::parse($row->last_seen)->lt(now()->subHours($staleHours));
 
             if (! $clear && ! $stale) {
+                // Any scan that is not clear breaks the streak. Without
+                // this a suppression could accumulate its clear scans
+                // across a relapse - clear, blocked, clear - and release on
+                // a provider that never actually recovered for two scans in
+                // a row. The refresh in applyMxGroups only resets the
+                // counter when the group is still over its suppression
+                // threshold, which leaves the whole band in between.
+                if (! $dryRun && (int) $row->clear_scans !== 0) {
+                    DB::table('mail_suppressions')
+                        ->where('id', $row->id)
+                        ->update(['clear_scans' => 0]);
+                }
+
                 continue;
             }
 

--- a/iznik-batch/app/Services/Mail/Deferrals/DeferralScanService.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/DeferralScanService.php
@@ -1,0 +1,400 @@
+<?php
+
+namespace App\Services\Mail\Deferrals;
+
+use App\Services\Mail\MailSuppressionService;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Decides what to suppress and what to release, from one probe of the relay.
+ *
+ * Two tiers, and the first is the one that matters.
+ *
+ * MX-group is primary because providers block per relay, not per domain. It
+ * fires when a relay family has a large deferred backlog AND has all but
+ * stopped accepting our mail. Both halves are needed: a big backlog on its
+ * own can just be a slow evening, and a quiet hour on its own can just be a
+ * quiet hour.
+ *
+ * Per-address is secondary and slower, for "452 4.2.2 ... over quota". That
+ * is one person's mailbox rather than our reputation, and it wants a
+ * forgiving trigger because a mailbox that is full today is often fine
+ * tomorrow.
+ *
+ * Release is deliberately harder than suppression. It needs deliveries to
+ * have actually resumed and the backlog to have drained, held across two
+ * consecutive scans, so a single quiet moment inside a provider's own backoff
+ * window cannot reopen the floodgates.
+ */
+class DeferralScanService
+{
+    public function __construct(
+        private readonly MailSuppressionService $suppressions,
+    ) {}
+
+    /**
+     * Apply a snapshot to the suppression table.
+     *
+     * @return array{suppressed: array<int, array<string, mixed>>, released: array<int, array<string, mixed>>, checked: int}
+     */
+    public function apply(RelayQueueSnapshot $snapshot, bool $dryRun = false): array
+    {
+        $cfg = (array) config('freegle.mail.deferrals', []);
+
+        $suppressed = [];
+        $released = [];
+
+        $active = $this->activeByKey();
+
+        $suppressed = array_merge(
+            $suppressed,
+            $this->applyMxGroups($snapshot, $active, $cfg, $dryRun)
+        );
+
+        $suppressed = array_merge(
+            $suppressed,
+            $this->applyAddresses($snapshot, $active, $cfg, $dryRun)
+        );
+
+        $released = $this->applyReleases($snapshot, $active, $cfg, $dryRun);
+
+        if (! $dryRun && ($suppressed !== [] || $released !== [])) {
+            $this->suppressions->flushCache();
+        }
+
+        return [
+            'suppressed' => $suppressed,
+            'released' => $released,
+            'checked' => count($snapshot->groups) + count($snapshot->addresses),
+        ];
+    }
+
+    /**
+     * @param  array<string, object>  $active
+     * @return array<int, array<string, mixed>>
+     */
+    private function applyMxGroups(RelayQueueSnapshot $snapshot, array $active, array $cfg, bool $dryRun): array
+    {
+        $minDeferred = (int) ($cfg['mxgroup_min_deferred'] ?? 500);
+        $maxDelivered = (int) ($cfg['mxgroup_max_delivered_per_hour'] ?? 10);
+
+        $newlySuppressed = [];
+
+        foreach ($snapshot->groups as $group => $stats) {
+            $key = MailSuppressionService::SCOPE_MXGROUP."\0".$group;
+            $existing = $active[$key] ?? null;
+
+            if ($stats['count'] < $minDeferred) {
+                continue;
+            }
+
+            $delivered = $snapshot->deliveriesFor($group);
+
+            // Without delivery data we cannot tell "they have stopped taking
+            // our mail" from "it is 3am and nobody is sending". A backlog
+            // this size is still worth acting on, but say so, because a
+            // suppression made on half the evidence should be visible as
+            // such when someone reads the log afterwards.
+            $blind = ! $snapshot->hasDeliveryData();
+
+            if (! $blind && $delivered > $maxDelivered) {
+                // Still being accepted at a healthy rate: a backlog here is
+                // congestion, not a block.
+                continue;
+            }
+
+            if ($existing !== null) {
+                // Already suppressed. Refresh the evidence and reset the
+                // clear-scan counter, because this scan is not clear.
+                if (! $dryRun) {
+                    $this->refresh($existing->id, $stats, clearScans: 0);
+                }
+
+                continue;
+            }
+
+            $record = [
+                'scope' => MailSuppressionService::SCOPE_MXGROUP,
+                'value' => $group,
+                'provider' => MxGrouper::providerName($group),
+                'deferred' => $stats['count'],
+                'delivered' => $delivered,
+                'blind' => $blind,
+                'reason' => $stats['reason'],
+                'deferred_since' => $this->toDate($stats['oldest']),
+                'domains' => array_keys($stats['domains']),
+            ];
+
+            if (! $dryRun) {
+                $record['id'] = $this->createMxGroupSuppression($group, $stats, $delivered, $blind);
+            }
+
+            $newlySuppressed[] = $record;
+        }
+
+        return $newlySuppressed;
+    }
+
+    /**
+     * @param  array<string, object>  $active
+     * @return array<int, array<string, mixed>>
+     */
+    private function applyAddresses(RelayQueueSnapshot $snapshot, array $active, array $cfg, bool $dryRun): array
+    {
+        $minDeferred = (int) ($cfg['address_min_deferred'] ?? 5);
+        $minHours = (int) ($cfg['address_min_hours'] ?? 24);
+        $cutoff = now()->subHours($minHours)->getTimestamp();
+
+        $newlySuppressed = [];
+
+        foreach ($snapshot->addresses as $address => $stats) {
+            if ($stats['count'] < $minDeferred) {
+                continue;
+            }
+
+            // The backlog has to have been stuck for a while, not just be big.
+            // A burst of retries within an hour is the relay working normally.
+            if ($stats['oldest'] === null || $stats['oldest'] > $cutoff) {
+                continue;
+            }
+
+            // If the address's whole provider is already suppressed, the
+            // address row would add nothing but noise.
+            if ($this->coveredByGroup($address, $active)) {
+                continue;
+            }
+
+            $key = MailSuppressionService::SCOPE_ADDRESS."\0".$address;
+            if (isset($active[$key])) {
+                if (! $dryRun) {
+                    $this->refresh($active[$key]->id, $stats, clearScans: 0);
+                }
+
+                continue;
+            }
+
+            $record = [
+                'scope' => MailSuppressionService::SCOPE_ADDRESS,
+                'value' => $address,
+                'deferred' => $stats['count'],
+                'reason' => $stats['reason'],
+                'deferred_since' => $this->toDate($stats['oldest']),
+            ];
+
+            if (! $dryRun) {
+                $record['id'] = DB::table('mail_suppressions')->insertGetId([
+                    'scope' => MailSuppressionService::SCOPE_ADDRESS,
+                    'value' => $address,
+                    'reason' => $stats['reason'],
+                    'deferred_since' => $this->toDate($stats['oldest']),
+                    'first_seen' => now(),
+                    'last_seen' => now(),
+                    'message_count' => $stats['count'],
+                ]);
+            }
+
+            $newlySuppressed[] = $record;
+        }
+
+        return $newlySuppressed;
+    }
+
+    /**
+     * @param  array<string, object>  $active
+     * @return array<int, array<string, mixed>>
+     */
+    private function applyReleases(RelayQueueSnapshot $snapshot, array $active, array $cfg, bool $dryRun): array
+    {
+        $releaseMax = (int) ($cfg['release_max_deferred'] ?? 100);
+        $needClear = max(1, (int) ($cfg['release_clear_scans'] ?? 2));
+        $staleHours = (int) ($cfg['stale_after_hours'] ?? 24);
+
+        $released = [];
+
+        foreach ($active as $key => $row) {
+            [$scope, $value] = explode("\0", $key, 2);
+
+            // Domain rows are children of an mxgroup row; releasing the
+            // parent cascades, so evaluating them separately would race.
+            if ($scope === MailSuppressionService::SCOPE_DOMAIN) {
+                continue;
+            }
+
+            $stats = $scope === MailSuppressionService::SCOPE_MXGROUP
+                ? ($snapshot->groups[$value] ?? null)
+                : ($snapshot->addresses[$value] ?? null);
+
+            $stillDeferred = $stats['count'] ?? 0;
+
+            $deliveriesResumed = $scope !== MailSuppressionService::SCOPE_MXGROUP
+                || ! $snapshot->hasDeliveryData()
+                || $snapshot->deliveriesFor($value) > 0;
+
+            $clear = $stillDeferred <= $releaseMax && $deliveriesResumed;
+
+            // Fail open. If the probe has been unable to confirm a
+            // suppression for this long, we are more likely to be broken than
+            // the provider is, and quietly not mailing a whole provider for
+            // ever is the worse failure.
+            $stale = $staleHours > 0
+                && $row->last_seen !== null
+                && Carbon::parse($row->last_seen)->lt(now()->subHours($staleHours));
+
+            if (! $clear && ! $stale) {
+                continue;
+            }
+
+            $clearScans = ((int) $row->clear_scans) + 1;
+
+            if (! $stale && $clearScans < $needClear) {
+                if (! $dryRun) {
+                    DB::table('mail_suppressions')
+                        ->where('id', $row->id)
+                        ->update(['clear_scans' => $clearScans, 'message_count' => $stillDeferred]);
+                }
+
+                continue;
+            }
+
+            $released[] = [
+                'id' => $row->id,
+                'scope' => $scope,
+                'value' => $value,
+                'provider' => $row->provider,
+                'deferred_since' => $row->deferred_since,
+                'still_deferred' => $stillDeferred,
+                'stale' => $stale,
+            ];
+
+            if (! $dryRun) {
+                // Children go with the parent, so a released provider does
+                // not leave orphan domain rows gating mail for ever.
+                DB::table('mail_suppressions')
+                    ->where('id', $row->id)
+                    ->orWhere('parentid', $row->id)
+                    ->update(['released_at' => now(), 'clear_scans' => 0]);
+            }
+        }
+
+        return $released;
+    }
+
+    /**
+     * Create the mxgroup row plus one child domain row per recipient domain we
+     * actually saw deferring through it.
+     *
+     * Materialising the domains is what keeps the sending-loop check to a
+     * plain indexed lookup with no DNS: the queue has already told us which
+     * domains this relay serves, and it is better evidence than an MX lookup
+     * would be, because it is what actually happened to our mail.
+     */
+    private function createMxGroupSuppression(string $group, array $stats, int $delivered, bool $blind): int
+    {
+        $provider = MxGrouper::providerName($group);
+        $since = $this->toDate($stats['oldest']);
+
+        return DB::transaction(function () use ($group, $stats, $delivered, $blind, $provider, $since) {
+            $reason = $stats['reason'];
+            if ($blind) {
+                $reason = '[no delivery data available] ' . $reason;
+            }
+
+            $id = DB::table('mail_suppressions')->insertGetId([
+                'scope' => MailSuppressionService::SCOPE_MXGROUP,
+                'value' => $group,
+                'provider' => $provider,
+                'reason' => $reason,
+                'deferred_since' => $since,
+                'first_seen' => now(),
+                'last_seen' => now(),
+                'message_count' => $stats['count'],
+            ]);
+
+            $rows = [];
+            foreach (array_keys($stats['domains']) as $domain) {
+                $rows[] = [
+                    'scope' => MailSuppressionService::SCOPE_DOMAIN,
+                    'value' => $domain,
+                    'parentid' => $id,
+                    'provider' => $provider,
+                    'reason' => $reason,
+                    'deferred_since' => $since,
+                    'first_seen' => now(),
+                    'last_seen' => now(),
+                    'message_count' => $stats['domains'][$domain],
+                ];
+            }
+
+            foreach (array_chunk($rows, 200) as $chunk) {
+                DB::table('mail_suppressions')->insert($chunk);
+            }
+
+            Log::warning('Mail deferrals: suppressing relay family', [
+                'mxgroup' => $group,
+                'provider' => $provider,
+                'deferred' => $stats['count'],
+                'delivered_last_hour' => $delivered,
+                'domains' => count($rows),
+                'deferred_since' => $since,
+            ]);
+
+            return $id;
+        });
+    }
+
+    private function refresh(int $id, array $stats, int $clearScans): void
+    {
+        DB::table('mail_suppressions')
+            ->where('id', $id)
+            ->orWhere('parentid', $id)
+            ->update([
+                'last_seen' => now(),
+                'clear_scans' => $clearScans,
+            ]);
+
+        DB::table('mail_suppressions')
+            ->where('id', $id)
+            ->update(['message_count' => $stats['count']]);
+    }
+
+    /**
+     * @param  array<string, object>  $active
+     */
+    private function coveredByGroup(string $address, array $active): bool
+    {
+        $at = strrpos($address, '@');
+        if ($at === false) {
+            return false;
+        }
+
+        $domain = substr($address, $at + 1);
+
+        return isset($active[MailSuppressionService::SCOPE_DOMAIN."\0".$domain]);
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    private function activeByKey(): array
+    {
+        $rows = DB::table('mail_suppressions')->whereNull('released_at')->get();
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[$row->scope."\0".strtolower((string) $row->value)] = $row;
+        }
+
+        return $map;
+    }
+
+    private function toDate(?int $ts): ?string
+    {
+        if ($ts === null || $ts <= 0) {
+            return null;
+        }
+
+        return Carbon::createFromTimestamp($ts)->toDateTimeString();
+    }
+}

--- a/iznik-batch/app/Services/Mail/Deferrals/MxGrouper.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/MxGrouper.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Services\Mail\Deferrals;
+
+/**
+ * Buckets a relay hostname into the family that actually shares a reputation.
+ *
+ * Providers block per sending-IP-to-receiving-infrastructure pair, not per
+ * recipient domain. When Yahoo stopped taking our mail on 2026-08-15 it took
+ * out yahoo.co.uk, yahoo.com, ymail.com, rocketmail.com, aol.com, aol.co.uk,
+ * aim.com and sky.com in one go - Sky's mail is Yahoo-hosted, which is not
+ * remotely guessable from the domain. All of them relay through
+ * *.am0.yahoodns.net, so the relay host is the honest unit of suppression and
+ * the recipient domain is not.
+ *
+ * The grouping is the registrable-ish suffix of the relay host: drop the
+ * per-machine label so mta5/mta6/mta7.am0.yahoodns.net collapse into one
+ * group. That is deliberately mechanical rather than a hand-maintained list
+ * of providers, because the next provider to defer us will not be on any list
+ * we wrote today.
+ */
+class MxGrouper
+{
+    /**
+     * Suffixes that are too broad to be a useful group on their own, so we
+     * keep one more label. Without this, everything hosted on a big platform
+     * would collapse into a single bucket and one customer's problem would
+     * suppress mail to all of them.
+     */
+    private const KEEP_EXTRA_LABEL = [
+        'protection.outlook.com',
+        'mail.protection.outlook.com',
+        'pphosted.com',
+        'ppe-hosted.com',
+        'mimecast.com',
+        'messagelabs.com',
+        'antispamcloud.com',
+        'emailsrvr.com',
+        'zoho.com',
+        'secureserver.net',
+    ];
+
+    /**
+     * Public suffixes we must never treat as a group, or a single deferral
+     * would suppress an entire country's mail.
+     */
+    private const NEVER_ALONE = [
+        'co.uk', 'org.uk', 'me.uk', 'ac.uk', 'gov.uk', 'net.uk', 'sch.uk',
+        'com.au', 'net.au', 'org.au', 'co.nz', 'co.za', 'com.br', 'co.jp',
+        'com', 'net', 'org', 'edu', 'gov', 'uk', 'de', 'fr', 'nl', 'ie', 'es', 'it',
+    ];
+
+    public static function group(string $host): string
+    {
+        $host = strtolower(trim($host));
+        $host = rtrim($host, '.');
+
+        if ($host === '') {
+            return '';
+        }
+
+        // A bare IP has no family to belong to; it is its own group.
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return $host;
+        }
+
+        $labels = explode('.', $host);
+        if (count($labels) <= 2) {
+            return $host;
+        }
+
+        foreach (self::KEEP_EXTRA_LABEL as $suffix) {
+            if (str_ends_with($host, '.' . $suffix)) {
+                $extra = count(explode('.', $suffix)) + 1;
+
+                return implode('.', array_slice($labels, -min($extra, count($labels))));
+            }
+        }
+
+        $candidate = implode('.', array_slice($labels, -2));
+
+        // Two labels is usually the family (yahoodns.net, google.com), but not
+        // when those two labels are only a public suffix.
+        if (in_array($candidate, self::NEVER_ALONE, true) && count($labels) >= 3) {
+            return implode('.', array_slice($labels, -3));
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * The relay host Postfix blamed, pulled out of a delay_reason.
+     *
+     * Postfix writes two shapes. When it got an SMTP answer:
+     *   host mta7.am0.yahoodns.net[67.195.228.94] said: 421 4.7.0 [TSS04] ...
+     * When it never got that far:
+     *   connect to mx1.example.com[198.51.100.5]:25: Connection timed out
+     *
+     * Returns null when neither shape matches - some delay reasons are purely
+     * local ("mail transport unavailable") and blaming a provider for those
+     * would suppress the wrong thing.
+     */
+    public static function fromDelayReason(string $reason): ?string
+    {
+        if (preg_match('/\bhost\s+([A-Za-z0-9._-]+)\[/', $reason, $m)) {
+            return self::group($m[1]);
+        }
+
+        if (preg_match('/\bconnect to\s+([A-Za-z0-9._-]+)\[/', $reason, $m)) {
+            return self::group($m[1]);
+        }
+
+        return null;
+    }
+
+    /**
+     * A short, member-facing name for a group, e.g. "Yahoo" for
+     * am0.yahoodns.net. Moderators and members should read the name of the
+     * company that is not accepting our mail, not a piece of DNS.
+     */
+    public static function providerName(string $group): ?string
+    {
+        $known = [
+            'yahoodns.net' => 'Yahoo',
+            'yahoo.com' => 'Yahoo',
+            'aol.com' => 'AOL',
+            'google.com' => 'Gmail',
+            'googlemail.com' => 'Gmail',
+            'outlook.com' => 'Microsoft',
+            'hotmail.com' => 'Microsoft',
+            'protection.outlook.com' => 'Microsoft',
+            'icloud.com' => 'Apple',
+            'me.com' => 'Apple',
+            'apple.com' => 'Apple',
+            'btinternet.com' => 'BT',
+            'bt.com' => 'BT',
+            'virginmedia.com' => 'Virgin Media',
+            'sky.com' => 'Sky',
+            'talktalk.co.uk' => 'TalkTalk',
+            'zoho.com' => 'Zoho',
+            'mimecast.com' => 'Mimecast',
+            'pphosted.com' => 'Proofpoint',
+        ];
+
+        foreach ($known as $suffix => $name) {
+            if ($group === $suffix || str_ends_with($group, '.' . $suffix)) {
+                return $name;
+            }
+        }
+
+        return null;
+    }
+}

--- a/iznik-batch/app/Services/Mail/Deferrals/MxGrouper.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/MxGrouper.php
@@ -69,12 +69,24 @@ class MxGrouper
             return $host;
         }
 
+        // Longest match wins. Both 'protection.outlook.com' and
+        // 'mail.protection.outlook.com' are listed, and taking the first hit
+        // rather than the longest would group every Microsoft 365 tenant
+        // together - exactly the collapse the list exists to prevent.
+        $best = NULL;
         foreach (self::KEEP_EXTRA_LABEL as $suffix) {
-            if (str_ends_with($host, '.' . $suffix)) {
-                $extra = count(explode('.', $suffix)) + 1;
-
-                return implode('.', array_slice($labels, -min($extra, count($labels))));
+            if (str_ends_with($host, '.' . $suffix)
+                && ($best === NULL || strlen($suffix) > strlen($best))) {
+                $best = $suffix;
             }
+        }
+
+        if ($best !== NULL) {
+            // One label beyond the platform suffix: the customer, e.g. the
+            // tenant in acme-com.mail.protection.outlook.com.
+            $extra = count(explode('.', $best)) + 1;
+
+            return implode('.', array_slice($labels, -min($extra, count($labels))));
         }
 
         $candidate = implode('.', array_slice($labels, -2));

--- a/iznik-batch/app/Services/Mail/Deferrals/RelayQueueSnapshot.php
+++ b/iznik-batch/app/Services/Mail/Deferrals/RelayQueueSnapshot.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Services\Mail\Deferrals;
+
+/**
+ * What one probe of the relay saw.
+ *
+ * A value object rather than a pile of arrays because the scan makes several
+ * decisions off the same numbers and it should be obvious which is which:
+ * deferrals are bucketed both by relay family (our reputation with a
+ * provider) and by individual address (one person's full mailbox), and those
+ * two signals want very different thresholds.
+ */
+class RelayQueueSnapshot
+{
+    /**
+     * Relay family => [count, oldest arrival unix ts, sample reason,
+     *                  domains => [domain => count]]
+     *
+     * @var array<string, array{count:int, oldest:?int, reason:string, domains:array<string,int>}>
+     */
+    public array $groups = [];
+
+    /**
+     * Address => [count, oldest arrival unix ts, sample reason]
+     *
+     * @var array<string, array{count:int, oldest:?int, reason:string}>
+     */
+    public array $addresses = [];
+
+    /** Relay family => deliveries seen in the log window. */
+    public array $delivered = [];
+
+    /** Queue ids per relay family, for --purge. */
+    public array $queueIds = [];
+
+    /** Deferred recipients we could not attribute to any relay. */
+    public int $unattributed = 0;
+
+    /** Queue lines that were not valid JSON (expect 1 when truncated). */
+    public int $unparseableLines = 0;
+
+    /** Whether the relay's queue listing was cut short by the byte cap. */
+    public bool $truncated = false;
+
+    public function addDeferral(string $address, string $reason, ?int $arrivalTime, ?string $queueId): void
+    {
+        $address = strtolower(trim($address));
+        if ($address === '') {
+            return;
+        }
+
+        if (! isset($this->addresses[$address])) {
+            $this->addresses[$address] = ['count' => 0, 'oldest' => null, 'reason' => $reason];
+        }
+        $this->addresses[$address]['count']++;
+        $this->addresses[$address]['oldest'] = $this->earliest($this->addresses[$address]['oldest'], $arrivalTime);
+
+        $group = MxGrouper::fromDelayReason($reason);
+        if ($group === null || $group === '') {
+            // A local-only failure ("mail transport unavailable") blames no
+            // provider. Counting it against one would suppress the wrong mail.
+            $this->unattributed++;
+
+            return;
+        }
+
+        if (! isset($this->groups[$group])) {
+            $this->groups[$group] = ['count' => 0, 'oldest' => null, 'reason' => $reason, 'domains' => []];
+        }
+        $this->groups[$group]['count']++;
+        $this->groups[$group]['oldest'] = $this->earliest($this->groups[$group]['oldest'], $arrivalTime);
+
+        $domain = $this->domainOf($address);
+        if ($domain !== null) {
+            $this->groups[$group]['domains'][$domain] = ($this->groups[$group]['domains'][$domain] ?? 0) + 1;
+        }
+
+        if ($queueId !== null && $queueId !== '') {
+            // Deduplicated: one queue file can hold many recipients in the
+            // same family, and purging wants each id once.
+            $this->queueIds[$group][$queueId] = true;
+        }
+    }
+
+    public function addDelivery(string $group): void
+    {
+        if ($group === '') {
+            return;
+        }
+
+        $this->delivered[$group] = ($this->delivered[$group] ?? 0) + 1;
+    }
+
+    public function deliveriesFor(string $group): int
+    {
+        return (int) ($this->delivered[$group] ?? 0);
+    }
+
+    /**
+     * Whether the probe brought back any delivery data at all.
+     *
+     * Distinguishes "nothing is being delivered anywhere", which would be an
+     * estate-wide emergency, from "we could not read the relay's log", which
+     * is a gap in our instrumentation. The release check must not treat the
+     * second as the first.
+     */
+    public function hasDeliveryData(): bool
+    {
+        return $this->delivered !== [];
+    }
+
+    /** @return string[] */
+    public function queueIdsFor(string $group): array
+    {
+        return array_keys($this->queueIds[$group] ?? []);
+    }
+
+    private function domainOf(string $address): ?string
+    {
+        $at = strrpos($address, '@');
+        if ($at === false || $at === strlen($address) - 1) {
+            return null;
+        }
+
+        return substr($address, $at + 1);
+    }
+
+    private function earliest(?int $current, ?int $candidate): ?int
+    {
+        if ($candidate === null || $candidate <= 0) {
+            return $current;
+        }
+
+        return $current === null ? $candidate : min($current, $candidate);
+    }
+}

--- a/iznik-batch/app/Services/Mail/DeliveryHealthService.php
+++ b/iznik-batch/app/Services/Mail/DeliveryHealthService.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Services\Mail;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Per-domain delivery health, from open tracking.
+ *
+ * We hand mail to a smarthost and it accepts everything, so nothing in the spool tells us
+ * whether a receiving provider actually delivered it. When a big provider starts refusing or
+ * silently binning our mail, the spool looks perfectly healthy and the digest lag figures look
+ * perfectly healthy, because from our side the mail went out.
+ *
+ * The one signal we do have is that people stop opening. email_tracking records sent_at and
+ * opened_at per recipient, so an abrupt collapse in a domain's open rate is a proxy for its
+ * mail no longer arriving.
+ *
+ * This is a comparison against each domain's OWN recent history, not against a fixed rate or
+ * against other domains. Open rates differ enormously and legitimately between providers -
+ * icloud.com opens at 56% and gmail.com at 23% on the same mail - so an absolute threshold
+ * would either miss real outages at the high end or cry wolf at the low end. It also means
+ * domains that never report opens at all (user.trashnothing.com forwards our mail on, so the
+ * pixel is never fetched from the real recipient) drop out on their own: their baseline is
+ * already zero, so there is nothing to lose.
+ *
+ * The recent window stops short of now. An email sent ten minutes ago has not had a fair chance
+ * to be opened, and including it would make every run look like the start of an outage.
+ *
+ * COST. One pass over email_tracking's sent_at range, which at the default windows is about 4.5
+ * million rows on production, grouped down to a few thousand domains. That is fine once a day
+ * and would not be fine any more often than that.
+ */
+class DeliveryHealthService
+{
+    /** Ignore the last few hours - mail that recent has not had a fair chance to be opened. */
+    public const SETTLE_HOURS = 6;
+
+    /** A domain needs this many sends in the recent window before its rate means anything. */
+    public const MIN_RECENT_SENDS = 500;
+
+    /** ...and this open rate in its own baseline, or there is no working delivery to have lost. */
+    public const MIN_BASELINE_OPEN_PERCENT = 5.0;
+
+    /** Flag when the recent rate falls to this fraction of the domain's own baseline. */
+    public const COLLAPSE_RATIO = 0.4;
+
+    /**
+     * Domains whose open rate has collapsed against their own baseline, worst first.
+     *
+     * @param int $recentDays Length of the window being judged.
+     * @param int $baselineDays Length of the comparison window immediately before it.
+     * @return array<int, array{domain: string, recent_sent: int, recent_open_percent: float,
+     *                          baseline_open_percent: float, ratio: float}>
+     */
+    public function collapsedDomains(int $recentDays = 1, int $baselineDays = 14, ?Carbon $now = null): array
+    {
+        $recentEnd = ($now ? $now->copy() : Carbon::now())->subHours(self::SETTLE_HOURS);
+        $recentStart = $recentEnd->copy()->subDays($recentDays);
+        $baselineStart = $recentStart->copy()->subDays($baselineDays);
+
+        // One pass over the sent_at range, splitting the two windows with conditional sums.
+        $rows = DB::table('email_tracking')
+            ->selectRaw("SUBSTRING_INDEX(recipient_email, '@', -1) AS domain")
+            ->selectRaw('SUM(sent_at >= ?) AS recent_sent', [$recentStart])
+            ->selectRaw('SUM(sent_at >= ? AND opened_at IS NOT NULL) AS recent_opened', [$recentStart])
+            ->selectRaw('SUM(sent_at < ?) AS baseline_sent', [$recentStart])
+            ->selectRaw('SUM(sent_at < ? AND opened_at IS NOT NULL) AS baseline_opened', [$recentStart])
+            ->where('sent_at', '>=', $baselineStart)
+            ->where('sent_at', '<', $recentEnd)
+            ->groupBy('domain')
+            ->havingRaw('recent_sent >= ?', [self::MIN_RECENT_SENDS])
+            ->get();
+
+        $collapsed = [];
+
+        foreach ($rows as $row) {
+            $recentSent = (int) $row->recent_sent;
+            $baselineSent = (int) $row->baseline_sent;
+
+            if ($recentSent < self::MIN_RECENT_SENDS || $baselineSent < self::MIN_RECENT_SENDS) {
+                continue;
+            }
+
+            $baselinePercent = 100 * (int) $row->baseline_opened / $baselineSent;
+
+            // Nothing to lose: this domain never reported opens even when it was healthy.
+            if ($baselinePercent < self::MIN_BASELINE_OPEN_PERCENT) {
+                continue;
+            }
+
+            $recentPercent = 100 * (int) $row->recent_opened / $recentSent;
+            $ratio = $recentPercent / $baselinePercent;
+
+            if ($ratio > self::COLLAPSE_RATIO) {
+                continue;
+            }
+
+            $collapsed[] = [
+                'domain' => $row->domain,
+                'recent_sent' => $recentSent,
+                'recent_open_percent' => round($recentPercent, 1),
+                'baseline_open_percent' => round($baselinePercent, 1),
+                'ratio' => round($ratio, 2),
+            ];
+        }
+
+        // Worst first, then by how much mail is affected, so the log leads with what matters.
+        usort($collapsed, static function (array $a, array $b): int {
+            return [$a['ratio'], -$a['recent_sent']] <=> [$b['ratio'], -$b['recent_sent']];
+        });
+
+        return $collapsed;
+    }
+}

--- a/iznik-batch/app/Services/Mail/DeliveryHealthService.php
+++ b/iznik-batch/app/Services/Mail/DeliveryHealthService.php
@@ -28,6 +28,13 @@ use Illuminate\Support\Facades\DB;
  * The recent window stops short of now. An email sent ten minutes ago has not had a fair chance
  * to be opened, and including it would make every run look like the start of an outage.
  *
+ * THE OTHER HALF. App\Services\Mail\Deferrals reads the relay's own queue and catches a
+ * provider that is REFUSING us outright, with a 4xx at the SMTP conversation. This catches the
+ * opposite shape: a provider that accepts everything and then quietly does nothing with it,
+ * which leaves no trace in any queue. Neither can see the other's failure, so both are needed.
+ * When the deferral scanner suppresses a provider, expect this to report the same domains a day
+ * or so later - that is the two agreeing, not a duplicate alert.
+ *
  * COST. One pass over email_tracking's sent_at range, which at the default windows is about 4.5
  * million rows on production, grouped down to a few thousand domains. That is fine once a day
  * and would not be fine any more often than that.

--- a/iznik-batch/app/Services/Mail/Incoming/BounceService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/BounceService.php
@@ -60,6 +60,19 @@ class BounceService
         'found on industry URI blacklists',
         'This message has been blocked',
         'is listed',
+        // A provider deferring us is a statement about our sending
+        // reputation, not about the member's address, so it must never count
+        // toward suspension. Postfix keeps deferring for maximal_queue_lifetime
+        // and only then mails one DSN per message carrying the original 4xx
+        // text - so a single episode can hand one member a week's worth of
+        // "bounces" for a mailbox that is perfectly fine.
+        // 2026-08-15: Yahoo 421-ed everything from the relay's IP with
+        // "[TSS04] ... temporarily deferred due to unexpected volume or user
+        // complaints"; members held about 9 queued messages each, well past
+        // SOFT_BOUNCE_THRESHOLD.
+        'temporarily deferred',
+        '[TSS04]',
+        'delivery time expired',
     ];
 
     /**

--- a/iznik-batch/app/Services/Mail/MailSuppressionService.php
+++ b/iznik-batch/app/Services/Mail/MailSuppressionService.php
@@ -72,6 +72,15 @@ class MailSuppressionService
             return null;
         }
 
+        // Never hold back our own operational mail. The volume is trivial -
+        // alerts, reports, mod notifications to team addresses - so there is
+        // nothing to save by suppressing it, and the failure mode is awful:
+        // the alert telling us a provider has stopped accepting our mail is
+        // exactly the message we would be dropping.
+        if ($this->isOurOwnAddress($email)) {
+            return null;
+        }
+
         $active = $this->active();
 
         // Most specific first: an individual mailbox over quota is a
@@ -139,11 +148,17 @@ class MailSuppressionService
      */
     public function shouldSkip(?string $email, ?int $userId, string $emailType): bool
     {
-        if (! $this->isSuppressed($email)) {
+        $suppression = $this->suppressionFor($email);
+
+        if ($suppression === null) {
             return false;
         }
 
-        $this->recordSuppressed($userId, $emailType);
+        // Carry the suppression's id through, so reporting never has to work
+        // out after the fact which provider was refusing this member - that
+        // would mean reimplementing the mailer's own address-ranking rules in
+        // a reporting query, against history that has already moved on.
+        $this->recordSuppressed($userId, $emailType, (int) $suppression->id);
 
         return true;
     }
@@ -199,6 +214,40 @@ class MailSuppressionService
         $this->cacheLoadedAt = $now;
 
         return $map;
+    }
+
+    /**
+     * Whether this is one of Freegle's own addresses rather than a member's.
+     *
+     * Covers the internal domains the mailer already knows about plus the
+     * site's own domain, which is where geeks@, support@, mentors@ and the
+     * per-group team addresses live.
+     */
+    private function isOurOwnAddress(string $email): bool
+    {
+        $at = strrpos($email, '@');
+        if ($at === false) {
+            return false;
+        }
+
+        $domain = substr($email, $at + 1);
+
+        $ours = array_map('strtolower', (array) config('freegle.mail.internal_domains', []));
+
+        foreach ([config('freegle.mail.noreply_addr'), config('freegle.mail.geeks_addr')] as $addr) {
+            $p = strrpos((string) $addr, '@');
+            if ($p !== false) {
+                $ours[] = strtolower(substr((string) $addr, $p + 1));
+            }
+        }
+
+        foreach (array_unique(array_filter($ours)) as $own) {
+            if ($domain === $own || str_ends_with($domain, '.' . $own)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function normalise(?string $email): ?string

--- a/iznik-batch/app/Services/Mail/MailSuppressionService.php
+++ b/iznik-batch/app/Services/Mail/MailSuppressionService.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Services\Mail;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * The gate: may we generate mail for this address right now?
+ *
+ * Called from inside every per-recipient sending loop, before the MJML render
+ * rather than at the point of sending, because rendering is where the money
+ * goes. During the 2026-08-15 Yahoo episode we spent three days rendering
+ * roughly 67,000 digests a day, plus per-post mail, for addresses that
+ * provably could not receive any of it.
+ *
+ * Answers come from `mail_suppressions`. Domain rows are materialised from
+ * queue evidence when a relay family is suppressed, so this method is two
+ * indexed lookups and never a DNS query - it has to be cheap enough to run
+ * hundreds of thousands of times an hour.
+ *
+ * Deliberately separate from users.bouncing, which means "this address is
+ * bad". This is our reputation with a provider, which is a different fact
+ * about a different party, and conflating them would show moderators the
+ * wrong story and leave members permanently flagged after an outage that was
+ * never their fault.
+ */
+class MailSuppressionService
+{
+    public const SCOPE_MXGROUP = 'mxgroup';
+
+    public const SCOPE_DOMAIN = 'domain';
+
+    public const SCOPE_ADDRESS = 'address';
+
+    /**
+     * Active suppressions, keyed "scope\0value".
+     *
+     * Loaded once per process. The sending loops are long-running batch jobs
+     * over tens of thousands of members, and a per-recipient query would cost
+     * more than the render we are trying to avoid. The cost of being at most
+     * one refresh window stale is one extra mail into a queue that is already
+     * holding thousands.
+     *
+     * @var array<string, object>|null
+     */
+    private ?array $cache = null;
+
+    private ?float $cacheLoadedAt = null;
+
+    /** Seconds before the in-process cache is reloaded. */
+    private const CACHE_TTL = 60.0;
+
+    /**
+     * Whether we should decline to generate mail for this address.
+     */
+    public function isSuppressed(?string $email): bool
+    {
+        return $this->suppressionFor($email) !== null;
+    }
+
+    /**
+     * The suppression covering this address, or null.
+     *
+     * Returns the row so callers can report what is happening: the "delayed
+     * since" date and the provider's name both come from here.
+     */
+    public function suppressionFor(?string $email): ?object
+    {
+        $email = $this->normalise($email);
+        if ($email === null) {
+            return null;
+        }
+
+        $active = $this->active();
+
+        // Most specific first: an individual mailbox over quota is a
+        // different problem from its provider deferring everyone, and the
+        // address row carries the more accurate reason.
+        $byAddress = $active[self::SCOPE_ADDRESS."\0".$email] ?? null;
+        if ($byAddress !== null) {
+            return $byAddress;
+        }
+
+        $at = strrpos($email, '@');
+        if ($at === false) {
+            return null;
+        }
+
+        $domain = substr($email, $at + 1);
+
+        return $active[self::SCOPE_DOMAIN."\0".$domain] ?? null;
+    }
+
+    /**
+     * Record that we declined to generate one mail, so release can send a
+     * single catch-up instead of replaying the backlog.
+     *
+     * $emailType uses the same vocabulary as EmailSpoolerService::spool(), so
+     * the catch-up policy can be written in the same terms as the mail it
+     * stands in for.
+     */
+    public function recordSuppressed(?int $userId, string $emailType): void
+    {
+        if ($userId === null || $userId <= 0) {
+            return;
+        }
+
+        try {
+            DB::statement(
+                'INSERT INTO mail_suppressed_counts (userid, emailtype, `count`, firstat, lastat)
+                 VALUES (?, ?, 1, NOW(), NOW())
+                 ON DUPLICATE KEY UPDATE
+                    `count` = `count` + 1,
+                    lastat = NOW(),
+                    -- A fresh episode after a catch-up starts counting again
+                    -- rather than resuming the old total.
+                    firstat = IF(caughtup_at IS NULL, firstat, NOW()),
+                    `count` = IF(caughtup_at IS NULL, `count`, 1),
+                    caughtup_at = NULL',
+                [$userId, substr($emailType, 0, 32)]
+            );
+        } catch (\Throwable $e) {
+            // Losing a counter costs us accuracy in one catch-up email. It
+            // must never cost us the send loop.
+            Log::warning('Mail suppression: could not record suppressed count', [
+                'userid' => $userId,
+                'emailtype' => $emailType,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Convenience for the sending loops: check, and count it if suppressed.
+     *
+     * Returns true when the caller should skip this recipient.
+     */
+    public function shouldSkip(?string $email, ?int $userId, string $emailType): bool
+    {
+        if (! $this->isSuppressed($email)) {
+            return false;
+        }
+
+        $this->recordSuppressed($userId, $emailType);
+
+        return true;
+    }
+
+    /**
+     * Drop the in-process cache. Called by the scan after it changes the
+     * suppression set, and by tests.
+     */
+    public function flushCache(): void
+    {
+        $this->cache = null;
+        $this->cacheLoadedAt = null;
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    private function active(): array
+    {
+        $now = microtime(true);
+
+        if ($this->cache !== null && $this->cacheLoadedAt !== null
+            && ($now - $this->cacheLoadedAt) < self::CACHE_TTL) {
+            return $this->cache;
+        }
+
+        try {
+            $rows = DB::table('mail_suppressions')
+                ->select(['id', 'scope', 'value', 'parentid', 'reason', 'provider', 'deferred_since', 'message_count'])
+                ->whereNull('released_at')
+                ->whereIn('scope', [self::SCOPE_DOMAIN, self::SCOPE_ADDRESS])
+                ->get();
+        } catch (\Throwable $e) {
+            // If we cannot read the table we must fail OPEN. A suppression
+            // bug that silently stops all mail would be far worse than the
+            // problem it was written to solve.
+            Log::error('Mail suppression: could not load suppressions, failing open', [
+                'error' => $e->getMessage(),
+            ]);
+
+            $this->cache = [];
+            $this->cacheLoadedAt = $now;
+
+            return $this->cache;
+        }
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[$row->scope."\0".strtolower((string) $row->value)] = $row;
+        }
+
+        $this->cache = $map;
+        $this->cacheLoadedAt = $now;
+
+        return $map;
+    }
+
+    private function normalise(?string $email): ?string
+    {
+        if ($email === null) {
+            return null;
+        }
+
+        $email = strtolower(trim($email));
+
+        return $email === '' ? null : $email;
+    }
+}

--- a/iznik-batch/app/Services/Mail/MailSuppressionService.php
+++ b/iznik-batch/app/Services/Mail/MailSuppressionService.php
@@ -100,7 +100,7 @@ class MailSuppressionService
      * the catch-up policy can be written in the same terms as the mail it
      * stands in for.
      */
-    public function recordSuppressed(?int $userId, string $emailType): void
+    public function recordSuppressed(?int $userId, string $emailType, ?int $suppressionId = null): void
     {
         if ($userId === null || $userId <= 0) {
             return;
@@ -108,17 +108,18 @@ class MailSuppressionService
 
         try {
             DB::statement(
-                'INSERT INTO mail_suppressed_counts (userid, emailtype, `count`, firstat, lastat)
-                 VALUES (?, ?, 1, NOW(), NOW())
+                'INSERT INTO mail_suppressed_counts (userid, emailtype, suppressionid, `count`, firstat, lastat)
+                 VALUES (?, ?, ?, 1, NOW(), NOW())
                  ON DUPLICATE KEY UPDATE
                     `count` = `count` + 1,
                     lastat = NOW(),
+                    suppressionid = VALUES(suppressionid),
                     -- A fresh episode after a catch-up starts counting again
                     -- rather than resuming the old total.
                     firstat = IF(caughtup_at IS NULL, firstat, NOW()),
                     `count` = IF(caughtup_at IS NULL, `count`, 1),
                     caughtup_at = NULL',
-                [$userId, substr($emailType, 0, 32)]
+                [$userId, substr($emailType, 0, 32), $suppressionId]
             );
         } catch (\Throwable $e) {
             // Losing a counter costs us accuracy in one catch-up email. It

--- a/iznik-batch/app/Services/Mail/SmtpFailureClassifier.php
+++ b/iznik-batch/app/Services/Mail/SmtpFailureClassifier.php
@@ -15,9 +15,18 @@ use Illuminate\Support\Facades\Log;
  * job tries to send to it. Transient failures (connect-refused, timed-out
  * to mail-host:25 at container startup) should NOT be marked as permanent.
  *
- * Extracted from EmailSpoolerService so direct-send paths (mail:mod-notifs,
- * mail:engage, mail:donations:*, etc.) can use the same classification
- * without duplicating the regex list.
+ * Extracted from EmailSpoolerService so any direct-send path can use the
+ * same classification without duplicating the regex list. (The paths this
+ * once named - mail:mod-notifs, mail:engage, mail:donations:* - all went
+ * through EmailSpoolerService::spool() in commit 3c8b5c6de and no longer
+ * bypass the spooler.)
+ *
+ * Note what this class CANNOT see. These patterns match failures our own SMTP
+ * client is handed when it passes a message to the relay. A provider
+ * deferring the relay's onward delivery happens a hop further out, long after
+ * we have been told 250 and moved on: SmtpFailureClassifier will never see a
+ * Yahoo 421. That blind spot is what App\Services\Mail\Deferrals exists
+ * for - it reads the relay's queue directly.
  */
 class SmtpFailureClassifier
 {

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -32,6 +32,25 @@ class UnifiedDigestService
 
     public const EMAIL_TYPE = 'UnifiedDigest';
 
+    /** The deferral gate, resolved once per run. */
+    private ?\App\Services\Mail\MailSuppressionService $suppressionService = NULL;
+
+    /**
+     * Whether a provider is currently refusing our mail to this member.
+     *
+     * Consulted before every render. The service is a singleton and caches
+     * the active suppression set in-process, so this stays cheap enough to
+     * call once per recipient across tens of thousands of members.
+     */
+    private function suppressions(): \App\Services\Mail\MailSuppressionService
+    {
+        if ($this->suppressionService === NULL) {
+            $this->suppressionService = app(\App\Services\Mail\MailSuppressionService::class);
+        }
+
+        return $this->suppressionService;
+    }
+
     /** Per-run cache of post reach radius in metres, keyed by msgid. */
     private array $reachRadiusCache = [];
 
@@ -133,6 +152,8 @@ class UnifiedDigestService
                     $stats['emails_sent'] += $result['count'];
                 } elseif ($result['status'] === 'no_posts') {
                     $stats['no_new_posts']++;
+                } elseif ($result['status'] === 'suppressed') {
+                    $stats['suppressed'] = ($stats['suppressed'] ?? 0) + 1;
                 }
             } catch (\Exception $e) {
                 Log::error("UnifiedDigestService: Failed to send digest to user {$user->id}", [
@@ -369,6 +390,16 @@ class UnifiedDigestService
             $sponsorsCache = null;
             foreach ($users as $uid => $user) {
                 if (!$user->email_preferred) {
+                    continue;
+                }
+                // The member's provider is refusing our mail, so rendering
+                // this would only add to a queue that cannot drain. Skipped
+                // here rather than at send time because the MJML render below
+                // is what actually costs us. Nothing to catch up later: the
+                // group cursor advances regardless of individual recipients
+                // (see $lastProcessed below), and a three-day-old OFFER is
+                // taken or gone by the time a provider recovers anyway.
+                if ($this->suppressions()->shouldSkip($user->email_preferred, (int) $uid, 'digest_immediate')) {
                     continue;
                 }
                 // Distance-preference filter (settings.browseMaxDistance) — skip
@@ -1034,6 +1065,13 @@ class UnifiedDigestService
             if (!$user->email_preferred) {
                 continue;
             }
+            // Provider is deferring us. Skipping before spool deliberately
+            // leaves rippling_reach_notified unwritten, so if the provider
+            // recovers while the post is still inside the reach window the
+            // next tick picks this member up again by itself.
+            if ($this->suppressions()->shouldSkip($user->email_preferred, (int) $user->id, 'digest_immediate')) {
+                continue;
+            }
             // Distance-preference filter (settings.browseMaxDistance). Deliberately
             // does NOT write rippling_reach_notified on a filtered-out skip (unlike
             // the "already sent" path below) - see the design doc's "Reach-mail
@@ -1557,7 +1595,7 @@ class UnifiedDigestService
      *
      * @param User $user
      * @param string $mode
-     * @return array{status: 'sent'|'no_posts'|'skipped', count: int}
+     * @return array{status: 'sent'|'no_posts'|'skipped'|'suppressed', count: int}
      */
     protected function sendDigestToUser(User $user, string $mode, bool $dryRun = false): array
     {
@@ -1566,6 +1604,16 @@ class UnifiedDigestService
         if (!$email) {
             Log::debug("UnifiedDigestService: User {$user->id} has no email address");
             return ['status' => 'skipped', 'count' => 0];
+        }
+
+        // The member's provider is refusing our mail. Return BEFORE the
+        // digest tracker is touched: leaving the watermark where it is means
+        // that when the provider recovers, the next daily run spans the whole
+        // gap and sends exactly one catch-up digest covering it, rather than
+        // one stale digest per day missed. That is the entire catch-up
+        // mechanism for digests - no replay queue needed.
+        if ($this->suppressions()->shouldSkip($email, (int) $user->id, 'digest_' . $mode)) {
+            return ['status' => 'suppressed', 'count' => 0];
         }
 
         // Get or create digest tracking record.

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -115,6 +115,7 @@ class UnifiedDigestService
             'users_processed' => 0,
             'emails_sent' => 0,
             'no_new_posts' => 0,
+            'suppressed' => 0,
             'errors' => 0,
         ];
 
@@ -153,7 +154,7 @@ class UnifiedDigestService
                 } elseif ($result['status'] === 'no_posts') {
                     $stats['no_new_posts']++;
                 } elseif ($result['status'] === 'suppressed') {
-                    $stats['suppressed'] = ($stats['suppressed'] ?? 0) + 1;
+                    $stats['suppressed']++;
                 }
             } catch (\Exception $e) {
                 Log::error("UnifiedDigestService: Failed to send digest to user {$user->id}", [

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -176,6 +176,68 @@ return [
         'trashnothing_domain' => env('FREEGLE_TRASHNOTHING_DOMAIN', 'trashnothing.com'),
         // Trash Nothing shared secret for mail authentication (skips spam check)
         'trashnothing_secret' => env('FREEGLE_TRASHNOTHING_SECRET', ''),
+
+        // Deferral-aware suppression (mail:deferrals:scan).
+        //
+        // Our relay 250-accepts a message and only later finds the receiving
+        // provider will not take it, so nothing in the sending path can see a
+        // deferral. This block configures the probe that reads the relay's
+        // own queue and the thresholds that decide when to stop generating.
+        'deferrals' => [
+            // Master switch. Off means the command no-ops and is not even
+            // scheduled, matching how ripple/firstreply are gated.
+            'enabled' => (bool) env('FREEGLE_MAIL_DEFERRALS_ENABLED', false),
+
+            // ssh target for the outbound relay, e.g. "deferrals@10.0.0.1".
+            // As with FREEGLE_MONITORING_HOSTS the estate's topology lives
+            // ONLY in the environment (.env.background on the batch host),
+            // never in committed code. Empty = disabled (dev/CI).
+            'host' => env('FREEGLE_MAIL_DEFERRALS_HOST', ''),
+
+            // Private key path INSIDE the container, bind-mounted from
+            // MAIL_DEFERRALS_SSH_KEY_HOST_PATH. Deliberately its own key
+            // rather than the monitoring one: that key is a root shell across
+            // the whole estate, whereas this only ever needs to read a queue.
+            // Ops restricts it with a forced command in authorized_keys.
+            'ssh_key' => env('FREEGLE_MAIL_DEFERRALS_SSH_KEY', '/etc/mail-deferrals-ssh-key'),
+
+            // Longer than the monitoring probe's 30s: during an incident the
+            // queue listing is the bulk of the payload, and a timeout here
+            // means flying blind for another cycle.
+            'ssh_timeout_seconds' => (int) env('FREEGLE_MAIL_DEFERRALS_SSH_TIMEOUT', 120),
+
+            // Cap on the queue listing we will pull back, so a runaway queue
+            // cannot exhaust PHP's memory. Truncation is reported and only
+            // ever understates the counts, which is safe against thresholds
+            // that are themselves lower bounds.
+            'max_queue_bytes' => (int) env('FREEGLE_MAIL_DEFERRALS_MAX_QUEUE_BYTES', 64 * 1024 * 1024),
+
+            // MX-group tier. Suppress a relay family once this many of its
+            // messages are deferred AND deliveries to it have all but
+            // stopped. During the 2026-08-15 Yahoo incident the ratio was
+            // about one delivery an hour against tens of thousands of
+            // deferral events, so this is not a close call in practice.
+            'mxgroup_min_deferred' => (int) env('FREEGLE_MAIL_DEFERRALS_MXGROUP_MIN', 500),
+            'mxgroup_max_delivered_per_hour' => (int) env('FREEGLE_MAIL_DEFERRALS_MXGROUP_MAX_DELIVERED', 10),
+
+            // Per-address tier. Catches "452 4.2.2 ... over quota", which is
+            // one person's mailbox rather than our reputation, so it wants a
+            // slower and more forgiving trigger.
+            'address_min_deferred' => (int) env('FREEGLE_MAIL_DEFERRALS_ADDRESS_MIN', 5),
+            'address_min_hours' => (int) env('FREEGLE_MAIL_DEFERRALS_ADDRESS_HOURS', 24),
+
+            // Release. Deliveries must have resumed and the deferred count
+            // must have fallen below this for two consecutive scans, so a
+            // single quiet scan inside a backoff window cannot reopen the
+            // floodgates.
+            'release_max_deferred' => (int) env('FREEGLE_MAIL_DEFERRALS_RELEASE_MAX', 100),
+            'release_clear_scans' => (int) env('FREEGLE_MAIL_DEFERRALS_RELEASE_SCANS', 2),
+
+            // How long a suppression may stand without the scan confirming it
+            // still applies. If the probe breaks we must fail open rather
+            // than silently stop mailing a provider for ever.
+            'stale_after_hours' => (int) env('FREEGLE_MAIL_DEFERRALS_STALE_HOURS', 24),
+        ],
     ],
 
     'mod_welfare' => [

--- a/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables.php
+++ b/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables.php
@@ -120,6 +120,14 @@ return new class extends Migration
                 // in the same terms as the mail it replaces.
                 $table->string('emailtype', 32);
 
+                // Which suppression was in force when we declined. Recorded
+                // at the time rather than re-derived later, because working
+                // out afterwards which provider was refusing a given member
+                // means resolving their send address the same way the mailer
+                // does - a ranking, not a flag - which is not something a
+                // reporting query should be reimplementing.
+                $table->unsignedBigInteger('suppressionid')->nullable();
+
                 $table->unsignedInteger('count')->default(0);
                 $table->timestamp('firstat')->useCurrent();
                 $table->timestamp('lastat')->useCurrent();
@@ -135,6 +143,7 @@ return new class extends Migration
                 $table->unique(['userid', 'emailtype'], 'userid_emailtype');
                 // The catch-up sweep: everything still owed.
                 $table->index(['caughtup_at'], 'caughtup_at');
+                $table->index(['suppressionid'], 'suppressionid');
             });
         }
 

--- a/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables.php
+++ b/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables.php
@@ -147,9 +147,37 @@ return new class extends Migration
             });
         }
 
+        $this->addActiveUniqueIndex();
         $this->addForeignKeys();
     }
 
+    /**
+     * At most one ACTIVE row per (scope, value).
+     *
+     * MySQL has no partial indexes, so a stored generated column holds the
+     * value only while the row is active and NULL once it is released. A
+     * unique index over that column enforces "one live suppression per
+     * target" while letting history keep as many released rows for the same
+     * target as it likes, because repeated NULLs do not collide.
+     *
+     * Without this, a scan that died half way could leave two active rows
+     * for one provider. activeByKey() keys its map on scope+value, so the
+     * second would be invisible to the scan and would keep gating mail long
+     * after the first was released.
+     */
+    private function addActiveUniqueIndex(): void
+    {
+        if (! Schema::hasTable('mail_suppressions') || Schema::hasColumn('mail_suppressions', 'active_value')) {
+            return;
+        }
+
+        DB::statement('ALTER TABLE mail_suppressions
+            ADD COLUMN active_value VARCHAR(255)
+            GENERATED ALWAYS AS (IF(released_at IS NULL, value, NULL)) STORED');
+
+        DB::statement('ALTER TABLE mail_suppressions
+            ADD UNIQUE KEY scope_active_value (scope, active_value)');
+    }
     /**
      * Foreign keys go in afterwards, guarded, so a re-run against a database
      * that already has them is a no-op rather than an error.
@@ -168,6 +196,17 @@ return new class extends Migration
                 $table->foreign('parentid', 'mail_suppressions_parentid_foreign')
                     ->references('id')->on('mail_suppressions')
                     ->onDelete('cascade');
+            });
+        }
+
+        if (Schema::hasTable('mail_suppressed_counts') && ! $exists('mail_suppressed_counts_suppressionid_foreign')) {
+            Schema::table('mail_suppressed_counts', function (Blueprint $table) {
+                // SET NULL rather than CASCADE: once a suppression's history
+                // is gone we still want to know we held mail for this member,
+                // just not which provider it was.
+                $table->foreign('suppressionid', 'mail_suppressed_counts_suppressionid_foreign')
+                    ->references('id')->on('mail_suppressions')
+                    ->onDelete('set null');
             });
         }
 

--- a/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables.php
+++ b/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables.php
@@ -1,0 +1,179 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tables behind deferral-aware mail suppression.
+ *
+ * Our bulk relay accepts a message with a 250 and only then discovers that the
+ * receiving provider will not take it. When a provider starts deferring us -
+ * 2026-08-15, Yahoo began 421-ing everything from the relay's IP with
+ * "[TSS04] ... temporarily deferred due to unexpected volume or user
+ * complaints" - the sending code sees nothing wrong and keeps rendering mail
+ * into a queue that cannot drain. Three days of that put 85,537 messages in
+ * the queue for about 9,400 people who received none of them.
+ *
+ * `mail_suppressions` is the gate. A row says "do not generate mail for this
+ * target until further notice". Scope is deliberately layered:
+ *
+ *   mxgroup  the relay host family the deferrals came from, e.g.
+ *            am0.yahoodns.net. This is the row that carries the evidence,
+ *            because a provider blocks per IP-to-relay pair, not per domain:
+ *            one Yahoo block took out yahoo.co.uk, yahoo.com, ymail.com,
+ *            rocketmail.com, aol.com, aol.co.uk, aim.com and sky.com, the
+ *            last of which is not recognisably Yahoo from its domain at all.
+ *   domain   a recipient domain seen deferring via a suppressed mxgroup.
+ *            Written as a child of the mxgroup row (see parentid) so the
+ *            per-address gate is a plain indexed lookup with no DNS in the
+ *            sending loop.
+ *   address  one mailbox, for the slower per-address signal that catches
+ *            "452 4.2.2 Recipient mailbox quota exceeded" - a real problem
+ *            with one person's mailbox rather than with our reputation.
+ *
+ * Rows are kept after release so the history of an episode survives; the
+ * active set is `released_at IS NULL`.
+ *
+ * Deliberately NOT users.bouncing. That flag means "this address is bad",
+ * it is shown to moderators as such, and historically it was never reset.
+ * A deferral is our reputation problem, not the member's address problem,
+ * and it has to read differently everywhere it surfaces.
+ *
+ * `mail_suppressed_counts` is what release needs. We do not store rendered
+ * mail - that would defeat the point of not rendering it - so instead we
+ * count, per member and per type of mail, what we declined to generate.
+ * On release that is enough to send one catch-up digest and one "you have
+ * unread messages" summary rather than replaying nine stale emails.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('mail_suppressions')) {
+            Schema::create('mail_suppressions', function (Blueprint $table) {
+                $table->comment('Targets we must not generate mail for while a provider is deferring us');
+                $table->bigIncrements('id');
+
+                // What kind of thing `value` names. See the class comment.
+                $table->enum('scope', ['mxgroup', 'domain', 'address']);
+                $table->string('value');
+
+                // Domain rows are derived from the mxgroup row that explains
+                // them, so releasing the parent releases the children and the
+                // reason only has to be recorded once.
+                $table->unsignedBigInteger('parentid')->nullable();
+
+                // The provider's own words, e.g. the 421 line we were given.
+                // Kept verbatim: when this fires at 3am it is the only
+                // evidence of why.
+                $table->text('reason')->nullable();
+
+                // Friendly name for the member-facing and moderator-facing
+                // text ("Yahoo is not currently accepting our mail").
+                // Nullable because we can always fall back to the value.
+                $table->string('provider', 64)->nullable();
+
+                // Arrival time of the oldest still-deferred message for this
+                // target. This is the "delayed since" date moderators see,
+                // and it is deliberately the start of the member's problem
+                // rather than the moment we noticed it.
+                $table->timestamp('deferred_since')->nullable();
+
+                $table->timestamp('first_seen')->useCurrent();
+                $table->timestamp('last_seen')->useCurrent();
+
+                // NULL while active. Set when deliveries resume and the
+                // deferred count has stayed below threshold for two
+                // consecutive scans.
+                $table->timestamp('released_at')->nullable();
+
+                // Deferred messages seen for this target at the last scan.
+                $table->unsignedInteger('message_count')->default(0);
+
+                // Consecutive scans that looked clear. Release needs two, so
+                // that a single quiet scan during a backoff window does not
+                // reopen the floodgates.
+                $table->unsignedTinyInteger('clear_scans')->default(0);
+
+                $table->timestamp('created')->useCurrent();
+                $table->timestamp('modified')->useCurrent()->useCurrentOnUpdate();
+
+                // The sending-loop lookup: scope + value + still active.
+                $table->index(['scope', 'value', 'released_at'], 'scope_value_released');
+                // Listing the active set, and expiring old history.
+                $table->index(['released_at'], 'released_at');
+                $table->index(['parentid'], 'parentid');
+            });
+        }
+
+        if (! Schema::hasTable('mail_suppressed_counts')) {
+            Schema::create('mail_suppressed_counts', function (Blueprint $table) {
+                $table->comment('What we declined to generate per member, so release can send one catch-up');
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('userid');
+
+                // The emailType already passed to EmailSpoolerService::spool(),
+                // e.g. digest_immediate, digest, chat, engage. Keeping the
+                // same vocabulary means the catch-up policy can be expressed
+                // in the same terms as the mail it replaces.
+                $table->string('emailtype', 32);
+
+                $table->unsignedInteger('count')->default(0);
+                $table->timestamp('firstat')->useCurrent();
+                $table->timestamp('lastat')->useCurrent();
+
+                // Claimed by the catch-up pass before it sends, so a crash
+                // mid-release cannot send the same catch-up twice. Cleared
+                // again if a later episode suppresses the same member.
+                $table->timestamp('caughtup_at')->nullable();
+
+                $table->timestamp('created')->useCurrent();
+                $table->timestamp('modified')->useCurrent()->useCurrentOnUpdate();
+
+                $table->unique(['userid', 'emailtype'], 'userid_emailtype');
+                // The catch-up sweep: everything still owed.
+                $table->index(['caughtup_at'], 'caughtup_at');
+            });
+        }
+
+        $this->addForeignKeys();
+    }
+
+    /**
+     * Foreign keys go in afterwards, guarded, so a re-run against a database
+     * that already has them is a no-op rather than an error.
+     */
+    private function addForeignKeys(): void
+    {
+        $exists = function (string $name): bool {
+            return DB::table('information_schema.TABLE_CONSTRAINTS')
+                ->whereRaw('CONSTRAINT_SCHEMA = DATABASE()')
+                ->where('CONSTRAINT_NAME', $name)
+                ->exists();
+        };
+
+        if (Schema::hasTable('mail_suppressions') && ! $exists('mail_suppressions_parentid_foreign')) {
+            Schema::table('mail_suppressions', function (Blueprint $table) {
+                $table->foreign('parentid', 'mail_suppressions_parentid_foreign')
+                    ->references('id')->on('mail_suppressions')
+                    ->onDelete('cascade');
+            });
+        }
+
+        if (Schema::hasTable('mail_suppressed_counts') && ! $exists('mail_suppressed_counts_userid_foreign')) {
+            Schema::table('mail_suppressed_counts', function (Blueprint $table) {
+                $table->foreign('userid', 'mail_suppressed_counts_userid_foreign')
+                    ->references('id')->on('users')
+                    ->onDelete('cascade');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mail_suppressed_counts');
+        Schema::dropIfExists('mail_suppressions');
+    }
+};

--- a/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables_migration.sql
@@ -34,7 +34,13 @@ CREATE TABLE IF NOT EXISTS `mail_suppressions` (
   `clear_scans` tinyint unsigned NOT NULL DEFAULT '0',
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  -- Holds the value only while the row is active, so the unique key below
+  -- enforces one live suppression per target. MySQL has no partial indexes,
+  -- and repeated NULLs do not collide, so history keeps as many released
+  -- rows for the same target as it likes.
+  `active_value` varchar(255) GENERATED ALWAYS AS (if((`released_at` is null),`value`,NULL)) STORED,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `scope_active_value` (`scope`,`active_value`),
   KEY `scope_value_released` (`scope`,`value`,`released_at`),
   KEY `released_at` (`released_at`),
   KEY `parentid` (`parentid`),

--- a/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables_migration.sql
@@ -46,6 +46,8 @@ CREATE TABLE IF NOT EXISTS `mail_suppressed_counts` (
   `userid` bigint unsigned NOT NULL,
   -- The emailType already passed to EmailSpoolerService::spool().
   `emailtype` varchar(32) NOT NULL,
+  -- Which suppression was in force when we declined, recorded at the time.
+  `suppressionid` bigint unsigned DEFAULT NULL,
   `count` int unsigned NOT NULL DEFAULT '0',
   `firstat` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `lastat` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -56,5 +58,7 @@ CREATE TABLE IF NOT EXISTS `mail_suppressed_counts` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `userid_emailtype` (`userid`,`emailtype`),
   KEY `caughtup_at` (`caughtup_at`),
+  KEY `suppressionid` (`suppressionid`),
+  CONSTRAINT `mail_suppressed_counts_suppressionid_foreign` FOREIGN KEY (`suppressionid`) REFERENCES `mail_suppressions` (`id`) ON DELETE SET NULL,
   CONSTRAINT `mail_suppressed_counts_userid_foreign` FOREIGN KEY (`userid`) REFERENCES `users` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='What we declined to generate per member, so release can send one catch-up';

--- a/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables_migration.sql
+++ b/iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables_migration.sql
@@ -1,0 +1,60 @@
+-- Production idempotent SQL: the tables behind deferral-aware mail suppression.
+--
+-- Our bulk relay accepts a message with a 250 and only then discovers that the receiving
+-- provider will not take it. When a provider starts deferring us - 2026-08-15, Yahoo began
+-- 421-ing everything from the relay's IP with "[TSS04] ... temporarily deferred due to
+-- unexpected volume or user complaints" - the sending code sees nothing wrong and keeps
+-- rendering mail into a queue that cannot drain.
+--
+-- mail_suppressions is the gate; mail_suppressed_counts is what release needs in order to
+-- send one catch-up rather than replaying the backlog.
+--
+-- All CREATE TABLE IF NOT EXISTS, so this is safe to re-run.
+-- See 2026_08_18_000001_create_mail_suppressions_tables.php.
+
+CREATE TABLE IF NOT EXISTS `mail_suppressions` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  -- mxgroup = the relay host family that deferred us (the row carrying the evidence);
+  -- domain = a recipient domain seen deferring via that relay, derived as a child row;
+  -- address = one mailbox, for the per-address quota-exceeded signal.
+  `scope` enum('mxgroup','domain','address') NOT NULL,
+  `value` varchar(255) NOT NULL,
+  `parentid` bigint unsigned DEFAULT NULL,
+  -- The provider's own words, kept verbatim.
+  `reason` text,
+  `provider` varchar(64) DEFAULT NULL,
+  -- Arrival time of the oldest still-deferred message: the "delayed since" date.
+  `deferred_since` timestamp NULL DEFAULT NULL,
+  `first_seen` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_seen` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  -- NULL while active.
+  `released_at` timestamp NULL DEFAULT NULL,
+  `message_count` int unsigned NOT NULL DEFAULT '0',
+  -- Release needs two consecutive clear scans.
+  `clear_scans` tinyint unsigned NOT NULL DEFAULT '0',
+  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `scope_value_released` (`scope`,`value`,`released_at`),
+  KEY `released_at` (`released_at`),
+  KEY `parentid` (`parentid`),
+  CONSTRAINT `mail_suppressions_parentid_foreign` FOREIGN KEY (`parentid`) REFERENCES `mail_suppressions` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Targets we must not generate mail for while a provider is deferring us';
+
+CREATE TABLE IF NOT EXISTS `mail_suppressed_counts` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `userid` bigint unsigned NOT NULL,
+  -- The emailType already passed to EmailSpoolerService::spool().
+  `emailtype` varchar(32) NOT NULL,
+  `count` int unsigned NOT NULL DEFAULT '0',
+  `firstat` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `lastat` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  -- Claimed by the catch-up pass before it sends.
+  `caughtup_at` timestamp NULL DEFAULT NULL,
+  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `userid_emailtype` (`userid`,`emailtype`),
+  KEY `caughtup_at` (`caughtup_at`),
+  CONSTRAINT `mail_suppressed_counts_userid_foreign` FOREIGN KEY (`userid`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='What we declined to generate per member, so release can send one catch-up';

--- a/iznik-batch/resources/views/emails/mjml/deferrals/unread-chat-catchup.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/deferrals/unread-chat-catchup.blade.php
@@ -1,0 +1,55 @@
+<mjml>
+  @include('emails.mjml.partials.head', ['preview' => 'You have unread messages waiting'])
+
+  <mj-body background-color="#f4f4f4">
+
+    @include('emails.mjml.partials.header')
+
+    <mj-section background-color="#ffffff" padding="20px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="bold">
+          You have unread messages
+        </mj-text>
+        <mj-text>
+          Hi {{ $recipientName }},
+        </mj-text>
+        <mj-text>
+          @if ($provider)
+            {{ $provider }} stopped accepting our emails on {{ $delayedSince }}, so we held off sending you
+            notifications rather than fill your inbox with messages that would not have arrived.
+          @else
+            Your email provider stopped accepting our emails on {{ $delayedSince }}, so we held off sending you
+            notifications rather than fill your inbox with messages that would not have arrived.
+          @endif
+          That is now fixed.
+        </mj-text>
+        <mj-text>
+          @if ($chatCount === 1)
+            While it was going on you had
+            {{ $messageCount === 1 ? 'a message' : $messageCount . ' messages' }}
+            in one chat.
+          @else
+            While it was going on you had
+            {{ $messageCount === 1 ? 'a message' : $messageCount . ' messages' }}
+            across {{ $chatCount }} chats.
+          @endif
+          We are sending this one email rather than all of them.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="0 20px 20px">
+      <mj-column>
+        <mj-button href="{{ $chatsUrl }}" border-radius="3px" font-size="16px">
+          Read your messages
+        </mj-button>
+        <mj-text font-size="13px" color="#666666">
+          Sorry about the gap. It was our problem, not yours, and nothing you sent was lost.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    @include('emails.mjml.partials.footer', ['email' => $email, 'settingsUrl' => $settingsUrl])
+
+  </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/text/deferrals/unread-chat-catchup.blade.php
+++ b/iznik-batch/resources/views/emails/text/deferrals/unread-chat-catchup.blade.php
@@ -1,0 +1,12 @@
+Hi {{ $recipientName }},
+
+@if ($provider){{ $provider }} stopped @else Your email provider stopped @endif accepting our emails on {{ $delayedSince }}, so we held off sending you notifications rather than fill your inbox with messages that would not have arrived. That is now fixed.
+
+@if ($chatCount === 1)While it was going on you had {{ $messageCount === 1 ? 'a message' : $messageCount . ' messages' }} in one chat.@else While it was going on you had {{ $messageCount === 1 ? 'a message' : $messageCount . ' messages' }} across {{ $chatCount }} chats.@endif We are sending this one email rather than all of them.
+
+Read your messages: {{ $chatsUrl }}
+
+Sorry about the gap. It was our problem, not yours, and nothing you sent was lost.
+
+--
+Change your email settings: {{ $settingsUrl }}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -635,32 +635,55 @@ foreach (range(0, $dailyShardCount - 1) as $dailyShard) {
 }
 
 // "Still lagging" alert — one hour after the 07:00-12:00 daily window closes, check whether the
-// morning run kept up. Counts recently-active daily recipients (sent within the last 7 days, so
-// this excludes the permanently-inactive who never get a digest and the never-sent) who did NOT
-// get today's digest. In steady state the morning window clears them and this is ~0; a large
-// count means we're under capacity and the lag is rotating (see streamDailyOverdueFirst) — the
+// morning run kept up. Counts daily recipients who did NOT get today's digest. In steady state
+// the morning window clears them and this is ~0; a large count means we're under capacity — the
 // signal to add throughput/hardware. Logged at error level so it reaches Sentry; fires daily
 // until capacity catches up, which is the intended KPI, not noise.
+//
+// This used to count only people whose last digest was within seven days, to leave out the
+// permanently-inactive and the never-sent. That also left out anyone who had fallen more than a
+// week behind, which is the group the alert most needs to report: measured on production
+// 2026-08-17, 2,003 members who are still using the site, are not bouncing, and still have a
+// community set to a daily digest had not had one for over a week, and 384 of them had not had
+// one for over a month. None of them appeared in this number. The claim that the lag rotates
+// fairly and nobody is permanently starved was not true, and this was the reason nobody could
+// see that.
+//
+// So the seven-day window is gone, and dormancy is excluded by asking whether the member has
+// used the site rather than by how long ago we last managed to mail them. Never-sent recipients
+// still have no row here, so they are still out of scope.
 Schedule::call(function () {
     $londonDayStartUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->setTimezone('UTC')->toDateTimeString();
-    $activeSinceUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->subDays(7)->setTimezone('UTC')->toDateTimeString();
+    $activeSinceUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->subDays(30)->setTimezone('UTC')->toDateTimeString();
 
-    $lagging = \Illuminate\Support\Facades\DB::table('users_digests')
-        ->where('mode', 'daily')
-        ->where('lastsent', '>=', $activeSinceUtc)
-        ->where('lastsent', '<', $londonDayStartUtc)
+    $laggingQuery = \Illuminate\Support\Facades\DB::table('users_digests')
+        ->join('users', 'users.id', '=', 'users_digests.userid')
+        ->where('users_digests.mode', 'daily')
+        ->where('users_digests.lastsent', '<', $londonDayStartUtc)
+        ->whereNull('users.deleted')
+        ->where('users.lastaccess', '>=', $activeSinceUtc);
+
+    $lagging = (clone $laggingQuery)->count();
+
+    // How much of that is more than a week old. The old measure could not see any of this, so
+    // report it separately: a rising figure here means the backlog is not rotating but settling
+    // on the same people.
+    $overAWeek = (clone $laggingQuery)
+        ->where('users_digests.lastsent', '<', \Carbon\Carbon::parse($londonDayStartUtc)->subDays(7)->toDateTimeString())
         ->count();
 
     $threshold = (int) env('FREEGLE_DIGEST_DAILY_LAG_ALERT_THRESHOLD', 5000);
     if ($lagging > $threshold) {
         \Illuminate\Support\Facades\Log::error('Daily digest still lagging after the 07:00-12:00 window', [
             'lagging_active_recipients' => $lagging,
+            'of_which_over_a_week_behind' => $overAWeek,
             'threshold' => $threshold,
             'checked_at' => 'London 13:00',
         ]);
     } else {
         \Illuminate\Support\Facades\Log::info('Daily digest kept up with the morning window', [
             'lagging_active_recipients' => $lagging,
+            'of_which_over_a_week_behind' => $overAWeek,
         ]);
     }
 })

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -652,6 +652,15 @@ foreach (range(0, $dailyShardCount - 1) as $dailyShard) {
 // So the seven-day window is gone, and dormancy is excluded by asking whether the member has
 // used the site rather than by how long ago we last managed to mail them. Never-sent recipients
 // still have no row here, so they are still out of scope.
+//
+// The same slot also asks whether the mail we sent actually arrived, per receiving domain. That
+// is not the same question and the lag figures cannot answer it. On 2026-08-16 every Yahoo-run
+// domain - yahoo.co.uk, yahoo.com, aol.com, sky.com, ymail.com, rocketmail.com - went from a
+// steady 16-36% open rate to zero and stayed there, following a send five times the normal daily
+// volume on 14 August. That is roughly 35,000 emails a day going nowhere. Nothing alerted,
+// because from our side every one of them was handed to the smarthost and accepted. Run against
+// production on 18 August the check below flags those six domains and nothing else. See
+// DeliveryHealthService.
 Schedule::call(function () {
     $londonDayStartUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->setTimezone('UTC')->toDateTimeString();
     $activeSinceUtc = \Carbon\Carbon::now('Europe/London')->startOfDay()->subDays(30)->setTimezone('UTC')->toDateTimeString();
@@ -685,6 +694,24 @@ Schedule::call(function () {
             'lagging_active_recipients' => $lagging,
             'of_which_over_a_week_behind' => $overAWeek,
         ]);
+    }
+
+    // Whether the mail we did send actually arrived is a separate question, and the figures
+    // above cannot answer it: they say we sent, not that anybody received. A provider that
+    // starts binning our mail leaves the lag looking perfectly healthy. Reported as its own
+    // log line rather than folded into the one above, so the two problems stay two Sentry
+    // issues - "we are short of capacity" and "a provider has stopped taking our mail" have
+    // nothing to do with each other and want different people.
+    $collapsed = app(\App\Services\Mail\DeliveryHealthService::class)->collapsedDomains();
+
+    if ($collapsed) {
+        \Illuminate\Support\Facades\Log::error('Email delivery has collapsed at one or more domains', [
+            'domains' => $collapsed,
+            'affected_recipients' => array_sum(array_column($collapsed, 'recent_sent')),
+            'checked_at' => 'London 13:00',
+        ]);
+    } else {
+        \Illuminate\Support\Facades\Log::info('Email delivery looks normal across domains');
     }
 })
     ->name('mail:digest:daily-lag-check')

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -824,6 +824,28 @@ Schedule::command('queue:background-tasks --max-iterations=60 --spool')
     ->appendOutputTo(cronLog('queue:background-tasks'))
     ->runInBackground();
 
+// Deferral-aware mail suppression.
+//
+// Our relay 250-accepts mail and only afterwards finds out that the receiving
+// provider will not take it, so nothing in the sending path can see a
+// deferral. This reads the relay's own queue, suppresses generation for
+// providers that have stopped accepting us, releases when they recover, and
+// alerts on the way in. Gated on config so it is not even scheduled where the
+// relay is unreachable (dev, CI), matching how ripple/firstreply are gated.
+//
+// Fifteen minutes is chosen against the incident it exists for: the queue was
+// growing by about 1,300 an hour, so this bounds what we can generate into a
+// blocked provider at roughly 300 messages. Deliberately no ->sentryMonitor():
+// it uses withoutOverlapping(), and Sentry derives its expected cadence from
+// the raw cron expression, so a blocked run would page as a missed check-in.
+if (config('freegle.mail.deferrals.enabled')) {
+    Schedule::command('mail:deferrals:scan')
+        ->everyFifteenMinutes()
+        ->withoutOverlapping(30)
+        ->sendOutputTo(cronLog('mail:deferrals:scan'))
+        ->runInBackground();
+}
+
 // Clean up old sent emails - run daily.
 Schedule::command('mail:spool:process --cleanup --cleanup-days=7')
     ->dailyAt('04:00')

--- a/iznik-batch/tests/Feature/Mail/DeferralCatchUpServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/DeferralCatchUpServiceTest.php
@@ -30,20 +30,21 @@ class DeferralCatchUpServiceTest extends TestCase
         $this->catchUp = new DeferralCatchUpService($this->suppressions);
     }
 
-    private function owe(int $userId, string $type, int $count = 9): void
+    private function owe(int $userId, string $type, int $count = 9, ?int $suppressionId = null): void
     {
         DB::table('mail_suppressed_counts')->insert([
             'userid' => $userId,
             'emailtype' => $type,
+            'suppressionid' => $suppressionId,
             'count' => $count,
             'firstat' => '2026-08-15 16:38:00',
             'lastat' => now(),
         ]);
     }
 
-    private function suppressDomain(string $domain): void
+    private function suppressDomain(string $domain): int
     {
-        DB::table('mail_suppressions')->insert([
+        $id = DB::table('mail_suppressions')->insertGetId([
             'scope' => 'domain',
             'value' => $domain,
             'provider' => 'Yahoo',
@@ -53,6 +54,8 @@ class DeferralCatchUpServiceTest extends TestCase
             'last_seen' => now(),
         ]);
         $this->suppressions->flushCache();
+
+        return $id;
     }
 
     public function test_sends_one_summary_for_unread_chats_not_one_per_message(): void
@@ -244,16 +247,16 @@ class DeferralCatchUpServiceTest extends TestCase
         $member = $this->createTestUser(['email_preferred' => 'held' . uniqid() . '@yahoo.co.uk']);
         $other = $this->createTestUser();
         $this->createTestChatMessage($this->createTestChatRoom($other, $member), $other);
-        $this->owe($member->id, 'chat', 4);
-
-        // Released, so the gate is open, but the history is still there to
-        // name who was refusing us.
-        DB::table('mail_suppressions')->insert([
+        // Released, so the gate is open, but the suppression we recorded at
+        // the time is still there to name who was refusing us.
+        $id = DB::table('mail_suppressions')->insertGetId([
             'scope' => 'domain', 'value' => 'yahoo.co.uk', 'provider' => 'Yahoo',
             'reason' => '421', 'deferred_since' => '2026-08-15 16:38:00',
             'first_seen' => now(), 'last_seen' => now(), 'released_at' => now(),
         ]);
         $this->suppressions->flushCache();
+
+        $this->owe($member->id, 'chat', 4, $id);
 
         $this->catchUp->run();
 

--- a/iznik-batch/tests/Feature/Mail/DeferralCatchUpServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/DeferralCatchUpServiceTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Mail\Deferrals\UnreadChatCatchUpMail;
+use App\Models\ChatRoom;
+use App\Services\Mail\Deferrals\DeferralCatchUpService;
+use App\Services\Mail\MailSuppressionService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * The promise this feature makes to a member is "we held your mail, and when
+ * it cleared we sent you ONE thing" - not "we sent you the nine emails you
+ * missed, all at once". These tests are about keeping that promise.
+ */
+class DeferralCatchUpServiceTest extends TestCase
+{
+    private DeferralCatchUpService $catchUp;
+
+    private MailSuppressionService $suppressions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->suppressions = new MailSuppressionService;
+        $this->suppressions->flushCache();
+        $this->catchUp = new DeferralCatchUpService($this->suppressions);
+    }
+
+    private function owe(int $userId, string $type, int $count = 9): void
+    {
+        DB::table('mail_suppressed_counts')->insert([
+            'userid' => $userId,
+            'emailtype' => $type,
+            'count' => $count,
+            'firstat' => '2026-08-15 16:38:00',
+            'lastat' => now(),
+        ]);
+    }
+
+    private function suppressDomain(string $domain): void
+    {
+        DB::table('mail_suppressions')->insert([
+            'scope' => 'domain',
+            'value' => $domain,
+            'provider' => 'Yahoo',
+            'reason' => '421 4.7.0 [TSS04] temporarily deferred',
+            'deferred_since' => '2026-08-15 16:38:00',
+            'first_seen' => now(),
+            'last_seen' => now(),
+        ]);
+        $this->suppressions->flushCache();
+    }
+
+    public function test_sends_one_summary_for_unread_chats_not_one_per_message(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom($other, $member);
+
+        // Nine messages they were never emailed about - the shape of the real
+        // incident, where members held around nine queued messages each.
+        for ($i = 0; $i < 9; $i++) {
+            $this->createTestChatMessage($room, $other);
+        }
+
+        $this->owe($member->id, 'chat', 9);
+
+        $result = $this->catchUp->run();
+
+        $this->assertSame(1, $result['sent']);
+        Mail::assertSent(UnreadChatCatchUpMail::class, 1);
+        Mail::assertSent(UnreadChatCatchUpMail::class, function ($mail) {
+            return $mail->chatCount === 1 && $mail->messageCount === 9;
+        });
+    }
+
+    public function test_counts_distinct_chats_not_just_messages(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $a = $this->createTestUser();
+        $b = $this->createTestUser();
+
+        $this->createTestChatMessage($this->createTestChatRoom($a, $member), $a);
+        $this->createTestChatMessage($this->createTestChatRoom($b, $member), $b);
+
+        $this->owe($member->id, 'chat', 2);
+
+        $this->catchUp->run();
+
+        Mail::assertSent(UnreadChatCatchUpMail::class, function ($mail) {
+            return $mail->chatCount === 2 && $mail->messageCount === 2;
+        });
+    }
+
+    public function test_does_not_count_the_members_own_messages(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom($other, $member);
+        $this->createTestChatMessage($room, $member);
+
+        $this->owe($member->id, 'chat', 1);
+
+        $result = $this->catchUp->run();
+
+        $this->assertSame(0, $result['sent']);
+        Mail::assertNothingSent();
+    }
+
+    public function test_sends_nothing_when_they_have_caught_up_in_the_meantime(): void
+    {
+        // Read everything already, or the other side gave up. No email is the
+        // right email.
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $this->owe($member->id, 'chat', 5);
+
+        $result = $this->catchUp->run();
+
+        $this->assertSame(0, $result['sent']);
+        $this->assertSame(1, $result['dropped']);
+        Mail::assertNothingSent();
+    }
+
+    public function test_drops_stale_post_and_newsletter_mail_rather_than_replaying_it(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $this->owe($member->id, 'digest_immediate', 52);
+        $this->owe($member->id, 'communitynews', 1);
+        $this->owe($member->id, 'engage', 1);
+
+        $result = $this->catchUp->run();
+
+        $this->assertSame(0, $result['sent']);
+        $this->assertSame(3, $result['dropped']);
+        Mail::assertNothingSent();
+    }
+
+    public function test_daily_digests_are_not_replayed_here(): void
+    {
+        // The digest catch-up is structural, not a replay: the gate returns
+        // before the digest tracker is advanced, so the next daily run spans
+        // the gap by itself. Sending one from here as well would double up.
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $this->owe($member->id, 'digest_daily', 3);
+
+        $result = $this->catchUp->run();
+
+        $this->assertSame(0, $result['sent']);
+        Mail::assertNothingSent();
+    }
+
+    public function test_waits_while_the_member_is_still_suppressed(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser(['email_preferred' => 'held' . uniqid() . '@yahoo.co.uk']);
+        $other = $this->createTestUser();
+        $this->createTestChatMessage($this->createTestChatRoom($other, $member), $other);
+
+        $this->owe($member->id, 'chat', 4);
+        $this->suppressDomain('yahoo.co.uk');
+
+        $result = $this->catchUp->run();
+
+        $this->assertSame(0, $result['sent']);
+        $this->assertSame(1, $result['skipped']);
+        Mail::assertNothingSent();
+
+        // The debt must still be owed, not quietly written off.
+        $this->assertDatabaseHas('mail_suppressed_counts', [
+            'userid' => $member->id, 'caughtup_at' => null,
+        ]);
+    }
+
+    public function test_never_sends_the_same_catch_up_twice(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $other = $this->createTestUser();
+        $this->createTestChatMessage($this->createTestChatRoom($other, $member), $other);
+        $this->owe($member->id, 'chat', 4);
+
+        $this->assertSame(1, $this->catchUp->run()['sent']);
+        $this->assertSame(0, $this->catchUp->run()['sent']);
+
+        Mail::assertSent(UnreadChatCatchUpMail::class, 1);
+    }
+
+    public function test_dry_run_reports_without_sending_or_claiming(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $other = $this->createTestUser();
+        $this->createTestChatMessage($this->createTestChatRoom($other, $member), $other);
+        $this->owe($member->id, 'chat', 4);
+
+        $result = $this->catchUp->run(dryRun: true);
+
+        $this->assertSame(1, $result['sent']);
+        Mail::assertNothingSent();
+        $this->assertDatabaseHas('mail_suppressed_counts', [
+            'userid' => $member->id, 'caughtup_at' => null,
+        ]);
+    }
+
+    public function test_clears_the_debt_for_a_member_with_no_usable_address(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        DB::table('users_emails')->where('userid', $member->id)->delete();
+        $this->owe($member->id, 'chat', 4);
+
+        $result = $this->catchUp->run();
+
+        $this->assertSame(1, $result['dropped']);
+        $this->assertDatabaseMissing('mail_suppressed_counts', [
+            'userid' => $member->id, 'caughtup_at' => null,
+        ]);
+    }
+
+    public function test_the_summary_names_the_provider_and_the_date_it_started(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser(['email_preferred' => 'held' . uniqid() . '@yahoo.co.uk']);
+        $other = $this->createTestUser();
+        $this->createTestChatMessage($this->createTestChatRoom($other, $member), $other);
+        $this->owe($member->id, 'chat', 4);
+
+        // Released, so the gate is open, but the history is still there to
+        // name who was refusing us.
+        DB::table('mail_suppressions')->insert([
+            'scope' => 'domain', 'value' => 'yahoo.co.uk', 'provider' => 'Yahoo',
+            'reason' => '421', 'deferred_since' => '2026-08-15 16:38:00',
+            'first_seen' => now(), 'last_seen' => now(), 'released_at' => now(),
+        ]);
+        $this->suppressions->flushCache();
+
+        $this->catchUp->run();
+
+        Mail::assertSent(UnreadChatCatchUpMail::class, function ($mail) {
+            return $mail->provider === 'Yahoo' && $mail->delayedSince === '15 August';
+        });
+    }
+
+    public function test_chat_room_type_does_not_matter_to_the_summary(): void
+    {
+        // A member waiting on a mod reply is as stranded as one waiting on
+        // another member.
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom($other, $member, ['chattype' => ChatRoom::TYPE_USER2MOD]);
+        $this->createTestChatMessage($room, $other);
+        $this->owe($member->id, 'chat', 1);
+
+        $this->assertSame(1, $this->catchUp->run()['sent']);
+    }
+}

--- a/iznik-batch/tests/Feature/Mail/DeferralCatchUpServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/DeferralCatchUpServiceTest.php
@@ -30,6 +30,27 @@ class DeferralCatchUpServiceTest extends TestCase
         $this->catchUp = new DeferralCatchUpService($this->suppressions);
     }
 
+    /**
+     * Put both people on the chat's roster.
+     *
+     * chat_roster is where the per-(chat, member) email watermark lives, and
+     * ChatNotificationService only ever notifies members who have a row - so
+     * a member with no row would never have been emailed, and would have
+     * nothing to catch up on. Creating them here keeps the fixture honest
+     * about that rather than testing a shape production never produces.
+     */
+    private function roster($room, $user1, $user2): void
+    {
+        foreach ([$user1->id, $user2->id] as $uid) {
+            DB::table('chat_roster')->insertOrIgnore([
+                'chatid' => $room->id,
+                'userid' => $uid,
+                'date' => now(),
+                'status' => 'Online',
+            ]);
+        }
+    }
+
     private function owe(int $userId, string $type, int $count = 9, ?int $suppressionId = null): void
     {
         DB::table('mail_suppressed_counts')->insert([
@@ -66,6 +87,8 @@ class DeferralCatchUpServiceTest extends TestCase
         $other = $this->createTestUser();
         $room = $this->createTestChatRoom($other, $member);
 
+        $this->roster($room, $other, $member);
+
         // Nine messages they were never emailed about - the shape of the real
         // incident, where members held around nine queued messages each.
         for ($i = 0; $i < 9; $i++) {
@@ -91,8 +114,12 @@ class DeferralCatchUpServiceTest extends TestCase
         $a = $this->createTestUser();
         $b = $this->createTestUser();
 
-        $this->createTestChatMessage($this->createTestChatRoom($a, $member), $a);
-        $this->createTestChatMessage($this->createTestChatRoom($b, $member), $b);
+        $room = $this->createTestChatRoom($a, $member);
+        $this->roster($room, $a, $member);
+        $this->createTestChatMessage($room, $a);
+        $room = $this->createTestChatRoom($b, $member);
+        $this->roster($room, $b, $member);
+        $this->createTestChatMessage($room, $b);
 
         $this->owe($member->id, 'chat', 2);
 
@@ -110,6 +137,7 @@ class DeferralCatchUpServiceTest extends TestCase
         $member = $this->createTestUser();
         $other = $this->createTestUser();
         $room = $this->createTestChatRoom($other, $member);
+        $this->roster($room, $other, $member);
         $this->createTestChatMessage($room, $member);
 
         $this->owe($member->id, 'chat', 1);
@@ -174,7 +202,9 @@ class DeferralCatchUpServiceTest extends TestCase
 
         $member = $this->createTestUser(['email_preferred' => 'held' . uniqid() . '@yahoo.co.uk']);
         $other = $this->createTestUser();
-        $this->createTestChatMessage($this->createTestChatRoom($other, $member), $other);
+        $room = $this->createTestChatRoom($other, $member);
+        $this->roster($room, $other, $member);
+        $this->createTestChatMessage($room, $other);
 
         $this->owe($member->id, 'chat', 4);
         $this->suppressDomain('yahoo.co.uk');
@@ -197,7 +227,9 @@ class DeferralCatchUpServiceTest extends TestCase
 
         $member = $this->createTestUser();
         $other = $this->createTestUser();
-        $this->createTestChatMessage($this->createTestChatRoom($other, $member), $other);
+        $room = $this->createTestChatRoom($other, $member);
+        $this->roster($room, $other, $member);
+        $this->createTestChatMessage($room, $other);
         $this->owe($member->id, 'chat', 4);
 
         $this->assertSame(1, $this->catchUp->run()['sent']);
@@ -212,7 +244,9 @@ class DeferralCatchUpServiceTest extends TestCase
 
         $member = $this->createTestUser();
         $other = $this->createTestUser();
-        $this->createTestChatMessage($this->createTestChatRoom($other, $member), $other);
+        $room = $this->createTestChatRoom($other, $member);
+        $this->roster($room, $other, $member);
+        $this->createTestChatMessage($room, $other);
         $this->owe($member->id, 'chat', 4);
 
         $result = $this->catchUp->run(dryRun: true);
@@ -246,7 +280,9 @@ class DeferralCatchUpServiceTest extends TestCase
 
         $member = $this->createTestUser(['email_preferred' => 'held' . uniqid() . '@yahoo.co.uk']);
         $other = $this->createTestUser();
-        $this->createTestChatMessage($this->createTestChatRoom($other, $member), $other);
+        $room = $this->createTestChatRoom($other, $member);
+        $this->roster($room, $other, $member);
+        $this->createTestChatMessage($room, $other);
         // Released, so the gate is open, but the suppression we recorded at
         // the time is still there to name who was refusing us.
         $id = DB::table('mail_suppressions')->insertGetId([
@@ -274,6 +310,7 @@ class DeferralCatchUpServiceTest extends TestCase
         $member = $this->createTestUser();
         $other = $this->createTestUser();
         $room = $this->createTestChatRoom($other, $member, ['chattype' => ChatRoom::TYPE_USER2MOD]);
+        $this->roster($room, $other, $member);
         $this->createTestChatMessage($room, $other);
         $this->owe($member->id, 'chat', 1);
 

--- a/iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Services\Mail\Deferrals\DeferralScanService;
+use App\Services\Mail\Deferrals\RelayQueueSnapshot;
+use App\Services\Mail\MailSuppressionService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The decision layer: what gets suppressed, what gets released, and what is
+ * deliberately left alone.
+ */
+class DeferralScanServiceTest extends TestCase
+{
+    private DeferralScanService $scan;
+
+    private MailSuppressionService $suppressions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'freegle.mail.deferrals.mxgroup_min_deferred' => 500,
+            'freegle.mail.deferrals.mxgroup_max_delivered_per_hour' => 10,
+            'freegle.mail.deferrals.address_min_deferred' => 5,
+            'freegle.mail.deferrals.address_min_hours' => 24,
+            'freegle.mail.deferrals.release_max_deferred' => 100,
+            'freegle.mail.deferrals.release_clear_scans' => 2,
+            'freegle.mail.deferrals.stale_after_hours' => 24,
+        ]);
+
+        $this->suppressions = app(MailSuppressionService::class);
+        $this->suppressions->flushCache();
+        $this->scan = new DeferralScanService($this->suppressions);
+    }
+
+    private const YAHOO_REASON = 'host mta7.am0.yahoodns.net[67.195.228.94] said: 421 4.7.0 '
+        . '[TSS04] Messages from 185.53.57.161 temporarily deferred due to unexpected volume';
+
+    private function snapshotWithYahooBlocked(int $deferred = 52000, ?int $delivered = 1): RelayQueueSnapshot
+    {
+        $s = new RelayQueueSnapshot;
+        $s->groups['yahoodns.net'] = [
+            'count' => $deferred,
+            'oldest' => strtotime('2026-08-15 16:38:00'),
+            'reason' => self::YAHOO_REASON,
+            'domains' => ['yahoo.co.uk' => 30000, 'yahoo.com' => 12000, 'sky.com' => 6000, 'aol.com' => 4000],
+        ];
+        if ($delivered !== null) {
+            $s->delivered['l.google.com'] = 5000;
+            $s->delivered['yahoodns.net'] = $delivered;
+        }
+
+        return $s;
+    }
+
+    // ===================================================================
+    // Suppression
+    // ===================================================================
+
+    public function test_suppresses_a_relay_family_that_has_stopped_taking_our_mail(): void
+    {
+        $result = $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $this->assertCount(1, $result['suppressed']);
+        $this->assertSame('yahoodns.net', $result['suppressed'][0]['value']);
+        $this->assertSame('Yahoo', $result['suppressed'][0]['provider']);
+
+        $this->assertDatabaseHas('mail_suppressions', [
+            'scope' => 'mxgroup',
+            'value' => 'yahoodns.net',
+            'provider' => 'Yahoo',
+            'released_at' => null,
+        ]);
+    }
+
+    public function test_records_the_deferral_start_not_the_moment_we_noticed(): void
+    {
+        // Moderators are shown "delayed since X". X has to be the start of
+        // the member's problem, not the start of our awareness of it.
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $row = DB::table('mail_suppressions')->where('scope', 'mxgroup')->first();
+
+        $this->assertSame('2026-08-15 16:38:00', (string) $row->deferred_since);
+    }
+
+    public function test_materialises_a_domain_row_for_every_domain_seen_behind_the_relay(): void
+    {
+        // Including sky.com, which is Yahoo-hosted and would never be guessed
+        // from the domain name.
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $domains = DB::table('mail_suppressions')->where('scope', 'domain')->pluck('value')->all();
+
+        $this->assertEqualsCanonicalizing(
+            ['yahoo.co.uk', 'yahoo.com', 'sky.com', 'aol.com'],
+            $domains
+        );
+    }
+
+    public function test_the_gate_closes_for_every_domain_behind_the_relay(): void
+    {
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+        $this->suppressions->flushCache();
+
+        $this->assertTrue($this->suppressions->isSuppressed('someone@sky.com'));
+        $this->assertTrue($this->suppressions->isSuppressed('SOMEONE@Yahoo.CO.UK'));
+        $this->assertFalse($this->suppressions->isSuppressed('someone@gmail.com'));
+    }
+
+    public function test_does_not_suppress_a_relay_that_is_merely_busy(): void
+    {
+        // A big backlog while deliveries continue is congestion, not a block.
+        $s = $this->snapshotWithYahooBlocked(deferred: 52000, delivered: 5000);
+
+        $result = $this->scan->apply($s);
+
+        $this->assertSame([], $result['suppressed']);
+        $this->assertDatabaseCount('mail_suppressions', 0);
+    }
+
+    public function test_does_not_suppress_a_backlog_below_the_threshold(): void
+    {
+        $result = $this->scan->apply($this->snapshotWithYahooBlocked(deferred: 100, delivered: 0));
+
+        $this->assertSame([], $result['suppressed']);
+    }
+
+    public function test_suppresses_on_queue_depth_alone_but_says_it_was_blind(): void
+    {
+        // No delivery data means we cannot tell a block from a quiet hour.
+        // A backlog this size is still worth acting on, but the reason must
+        // record that the decision rested on half the evidence.
+        $s = $this->snapshotWithYahooBlocked(deferred: 52000, delivered: null);
+
+        $result = $this->scan->apply($s);
+
+        $this->assertCount(1, $result['suppressed']);
+        $this->assertTrue($result['suppressed'][0]['blind']);
+
+        $row = DB::table('mail_suppressions')->where('scope', 'mxgroup')->first();
+        $this->assertStringContainsString('no delivery data', (string) $row->reason);
+    }
+
+    public function test_dry_run_reports_without_writing(): void
+    {
+        $result = $this->scan->apply($this->snapshotWithYahooBlocked(), dryRun: true);
+
+        $this->assertCount(1, $result['suppressed']);
+        $this->assertDatabaseCount('mail_suppressions', 0);
+    }
+
+    public function test_does_not_duplicate_an_existing_suppression(): void
+    {
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+        $result = $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $this->assertSame([], $result['suppressed']);
+        $this->assertSame(1, DB::table('mail_suppressions')->where('scope', 'mxgroup')->count());
+    }
+
+    // ===================================================================
+    // Per-address tier
+    // ===================================================================
+
+    private function snapshotWithFullMailbox(int $count = 9, string $age = '-3 days'): RelayQueueSnapshot
+    {
+        $s = new RelayQueueSnapshot;
+        $s->addresses['full@example.com'] = [
+            'count' => $count,
+            'oldest' => strtotime($age),
+            'reason' => 'host mx.example.com[203.0.113.10] said: 452 4.2.2 The email account '
+                . 'that you tried to reach is over quota',
+        ];
+        $s->delivered['example.com'] = 500;
+
+        return $s;
+    }
+
+    public function test_suppresses_a_single_mailbox_that_has_been_full_for_a_while(): void
+    {
+        $result = $this->scan->apply($this->snapshotWithFullMailbox());
+
+        $this->assertCount(1, $result['suppressed']);
+        $this->assertSame('address', $result['suppressed'][0]['scope']);
+        $this->assertSame('full@example.com', $result['suppressed'][0]['value']);
+    }
+
+    public function test_does_not_suppress_a_mailbox_on_a_short_burst_of_retries(): void
+    {
+        // Retries within the hour are the relay working normally.
+        $result = $this->scan->apply($this->snapshotWithFullMailbox(count: 9, age: '-10 minutes'));
+
+        $this->assertSame([], $result['suppressed']);
+    }
+
+    public function test_does_not_add_an_address_row_when_its_provider_is_already_suppressed(): void
+    {
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $s = new RelayQueueSnapshot;
+        $s->addresses['someone@sky.com'] = [
+            'count' => 20,
+            'oldest' => strtotime('-3 days'),
+            'reason' => self::YAHOO_REASON,
+        ];
+        $s->groups['yahoodns.net'] = [
+            'count' => 52000, 'oldest' => strtotime('-3 days'),
+            'reason' => self::YAHOO_REASON, 'domains' => ['sky.com' => 20],
+        ];
+
+        $result = $this->scan->apply($s);
+
+        $this->assertSame(
+            0,
+            DB::table('mail_suppressions')->where('scope', 'address')->count(),
+            'an address row under an already-suppressed provider adds nothing but noise'
+        );
+        $this->assertSame([], $result['suppressed']);
+    }
+
+    // ===================================================================
+    // Release
+    // ===================================================================
+
+    private function recovered(): RelayQueueSnapshot
+    {
+        $s = new RelayQueueSnapshot;
+        $s->groups['yahoodns.net'] = [
+            'count' => 5, 'oldest' => strtotime('-1 hour'),
+            'reason' => self::YAHOO_REASON, 'domains' => ['yahoo.co.uk' => 5],
+        ];
+        $s->delivered['yahoodns.net'] = 4000;
+
+        return $s;
+    }
+
+    public function test_release_needs_two_consecutive_clear_scans(): void
+    {
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $first = $this->scan->apply($this->recovered());
+        $this->assertSame([], $first['released'], 'one quiet scan can just be a backoff window');
+        $this->assertDatabaseHas('mail_suppressions', ['scope' => 'mxgroup', 'released_at' => null]);
+
+        $second = $this->scan->apply($this->recovered());
+        $this->assertCount(1, $second['released']);
+        $this->assertSame('yahoodns.net', $second['released'][0]['value']);
+    }
+
+    public function test_release_cascades_to_the_domain_rows(): void
+    {
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+        $this->scan->apply($this->recovered());
+        $this->scan->apply($this->recovered());
+
+        $this->assertSame(
+            0,
+            DB::table('mail_suppressions')->whereNull('released_at')->count(),
+            'a released provider must not leave orphan domain rows gating mail for ever'
+        );
+
+        $this->suppressions->flushCache();
+        $this->assertFalse($this->suppressions->isSuppressed('someone@sky.com'));
+    }
+
+    public function test_a_clear_scan_followed_by_a_bad_one_resets_the_counter(): void
+    {
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+        $this->scan->apply($this->recovered());
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+        $result = $this->scan->apply($this->recovered());
+
+        $this->assertSame([], $result['released'], 'the clear run has to be consecutive');
+    }
+
+    public function test_does_not_release_while_deliveries_have_not_resumed(): void
+    {
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        // Backlog drained (we purged it) but the provider is still refusing.
+        $s = new RelayQueueSnapshot;
+        $s->groups['yahoodns.net'] = [
+            'count' => 0, 'oldest' => null,
+            'reason' => self::YAHOO_REASON, 'domains' => [],
+        ];
+        $s->delivered['l.google.com'] = 5000;
+
+        $this->scan->apply($s);
+        $result = $this->scan->apply($s);
+
+        $this->assertSame([], $result['released']);
+    }
+
+    public function test_fails_open_when_the_probe_has_not_confirmed_a_suppression_for_too_long(): void
+    {
+        // Quietly not mailing a whole provider for ever, because our own
+        // probe broke, is worse than the problem this feature solves.
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        DB::table('mail_suppressions')->update(['last_seen' => now()->subDays(3)]);
+
+        $result = $this->scan->apply(new RelayQueueSnapshot);
+
+        $this->assertCount(1, $result['released']);
+        $this->assertTrue($result['released'][0]['stale']);
+    }
+}

--- a/iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
@@ -163,6 +163,40 @@ class DeferralScanServiceTest extends TestCase
         $this->assertSame(1, DB::table('mail_suppressions')->where('scope', 'mxgroup')->count());
     }
 
+    public function test_only_one_active_row_can_exist_per_target(): void
+    {
+        // Enforced in the schema, not just in the scan. A half-finished run
+        // leaving two active rows for one provider would be invisible:
+        // activeByKey() maps on scope+value, so the second would keep
+        // gating mail long after the first was released.
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        DB::table('mail_suppressions')->insert([
+            'scope' => 'mxgroup',
+            'value' => 'yahoodns.net',
+            'first_seen' => now(),
+            'last_seen' => now(),
+        ]);
+    }
+
+    public function test_released_rows_may_repeat_so_history_survives(): void
+    {
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+        $this->scan->apply($this->recovered());
+        $this->scan->apply($this->recovered());
+
+        // Same provider blocks us again a week later.
+        $result = $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $this->assertCount(1, $result['suppressed']);
+        $this->assertSame(
+            2,
+            DB::table('mail_suppressions')->where('scope', 'mxgroup')->count(),
+            'the first episode should still be on the record'
+        );
+    }
     // ===================================================================
     // Per-address tier
     // ===================================================================

--- a/iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
@@ -257,6 +257,59 @@ class DeferralScanServiceTest extends TestCase
         $this->assertSame([], $result['suppressed']);
     }
 
+    public function test_a_still_full_mailbox_is_not_released_after_two_scans(): void
+    {
+        // The relay-sized release threshold (100) is meaningless for one
+        // mailbox, which holds single figures. Left as it was, a member
+        // whose mailbox was still bouncing us would be released on the
+        // second scan - about half an hour - defeating the whole tier.
+        $this->scan->apply($this->snapshotWithFullMailbox());
+        $this->scan->apply($this->snapshotWithFullMailbox());
+        $result = $this->scan->apply($this->snapshotWithFullMailbox());
+
+        $this->assertSame([], $result['released']);
+        $this->assertDatabaseHas('mail_suppressions', [
+            'scope' => 'address', 'value' => 'full@example.com', 'released_at' => null,
+        ]);
+    }
+
+    public function test_a_mailbox_is_released_once_it_stops_deferring(): void
+    {
+        $this->scan->apply($this->snapshotWithFullMailbox());
+
+        $empty = new RelayQueueSnapshot;
+        $empty->delivered['example.com'] = 500;
+
+        $this->assertSame([], $this->scan->apply($empty)['released'], 'one clear scan is not enough');
+
+        $result = $this->scan->apply($empty);
+        $this->assertCount(1, $result['released']);
+        $this->assertSame('full@example.com', $result['released'][0]['value']);
+    }
+
+    public function test_a_relapse_between_two_quiet_scans_breaks_the_streak(): void
+    {
+        // The band between release_max_deferred (100) and
+        // mxgroup_min_deferred (500) is the gap: a relapse into it trips
+        // neither the suppression refresh nor the release accumulation, so
+        // the counter used to sit frozen and the next quiet scan released a
+        // provider that had never been quiet twice running.
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $this->scan->apply($this->recovered());
+
+        $relapse = new RelayQueueSnapshot;
+        $relapse->groups['yahoodns.net'] = [
+            'count' => 300, 'oldest' => strtotime('-2 hours'),
+            'reason' => self::YAHOO_REASON, 'domains' => ['yahoo.co.uk' => 300],
+        ];
+        $relapse->delivered['yahoodns.net'] = 2;
+        $this->scan->apply($relapse);
+
+        $result = $this->scan->apply($this->recovered());
+
+        $this->assertSame([], $result['released'], 'the two clear scans have to be consecutive');
+    }
     // ===================================================================
     // Release
     // ===================================================================

--- a/iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/DeferralScanServiceTest.php
@@ -296,6 +296,22 @@ class DeferralScanServiceTest extends TestCase
         $this->assertSame([], $result['released']);
     }
 
+    public function test_a_long_gap_does_not_release_a_provider_that_is_still_blocking(): void
+    {
+        // The probe was down for a day. When it comes back and finds the
+        // provider still solidly blocked, that IS confirmation - releasing on
+        // the strength of the stale last_seen it is about to overwrite would
+        // reopen the floodgates onto a queue that still cannot drain.
+        $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        DB::table('mail_suppressions')->update(['last_seen' => now()->subDays(3)]);
+
+        $result = $this->scan->apply($this->snapshotWithYahooBlocked());
+
+        $this->assertSame([], $result['released']);
+        $this->assertDatabaseHas('mail_suppressions', ['scope' => 'mxgroup', 'released_at' => null]);
+    }
+
     public function test_fails_open_when_the_probe_has_not_confirmed_a_suppression_for_too_long(): void
     {
         // Quietly not mailing a whole provider for ever, because our own

--- a/iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
@@ -116,6 +116,19 @@ class MailSuppressionServiceTest extends TestCase
         $this->assertFalse($this->service->isSuppressed('not-an-address'));
     }
 
+    public function test_suppression_for_returns_the_row_so_callers_can_report_it(): void
+    {
+        // shouldSkip() needs the row, not just a boolean, so the count it
+        // writes records WHICH suppression held the mail. Deriving that
+        // later would mean reimplementing the mailer address ranking.
+        $id = $this->suppress('domain', 'yahoo.co.uk');
+        $this->service->flushCache();
+
+        $row = $this->service->suppressionFor('someone@yahoo.co.uk');
+
+        $this->assertNotNull($row);
+        $this->assertSame($id, (int) $row->id);
+    }
     public function test_never_suppresses_our_own_operational_mail(): void
     {
         // The alert saying a provider has stopped accepting our mail is

--- a/iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Services\Mail\MailSuppressionService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MailSuppressionServiceTest extends TestCase
+{
+    private MailSuppressionService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new MailSuppressionService;
+    }
+
+    private function suppress(string $scope, string $value, array $extra = []): int
+    {
+        $this->service->flushCache();
+
+        return DB::table('mail_suppressions')->insertGetId(array_merge([
+            'scope' => $scope,
+            'value' => $value,
+            'reason' => '421 4.7.0 [TSS04] temporarily deferred',
+            'provider' => 'Yahoo',
+            'deferred_since' => '2026-08-15 16:38:00',
+            'first_seen' => now(),
+            'last_seen' => now(),
+            'message_count' => 52000,
+        ], $extra));
+    }
+
+    public function test_nothing_is_suppressed_by_default(): void
+    {
+        $this->assertFalse($this->service->isSuppressed('someone@yahoo.co.uk'));
+    }
+
+    public function test_suppresses_by_domain(): void
+    {
+        $this->suppress('domain', 'yahoo.co.uk');
+        $this->service->flushCache();
+
+        $this->assertTrue($this->service->isSuppressed('someone@yahoo.co.uk'));
+        $this->assertFalse($this->service->isSuppressed('someone@gmail.com'));
+    }
+
+    public function test_matching_ignores_case_and_whitespace(): void
+    {
+        $this->suppress('domain', 'yahoo.co.uk');
+        $this->service->flushCache();
+
+        $this->assertTrue($this->service->isSuppressed('  SomeOne@Yahoo.CO.UK  '));
+    }
+
+    public function test_suppresses_by_exact_address(): void
+    {
+        $this->suppress('address', 'full@example.com');
+        $this->service->flushCache();
+
+        $this->assertTrue($this->service->isSuppressed('full@example.com'));
+        $this->assertFalse($this->service->isSuppressed('other@example.com'));
+    }
+
+    public function test_an_address_row_wins_over_its_domain_row(): void
+    {
+        // The address row carries the more accurate reason: one full mailbox
+        // is a different story from a provider refusing everyone.
+        $this->suppress('domain', 'example.com', ['reason' => 'provider deferral', 'provider' => 'Example']);
+        $this->suppress('address', 'full@example.com', ['reason' => '452 4.2.2 over quota', 'provider' => null]);
+        $this->service->flushCache();
+
+        $row = $this->service->suppressionFor('full@example.com');
+
+        $this->assertStringContainsString('over quota', (string) $row->reason);
+    }
+
+    public function test_an_mxgroup_row_alone_does_not_gate_anything(): void
+    {
+        // The mxgroup row carries the evidence; the domain children are what
+        // the sending loops match on. Gating on the group alone would need a
+        // DNS lookup per recipient, which is exactly what we are avoiding.
+        $this->suppress('mxgroup', 'yahoodns.net');
+        $this->service->flushCache();
+
+        $this->assertFalse($this->service->isSuppressed('someone@yahoo.co.uk'));
+    }
+
+    public function test_a_released_suppression_stops_gating(): void
+    {
+        $this->suppress('domain', 'yahoo.co.uk', ['released_at' => now()]);
+        $this->service->flushCache();
+
+        $this->assertFalse($this->service->isSuppressed('someone@yahoo.co.uk'));
+    }
+
+    public function test_exposes_the_delayed_since_date_and_provider(): void
+    {
+        $this->suppress('domain', 'yahoo.co.uk');
+        $this->service->flushCache();
+
+        $row = $this->service->suppressionFor('someone@yahoo.co.uk');
+
+        $this->assertSame('Yahoo', $row->provider);
+        $this->assertSame('2026-08-15 16:38:00', (string) $row->deferred_since);
+    }
+
+    public function test_tolerates_a_missing_or_malformed_address(): void
+    {
+        $this->suppress('domain', 'yahoo.co.uk');
+        $this->service->flushCache();
+
+        $this->assertFalse($this->service->isSuppressed(null));
+        $this->assertFalse($this->service->isSuppressed(''));
+        $this->assertFalse($this->service->isSuppressed('not-an-address'));
+    }
+
+    // ===================================================================
+    // Counting what we declined to send
+    // ===================================================================
+
+    public function test_records_and_accumulates_what_it_declined_to_generate(): void
+    {
+        $user = $this->createTestUser();
+
+        $this->service->recordSuppressed($user->id, 'digest_immediate');
+        $this->service->recordSuppressed($user->id, 'digest_immediate');
+        $this->service->recordSuppressed($user->id, 'chat');
+
+        $this->assertDatabaseHas('mail_suppressed_counts', [
+            'userid' => $user->id, 'emailtype' => 'digest_immediate', 'count' => 2,
+        ]);
+        $this->assertDatabaseHas('mail_suppressed_counts', [
+            'userid' => $user->id, 'emailtype' => 'chat', 'count' => 1,
+        ]);
+    }
+
+    public function test_a_fresh_episode_starts_counting_again_rather_than_resuming(): void
+    {
+        $user = $this->createTestUser();
+
+        $this->service->recordSuppressed($user->id, 'chat');
+        $this->service->recordSuppressed($user->id, 'chat');
+        DB::table('mail_suppressed_counts')->update(['caughtup_at' => now()->subDay()]);
+
+        $this->service->recordSuppressed($user->id, 'chat');
+
+        $row = DB::table('mail_suppressed_counts')->where('userid', $user->id)->first();
+        $this->assertSame(1, (int) $row->count, 'the second episode is its own story');
+        $this->assertNull($row->caughtup_at);
+    }
+
+    public function test_should_skip_both_answers_and_counts(): void
+    {
+        $user = $this->createTestUser();
+        $this->suppress('domain', 'yahoo.co.uk');
+        $this->service->flushCache();
+
+        $this->assertTrue($this->service->shouldSkip('someone@yahoo.co.uk', $user->id, 'digest_daily'));
+        $this->assertFalse($this->service->shouldSkip('someone@gmail.com', $user->id, 'digest_daily'));
+
+        $this->assertSame(
+            1,
+            DB::table('mail_suppressed_counts')->where('userid', $user->id)->count(),
+            'only the skipped one should be counted'
+        );
+    }
+
+    public function test_counting_never_breaks_the_send_loop(): void
+    {
+        // Losing a counter costs accuracy in one catch-up email. It must not
+        // cost us the whole digest run.
+        $this->service->recordSuppressed(null, 'chat');
+        $this->service->recordSuppressed(0, 'chat');
+        $this->service->recordSuppressed(999999999, 'chat');
+
+        $this->assertTrue(true, 'no exception escaped');
+    }
+}

--- a/iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
@@ -116,6 +116,20 @@ class MailSuppressionServiceTest extends TestCase
         $this->assertFalse($this->service->isSuppressed('not-an-address'));
     }
 
+    public function test_never_suppresses_our_own_operational_mail(): void
+    {
+        // The alert saying a provider has stopped accepting our mail is
+        // exactly the message we would be dropping. The volume is trivial, so
+        // there is nothing to save and everything to lose.
+        $this->suppress('domain', 'ilovefreegle.org');
+        $this->suppress('domain', 'users.ilovefreegle.org');
+        $this->service->flushCache();
+
+        $this->assertFalse($this->service->isSuppressed('geeks@ilovefreegle.org'));
+        $this->assertFalse($this->service->isSuppressed('geek-alerts@ilovefreegle.org'));
+        $this->assertFalse($this->service->isSuppressed('somegroup-volunteers@groups.ilovefreegle.org'));
+    }
+
     // ===================================================================
     // Counting what we declined to send
     // ===================================================================

--- a/iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
+++ b/iznik-batch/tests/Feature/Mail/MailSuppressionServiceTest.php
@@ -154,7 +154,7 @@ class MailSuppressionServiceTest extends TestCase
     public function test_should_skip_both_answers_and_counts(): void
     {
         $user = $this->createTestUser();
-        $this->suppress('domain', 'yahoo.co.uk');
+        $id = $this->suppress('domain', 'yahoo.co.uk');
         $this->service->flushCache();
 
         $this->assertTrue($this->service->shouldSkip('someone@yahoo.co.uk', $user->id, 'digest_daily'));
@@ -165,6 +165,24 @@ class MailSuppressionServiceTest extends TestCase
             DB::table('mail_suppressed_counts')->where('userid', $user->id)->count(),
             'only the skipped one should be counted'
         );
+    }
+
+    public function test_records_which_suppression_was_in_force_at_the_time(): void
+    {
+        // Recorded now, not re-derived later: by the time anything reports on
+        // this the suppression will have been released and the member's
+        // address may have changed.
+        $user = $this->createTestUser();
+        $id = $this->suppress('domain', 'yahoo.co.uk');
+        $this->service->flushCache();
+
+        $this->service->shouldSkip('someone@yahoo.co.uk', $user->id, 'chat');
+
+        $this->assertDatabaseHas('mail_suppressed_counts', [
+            'userid' => $user->id,
+            'emailtype' => 'chat',
+            'suppressionid' => $id,
+        ]);
     }
 
     public function test_counting_never_breaks_the_send_loop(): void

--- a/iznik-batch/tests/Feature/Mail/ScanDeferralsCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/ScanDeferralsCommandTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Monitoring\HostCommandRunner;
+use App\Services\Mail\Deferrals\DeferralProbe;
+use App\Services\Mail\MailSuppressionService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * End to end, replaying the incident this exists for.
+ *
+ * The acceptance test the work was specified against: with a provider
+ * blocking, one scan cycle marks the relay family suppressed and stops mail
+ * generation for the affected addresses. The queue stops growing.
+ */
+class ScanDeferralsCommandTest extends TestCase
+{
+    private array $scripts = [];
+
+    private ?string $canned = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'freegle.mail.deferrals.enabled' => true,
+            'freegle.mail.deferrals.host' => 'deferrals@relay.test',
+            'freegle.mail.deferrals.max_queue_bytes' => 1024 * 1024,
+            'freegle.mail.deferrals.mxgroup_min_deferred' => 500,
+            'freegle.mail.deferrals.mxgroup_max_delivered_per_hour' => 10,
+            'freegle.mail.deferrals.address_min_deferred' => 5,
+            'freegle.mail.deferrals.address_min_hours' => 24,
+            'freegle.mail.deferrals.release_max_deferred' => 100,
+            'freegle.mail.deferrals.release_clear_scans' => 2,
+            'freegle.mail.deferrals.stale_after_hours' => 24,
+        ]);
+
+        // Swap in a fake relay so nothing here goes near ssh.
+        $test = $this;
+        $this->app->when(DeferralProbe::class)
+            ->needs(HostCommandRunner::class)
+            ->give(function () use ($test) {
+                return new class($test) implements HostCommandRunner
+                {
+                    public function __construct(private $test)
+                    {
+                    }
+
+                    public function run(string $target, string $script): ?string
+                    {
+                        return $this->test->relayResponds($target, $script);
+                    }
+                };
+            });
+
+        app(MailSuppressionService::class)->flushCache();
+    }
+
+    public function relayResponds(string $target, string $script): ?string
+    {
+        $this->scripts[] = $script;
+
+        return $this->canned;
+    }
+
+    private function relayReturns(string $queue, string $delivered = ''): void
+    {
+        $this->canned = DeferralProbe::MARK_QUEUE . "\n" . $queue . "\n"
+            . DeferralProbe::MARK_DELIVERED . "\n" . $delivered . "\n"
+            . DeferralProbe::MARK_END . "\n";
+    }
+
+    /**
+     * The queue as it looked on 2026-08-16, scaled down.
+     */
+    private function yahooBlockedQueue(int $messages = 600): string
+    {
+        $lines = [];
+        $domains = ['yahoo.co.uk', 'yahoo.com', 'sky.com', 'aol.com'];
+
+        for ($i = 0; $i < $messages; $i++) {
+            $lines[] = json_encode([
+                'queue_name' => 'deferred',
+                'queue_id' => 'QID' . str_pad((string) $i, 7, '0', STR_PAD_LEFT),
+                'arrival_time' => strtotime('2026-08-15 16:38:00') + $i,
+                'sender' => 'noreply@ilovefreegle.org',
+                'recipients' => [[
+                    'address' => 'member' . $i . '@' . $domains[$i % 4],
+                    'delay_reason' => 'host mta7.am0.yahoodns.net[67.195.228.94] said: 421 4.7.0 '
+                        . '[TSS04] Messages from 185.53.57.161 temporarily deferred due to '
+                        . 'unexpected volume or user complaints (in reply to MAIL FROM command)',
+                ]],
+            ]);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /** Gmail is still taking our mail; Yahoo has taken one message all hour. */
+    private function deliveredLog(): string
+    {
+        $lines = [];
+        for ($i = 0; $i < 500; $i++) {
+            $lines[] = "Aug 18 09:00:00 relay postfix/smtp[$i]: G$i: to=<a$i@gmail.com>, "
+                . 'relay=gmail-smtp-in.l.google.com[1.2.3.4]:25, delay=1, status=sent (250 ok)';
+        }
+        $lines[] = 'Aug 18 09:30:00 relay postfix/smtp[999]: Y1: to=<lucky@yahoo.co.uk>, '
+            . 'relay=mta7.am0.yahoodns.net[67.195.228.94]:25, delay=8000, status=sent (250 ok)';
+
+        return implode("\n", $lines);
+    }
+
+    public function test_one_scan_suppresses_the_blocked_provider_and_all_its_domains(): void
+    {
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        $this->assertDatabaseHas('mail_suppressions', [
+            'scope' => 'mxgroup', 'value' => 'yahoodns.net', 'provider' => 'Yahoo', 'released_at' => null,
+        ]);
+
+        // Every domain behind that one relay, including Sky, which is
+        // Yahoo-hosted and unguessable from its name.
+        $domains = DB::table('mail_suppressions')->where('scope', 'domain')->pluck('value')->all();
+        $this->assertEqualsCanonicalizing(
+            ['yahoo.co.uk', 'yahoo.com', 'sky.com', 'aol.com'],
+            $domains
+        );
+
+        $suppressions = app(MailSuppressionService::class);
+        $suppressions->flushCache();
+        $this->assertTrue($suppressions->isSuppressed('someone@sky.com'));
+        $this->assertFalse($suppressions->isSuppressed('someone@gmail.com'));
+    }
+
+    public function test_the_delayed_since_date_is_when_the_member_stopped_receiving_mail(): void
+    {
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        $row = DB::table('mail_suppressions')->where('scope', 'mxgroup')->first();
+        $this->assertSame('2026-08-15 16:38:00', (string) $row->deferred_since);
+    }
+
+    public function test_gmail_keeps_getting_mail_while_yahoo_is_blocked(): void
+    {
+        // The failure that would matter most: over-suppressing and taking out
+        // providers that are perfectly happy.
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        $this->assertSame(
+            0,
+            DB::table('mail_suppressions')->where('value', 'like', '%google%')->count()
+        );
+    }
+
+    public function test_does_nothing_when_the_feature_is_off(): void
+    {
+        config(['freegle.mail.deferrals.enabled' => false]);
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        $this->assertDatabaseCount('mail_suppressions', 0);
+        $this->assertSame([], $this->scripts, 'a disabled feature must not touch the relay at all');
+    }
+
+    public function test_does_nothing_when_no_relay_is_configured(): void
+    {
+        // Dev and CI, where the topology is deliberately absent.
+        config(['freegle.mail.deferrals.host' => '']);
+
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        $this->assertDatabaseCount('mail_suppressions', 0);
+    }
+
+    public function test_fails_loudly_when_the_relay_cannot_be_read(): void
+    {
+        // Running green while blind is exactly how the original incident
+        // stayed invisible for three days.
+        $this->canned = null;
+
+        $this->artisan('mail:deferrals:scan')->assertFailed();
+
+        $this->assertDatabaseCount('mail_suppressions', 0);
+    }
+
+    public function test_dry_run_changes_nothing(): void
+    {
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan --dry-run')->assertSuccessful();
+
+        $this->assertDatabaseCount('mail_suppressions', 0);
+    }
+
+    public function test_purge_is_dry_run_without_force(): void
+    {
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan --purge')->assertSuccessful();
+
+        foreach ($this->scripts as $script) {
+            $this->assertStringNotContainsString(
+                'postsuper',
+                $script,
+                'purge must not delete anything without --force'
+            );
+        }
+    }
+
+    public function test_purge_with_force_deletes_only_the_suppressed_relays_queue(): void
+    {
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan --purge --force')->assertSuccessful();
+
+        $purges = array_values(array_filter(
+            $this->scripts,
+            fn ($s) => str_contains($s, 'postsuper')
+        ));
+
+        $this->assertNotEmpty($purges, 'purge --force should have asked the relay to delete');
+        $this->assertStringContainsString('QID0000000', $purges[0]);
+        $this->assertStringNotContainsString(
+            ' ALL',
+            $purges[0],
+            'never postsuper -d ALL: that would delete mail to providers that are fine'
+        );
+    }
+
+    public function test_purge_does_nothing_when_nothing_is_suppressed(): void
+    {
+        // A small backlog is normal traffic, not a block.
+        $this->relayReturns($this->yahooBlockedQueue(10), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan --purge --force')->assertSuccessful();
+
+        foreach ($this->scripts as $script) {
+            $this->assertStringNotContainsString('postsuper', $script);
+        }
+    }
+
+    public function test_the_probe_reads_the_queue_without_writing_to_it(): void
+    {
+        $this->relayReturns($this->yahooBlockedQueue(10), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        $this->assertNotEmpty($this->scripts);
+        $this->assertStringContainsString('postqueue -j', $this->scripts[0]);
+        $this->assertStringNotContainsString('postsuper', $this->scripts[0]);
+        // mailq takes minutes over a queue this size; -j is the whole point.
+        $this->assertStringNotContainsString('mailq', $this->scripts[0]);
+    }
+}

--- a/iznik-batch/tests/Feature/Mail/ScanDeferralsCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/ScanDeferralsCommandTest.php
@@ -249,6 +249,83 @@ class ScanDeferralsCommandTest extends TestCase
         }
     }
 
+    public function test_dry_run_outranks_force_and_deletes_nothing(): void
+    {
+        // Someone reaching for --dry-run is asking what would happen.
+        // Answering that by deleting mail off a production relay would be
+        // the worst possible reply.
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan --dry-run --purge --force')->assertSuccessful();
+
+        foreach ($this->scripts as $script) {
+            $this->assertStringNotContainsString('postsuper', $script);
+        }
+        $this->assertDatabaseCount('mail_suppressions', 0);
+    }
+
+    public function test_an_unreachable_relay_still_lets_a_stuck_suppression_time_out(): void
+    {
+        // A broken probe is exactly when a suppression is most likely to
+        // stick on for ever, because the normal release path needs a
+        // snapshot it never gets.
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        DB::table('mail_suppressions')->update(['last_seen' => now()->subDays(3)]);
+        $this->canned = null;
+
+        $this->artisan('mail:deferrals:scan')->assertFailed();
+
+        $this->assertSame(
+            0,
+            DB::table('mail_suppressions')->whereNull('released_at')->count(),
+            'a suppression nobody can confirm any more must fail open'
+        );
+    }
+
+    public function test_an_unreachable_relay_does_not_release_a_recent_suppression(): void
+    {
+        // An absent snapshot is not evidence that anything recovered. Two
+        // failed probes in a row must not release everything we have.
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        $this->canned = null;
+        $this->artisan('mail:deferrals:scan')->assertFailed();
+        $this->artisan('mail:deferrals:scan')->assertFailed();
+
+        $this->assertDatabaseHas('mail_suppressions', [
+            'scope' => 'mxgroup', 'value' => 'yahoodns.net', 'released_at' => null,
+        ]);
+    }
+
+    public function test_a_domain_first_seen_mid_episode_is_gated_too(): void
+    {
+        // An episode lasting days keeps turning up domains that were not in
+        // the queue when it started, because someone at that provider only
+        // becomes due an email later.
+        $this->relayReturns($this->yahooBlockedQueue(), $this->deliveredLog());
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        $extra = json_encode([
+            'queue_name' => 'deferred',
+            'queue_id' => 'LATECOMER1',
+            'arrival_time' => strtotime('2026-08-17 09:00:00'),
+            'recipients' => [[
+                'address' => 'someone@ymail.com',
+                'delay_reason' => 'host mta7.am0.yahoodns.net[67.195.228.94] said: 421 4.7.0 '
+                    . '[TSS04] temporarily deferred',
+            ]],
+        ]);
+        $this->relayReturns($this->yahooBlockedQueue() . "\n" . $extra, $this->deliveredLog());
+
+        $this->artisan('mail:deferrals:scan')->assertSuccessful();
+
+        $suppressions = app(MailSuppressionService::class);
+        $suppressions->flushCache();
+        $this->assertTrue($suppressions->isSuppressed('someone@ymail.com'));
+    }
     public function test_the_probe_reads_the_queue_without_writing_to_it(): void
     {
         $this->relayReturns($this->yahooBlockedQueue(10), $this->deliveredLog());

--- a/iznik-batch/tests/TestCase.php
+++ b/iznik-batch/tests/TestCase.php
@@ -51,6 +51,13 @@ abstract class TestCase extends BaseTestCase
 
         parent::setUp();
 
+        // MailSuppressionService is a singleton that caches the active
+        // suppression set in-process for a minute, which is right in a batch
+        // job over tens of thousands of members and wrong here: a test that
+        // inserts a suppression would leave it visible to the next test in
+        // the same process, long after its transaction rolled back, and mail
+        // in an unrelated test would silently stop being generated.
+        app(\App\Services\Mail\MailSuppressionService::class)->flushCache();
         // Force mail driver to 'array' for testing.
         // Docker's MAIL_MAILER=smtp would otherwise override phpunit.xml's setting.
         config(['mail.default' => 'array']);

--- a/iznik-batch/tests/Unit/Mail/UnsubscribeCategoryCoverageTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnsubscribeCategoryCoverageTest.php
@@ -42,6 +42,10 @@ class UnsubscribeCategoryCoverageTest extends TestCase
         \App\Mail\Chat\ChatReviewPendingMail::class => null,
         \App\Mail\Chat\ChatReviewSummaryMail::class => null,
         \App\Mail\Chat\SpamWarningMail::class => null,
+        // Sent once after a provider stops accepting our mail, in place of the
+        // chat notifications we declined to send, so it belongs to the same
+        // category those would have carried.
+        \App\Mail\Deferrals\UnreadChatCatchUpMail::class => UnsubscribeService::TYPE_CHAT,
         \App\Mail\CommunityNews\CommunityNewsMail::class => UnsubscribeService::TYPE_NEWSLETTER,
         \App\Mail\Digest\DigestReplyNotice::class => null,
         \App\Mail\Digest\UnifiedDigest::class => UnsubscribeService::TYPE_DIGEST,

--- a/iznik-batch/tests/Unit/Services/Mail/Deferrals/DeferralProbeTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Deferrals/DeferralProbeTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Tests\Unit\Services\Mail\Deferrals;
+
+use App\Monitoring\HostCommandRunner;
+use App\Services\Mail\Deferrals\DeferralProbe;
+use Tests\TestCase;
+
+/**
+ * The probe is the only thing standing between us and flying blind, so these
+ * tests feed it the shapes a real relay actually produces - including the
+ * awkward ones - rather than an idealised sample.
+ */
+class DeferralProbeTest extends TestCase
+{
+    private function runner(?string $output, ?callable $spy = null): HostCommandRunner
+    {
+        return new class($output, $spy) implements HostCommandRunner
+        {
+            public function __construct(
+                private readonly ?string $output,
+                private $spy,
+            ) {
+            }
+
+            public function run(string $target, string $script): ?string
+            {
+                if ($this->spy !== null) {
+                    ($this->spy)($target, $script);
+                }
+
+                return $this->output;
+            }
+        };
+    }
+
+    private function queueLine(array $overrides = []): string
+    {
+        return json_encode(array_merge([
+            'queue_name' => 'deferred',
+            'queue_id' => 'ABC123DEF',
+            'arrival_time' => 1755270000,
+            'message_size' => 4096,
+            'sender' => 'noreply@ilovefreegle.org',
+            'recipients' => [
+                [
+                    'address' => 'someone@yahoo.co.uk',
+                    'delay_reason' => 'host mta7.am0.yahoodns.net[67.195.228.94] said: 421 4.7.0 '
+                        . '[TSS04] Messages from 185.53.57.161 temporarily deferred due to '
+                        . 'unexpected volume or user complaints (in reply to MAIL FROM command)',
+                ],
+            ],
+        ], $overrides));
+    }
+
+    private function wrap(string $queue, string $delivered = '', bool $truncated = false): string
+    {
+        return DeferralProbe::MARK_QUEUE . "\n"
+            . $queue . "\n"
+            . ($truncated ? DeferralProbe::MARK_TRUNCATED . "\n" : '')
+            . DeferralProbe::MARK_DELIVERED . "\n"
+            . $delivered . "\n"
+            . DeferralProbe::MARK_END . "\n";
+    }
+
+    public function test_returns_null_when_the_relay_is_unreachable(): void
+    {
+        $probe = new DeferralProbe($this->runner(null));
+
+        $this->assertNull($probe->probe('relay@host', 1024));
+    }
+
+    public function test_refuses_output_that_never_reached_the_end_marker(): void
+    {
+        // Half a queue listing understates every count, and understated
+        // counts silently fail to trip a threshold. Better to see nothing
+        // than to see half and believe it.
+        $probe = new DeferralProbe($this->runner(DeferralProbe::MARK_QUEUE . "\n" . $this->queueLine()));
+
+        $this->assertNull($probe->probe('relay@host', 1024));
+    }
+
+    public function test_buckets_deferrals_by_relay_family(): void
+    {
+        $probe = new DeferralProbe($this->runner($this->wrap(
+            $this->queueLine() . "\n" . $this->queueLine(['queue_id' => 'ZZZ999'])
+        )));
+
+        $snapshot = $probe->probe('relay@host', 1024);
+
+        $this->assertSame(2, $snapshot->groups['yahoodns.net']['count']);
+        $this->assertSame(1755270000, $snapshot->groups['yahoodns.net']['oldest']);
+        $this->assertSame(2, $snapshot->addresses['someone@yahoo.co.uk']['count']);
+    }
+
+    public function test_records_the_recipient_domains_seen_behind_a_relay(): void
+    {
+        // This is what lets the sending-loop check be a plain indexed lookup
+        // rather than a DNS query: the queue has already told us that
+        // sky.com goes via Yahoo, which no amount of guessing would.
+        $queue = implode("\n", [
+            $this->queueLine(),
+            $this->queueLine(['recipients' => [[
+                'address' => 'someone@sky.com',
+                'delay_reason' => 'host mta5.am0.yahoodns.net[1.2.3.4] said: 421 4.7.0 [TSS04] temporarily deferred',
+            ]]]),
+        ]);
+
+        $snapshot = (new DeferralProbe($this->runner($this->wrap($queue))))->probe('relay@host', 1024);
+
+        $this->assertEqualsCanonicalizing(
+            ['yahoo.co.uk', 'sky.com'],
+            array_keys($snapshot->groups['yahoodns.net']['domains'])
+        );
+    }
+
+    public function test_ignores_recipients_that_have_not_been_attempted_yet(): void
+    {
+        // delay_reason is absent until Postfix has actually tried. A message
+        // sitting in incoming is not evidence of anything.
+        $queue = $this->queueLine(['recipients' => [['address' => 'nobody@example.com']]]);
+
+        $snapshot = (new DeferralProbe($this->runner($this->wrap($queue))))->probe('relay@host', 1024);
+
+        $this->assertSame([], $snapshot->groups);
+        $this->assertSame([], $snapshot->addresses);
+    }
+
+    public function test_ignores_queues_that_are_not_deferred_or_active(): void
+    {
+        $queue = $this->queueLine(['queue_name' => 'hold']);
+
+        $snapshot = (new DeferralProbe($this->runner($this->wrap($queue))))->probe('relay@host', 1024);
+
+        $this->assertSame([], $snapshot->groups);
+    }
+
+    public function test_counts_a_deferral_that_blames_no_provider_separately(): void
+    {
+        $queue = $this->queueLine(['recipients' => [[
+            'address' => 'someone@example.com',
+            'delay_reason' => 'mail transport unavailable',
+        ]]]);
+
+        $snapshot = (new DeferralProbe($this->runner($this->wrap($queue))))->probe('relay@host', 1024);
+
+        $this->assertSame([], $snapshot->groups);
+        $this->assertSame(1, $snapshot->unattributed);
+        // It is still a deferral for that address, just not a provider's fault.
+        $this->assertSame(1, $snapshot->addresses['someone@example.com']['count']);
+    }
+
+    public function test_parses_delivered_lines_into_relay_families(): void
+    {
+        $delivered = implode("\n", [
+            'Aug 18 09:00:01 relay postfix/smtp[1]: A1: to=<a@gmail.com>, relay=gmail-smtp-in.l.google.com[1.2.3.4]:25, delay=1, status=sent (250 ok)',
+            'Aug 18 09:00:02 relay postfix/smtp[2]: A2: to=<b@gmail.com>, relay=gmail-smtp-in.l.google.com[1.2.3.4]:25, delay=1, status=sent (250 ok)',
+            'Aug 18 09:00:03 relay postfix/local[3]: A3: to=<c@localhost>, relay=local, delay=0, status=sent (delivered to mailbox)',
+        ]);
+
+        $snapshot = (new DeferralProbe($this->runner($this->wrap($this->queueLine(), $delivered))))
+            ->probe('relay@host', 1024);
+
+        $this->assertSame(2, $snapshot->deliveriesFor('l.google.com'));
+        // A local delivery is not a provider accepting our mail, so it must
+        // not count as evidence that one has recovered.
+        $this->assertSame(0, $snapshot->deliveriesFor('local'));
+        $this->assertTrue($snapshot->hasDeliveryData());
+    }
+
+    public function test_distinguishes_no_deliveries_from_no_delivery_data(): void
+    {
+        // "Nothing is being delivered anywhere" is an estate-wide emergency.
+        // "We could not read the relay's log" is a gap in our instruments.
+        // Suppression decisions differ, so these must not look the same.
+        $snapshot = (new DeferralProbe($this->runner($this->wrap($this->queueLine()))))
+            ->probe('relay@host', 1024);
+
+        $this->assertFalse($snapshot->hasDeliveryData());
+        $this->assertSame(0, $snapshot->deliveriesFor('yahoodns.net'));
+    }
+
+    public function test_reports_truncation_rather_than_pretending_the_queue_was_complete(): void
+    {
+        $snapshot = (new DeferralProbe($this->runner($this->wrap($this->queueLine(), '', true))))
+            ->probe('relay@host', 1024);
+
+        $this->assertTrue($snapshot->truncated);
+    }
+
+    public function test_survives_a_half_written_json_line_from_truncation(): void
+    {
+        $queue = $this->queueLine() . "\n" . '{"queue_name":"deferred","recipi';
+
+        $snapshot = (new DeferralProbe($this->runner($this->wrap($queue))))->probe('relay@host', 1024);
+
+        $this->assertSame(1, $snapshot->groups['yahoodns.net']['count']);
+        $this->assertSame(1, $snapshot->unparseableLines);
+    }
+
+    public function test_dedupes_queue_ids_for_purging(): void
+    {
+        // One queue file can hold several recipients in the same family, and
+        // postsuper wants each id once.
+        $queue = $this->queueLine(['recipients' => [
+            ['address' => 'a@yahoo.co.uk', 'delay_reason' => 'host mta7.am0.yahoodns.net[1.2.3.4] said: 421 temporarily deferred'],
+            ['address' => 'b@yahoo.com', 'delay_reason' => 'host mta7.am0.yahoodns.net[1.2.3.4] said: 421 temporarily deferred'],
+        ]]);
+
+        $snapshot = (new DeferralProbe($this->runner($this->wrap($queue))))->probe('relay@host', 1024);
+
+        $this->assertSame(['ABC123DEF'], $snapshot->queueIdsFor('yahoodns.net'));
+    }
+
+    public function test_purge_refuses_anything_that_is_not_a_queue_id(): void
+    {
+        // The ids come from the relay's own listing, but they end up in a
+        // shell command on a production host.
+        $sent = [];
+        $probe = new DeferralProbe($this->runner('ok', function ($target, $script) use (&$sent) {
+            $sent[] = $script;
+        }));
+
+        $deleted = $probe->purge('relay@host', ['GOODID1234', 'rm -rf /', '; postsuper -d ALL']);
+
+        $this->assertSame(1, $deleted);
+        $this->assertStringContainsString('GOODID1234', $sent[0]);
+        $this->assertStringNotContainsString('rm -rf', $sent[0]);
+        $this->assertStringNotContainsString('ALL', $sent[0]);
+    }
+
+    public function test_purge_does_nothing_when_given_nothing_usable(): void
+    {
+        $called = false;
+        $probe = new DeferralProbe($this->runner('ok', function () use (&$called) {
+            $called = true;
+        }));
+
+        $this->assertSame(0, $probe->purge('relay@host', ['../../etc/passwd']));
+        $this->assertFalse($called, 'must not open a shell on the relay with nothing to do');
+    }
+}

--- a/iznik-batch/tests/Unit/Services/Mail/Deferrals/DeferralProbeTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Deferrals/DeferralProbeTest.php
@@ -161,7 +161,7 @@ class DeferralProbeTest extends TestCase
         $snapshot = (new DeferralProbe($this->runner($this->wrap($this->queueLine(), $delivered))))
             ->probe('relay@host', 1024);
 
-        $this->assertSame(2, $snapshot->deliveriesFor('l.google.com'));
+        $this->assertSame(2, $snapshot->deliveriesFor('google.com'));
         // A local delivery is not a provider accepting our mail, so it must
         // not count as evidence that one has recovered.
         $this->assertSame(0, $snapshot->deliveriesFor('local'));

--- a/iznik-batch/tests/Unit/Services/Mail/Deferrals/MxGrouperTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Deferrals/MxGrouperTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Unit\Services\Mail\Deferrals;
+
+use App\Services\Mail\Deferrals\MxGrouper;
+use Tests\TestCase;
+
+class MxGrouperTest extends TestCase
+{
+    // ===================================================================
+    // Grouping
+    //
+    // The whole point of grouping by relay rather than by recipient domain:
+    // on 2026-08-15 one Yahoo block took out yahoo.co.uk, yahoo.com, ymail,
+    // rocketmail, aol.com, aol.co.uk, aim.com and sky.com at once, because
+    // they all relay through *.am0.yahoodns.net.
+    // ===================================================================
+
+    public function test_collapses_yahoo_relay_machines_into_one_family(): void
+    {
+        $this->assertSame('yahoodns.net', MxGrouper::group('mta5.am0.yahoodns.net'));
+        $this->assertSame('yahoodns.net', MxGrouper::group('mta6.am0.yahoodns.net'));
+        $this->assertSame('yahoodns.net', MxGrouper::group('mta7.am0.yahoodns.net'));
+    }
+
+    public function test_grouping_is_case_and_trailing_dot_insensitive(): void
+    {
+        $this->assertSame('yahoodns.net', MxGrouper::group('MTA7.AM0.YahooDNS.NET.'));
+    }
+
+    public function test_keeps_an_extra_label_for_shared_hosting_platforms(): void
+    {
+        // Without this, one customer's problem on a big filtering platform
+        // would suppress mail to every organisation behind it.
+        $this->assertSame(
+            'acme.mail.protection.outlook.com',
+            MxGrouper::group('acme.mail.protection.outlook.com')
+        );
+        $this->assertNotSame(
+            MxGrouper::group('acme.mail.protection.outlook.com'),
+            MxGrouper::group('other.mail.protection.outlook.com')
+        );
+    }
+
+    public function test_never_groups_down_to_a_public_suffix(): void
+    {
+        // "co.uk" as a group would suppress an entire country's mail.
+        $this->assertSame('talktalk.co.uk', MxGrouper::group('mx1.talktalk.co.uk'));
+    }
+
+    public function test_a_bare_ip_is_its_own_group(): void
+    {
+        $this->assertSame('198.51.100.5', MxGrouper::group('198.51.100.5'));
+    }
+
+    public function test_a_two_label_host_is_already_its_own_group(): void
+    {
+        $this->assertSame('example.com', MxGrouper::group('example.com'));
+    }
+
+    // ===================================================================
+    // Pulling the relay out of a delay_reason
+    // ===================================================================
+
+    public function test_extracts_relay_from_a_said_style_delay_reason(): void
+    {
+        $reason = 'host mta7.am0.yahoodns.net[67.195.228.94] said: 421 4.7.0 [TSS04] '
+            . 'Messages from 185.53.57.161 temporarily deferred due to unexpected volume '
+            . 'or user complaints - 4.16.55.1 (in reply to MAIL FROM command)';
+
+        $this->assertSame('yahoodns.net', MxGrouper::fromDelayReason($reason));
+    }
+
+    public function test_extracts_relay_from_a_connect_style_delay_reason(): void
+    {
+        // A connection-level failure never reaches an SMTP dialog, so there
+        // is no "said:" clause and no SMTP code to key off.
+        $reason = 'connect to mx1.example.com[198.51.100.5]:25: Connection timed out';
+
+        $this->assertSame('example.com', MxGrouper::fromDelayReason($reason));
+    }
+
+    public function test_extracts_relay_from_a_quota_delay_reason(): void
+    {
+        $reason = 'host mx.example.com[203.0.113.10] said: 452 4.2.2 The email account '
+            . 'that you tried to reach is over quota (in reply to RCPT TO command)';
+
+        $this->assertSame('example.com', MxGrouper::fromDelayReason($reason));
+    }
+
+    public function test_blames_nobody_for_a_purely_local_failure(): void
+    {
+        // "mail transport unavailable" is our problem, not a provider's.
+        // Attributing it to one would suppress entirely the wrong mail.
+        $this->assertNull(MxGrouper::fromDelayReason('mail transport unavailable'));
+        $this->assertNull(MxGrouper::fromDelayReason('delivery temporarily suspended'));
+    }
+
+    // ===================================================================
+    // Naming the provider
+    // ===================================================================
+
+    public function test_names_the_provider_a_member_would_recognise(): void
+    {
+        $this->assertSame('Yahoo', MxGrouper::providerName('yahoodns.net'));
+        $this->assertSame('Gmail', MxGrouper::providerName('google.com'));
+        $this->assertSame('Microsoft', MxGrouper::providerName('acme.mail.protection.outlook.com'));
+    }
+
+    public function test_returns_null_for_a_relay_we_have_no_friendly_name_for(): void
+    {
+        $this->assertNull(MxGrouper::providerName('mx.somesmallisp.example'));
+    }
+}

--- a/iznik-batch/tests/Unit/Services/Mail/DeliveryHealthServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/DeliveryHealthServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit\Services\Mail;
+
+use App\Services\Mail\DeliveryHealthService;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DeliveryHealthServiceTest extends TestCase
+{
+    private DeliveryHealthService $service;
+
+    /** Fixed "now" so the windows are deterministic. */
+    private Carbon $now;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new DeliveryHealthService;
+        $this->now = Carbon::parse('2026-08-18 13:00:00');
+
+        // The service aggregates every row in the window, so rows left by other tests would
+        // shift the rates it computes. Start from a known-empty table.
+        DB::table('email_tracking')->delete();
+    }
+
+    /**
+     * Seed $sent emails at $daysAgo, of which $openedPercent were opened.
+     *
+     * Not seed() - Laravel's TestCase already has a public one for database seeders, and
+     * PHP will not let a subclass narrow it to private.
+     *
+     * $hoursAgo lets a test place mail inside the settle window instead.
+     */
+    private function seedSends(string $domain, int $daysAgo, int $sent, float $openedPercent, ?int $hoursAgo = null): void
+    {
+        // An hour inside the settle boundary, not exactly on it: the service's window is
+        // half-open (sent_at < recentEnd), so rows placed exactly on the boundary fall out of
+        // both windows and every assertion here would pass for the wrong reason.
+        $sentAt = $hoursAgo !== null
+            ? $this->now->copy()->subHours($hoursAgo)
+            : $this->now->copy()->subHours(DeliveryHealthService::SETTLE_HOURS + 1)->subDays($daysAgo);
+
+        $toOpen = (int) round($sent * $openedPercent / 100);
+
+        $rows = [];
+        for ($i = 0; $i < $sent; $i++) {
+            $rows[] = [
+                'tracking_id' => bin2hex(random_bytes(16)),
+                'email_type' => 'Digest',
+                'recipient_email' => "member{$i}@{$domain}",
+                'sent_at' => $sentAt->toDateTimeString(),
+                'opened_at' => $i < $toOpen ? $sentAt->copy()->addHour()->toDateTimeString() : null,
+            ];
+        }
+
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('email_tracking')->insert($chunk);
+        }
+    }
+
+    private function domains(): array
+    {
+        return array_column($this->service->collapsedDomains(1, 14, $this->now), 'domain');
+    }
+
+    public function test_flags_a_domain_whose_open_rate_has_collapsed(): void
+    {
+        // Healthy through the baseline, then effectively nothing - the Yahoo shape.
+        $this->seedSends('yahoo.example', 5, 600, 30.0);
+        $this->seedSends('yahoo.example', 0, 600, 0.2);
+
+        $collapsed = $this->service->collapsedDomains(1, 14, $this->now);
+
+        $this->assertCount(1, $collapsed);
+        $this->assertSame('yahoo.example', $collapsed[0]['domain']);
+        $this->assertSame(600, $collapsed[0]['recent_sent']);
+        $this->assertEqualsWithDelta(30.0, $collapsed[0]['baseline_open_percent'], 0.5);
+        $this->assertLessThan(DeliveryHealthService::COLLAPSE_RATIO, $collapsed[0]['ratio']);
+    }
+
+    public function test_leaves_a_steady_domain_alone(): void
+    {
+        $this->seedSends('steady.example', 5, 600, 30.0);
+        $this->seedSends('steady.example', 0, 600, 28.0);
+
+        $this->assertSame([], $this->domains());
+    }
+
+    public function test_ignores_a_domain_that_never_reported_opens(): void
+    {
+        // A forwarder: our pixel is never fetched from the real recipient, so its rate is
+        // always zero. There is no working delivery to have lost, and it must not alert daily.
+        $this->seedSends('forwarder.example', 5, 600, 0.0);
+        $this->seedSends('forwarder.example', 0, 600, 0.0);
+
+        $this->assertSame([], $this->domains());
+    }
+
+    public function test_ignores_a_domain_below_the_volume_floor(): void
+    {
+        $small = DeliveryHealthService::MIN_RECENT_SENDS - 100;
+        $this->seedSends('tiny.example', 5, $small, 30.0);
+        $this->seedSends('tiny.example', 0, $small, 0.0);
+
+        $this->assertSame([], $this->domains());
+    }
+
+    public function test_ignores_mail_too_recent_to_have_been_opened(): void
+    {
+        // Mail sent an hour ago is unopened because nobody has looked yet, not because it did
+        // not arrive. Counting it would make every run report an outage.
+        $this->seedSends('settling.example', 5, 600, 30.0);
+        $this->seedSends('settling.example', 0, 600, 30.0);
+        $this->seedSends('settling.example', 0, 5000, 0.0, hoursAgo: 1);
+
+        $this->assertSame([], $this->domains());
+    }
+}

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/BounceServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/BounceServiceTest.php
@@ -312,6 +312,81 @@ DSN;
         $this->assertTrue($this->service->shouldIgnoreBounce($code));
     }
 
+    // ===================================================================
+    // Deferral Tests
+    //
+    // 2026-08-15: Yahoo started 421-ing every message from bulk2's IP with
+    // "[TSS04] ... temporarily deferred due to unexpected volume or user
+    // complaints". Those messages sit in the queue until
+    // maximal_queue_lifetime, then Postfix emits one DSN per message
+    // carrying the original 421 text (or "delivery time expired"). Without
+    // these ignore patterns each affected user - who held ~9 queued
+    // messages - would sail past SOFT_BOUNCE_THRESHOLD and be suspended for
+    // a problem that is ours, not theirs.
+    // ===================================================================
+
+    public function test_classifies_yahoo_tss04_deferral_as_ignorable(): void
+    {
+        $code = 'smtp; 421 4.7.0 [TSS04] Messages from 185.53.57.161 temporarily deferred due to '
+            . 'unexpected volume or user complaints - 4.16.55.1; see '
+            . 'https://postmaster.yahooinc.com/error-codes';
+
+        $this->assertTrue($this->service->shouldIgnoreBounce($code));
+    }
+
+    public function test_classifies_postfix_relay_deferral_as_ignorable(): void
+    {
+        // Postfix's wording when the remote said 421 during the SMTP
+        // conversation rather than when the destination is in backoff -
+        // note it does NOT contain "delivery temporarily suspended".
+        $code = 'X-Postfix; host mta7.am0.yahoodns.net[98.136.96.92] refused to talk to me: '
+            . '421 4.7.0 [TSS04] Messages temporarily deferred';
+
+        $this->assertTrue($this->service->shouldIgnoreBounce($code));
+    }
+
+    public function test_classifies_queue_lifetime_expiry_as_ignorable(): void
+    {
+        $code = 'X-Postfix; delivery time expired';
+
+        $this->assertTrue($this->service->shouldIgnoreBounce($code));
+    }
+
+    public function test_deferral_expiry_dsn_does_not_record_a_bounce(): void
+    {
+        $user = $this->createTestUser(['bouncing' => 0]);
+        $userEmail = UserEmail::where('userid', $user->id)->where('preferred', 1)->first();
+
+        // Envelope sender on our bulk mail is noreply@, not VERP, so
+        // attribution falls back to the DSN's Original-Recipient header.
+        $rawBounce = <<<DSN
+Reporting-MTA: dns; bulk2.ilovefreegle.org
+Action: failed
+Status: 4.7.0
+Diagnostic-Code: X-Postfix; delivery time expired: host mta7.am0.yahoodns.net said: 421 4.7.0 [TSS04] Messages from 185.53.57.161 temporarily deferred due to unexpected volume or user complaints
+Original-Recipient: rfc822;{$userEmail->email}
+DSN;
+
+        $parsedEmail = $this->createParsedEmail([
+            'rawMessage' => $rawBounce,
+            'envelopeTo' => 'noreply@ilovefreegle.org',
+            'bounceRecipient' => $userEmail->email,
+            'bounceStatus' => '4.7.0',
+        ]);
+
+        $result = $this->service->processBounce($parsedEmail);
+
+        $this->assertTrue($result['success']);
+        $this->assertTrue($result['ignored'] ?? false, 'A queue-expiry deferral DSN must be ignored');
+
+        $this->assertDatabaseMissing('bounces_emails', [
+            'emailid' => $userEmail->id,
+        ]);
+
+        $user->refresh();
+        $this->assertEquals(0, $user->bouncing, 'Our IP reputation must never suspend the member');
+    }
+
     public function test_classifies_421_temporary_error_as_not_permanent(): void
     {
         $code = '421 Try again later';

--- a/iznik-nuxt3/api/EmailTrackingAPI.js
+++ b/iznik-nuxt3/api/EmailTrackingAPI.js
@@ -13,6 +13,14 @@ export default class EmailTrackingAPI extends BaseAPI {
   }
 
   /**
+   * Providers currently refusing our mail, and the members whose mail we are
+   * holding as a result.
+   */
+  async fetchDeferrals() {
+    return await this.$getv2('/modtools/email/deferrals')
+  }
+
+  /**
    * Fetch email tracking records for a specific user.
    * @param {number|string} userIdOrEmail - The user ID or email address
    * @param {Object} params - Query parameters

--- a/iznik-nuxt3/modtools/components/ModMailDelayed.vue
+++ b/iznik-nuxt3/modtools/components/ModMailDelayed.vue
@@ -1,0 +1,46 @@
+<template>
+  <NoticeMessage v-if="since" variant="info" class="mb-2">
+    <p>
+      <strong>Email delayed since {{ dateshort(since) }}</strong>
+      <span v-if="provider">
+        - {{ provider }} is not currently accepting our mail.</span
+      >
+      <span v-else> - their email provider is not currently accepting our mail.</span>
+    </p>
+    <p class="mb-0">
+      This is a problem at our end, not with their address, so there's nothing
+      for them or for you to fix. We've paused
+      <span v-if="count">the {{ count }} emails we'd otherwise have sent them</span>
+      <span v-else>their emails</span>
+      rather than pile up mail that can't be delivered, and we'll send a
+      catch-up once it clears.
+    </p>
+  </NoticeMessage>
+</template>
+<script setup>
+import { dateshort } from '~/composables/useTimeFormat'
+
+// Deliberately a separate component from ModBouncing, and deliberately
+// "info" rather than "danger". Moderators read "bouncing" as "this address
+// is bad" and act on it - chase the member, remove them. A deferral is our
+// sending reputation with their provider, the address is fine, and the only
+// correct action is to wait. Showing the two the same way would get members
+// chased for our problem.
+defineProps({
+  since: {
+    type: String,
+    required: false,
+    default: null,
+  },
+  provider: {
+    type: String,
+    required: false,
+    default: null,
+  },
+  count: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
+})
+</script>

--- a/iznik-nuxt3/modtools/components/ModMailDelayed.vue
+++ b/iznik-nuxt3/modtools/components/ModMailDelayed.vue
@@ -5,12 +5,16 @@
       <span v-if="provider">
         - {{ provider }} is not currently accepting our mail.</span
       >
-      <span v-else> - their email provider is not currently accepting our mail.</span>
+      <span v-else>
+        - their email provider is not currently accepting our mail.</span
+      >
     </p>
     <p class="mb-0">
       This is a problem at our end, not with their address, so there's nothing
       for them or for you to fix. We've paused
-      <span v-if="count">the {{ count }} emails we'd otherwise have sent them</span>
+      <span v-if="count"
+        >the {{ count }} emails we'd otherwise have sent them</span
+      >
       <span v-else>their emails</span>
       rather than pile up mail that can't be delivered, and we'll send a
       catch-up once it clears.

--- a/iznik-nuxt3/modtools/components/ModMember.vue
+++ b/iznik-nuxt3/modtools/components/ModMember.vue
@@ -86,6 +86,12 @@
           {{ user.locationchanges }} times in the last 90 days.
         </NoticeMessage>
         <ModBouncing v-if="user.bouncing" :userid="member.userid" />
+        <ModMailDelayed
+          v-if="member.maildelayedsince"
+          :since="member.maildelayedsince"
+          :provider="member.maildelayedprovider"
+          :count="member.maildelayedcount || 0"
+        />
         <NoticeMessage v-if="member.bandate">
           Banned
           <span :title="datetime(member.bandate)">{{

--- a/iznik-nuxt3/modtools/components/ModSupportMailDeferrals.vue
+++ b/iznik-nuxt3/modtools/components/ModSupportMailDeferrals.vue
@@ -1,0 +1,131 @@
+<template>
+  <div>
+    <NoticeMessage variant="info" class="mb-3">
+      <p class="mb-0">
+        <strong>Providers refusing our mail.</strong> When a provider stops
+        accepting mail from our sending servers, we pause generating email for
+        everyone at that provider rather than pile up mail that can't be
+        delivered. This is our sending reputation, not a problem with anyone's
+        address.
+      </p>
+    </NoticeMessage>
+
+    <div v-if="loading" class="text-center p-4">
+      <v-icon icon="sync" class="fa-spin" /> Loading...
+    </div>
+
+    <NoticeMessage v-else-if="error" variant="danger">
+      {{ error }}
+    </NoticeMessage>
+
+    <template v-else>
+      <NoticeMessage v-if="!suppressions.length" variant="success" class="mb-3">
+        Nothing is being deferred. Every provider is accepting our mail.
+      </NoticeMessage>
+
+      <template v-else>
+        <h3 class="mb-2">Currently suppressed</h3>
+        <b-table-simple responsive striped class="mb-4">
+          <b-thead>
+            <b-tr>
+              <b-th>Provider</b-th>
+              <b-th>Relay or address</b-th>
+              <b-th>Delayed since</b-th>
+              <b-th class="text-end">Queued</b-th>
+              <b-th>Why</b-th>
+            </b-tr>
+          </b-thead>
+          <b-tbody>
+            <b-tr v-for="s in suppressions" :key="'sup-' + s.id">
+              <b-td>{{ s.provider || 'Unknown' }}</b-td>
+              <b-td>
+                <code>{{ s.value }}</code>
+                <b-badge
+                  v-if="s.scope === 'address'"
+                  variant="secondary"
+                  class="ms-1"
+                >
+                  single mailbox
+                </b-badge>
+              </b-td>
+              <b-td>
+                <span :title="s.deferredsince">{{
+                  dateshort(s.deferredsince)
+                }}</span>
+              </b-td>
+              <b-td class="text-end">{{ s.messagecount }}</b-td>
+              <b-td class="small text-muted">{{ s.reason }}</b-td>
+            </b-tr>
+          </b-tbody>
+        </b-table-simple>
+      </template>
+
+      <h3 class="mb-2">
+        Members with mail held
+        <b-badge v-if="members.length" variant="info">{{
+          members.length
+        }}</b-badge>
+      </h3>
+
+      <p v-if="!members.length" class="text-muted">
+        No mail has been held back yet. A suppression starts holding mail from
+        the moment it's created, so this fills up as each member's next email
+        comes due.
+      </p>
+
+      <template v-else>
+        <NoticeMessage
+          v-if="members.length >= memberLimit && memberLimit > 0"
+          variant="warning"
+          class="mb-2"
+        >
+          Showing the first {{ memberLimit }} members. There are more.
+        </NoticeMessage>
+
+        <b-table-simple responsive striped small>
+          <b-thead>
+            <b-tr>
+              <b-th>Member</b-th>
+              <b-th>Email</b-th>
+              <b-th>Provider</b-th>
+              <b-th>Delayed since</b-th>
+              <b-th class="text-end">Held</b-th>
+            </b-tr>
+          </b-thead>
+          <b-tbody>
+            <b-tr v-for="m in members" :key="'mem-' + m.userid">
+              <b-td>
+                <nuxt-link :to="'/support/' + m.userid">
+                  {{ m.displayname || '#' + m.userid }}
+                </nuxt-link>
+              </b-td>
+              <b-td class="small">{{ m.email }}</b-td>
+              <b-td>{{ m.provider || 'Unknown' }}</b-td>
+              <b-td>
+                <span :title="m.since">{{ dateshort(m.since) }}</span>
+              </b-td>
+              <b-td class="text-end">{{ m.heldmessages }}</b-td>
+            </b-tr>
+          </b-tbody>
+        </b-table-simple>
+      </template>
+    </template>
+  </div>
+</template>
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useEmailTrackingStore } from '~/modtools/stores/emailtracking'
+import { dateshort } from '~/composables/useTimeFormat'
+
+const store = useEmailTrackingStore()
+
+const loading = computed(() => store.deferralsLoading)
+const error = computed(() => store.deferralsError)
+const suppressions = computed(() => store.deferralSuppressions)
+const members = computed(() => store.deferralMembers)
+const memberLimit = computed(() => store.deferralMemberLimit)
+
+onMounted(() => {
+  store.fetchDeferrals()
+})
+</script>

--- a/iznik-nuxt3/modtools/pages/sysadmin/index.vue
+++ b/iznik-nuxt3/modtools/pages/sysadmin/index.vue
@@ -207,6 +207,8 @@ const topTabMap = {
   mail: 2,
   outgoing: 2,
   incoming: 2,
+  delayed: 2,
+  deferrals: 2,
   behaviour: 3,
   digest: 3,
   scrolling: 3,

--- a/iznik-nuxt3/modtools/pages/sysadmin/index.vue
+++ b/iznik-nuxt3/modtools/pages/sysadmin/index.vue
@@ -85,6 +85,15 @@
                 :key="'incomingemail-' + incomingEmailBump"
               />
             </b-tab>
+            <b-tab @click="onDeferralsTab">
+              <template #title>
+                <span class="subtab-label">Delayed</span>
+              </template>
+              <ModSupportMailDeferrals
+                v-if="showDeferrals"
+                :key="'deferrals-' + deferralsBump"
+              />
+            </b-tab>
           </b-tabs>
         </b-tab>
 
@@ -180,6 +189,8 @@ const showDigestClicks = ref(false)
 const digestClicksBump = ref(0)
 const showIncomingEmail = ref(false)
 const incomingEmailBump = ref(0)
+const showDeferrals = ref(false)
+const deferralsBump = ref(0)
 const showRippling = ref(false)
 const ripplingBump = ref(0)
 const showRecommendations = ref(false)
@@ -224,10 +235,16 @@ function onIncomingEmailTab() {
   incomingEmailBump.value = Date.now()
 }
 
+function onDeferralsTab() {
+  showDeferrals.value = true
+  deferralsBump.value = Date.now()
+}
+
 // Opening the Mail tab shows whichever email sub-tab is active (Outgoing by
 // default), so the first render isn't blank before a sub-tab is clicked.
 function onMailTab() {
   if (mailSubTab.value === 1) onIncomingEmailTab()
+  else if (mailSubTab.value === 2) onDeferralsTab()
   else onEmailStatsTab()
 }
 
@@ -272,6 +289,9 @@ onMounted(() => {
     } else if (tab === 'incoming') {
       mailSubTab.value = 1
       onIncomingEmailTab()
+    } else if (tab === 'delayed' || tab === 'deferrals') {
+      mailSubTab.value = 2
+      onDeferralsTab()
     } else if (tab === 'behaviour' || tab === 'digest' || tab === 'scrolling') {
       behaviourSubTab.value = 0
       onDigestClicksTab()

--- a/iznik-nuxt3/modtools/stores/emailtracking.js
+++ b/iznik-nuxt3/modtools/stores/emailtracking.js
@@ -34,6 +34,13 @@ export const useEmailTrackingStore = defineStore({
     userEmailsLoading: false,
     userEmailsError: null,
 
+    // Deferral suppressions: providers refusing our mail right now.
+    deferralSuppressions: [],
+    deferralMembers: [],
+    deferralMemberLimit: 0,
+    deferralsLoading: false,
+    deferralsError: null,
+
     // Email types for filtering.
     emailTypes: [],
 
@@ -127,6 +134,22 @@ export const useEmailTrackingStore = defineStore({
 
     setFilters(filters) {
       this.filters = { ...this.filters, ...filters }
+    },
+
+    async fetchDeferrals() {
+      this.deferralsLoading = true
+      this.deferralsError = null
+
+      try {
+        const response = await api(this.config).emailtracking.fetchDeferrals()
+        this.deferralSuppressions = response?.suppressions || []
+        this.deferralMembers = response?.members || []
+        this.deferralMemberLimit = response?.memberlimit || 0
+      } catch (e) {
+        this.deferralsError = e.message
+      } finally {
+        this.deferralsLoading = false
+      }
     },
 
     async fetchStats() {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMailDelayed.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMailDelayed.spec.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ModMailDelayed from '~/modtools/components/ModMailDelayed.vue'
+
+// NoticeMessage is auto-imported in the app; stub it here but keep the
+// variant, because whether this reads as information or as a fault is the
+// entire point of the component.
+const NoticeMessage = {
+  props: ['variant'],
+  template: '<div class="notice" :data-variant="variant"><slot /></div>',
+}
+
+function render(props = {}) {
+  return mount(ModMailDelayed, {
+    props: {
+      since: '2026-08-15 16:38:00',
+      provider: 'Yahoo',
+      count: 9,
+      ...props,
+    },
+    global: { stubs: { NoticeMessage } },
+  })
+}
+
+// The template wraps across lines, so compare on collapsed whitespace rather
+// than let a reflow break the test.
+function words(wrapper) {
+  return wrapper.text().replace(/\s+/g, ' ').trim()
+}
+
+describe('ModMailDelayed', () => {
+  it('names the provider and the date it started', () => {
+    const text = words(render())
+
+    expect(text).toContain('Email delayed since')
+    expect(text).toContain('Yahoo is not currently accepting our mail')
+  })
+
+  it('says how much has been held back', () => {
+    expect(words(render({ count: 9 }))).toContain('9 emails')
+  })
+
+  it('copes when we cannot name the provider', () => {
+    expect(words(render({ provider: null }))).toContain(
+      'their email provider is not currently accepting our mail',
+    )
+  })
+
+  it('renders nothing at all when the member is not delayed', () => {
+    expect(render({ since: null }).find('.notice').exists()).toBe(false)
+  })
+
+  // Why this is a separate component from ModBouncing rather than a variant
+  // of it: moderators read "bouncing" as "this address is bad" and act on it,
+  // chasing or removing the member. A deferral is our sending reputation, the
+  // address is fine, and the only correct action is to wait.
+  it('reads as information rather than as a fault, unlike bouncing', () => {
+    expect(render().find('.notice').attributes('data-variant')).toBe('info')
+  })
+
+  it('tells the moderator there is nothing to fix', () => {
+    const text = words(render())
+
+    expect(text).toContain(
+      'This is a problem at our end, not with their address',
+    )
+    expect(text).toContain('nothing for them or for you to fix')
+  })
+
+  it('promises a catch-up, so nobody goes chasing it by hand', () => {
+    expect(words(render())).toContain("we'll send a catch-up once it clears")
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMember.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMember.spec.js
@@ -157,6 +157,10 @@ describe('ModMember', () => {
             template: '<div class="mod-bouncing" />',
             props: ['user'],
           },
+          ModMailDelayed: {
+            template: '<div class="mod-mail-delayed" />',
+            props: ['since', 'provider', 'count'],
+          },
           ModDeletedOrForgotten: {
             template: '<div class="mod-deleted-or-forgotten" />',
             props: ['user'],

--- a/iznik-nuxt3/tests/unit/pages/modtools/sysadmin.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/sysadmin.spec.js
@@ -35,6 +35,7 @@ function mountComponent() {
         ModSysAdminCronJobs: stub('c-cronjobs'),
         ModSupportEmailStats: stub('c-emailstats'),
         ModSupportIncomingEmail: stub('c-incomingemail'),
+        ModSupportMailDeferrals: stub('c-maildeferrals'),
         ModSysAdminDigestClicks: stub('c-digestclicks'),
         ModSysAdminBrowseScroll: stub('c-browsescroll'),
         ModSysAdminRecommendations: stub('c-recommendations'),
@@ -106,6 +107,16 @@ describe('sysadmin page tab grouping', () => {
     const wrapper = mountComponent()
     await flushPromises()
     expect(wrapper.find('.c-emailstats').exists()).toBe(true)
+  })
+
+  it('opens the Delayed sub-tab from ?tab=delayed', async () => {
+    // Added after Outgoing and Incoming rather than before them, so the
+    // existing sub-tab indices - and the deep-links that use them - keep
+    // working.
+    mockRouteQuery.value = { tab: 'delayed' }
+    const wrapper = mountComponent()
+    await flushPromises()
+    expect(wrapper.find('.c-maildeferrals').exists()).toBe(true)
   })
 
   it('keeps the old ?tab=incoming deep-link working (now under Mail)', async () => {

--- a/iznik-server-go/emailtracking/deferrals.go
+++ b/iznik-server-go/emailtracking/deferrals.go
@@ -64,7 +64,9 @@ func Deferrals(c *fiber.Ctx) error {
 		Select("ms.id, ms.scope, ms.value, ms.provider, ms.reason, ms.deferred_since, " +
 			"ms.first_seen, ms.last_seen, ms.message_count, " +
 			"(SELECT COUNT(DISTINCT msc.userid) FROM mail_suppressed_counts msc " +
-			" WHERE msc.caughtup_at IS NULL) AS membersaffected").
+			" WHERE msc.caughtup_at IS NULL AND msc.suppressionid IN " +
+			"  (SELECT c.id FROM mail_suppressions c WHERE c.id = ms.id OR c.parentid = ms.id)" +
+			") AS membersaffected").
 		Where("ms.released_at IS NULL AND ms.scope IN ('mxgroup','address')").
 		Order("ms.deferred_since ASC").
 		Scan(&suppressions)
@@ -86,10 +88,12 @@ func Deferrals(c *fiber.Ctx) error {
 		Select("msc.userid, u.fullname AS displayname, ue.email, " +
 			"ms.provider, MIN(msc.firstat) AS since, SUM(msc.count) AS heldmessages").
 		Joins("JOIN users u ON u.id = msc.userid").
-		Joins("LEFT JOIN users_emails ue ON ue.userid = msc.userid AND ue.preferred = 1").
-		Joins("LEFT JOIN mail_suppressions ms ON ms.released_at IS NULL AND " +
-			"((ms.scope = 'domain' AND ms.value = SUBSTRING_INDEX(ue.email, '@', -1)) " +
-			" OR (ms.scope = 'address' AND ms.value = ue.email))").
+		Joins("LEFT JOIN mail_suppressions ms ON ms.id = msc.suppressionid").
+		// The address we would have mailed, resolved the same way the mailer
+		// resolves it: highest preferred, then highest validated. Joined on a
+		// single id so a member with several addresses still yields one row.
+		Joins("LEFT JOIN users_emails ue ON ue.id = (SELECT ue2.id FROM users_emails ue2 " +
+			"WHERE ue2.userid = msc.userid ORDER BY ue2.preferred DESC, ue2.validated DESC LIMIT 1)").
 		Where("msc.caughtup_at IS NULL").
 		Group("msc.userid, u.fullname, ue.email, ms.provider").
 		Order("since ASC").

--- a/iznik-server-go/emailtracking/deferrals.go
+++ b/iznik-server-go/emailtracking/deferrals.go
@@ -1,0 +1,110 @@
+package emailtracking
+
+import (
+	"github.com/freegle/iznik-server-go/auth"
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/user"
+	"github.com/gofiber/fiber/v2"
+)
+
+// MailSuppression is one active deferral suppression, as shown to support.
+type MailSuppression struct {
+	ID            uint64  `json:"id"`
+	Scope         string  `json:"scope"`
+	Value         string  `json:"value"`
+	Provider      *string `json:"provider"`
+	Reason        *string `json:"reason"`
+	DeferredSince *string `json:"deferredsince" gorm:"column:deferred_since"`
+	FirstSeen     *string `json:"firstseen" gorm:"column:first_seen"`
+	LastSeen      *string `json:"lastseen" gorm:"column:last_seen"`
+	MessageCount  uint64  `json:"messagecount" gorm:"column:message_count"`
+	// How many members we have actually declined to mail behind this
+	// suppression. Zero at the start of an episode and climbing thereafter,
+	// which is the honest picture: the suppression is live from the moment it
+	// is written, but nobody has missed anything yet.
+	MembersAffected uint64 `json:"membersaffected" gorm:"column:membersaffected"`
+}
+
+// DelayedMember is one member whose mail we are currently holding.
+type DelayedMember struct {
+	Userid       uint64  `json:"userid"`
+	Displayname  *string `json:"displayname"`
+	Email        *string `json:"email"`
+	Provider     *string `json:"provider"`
+	Since        *string `json:"since"`
+	HeldMessages uint64  `json:"heldmessages" gorm:"column:heldmessages"`
+}
+
+// Deferrals handles GET /modtools/email/deferrals.
+//
+// Support's view of a deferral episode: which providers have stopped accepting
+// our mail, since when, and which members are affected. This is the "list all
+// currently-delayed members" tool - the per-member notice in ModTools only
+// tells you about a member you already happen to be looking at, which is no
+// use when you are trying to work out how big a problem is.
+func Deferrals(c *fiber.Ctx) error {
+	db := database.DBConn
+
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	if !auth.IsAdminOrSupport(myid) {
+		return fiber.NewError(fiber.StatusForbidden, "Support or Admin role required")
+	}
+
+	suppressions := []MailSuppression{}
+
+	// Only the mxgroup and address rows: the domain rows are derived children
+	// of an mxgroup row and listing them would just repeat it once per domain.
+	// keep-raw: a correlated count over a child table, which GORM's struct
+	// conditions cannot express as a selected column.
+	res := db.Table("mail_suppressions ms").
+		Select("ms.id, ms.scope, ms.value, ms.provider, ms.reason, ms.deferred_since, " +
+			"ms.first_seen, ms.last_seen, ms.message_count, " +
+			"(SELECT COUNT(DISTINCT msc.userid) FROM mail_suppressed_counts msc " +
+			" WHERE msc.caughtup_at IS NULL) AS membersaffected").
+		Where("ms.released_at IS NULL AND ms.scope IN ('mxgroup','address')").
+		Order("ms.deferred_since ASC").
+		Scan(&suppressions)
+
+	if res.Error != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Could not read suppressions")
+	}
+
+	members := []DelayedMember{}
+
+	// Members with mail actually held. Driven from mail_suppressed_counts
+	// rather than from the suppression's domain list, because that is the set
+	// with something to show for it - a count, and a date it started.
+	//
+	// keep-raw: an aggregate over a per-type child table joined back to the
+	// suppression that explains it; the same shape as the raw SELECTs used
+	// throughout this package.
+	res = db.Table("mail_suppressed_counts msc").
+		Select("msc.userid, u.fullname AS displayname, ue.email, " +
+			"ms.provider, MIN(msc.firstat) AS since, SUM(msc.count) AS heldmessages").
+		Joins("JOIN users u ON u.id = msc.userid").
+		Joins("LEFT JOIN users_emails ue ON ue.userid = msc.userid AND ue.preferred = 1").
+		Joins("LEFT JOIN mail_suppressions ms ON ms.released_at IS NULL AND " +
+			"((ms.scope = 'domain' AND ms.value = SUBSTRING_INDEX(ue.email, '@', -1)) " +
+			" OR (ms.scope = 'address' AND ms.value = ue.email))").
+		Where("msc.caughtup_at IS NULL").
+		Group("msc.userid, u.fullname, ue.email, ms.provider").
+		Order("since ASC").
+		Limit(1000).
+		Scan(&members)
+
+	if res.Error != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Could not read delayed members")
+	}
+
+	return c.JSON(fiber.Map{
+		"suppressions": suppressions,
+		"members":      members,
+		// Capped so an estate-wide episode cannot try to render 9,400 rows in
+		// a browser. Say so rather than silently truncate.
+		"memberlimit": 1000,
+	})
+}

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -327,6 +327,41 @@ func PostMemberships(c *fiber.Ctx) error {
 	}
 }
 
+// mailDelayedCols surfaces deferral-aware mail suppression on a member row.
+//
+// A provider that stops accepting our mail (Yahoo did, on 2026-08-15, for
+// every address it hosts) leaves the member receiving nothing while their
+// address is perfectly fine. Moderators need to see that, and to see that it
+// reads differently from "bouncing", which they correctly interpret as a bad
+// address.
+//
+// Correlated subqueries rather than joins on purpose: a member can have more
+// than one email row, and a suppression can match both by domain and by
+// address, so a join would multiply member rows. mail_suppressions holds only
+// a handful of active rows and both lookups are covered by indexes.
+//
+// The address-scope row is preferred over the domain-scope one because it
+// carries the more specific reason (one full mailbox, rather than a whole
+// provider deferring us).
+//
+// keep-raw: this is a column-list fragment spliced into the four hand-written
+// SELECTs below, which are the established shape in this file; expressing it
+// as a builder would diverge it from all four.
+const mailDelayedCols = `(SELECT ms.deferred_since FROM mail_suppressions ms
+	  JOIN users_emails ue ON ue.userid = u.id AND ue.preferred = 1
+	 WHERE ms.released_at IS NULL
+	   AND ((ms.scope = 'domain' AND ms.value = SUBSTRING_INDEX(ue.email, '@', -1))
+	     OR (ms.scope = 'address' AND ms.value = ue.email))
+	 ORDER BY ms.scope = 'address' DESC LIMIT 1) AS maildelayedsince,
+	(SELECT ms.provider FROM mail_suppressions ms
+	  JOIN users_emails ue ON ue.userid = u.id AND ue.preferred = 1
+	 WHERE ms.released_at IS NULL
+	   AND ((ms.scope = 'domain' AND ms.value = SUBSTRING_INDEX(ue.email, '@', -1))
+	     OR (ms.scope = 'address' AND ms.value = ue.email))
+	 ORDER BY ms.scope = 'address' DESC LIMIT 1) AS maildelayedprovider,
+	(SELECT SUM(msc.count) FROM mail_suppressed_counts msc
+	 WHERE msc.userid = u.id AND msc.caughtup_at IS NULL) AS maildelayedcount`
+
 // GetMembershipsMember is the response struct for individual members in GetMemberships.
 type GetMembershipsMember struct {
 	ID                  uint64                  `json:"id"`
@@ -354,6 +389,15 @@ type GetMembershipsMember struct {
 	Engagement          *string                 `json:"engagement"`
 	Lastmodmail         *string                 `json:"lastmodmail,omitempty"`
 	Bouncing            bool                    `json:"bouncing" gorm:"column:bouncing"`
+	// Set while the member's email provider is refusing our mail. This is
+	// deliberately NOT the same thing as Bouncing: bouncing means their
+	// address is bad, whereas this is our own sending reputation with their
+	// provider, and moderators must be able to tell the two apart. Pointers
+	// so a query branch that does not select them reads as unknown rather
+	// than as a confident "not delayed".
+	MailDelayedSince    *string `json:"maildelayedsince" gorm:"column:maildelayedsince"`
+	MailDelayedProvider *string `json:"maildelayedprovider" gorm:"column:maildelayedprovider"`
+	MailDelayedCount    *int    `json:"maildelayedcount" gorm:"column:maildelayedcount"`
 }
 
 // GetMemberships handles GET /memberships - list group members (moderator use).
@@ -424,7 +468,7 @@ func GetMemberships(c *fiber.Ctx) error {
 				"u.fullname, u.firstname, u.lastname, u.engagement, "+
 				"b.userid AS id, NULL AS heldby, NULL AS settings, "+
 				"0 AS emailfrequency, 'DEFAULT' AS ourPostingStatus, 0 AS eventsallowed, 0 AS volunteeringallowed, "+
-				"NULL AS reviewrequestedat, NULL AS reviewedat, NULL AS reviewreason").
+				"NULL AS reviewrequestedat, NULL AS reviewedat, NULL AS reviewreason, "+mailDelayedCols).
 			Joins("JOIN users u ON u.id = b.userid").
 			Where("b.groupid = ?", groupid)
 		if contextID > 0 {
@@ -457,7 +501,7 @@ func GetMemberships(c *fiber.Ctx) error {
 				"m.emailfrequency, m.ourPostingStatus, m.eventsallowed, m.volunteeringallowed, "+
 				"b.date AS bandate, b.byuser AS bannedby, "+
 				"m.reviewrequestedat, m.reviewedat, m.reviewreason, u.engagement, "+
-				"MAX(l.timestamp) AS lastmodmail").
+				"MAX(l.timestamp) AS lastmodmail, "+mailDelayedCols).
 			Joins("JOIN users u ON u.id = m.userid").
 			Joins("LEFT JOIN users_banned b ON b.userid = m.userid AND b.groupid = m.groupid").
 			Joins("INNER JOIN logs l ON l.user = m.userid AND l.groupid = m.groupid "+
@@ -482,7 +526,7 @@ func GetMemberships(c *fiber.Ctx) error {
 		"u.fullname, u.firstname, u.lastname, m.settings, " +
 		"m.emailfrequency, m.ourPostingStatus, m.eventsallowed, m.volunteeringallowed, " +
 		"b.date AS bandate, b.byuser AS bannedby, " +
-		"m.reviewrequestedat, m.reviewedat, m.reviewreason, u.engagement, u.bouncing"
+		"m.reviewrequestedat, m.reviewedat, m.reviewreason, u.engagement, u.bouncing, " + mailDelayedCols
 
 	// filterWhereSQL returns the filter-specific WHERE fragment (with
 	// comments/notes, moderation team, bouncing, or none) - one of 4 fixed
@@ -699,7 +743,7 @@ func getSpamMembers(c *fiber.Ctx, myid uint64, groupid uint64, limit int) error 
 			"u.fullname, u.firstname, u.lastname, m.settings, "+
 			"m.emailfrequency, m.ourPostingStatus, m.eventsallowed, m.volunteeringallowed, "+
 			"b.date AS bandate, b.byuser AS bannedby, "+
-			"m.reviewrequestedat, m.reviewedat, m.reviewreason, u.engagement, u.bouncing").
+			"m.reviewrequestedat, m.reviewedat, m.reviewreason, u.engagement, u.bouncing, "+mailDelayedCols).
 		Joins("JOIN users u ON u.id = m.userid").
 		Joins("LEFT JOIN users_banned b ON b.userid = m.userid AND b.groupid = m.groupid").
 		Where("m.groupid IN ? AND m.reviewrequestedat IS NOT NULL AND (m.reviewedat IS NULL OR m.reviewrequestedat > m.reviewedat)", modGroupIDs).

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -329,38 +329,40 @@ func PostMemberships(c *fiber.Ctx) error {
 
 // mailDelayedCols surfaces deferral-aware mail suppression on a member row.
 //
-// A provider that stops accepting our mail (Yahoo did, on 2026-08-15, for
-// every address it hosts) leaves the member receiving nothing while their
-// address is perfectly fine. Moderators need to see that, and to see that it
-// reads differently from "bouncing", which they correctly interpret as a bad
-// address.
+// A provider that stops accepting our mail - Yahoo did, on 2026-08-15, for
+// every address it hosts - leaves the member receiving nothing while their
+// own address is perfectly fine. Moderators need to see that, and to see that
+// it reads differently from "bouncing", which they correctly interpret as a
+// bad address and act on.
 //
-// Correlated subqueries rather than joins on purpose: a member can have more
-// than one email row, and a suppression can match both by domain and by
-// address, so a join would multiply member rows. mail_suppressions holds only
-// a handful of active rows and both lookups are covered by indexes.
+// All three read from mail_suppressed_counts, which the batch side writes as
+// it declines to generate each email. That is deliberate: working out from
+// scratch which provider is refusing a given member would mean resolving
+// their send address the way the mailer does (a ranking over users_emails,
+// not a flag) and then matching it by domain - which is not something a
+// reporting query should be reimplementing, and would not be indexable
+// either. The batch side already knows the answer at the moment it decides,
+// so it records it.
 //
-// The address-scope row is preferred over the domain-scope one because it
-// carries the more specific reason (one full mailbox, rather than a whole
-// provider deferring us).
+// The consequence worth knowing: a member shows as delayed once we have
+// actually held something back for them, not from the instant the provider
+// is suppressed. In practice that is the next digest or post notification
+// they were due.
 //
-// keep-raw: this is a column-list fragment spliced into the four hand-written
-// SELECTs below, which are the established shape in this file; expressing it
-// as a builder would diverge it from all four.
-const mailDelayedCols = `(SELECT ms.deferred_since FROM mail_suppressions ms
-	  JOIN users_emails ue ON ue.userid = u.id AND ue.preferred = 1
-	 WHERE ms.released_at IS NULL
-	   AND ((ms.scope = 'domain' AND ms.value = SUBSTRING_INDEX(ue.email, '@', -1))
-	     OR (ms.scope = 'address' AND ms.value = ue.email))
-	 ORDER BY ms.scope = 'address' DESC LIMIT 1) AS maildelayedsince,
-	(SELECT ms.provider FROM mail_suppressions ms
-	  JOIN users_emails ue ON ue.userid = u.id AND ue.preferred = 1
-	 WHERE ms.released_at IS NULL
-	   AND ((ms.scope = 'domain' AND ms.value = SUBSTRING_INDEX(ue.email, '@', -1))
-	     OR (ms.scope = 'address' AND ms.value = ue.email))
-	 ORDER BY ms.scope = 'address' DESC LIMIT 1) AS maildelayedprovider,
+// Correlated subqueries rather than joins, because a member has one row per
+// type of mail held and a join would multiply member rows. Each is keyed on
+// msc.userid, the leading column of the table's unique index.
+//
+// keep-raw: column-list fragment spliced into the four hand-written SELECTs
+// below, which are the established shape in this file.
+const mailDelayedCols = `(SELECT MIN(msc.firstat) FROM mail_suppressed_counts msc
+	 WHERE msc.userid = u.id AND msc.caughtup_at IS NULL) AS maildelayedsince,
 	(SELECT SUM(msc.count) FROM mail_suppressed_counts msc
-	 WHERE msc.userid = u.id AND msc.caughtup_at IS NULL) AS maildelayedcount`
+	 WHERE msc.userid = u.id AND msc.caughtup_at IS NULL) AS maildelayedcount,
+	(SELECT ms.provider FROM mail_suppressed_counts msc
+	   JOIN mail_suppressions ms ON ms.id = msc.suppressionid
+	 WHERE msc.userid = u.id AND msc.caughtup_at IS NULL
+	 ORDER BY msc.id DESC LIMIT 1) AS maildelayedprovider`
 
 // GetMembershipsMember is the response struct for individual members in GetMemberships.
 type GetMembershipsMember struct {

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -1474,6 +1474,18 @@ func SetupRoutes(app *fiber.App) {
 		// @Failure 403 {object} fiber.Error "Forbidden"
 		rg.Get("/modtools/email/stats", emailtracking.Stats)
 
+		// Deferral suppressions (authenticated, admin only)
+		// @Router /modtools/email/deferrals [get]
+		// @Summary List providers currently refusing our mail, and the members affected
+		// @Description Support view of deferral-aware mail suppression: active suppressions plus members whose mail is being held
+		// @Tags emailtracking
+		// @Produce json
+		// @Security BearerAuth
+		// @Success 200 {object} map[string]interface{}
+		// @Failure 401 {object} fiber.Error "Unauthorized"
+		// @Failure 403 {object} fiber.Error "Forbidden"
+		rg.Get("/modtools/email/deferrals", emailtracking.Deferrals)
+
 		// Email Statistics Time Series (authenticated, admin only)
 		// @Router /email/stats/timeseries [get]
 		// @Summary Get daily email statistics for charting

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -381,10 +381,11 @@ func TestDeleteMembershipsModRemovesMember(t *testing.T) {
 // the row is written at all.
 //
 // AssertFlip protocol (fix already in master via 0d342ced6):
-//   Step 1 — Assert CORRECT behaviour (passes on fixed master):
-//     Group/Left log exists AND byuser is non-nil AND byuser equals the acting user.
-//   Step 2 — Invert (would fail on fixed master, proves assertion is meaningful):
-//     assert byuser IS nil — fails because fix sets it.
+//
+//	Step 1 — Assert CORRECT behaviour (passes on fixed master):
+//	  Group/Left log exists AND byuser is non-nil AND byuser equals the acting user.
+//	Step 2 — Invert (would fail on fixed master, proves assertion is meaningful):
+//	  assert byuser IS nil — fails because fix sets it.
 //
 // Self-leave: byuser must equal the leaving user's own ID.
 // Mod-removes: byuser must equal the moderator's ID (not the removed member's).
@@ -4347,4 +4348,124 @@ func TestDeleteMembershipsDemotesStaleModeratorSystemRole(t *testing.T) {
 	var systemrole string
 	database.DBConn.Raw("SELECT systemrole FROM users WHERE id = ?", userID).Scan(&systemrole)
 	assert.Equal(t, "User", systemrole, "leaving the only mod group must demote systemrole to User")
+}
+
+// TestGetMembershipsMailDelayed covers the deferral-aware suppression fields.
+//
+// These exist because "email delayed" and "bouncing" mean different things and
+// moderators act on them differently: bouncing means the member's address is
+// bad, whereas delayed means a provider has stopped accepting mail from OUR
+// servers and there is nothing anyone can do but wait.
+func TestGetMembershipsMailDelayed(t *testing.T) {
+	prefix := uniquePrefix("mf_delay")
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	delayedID := CreateTestUser(t, prefix+"_delayed", "User")
+	CreateTestMembership(t, delayedID, groupID, "Member")
+
+	normalID := CreateTestUser(t, prefix+"_normal", "User")
+	CreateTestMembership(t, normalID, groupID, "Member")
+
+	var suppressionID uint64
+	db.Exec("INSERT INTO mail_suppressions (scope, value, provider, reason, deferred_since, first_seen, last_seen) "+
+		"VALUES ('domain', ?, 'Yahoo', '421 4.7.0 [TSS04] temporarily deferred', ?, NOW(), NOW())",
+		prefix+".example", "2026-08-15 16:38:00")
+	db.Raw("SELECT id FROM mail_suppressions WHERE value = ?", prefix+".example").Scan(&suppressionID)
+
+	db.Exec("INSERT INTO mail_suppressed_counts (userid, emailtype, suppressionid, count, firstat, lastat) "+
+		"VALUES (?, 'digest_immediate', ?, 7, ?, NOW())",
+		delayedID, suppressionID, "2026-08-15 16:38:00")
+	db.Exec("INSERT INTO mail_suppressed_counts (userid, emailtype, suppressionid, count, firstat, lastat) "+
+		"VALUES (?, 'chat', ?, 2, ?, NOW())",
+		delayedID, suppressionID, "2026-08-16 09:00:00")
+
+	defer func() {
+		db.Exec("DELETE FROM mail_suppressed_counts WHERE userid IN (?, ?)", delayedID, normalID)
+		db.Exec("DELETE FROM mail_suppressions WHERE value = ?", prefix+".example")
+	}()
+
+	url := fmt.Sprintf("/api/memberships?groupid=%d&collection=Approved&jwt=%s", groupID, token)
+	req := httptest.NewRequest("GET", url, nil)
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	membersRaw, ok := result["members"]
+	assert.True(t, ok, "response should include members")
+	members := membersRaw.([]interface{})
+
+	var sawDelayed, sawNormal bool
+	for _, raw := range members {
+		m := raw.(map[string]interface{})
+		uid := uint64(m["userid"].(float64))
+
+		if uid == delayedID {
+			sawDelayed = true
+			assert.NotNil(t, m["maildelayedsince"], "delayed member should carry a since date")
+			assert.Contains(t, m["maildelayedsince"], "2026-08-15",
+				"since must be when we first held mail, not when we noticed")
+			assert.Equal(t, "Yahoo", m["maildelayedprovider"],
+				"moderators should read the provider's name, not a piece of DNS")
+			// 7 digests plus 2 chat notifications, summed across types.
+			assert.Equal(t, float64(9), m["maildelayedcount"])
+			// Delayed is NOT bouncing - their address is fine.
+			assert.Equal(t, false, m["bouncing"])
+		}
+
+		if uid == normalID {
+			sawNormal = true
+			assert.Nil(t, m["maildelayedsince"], "an unaffected member must not look delayed")
+			assert.Nil(t, m["maildelayedcount"])
+		}
+	}
+
+	assert.True(t, sawDelayed, "the delayed member should be in the list")
+	assert.True(t, sawNormal, "the unaffected member should be in the list")
+}
+
+// TestGetMembershipsMailDelayedClearedOnCatchUp proves the notice goes away
+// once the catch-up has been sent, rather than sticking around for ever the
+// way the legacy bouncing flag did.
+func TestGetMembershipsMailDelayedClearedOnCatchUp(t *testing.T) {
+	prefix := uniquePrefix("mf_dlyclr")
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	memberID := CreateTestUser(t, prefix+"_m", "User")
+	CreateTestMembership(t, memberID, groupID, "Member")
+
+	db.Exec("INSERT INTO mail_suppressed_counts (userid, emailtype, count, firstat, lastat, caughtup_at) "+
+		"VALUES (?, 'chat', 3, NOW(), NOW(), NOW())", memberID)
+
+	defer db.Exec("DELETE FROM mail_suppressed_counts WHERE userid = ?", memberID)
+
+	url := fmt.Sprintf("/api/memberships?groupid=%d&collection=Approved&jwt=%s", groupID, token)
+	req := httptest.NewRequest("GET", url, nil)
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	for _, raw := range result["members"].([]interface{}) {
+		m := raw.(map[string]interface{})
+		if uint64(m["userid"].(float64)) == memberID {
+			assert.Nil(t, m["maildelayedsince"], "a caught-up member is no longer delayed")
+			return
+		}
+	}
+
+	t.Fatal("member not found in list")
 }


### PR DESCRIPTION
## What this does

Stops us generating email for people whose email provider has temporarily stopped accepting mail from our sending servers, and tells us when that is happening.

Today nothing in this codebase can see such a block. Our bulk relay takes each message from us, answers "queued", and takes responsibility for delivering it onward. The conversation with Gmail, Yahoo or Microsoft happens on the relay afterwards, where we never look. So when a provider starts refusing us, the sending jobs carry on rendering email at full rate into a queue that cannot empty, and no alert fires.

On 2026-08-15 Yahoo began refusing every message from the relay's address with `421 4.7.0 [TSS04] ... temporarily deferred due to unexpected volume or user complaints`. Three days later it was still unnoticed: 85,537 messages queued and growing by roughly 1,300 an hour, and about 9,400 people had received nothing.

**This replaces #1365**, whose two commits are carried here unchanged. They belong with this
work rather than beside it: one covers the failure this cannot see, and the other fixes the
measurement that should have made the whole episode visible.

## The end state

**`mail:deferrals:scan`** runs every fifteen minutes. It reads the relay's mail queue over the ssh mechanism the host health checks already use, decides which providers have stopped accepting us, and raises a Sentry alert both when it suppresses one and when it cannot read the relay at all.

**Deferrals are grouped by the receiving server, not by the recipient's domain.** One Yahoo block covered `yahoo.co.uk`, `yahoo.com`, `ymail.com`, `rocketmail.com`, `aol.com`, `aol.co.uk`, `aim.com` and `sky.com`. Sky's email is run by Yahoo, which nothing about the domain name reveals. All eight go through `*.am0.yahoodns.net`. Grouping by receiving server catches all of them; grouping by domain would be an endless game of catch-up.

**A provider is suppressed** when its queued backlog is large *and* it has all but stopped accepting our mail. Both halves matter: a large backlog on its own can be a slow evening, and a quiet hour on its own can be a quiet hour. A second, slower rule covers a single mailbox that is full (`452 4.2.2 ... over quota`), which is one person's problem rather than our reputation.

**Each sending job checks before it builds the email**, not before it sends it, because building is where the money goes: turning a digest into HTML and AMP is the expensive part. `EmailSpoolerService::spool()` has a second check as a safety net for any path that does not check earlier.

This is deliberately not the existing `users.bouncing` flag. That one means "this address is bad", moderators act on it by chasing or removing the member, and historically it was never cleared. A provider refusing us is our problem, the address is fine, and the only right action is to wait.

**When a provider recovers**, we do not replay the backlog. We never stored the emails we declined to build, and most would be worse than useless by now:

| Type | What happens |
|---|---|
| `[Group] OFFER:` / `WANTED:` notifications | Dropped. A three-day-old post is taken or gone. |
| Community News, WeMissYou, volunteering | Dropped. All are regular sends; the next one is a better email than a stale one. |
| Daily digest | One catch-up covering the whole gap. This needs no code: the check returns before the "where we got to last time" marker moves, so the next daily run spans the gap by itself. |
| Chat notifications | One "you have unread messages" summary. Never replayed one by one, because a stack of days-old notifications landing at once is its own harm, and is the behaviour that gets a sender blocked in the first place. |

**`mail:deferrals:scan --purge`** deletes the queued backlog for a suppressed provider, and refuses to do anything without `--force` as well. This is not tidying. Left alone, the relay retries until its queue lifetime expires and then sends us one failure notice per message. With about nine queued messages per affected person, that would push essentially all of them past the five-soft-failures-in-fourteen-days threshold in `BounceService::checkAndSuspendUser()` and suspend them for a problem that was ours. `BounceService` also now ignores `temporarily deferred`, `[TSS04]` and `delivery time expired`, so any such notice that does reach us never counts against the member.

**Moderators see** "Email delayed since 15 August - Yahoo is not currently accepting our mail", styled and worded so it cannot be read as the member's address being broken. Sysadmin > Mail > Delayed lists every affected provider and member.

## The other way a provider fails us, and why it is here

Everything above catches a provider that **refuses** us. The refusal leaves the message in the
relay's queue, which is what makes it countable.

A provider can also accept every message and then quietly do nothing with it. That leaves no
queue entry, so the scan above is blind to it, and from our side everything looks perfect. On
2026-08-16 every Yahoo-run domain - `yahoo.co.uk`, `yahoo.com`, `aol.com`, `sky.com`,
`ymail.com`, `rocketmail.com` - went from a steady 16-36% open rate to zero and stayed there,
after a send five times the normal daily volume two days earlier. That is roughly 35,000 emails
a day going nowhere, and nothing alerted.

`DeliveryHealthService` watches for that, once a day, by comparing each domain against **its
own** recent history rather than a fixed figure or other domains. Open rates differ hugely and
legitimately between providers - `icloud.com` opens at 56% where `gmail.com` opens at 23% on the
same mail - so any absolute threshold would either miss real outages at the top or cry wolf at
the bottom. Domains that never report opens fall out by themselves, because their baseline is
already zero. Run against production on 18 August it names those six domains and nothing else.

The two stay separate alerts. "A provider has stopped taking our mail" and "we are short of
capacity" are different problems wanting different people. When the scan suppresses a provider,
expect the open-rate check to name the same domains a day or so later: that is the two agreeing.

### The lag alarm could not see the people worst affected

The daily-digest lag alert counted only recipients whose last digest was within seven days, to
leave out the permanently inactive. That also left out everyone who had fallen further behind -
exactly the group it exists to report. Measured on production on 2026-08-17, among members still
using the site, not bouncing, and still holding a community set to a daily digest:

| Last digest | Counted by the alert |
|---|---|
| Within a week | 3,627 yes |
| Over a week | 2,003 no |
| Over a month | 384 no |

Dormancy is now judged by whether the member has used the site, rather than by how long ago we
last managed to mail them, so the alert cannot lose sight of someone precisely because their
situation got worse. It also reports the over-a-week share separately, which is what tells a
rotating backlog apart from a stuck one. The corrected form reports 6,758 lagging, 3,099 of them
over a week behind; the old form reported 6,653 and could not break it down.

This makes nothing faster. It stops the measurement hiding the problem.

## What it deliberately does not do

- Email already written to the outgoing folder when a suppression starts still goes out. Holding it at send time would need a per-message delay the folder format does not have, and the sending daemon retries a second later, so it would spin against a provider already unhappy with our volume. That is minutes of email against days of the problem.
- The safety-net check in the spooler writes a log line but does not count what it skipped, because at that point the email may carry no member id. Anything it catches is a gap in an earlier check rather than a number to record.
- Our own addresses are never suppressed at any level. The volume is trivial, and the alternative is absurd: the alert saying a provider has stopped accepting our mail would be the message we dropped.
- A member is shown as delayed once we have actually held something back for them, not from the instant their provider is suppressed.
- A domain served by two suppressed providers gets one row, under whichever claimed it first. Releasing that one releases the row while the other is still blocking; the next scan re-creates it. Exposure is one scan interval.

## How the relay is reached

A restricted ssh key, mounted read-only into the batch container, driven through `App\Monitoring\SshHostCommandRunner`.

That mechanism is already deployed and tested, is already wired up so tests can swap in a fake, and `openssh-client` is already in the batch image for it. The alternatives cost more for less: having the relay write to the database would put database credentials and a new network path onto a mail-signing machine with no precedent here, and a small web service on the relay means writing and securing something new on a machine that has no build, deployment or configuration presence in this repository at all.

It uses its own key and its own settings rather than `FREEGLE_MONITORING_HOSTS`, which is a full administrative login across every machine. `.env.background.example` spells out the `authorized_keys` restriction ops must add; without it, that key is a login on the relay.

## Corrections to assumptions in the brief

- The note in `SmtpFailureClassifier` naming `mail:mod-notifs`, `mail:engage` and `mail:donations:*` as paths that skip the spooler is out of date. All three were moved onto `spool()` in `3c8b5c6de`. Corrected here. The only remaining path to a member's own mailbox is the farewell email in `User::removeMembership()`, which is now checked directly.
- The outgoing mail store is files under `storage/spool/mail`, not a database table.
- `AlertService.php` is not the Sentry mechanism; it sends broadcast email to moderators. The guarded `\Sentry\captureMessage()` form is used instead.
- The daily digest catch-up needs no code, and the per-post notifications are `UnifiedDigestService --mode=immediate` with one marker shared by a whole community, so dropping stale posts is what happens whether we choose it or not.

## Code quality review

Sixteen findings from an adversarial review were checked against the source; fourteen were confirmed and fixed, each with a test that fails without the fix. The two not changed are the spooler safety net not counting, and the bounce patterns being unconditional (a queue-expiry notice arrives days later, when the suppression has usually been lifted) - both written down above.

The ones worth a reviewer's attention:

| Problem | Why it mattered |
|---|---|
| `--dry-run` did not stop `--purge --force` | Asking what would happen, answered by deleting live email |
| The give-up-and-resume rule never ran when the relay could not be read | Exactly when a suppression is most likely to stay on for ever |
| Domains appearing partway through were never checked | A days-long block keeps finding new ones as people become due email |
| Single mailboxes used the provider-sized release threshold | A still-full mailbox read as recovered on the next scan and was released in about half an hour |
| A scan that was neither clear nor stale left the counter untouched | clear, blocked, clear released a provider that was never quiet twice running |
| The release step read state the same run had already replaced | It judged rows from before the run's own updates, then wrote over them |
| The catch-up ignored whether the email was actually accepted | A member permanently owed a catch-up nobody knew about |
| Chat was checked before the member's notification preference | Someone with chat email turned off would get a summary they never asked for |
| One foreign key was in the hand-run SQL but not the migration | The two would have drifted apart |

Two more came from writing the tests. The unread-chat query filtered on `whereNull('reviewrejected')`, but that column cannot be null and defaults to `0`, so it matched nothing and nobody would ever have received a catch-up. And `?tab=delayed` did nothing, because the sysadmin link handler is guarded on a lookup table the new tab was never added to.

Checked against a real Percona server rather than assumed: the hand-run SQL applies and re-applies cleanly, the per-member counter behaves correctly after a catch-up, and the new index rejects a second live suppression for one target while allowing history to repeat.

## Test plan

Run against the worktree containers through the status API. Each figure is from a named commit
on this branch, not from an earlier draft:

| Suite | Result | At |
|---|---|---|
| Laravel, the deferral suites | 152 passed, 0 failed | `cbb65b3b0` |
| Laravel, the unsubscribe ratchet plus delivery health, catch-up and suppression | 46 passed, 0 failed | `91db30f69` |
| Go, full suite | 4170 passed, 0 failed | `ec94de277` |
| Vitest, `ModMailDelayed` / `ModMember` / `sysadmin` | 7, 81 and 12 passed | `ec94de277` |

The first CI run on this branch failed on three Laravel tests, all one omission: a new mailable
has to declare its unsubscribe category as a constant and be listed in the coverage test, so a
typo cannot quietly fall back to turning all of a member's email off. That ratchet was outside
the filter used locally, which is why it took CI to find it. Fixed in `91db30f69`.
`ScanDeferralsCommandTest` is the acceptance test: given the relay queue in the shape it was in on 2026-08-16, one scan suppresses Yahoo and every domain behind it while Gmail keeps receiving, and `--purge` refuses to run without `--force` and never asks the relay to delete everything.

Note for anyone reproducing the Go run locally: `/api/tests/go` copies its database from the development one without applying migrations first, so a new migration must be applied there by hand. CI is unaffected, because `scripts/setup-test-database.sh` migrates before it copies.

## Applying this

Schema changes are operator-only, so nothing here touches the live database. The whole of
`iznik-batch/database/migrations/2026_08_18_000001_create_mail_suppressions_tables_migration.sql`
is reproduced below so it can be read and run without checking the branch out. It is safe to
run more than once: every statement is CREATE TABLE IF NOT EXISTS.

```sql
-- Production idempotent SQL: the tables behind deferral-aware mail suppression.
--
-- Our bulk relay accepts a message with a 250 and only then discovers that the receiving
-- provider will not take it. When a provider starts deferring us - 2026-08-15, Yahoo began
-- 421-ing everything from the relay's IP with "[TSS04] ... temporarily deferred due to
-- unexpected volume or user complaints" - the sending code sees nothing wrong and keeps
-- rendering mail into a queue that cannot drain.
--
-- mail_suppressions is the gate; mail_suppressed_counts is what release needs in order to
-- send one catch-up rather than replaying the backlog.
--
-- All CREATE TABLE IF NOT EXISTS, so this is safe to re-run.
-- See 2026_08_18_000001_create_mail_suppressions_tables.php.

CREATE TABLE IF NOT EXISTS `mail_suppressions` (
  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
  -- mxgroup = the relay host family that deferred us (the row carrying the evidence);
  -- domain = a recipient domain seen deferring via that relay, derived as a child row;
  -- address = one mailbox, for the per-address quota-exceeded signal.
  `scope` enum('mxgroup','domain','address') NOT NULL,
  `value` varchar(255) NOT NULL,
  `parentid` bigint unsigned DEFAULT NULL,
  -- The provider's own words, kept verbatim.
  `reason` text,
  `provider` varchar(64) DEFAULT NULL,
  -- Arrival time of the oldest still-deferred message: the "delayed since" date.
  `deferred_since` timestamp NULL DEFAULT NULL,
  `first_seen` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `last_seen` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  -- NULL while active.
  `released_at` timestamp NULL DEFAULT NULL,
  `message_count` int unsigned NOT NULL DEFAULT '0',
  -- Release needs two consecutive clear scans.
  `clear_scans` tinyint unsigned NOT NULL DEFAULT '0',
  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  -- Holds the value only while the row is active, so the unique key below
  -- enforces one live suppression per target. MySQL has no partial indexes,
  -- and repeated NULLs do not collide, so history keeps as many released
  -- rows for the same target as it likes.
  `active_value` varchar(255) GENERATED ALWAYS AS (if((`released_at` is null),`value`,NULL)) STORED,
  PRIMARY KEY (`id`),
  UNIQUE KEY `scope_active_value` (`scope`,`active_value`),
  KEY `scope_value_released` (`scope`,`value`,`released_at`),
  KEY `released_at` (`released_at`),
  KEY `parentid` (`parentid`),
  CONSTRAINT `mail_suppressions_parentid_foreign` FOREIGN KEY (`parentid`) REFERENCES `mail_suppressions` (`id`) ON DELETE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Targets we must not generate mail for while a provider is deferring us';

CREATE TABLE IF NOT EXISTS `mail_suppressed_counts` (
  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
  `userid` bigint unsigned NOT NULL,
  -- The emailType already passed to EmailSpoolerService::spool().
  `emailtype` varchar(32) NOT NULL,
  -- Which suppression was in force when we declined, recorded at the time.
  `suppressionid` bigint unsigned DEFAULT NULL,
  `count` int unsigned NOT NULL DEFAULT '0',
  `firstat` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `lastat` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  -- Claimed by the catch-up pass before it sends.
  `caughtup_at` timestamp NULL DEFAULT NULL,
  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`),
  UNIQUE KEY `userid_emailtype` (`userid`,`emailtype`),
  KEY `caughtup_at` (`caughtup_at`),
  KEY `suppressionid` (`suppressionid`),
  CONSTRAINT `mail_suppressed_counts_suppressionid_foreign` FOREIGN KEY (`suppressionid`) REFERENCES `mail_suppressions` (`id`) ON DELETE SET NULL,
  CONSTRAINT `mail_suppressed_counts_userid_foreign` FOREIGN KEY (`userid`) REFERENCES `users` (`id`) ON DELETE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='What we declined to generate per member, so release can send one catch-up';
```

Afterwards, both tables should exist and there should be three foreign keys:

```sql
SHOW TABLES LIKE 'mail_suppress%';

SELECT CONSTRAINT_NAME, TABLE_NAME
  FROM information_schema.TABLE_CONSTRAINTS
 WHERE CONSTRAINT_SCHEMA = DATABASE()
   AND CONSTRAINT_NAME LIKE 'mail_suppress%';
```

Nothing reads or writes those tables until `FREEGLE_MAIL_DEFERRALS_ENABLED` is set, and the
scheduled entry is wrapped in the same check, so applying the schema on its own changes no
behaviour. Turning it on also needs `FREEGLE_MAIL_DEFERRALS_HOST` and
`MAIL_DEFERRALS_SSH_KEY_HOST_PATH` in `.env.background`, plus the forced-command
`authorized_keys` entry on the relay described in `.env.background.example` - without that
restriction the key is a login on the relay rather than a queue reader.
